### PR TITLE
Fix comment about misuse of .tech TLD from @niklasl, step 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ Vagrant box. If rolling your own server environment, update `DBHOST`, `DBUSER`, 
 `WHELK_REST_API_URL` config settings accordingly.
 
 For authenticating using [login.libris.kb.se](https://login.libris.kb.se),
-copy `instance/config.cfg.local -> config.cfg`, add the client secret to `instance/config.cfg` and
-insert the following record in `/etc/hosts` file:
+copy `instance/config.cfg.local -> config.cfg` and add the client secret to `instance/config.cfg`.
 
-    127.0.0.1       localhost.tech
+If you're not connected to KB internal DNS, you need to add the following record to `/etc/hosts`:
+
+    127.0.0.1       kblocalhost.kb.se
 
 
 ## Starting the Flask Application
@@ -46,7 +47,7 @@ insert the following record in `/etc/hosts` file:
 
 This will serve:
 
-* Libris Katalogiseringsverktyg on <http://localhost.tech:5000/>
+* Libris Katalogiseringsverktyg on <http://kblocalhost.kb.se:5000/>
 * `id.kb.se` on <http://localhost:5000/>  
 
 

--- a/instance/config.cfg.local
+++ b/instance/config.cfg.local
@@ -15,6 +15,6 @@ AUTHORIZED_ROLES=['cataloger', 'registrant']
 OAUTH_AUTHORIZATION_URL='https://login.libris.kb.se/oauth/authorize'
 OAUTH_TOKEN_URL='https://login.libris.kb.se/oauth/token'
 OAUTH_VERIFY_URL='https://login.libris.kb.se/oauth/verify'
-OAUTH_REDIRECT_URI='http://localhost.tech:5000/login/authorized'
+OAUTH_REDIRECT_URI='http://kblocalhost.kb.se:5000/login/authorized'
 OAUTH_CLIENT_ID='51aec4d330bf9cb9af603af778850886'
 OAUTH_CLIENT_SECRET='<Ask ola.blissing@kb.se for the secrets.>'


### PR DESCRIPTION
Less tech, more KB. Also— as with libris/xl_vagrant_up#3 —this is a breaking change with respect to successful OAuthorization via Libris Login.
