### PR TITLE
Fix duplicate keys in type dropdown tree by using a parentChainString as key

### DIFF
--- a/viewer/v2client/src/components/inspector/search-window.vue
+++ b/viewer/v2client/src/components/inspector/search-window.vue
@@ -231,7 +231,7 @@ export default {
                 <option :value="getRange">{{"All types" | translatePhrase}}</option>
                 <option 
                   v-for="term in getClassTree" 
-                  :key="term.id" 
+                  :key="term.parentChainString" 
                   :value="term.id" 
                   v-html="getFormattedSelectOption(term, settings, resources.vocab, resources.context)"></option>
               </select>

--- a/viewer/v2client/src/utils/vocab.js
+++ b/viewer/v2client/src/utils/vocab.js
@@ -564,16 +564,17 @@ export function isAbstract(itemId, vocab, vocabPfx, context) {
   return (termObject.hasOwnProperty('abstract') && termObject.abstract === true);
 }
 
-export function getTree(term, vocab, vocabPfx, context, counter = 0) {
+export function getTree(term, vocab, vocabPfx, context, counter = 0, parentChainString = '') {
   const treeNode = {
     id: term,
     sub: [],
     abstract: isAbstract(term, vocab, vocabPfx, context),
     depth: counter,
+    parentChainString: parentChainString+term,
   };
   const subs = getTermObject(term, vocab, vocabPfx, context).baseClassOf;
   _.each(subs, (sub) => {
-    treeNode.sub.push(getTree(sub, vocab, vocabPfx, context, counter + 1));
+    treeNode.sub.push(getTree(sub, vocab, vocabPfx, context, counter + 1, parentChainString+term));
   });
   return treeNode;
 }


### PR DESCRIPTION
Fix duplicate keys in type dropdown tree by using a parentChainString as key