### PR TITLE
Cleanup and more consistency in vocab utility

### DIFF
--- a/viewer/v2client/src/components/Inspector.vue
+++ b/viewer/v2client/src/components/Inspector.vue
@@ -308,7 +308,6 @@ export default {
       return VocabUtil.getRecordType(
         this.inspector.data.mainEntity['@type'], 
         this.resources.vocab, 
-        this.settings, 
         this.resources.context);
     },
   },

--- a/viewer/v2client/src/components/create/creation-card.vue
+++ b/viewer/v2client/src/components/create/creation-card.vue
@@ -38,9 +38,9 @@ export default {
     },
     getClassTree() {
       const tree = [this.creation].map(type => {
-        return VocabUtil.getTree(type, this.resources.vocab, this.settings.vocabPfx, this.resources.context);
+        return VocabUtil.getTree(type, this.resources.vocab, this.resources.context);
       });
-      return VocabUtil.flattenTree(tree, this.resources.vocab, this.settings.vocabPfx, this.resources.context, this.settings.language);
+      return VocabUtil.flattenTree(tree, this.resources.vocab, this.resources.context, this.settings.language);
     },
   },
 };

--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -106,14 +106,12 @@ export default {
         return VocabUtil.getTree(
           type, 
           this.resources.vocab, 
-          this.settings.vocabPfx, 
           this.resources.context
         );
       });
       return VocabUtil.flattenTree(
         tree, 
         this.resources.vocab, 
-        this.settings.vocabPfx, 
         this.resources.context, 
         this.settings.language
       );
@@ -139,7 +137,6 @@ export default {
         this.entityType, 
         this.fieldKey, 
         this.resources.vocab, 
-        this.settings.vocabPfx, 
         this.resources.context)
         .map(item => StringUtil.getCompactUri(item, this.resources.context));
       return fetchedRange;
@@ -149,7 +146,6 @@ export default {
         this.entityType, 
         this.fieldKey, 
         this.resources.vocab, 
-        this.settings.vocabPfx, 
         this.resources.context, 
         this.resources.vocabClasses
       ).map(item => StringUtil.getCompactUri(item, this.resources.context));;
@@ -159,7 +155,7 @@ export default {
       const types = this.getFullRange;
       const typeArray = [];
       for (const type of types) {
-        typeArray.push(type.replace(this.settings.vocabPfx, ''));
+        typeArray.push(StringUtil.getCompactUri(type, this.resources.context));
       }
       return typeArray;
     },

--- a/viewer/v2client/src/components/inspector/entity-form.vue
+++ b/viewer/v2client/src/components/inspector/entity-form.vue
@@ -41,8 +41,7 @@ export default {
       if (VocabUtil.isSubClassOf(
           this.inspector.data[this.editingObject]['@type'], 
           'Instance', 
-          this.resources.vocab, 
-          this.settings.vocabPfx, 
+          this.resources.vocab,  
           this.resources.context
         )
       ) {
@@ -51,7 +50,6 @@ export default {
           this.inspector.data[this.editingObject]['@type'], 
           'Work', 
           this.resources.vocab, 
-          this.settings.vocabPfx, 
           this.resources.context
           )
         ) {
@@ -59,7 +57,6 @@ export default {
       } else if (VocabUtil.isSubClassOf(
           this.inspector.data[this.editingObject]['@type'], 
           'Agent', this.resources.vocab, 
-          this.settings.vocabPfx, 
           this.resources.context
           )
         ) {
@@ -68,7 +65,6 @@ export default {
           this.inspector.data[this.editingObject]['@type'], 
           'Concept', 
           this.resources.vocab, 
-          this.settings.vocabPfx, 
           this.resources.context
         )
       ) {
@@ -97,7 +93,6 @@ export default {
       const allowed = VocabUtil.getPropertiesFromArray(
         formObj['@type'],
         this.resources.vocabClasses,
-        this.settings.vocabPfx,
         this.resources.vocabProperties,
         this.resources.context
       );
@@ -175,12 +170,11 @@ export default {
         const baseClasses = VocabUtil.getBaseClassesFromArray(
           formObj['@type'],
           this.resources.vocab,
-          this.settings.vocabPfx,
           this.resources.context
         );
         for (const baseClass of baseClasses) {
           propertyList = DisplayUtil.getProperties(
-            baseClass.replace(this.settings.vocabPfx, ''),
+            StringUtil.getCompactUri(baseClass, this.resources.context),
             'cards',
             this.resources.display,
             this.settings

--- a/viewer/v2client/src/components/inspector/entity-form.vue
+++ b/viewer/v2client/src/components/inspector/entity-form.vue
@@ -103,10 +103,9 @@ export default {
       );
       // Add the "added" property
       for (const element of allowed) {
-        const oId = element.item['@id'].replace(settings.vocabPfx, '');
+        const oId = StringUtil.getCompactUri(element.item['@id'], this.resources.context);
         element.added = (formObj.hasOwnProperty(oId));
       }
-
       const extendedAllowed = allowed.map(property => {
         const labelByLang = property.item.labelByLang;
         const prefLabelByLang = property.item.prefLabelByLang;

--- a/viewer/v2client/src/components/inspector/field-adder.vue
+++ b/viewer/v2client/src/components/inspector/field-adder.vue
@@ -53,7 +53,6 @@ export default {
         this.entityType, 
         this.settings.language, 
         this.resources.vocab, 
-        this.settings.vocabPfx, 
         this.resources.context
       );
       return `${title}: ${contextString}`;

--- a/viewer/v2client/src/components/inspector/field.vue
+++ b/viewer/v2client/src/components/inspector/field.vue
@@ -103,7 +103,7 @@ export default {
       if (this.key === '_uid') {
         return null;
       }
-      return VocabUtil.getTermObject(this.fieldKey, this.resources.vocab, this.settings.vocabPfx, this.resources.context);
+      return VocabUtil.getTermObject(this.fieldKey, this.resources.vocab, this.resources.context);
     },
     propertyComment() {
       if (this.keyAsVocabProperty && this.keyAsVocabProperty.commentByLang) {
@@ -145,7 +145,6 @@ export default {
       return VocabUtil.getPropertyTypes(
         this.fieldKey,
         this.resources.vocab,
-        this.settings.vocabPfx,
         this.resources.context
       );
     },

--- a/viewer/v2client/src/components/inspector/item-enumeration.vue
+++ b/viewer/v2client/src/components/inspector/item-enumeration.vue
@@ -60,13 +60,12 @@ export default {
       const types = VocabUtil.getRange(
         this.key,
         this.vocab,
-        this.settings.vocabPfx,
         this.context
       );
       return types;
     },
     disabledLabel() {
-      return `${StringUtil.getUiPhraseByLang('Choose', this.settings.language)} ${StringUtil.labelByLang(this.key, this.settings.language, this.vocab, this.settings.vocabPfx, this.context)}`;
+      return `${StringUtil.getUiPhraseByLang('Choose', this.settings.language)} ${StringUtil.labelByLang(this.key, this.settings.language, this.vocab, this.context)}`;
     },
   },
   ready() {

--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -113,13 +113,12 @@ export default {
       const formObj = this.item;
       const allowed = VocabUtil.getPropertiesFromArray([StringUtil.convertToVocabKey(StringUtil.convertToBaseUri(formObj['@type'], this.resources.context), this.resources.context)],
         this.resources.vocabClasses,
-        this.settings.vocabPfx,
         this.resources.vocabProperties,
         this.resources.context
       );
       // Add the "added" property
       for (const element of allowed) {
-        const oId = element.item['@id'].replace(settings.vocabPfx, '');
+        const oId = StringUtil.getCompactUri(element.item['@id'], this.resources.context);
         element.added = (formObj.hasOwnProperty(oId));
       }
 
@@ -251,11 +250,10 @@ export default {
         const baseClasses = VocabUtil.getBaseClassesFromArray(
           item['@type'],
           this.resources.vocab,
-          this.settings.vocabPfx
         );
         for (const className of baseClasses) {
           inputKeys = DisplayUtil.getProperties(
-            className.replace(this.settings.vocabPfx, ''),
+            StringUtil.getCompactUri(className, this.resources.context),
             'cards',
             this.resources.display,
             this.settings

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -121,13 +121,12 @@ export default {
       const allowed = VocabUtil.getPropertiesFromArray(
         [StringUtil.convertToVocabKey(StringUtil.convertToBaseUri(formObj['@type'], this.resources.context), this.resources.context)],
         this.resources.vocabClasses,
-        this.settings.vocabPfx,
         this.resources.vocabProperties,
         this.resources.context
       );
       // Add the "added" property
       for (const element of allowed) {
-        const oId = element.item['@id'].replace(settings.vocabPfx, '');
+        const oId = StringUtil.getCompactUri(element.item['@id'], this.resources.context);
         element.added = (formObj.hasOwnProperty(oId) && formObj[oId] !== null);
       }
 

--- a/viewer/v2client/src/components/inspector/item-vocab.vue
+++ b/viewer/v2client/src/components/inspector/item-vocab.vue
@@ -45,7 +45,6 @@ export default {
         this.entityType,
         this.fieldKey,
         this.resources.vocab,
-        this.settings.vocabPfx,
         this.resources.context,
         this.resources.vocabClasses,
       );
@@ -93,7 +92,6 @@ export default {
         value, 
         this.settings.language, 
         this.resources.vocab, 
-        this.settings.vocabPfx, 
         this.resources.context)
       );
     },

--- a/viewer/v2client/src/components/inspector/reverse-relations.vue
+++ b/viewer/v2client/src/components/inspector/reverse-relations.vue
@@ -80,7 +80,6 @@ export default {
       return VocabUtil.getRecordType(
         this.inspector.data.mainEntity['@type'], 
         this.resources.vocab, 
-        this.settings, 
         this.resources.context
       );
     },

--- a/viewer/v2client/src/components/inspector/search-window.vue
+++ b/viewer/v2client/src/components/inspector/search-window.vue
@@ -89,18 +89,18 @@ export default {
       'status',
     ]),
     getRange() {
-      const fetchedRange = VocabUtil.getRange(this.entityType, this.fieldKey, this.resources.vocab, this.settings.vocabPfx, this.resources.context)
-        .map(item => item.replace(this.settings.vocabPfx, ''));
+      const fetchedRange = VocabUtil.getRange(this.entityType, this.fieldKey, this.resources.vocab, this.resources.context)
+        .map(item => StringUtil.getCompactUri(item, this.resources.context));
       return fetchedRange;
     },
     getFullRange() {
-      return VocabUtil.getFullRange(this.entityType, this.fieldKey, this.resources.vocab, this.settings.vocabPfx, this.resources.context, this.resources.vocabClasses);
+      return VocabUtil.getFullRange(this.entityType, this.fieldKey, this.resources.vocab, this.resources.context, this.resources.vocabClasses);
     },
     allSearchTypes() {
       const types = this.getFullRange;
       const typeArray = [];
       for (const type of types) {
-        typeArray.push(type.replace(this.settings.vocabPfx, ''));
+        typeArray.push(StringUtil.getCompactUri(type, this.resources.context));
       }
       return typeArray;
     },
@@ -112,9 +112,9 @@ export default {
     },
     getClassTree() {
       const tree = this.getRange.map(type => {
-        return VocabUtil.getTree(type, this.resources.vocab, this.settings.vocabPfx, this.resources.context);
+        return VocabUtil.getTree(type, this.resources.vocab, this.resources.context);
       });
-      return VocabUtil.flattenTree(tree, this.resources.vocab, this.settings.vocabPfx, this.resources.context, this.settings.language);
+      return VocabUtil.flattenTree(tree, this.resources.vocab, this.resources.context, this.settings.language);
     },
   },
   mounted() {

--- a/viewer/v2client/src/components/inspector/toolbar.vue
+++ b/viewer/v2client/src/components/inspector/toolbar.vue
@@ -135,10 +135,9 @@ export default {
       const baseClasses = VocabUtil.getBaseClasses(
         this.inspector.data.mainEntity['@type'], 
         this.resources.vocab, 
-        this.settings.vocabPfx, 
         this.resources.context
       )
-        .map(id => id.replace(this.settings.vocabPfx, ''));
+        .map(id => StringUtil.getCompactUri(id, this.resources.context));
       return baseClasses.indexOf(type) > -1;
     },
     download(text) {
@@ -177,7 +176,6 @@ export default {
       return VocabUtil.getRecordType(
         this.inspector.data.mainEntity['@type'], 
         this.resources.vocab, 
-        this.settings, 
         this.resources.context);
     },
     canEditThisType() {
@@ -227,13 +225,12 @@ export default {
       const allowed = VocabUtil.getPropertiesFromArray(
         [StringUtil.convertToVocabKey(StringUtil.convertToBaseUri(formObj['@type'], this.resources.context), this.resources.context)],
         this.resources.vocabClasses,
-        this.settings.vocabPfx,
         this.resources.vocabProperties,
         this.resources.context
       );
       // Add the "added" property
       for (const element of allowed) {
-        const oId = element.item['@id'].replace(settings.vocabPfx, '');
+        const oId = StringUtil.getCompactUri(element.item['@id'], this.resources.context);
         element.added = (formObj.hasOwnProperty(oId) && formObj[oId] !== null);
       }
 

--- a/viewer/v2client/src/components/search/result-controls.vue
+++ b/viewer/v2client/src/components/search/result-controls.vue
@@ -37,7 +37,7 @@ export default {
                 };
                 if (typeof item.object !== 'undefined') {
                   if (item.variable === '@type') {
-                    filterObj.label = StringUtil.getLabelByLang(item.object['@id'], this.settings.language, this.resources.vocab, this.settings.vocabPfx, this.resources.context);
+                    filterObj.label = StringUtil.getLabelByLang(item.object['@id'], this.settings.language, this.resources.vocab, this.resources.context);
                   } else {
                     filterObj.label = item.object['@id'].replace('https://id.kb.se/', '');
                   }

--- a/viewer/v2client/src/components/search/search-form.vue
+++ b/viewer/v2client/src/components/search/search-form.vue
@@ -167,8 +167,8 @@ export default {
       dataSetFilters() {
         return this.settings.dataSetFilters.libris.map(term => {
             return {
-            '@id': term.replace(this.settings.vocabPfx, ''),
-            'label': StringUtil.getLabelByLang(term, this.settings.language, this.resources.vocab, this.settings.vocabPfx, this.resources.context)
+            '@id': StringUtil.getCompactUri(term, this.resources.context),
+            'label': StringUtil.getLabelByLang(term, this.settings.language, this.resources.vocab, this.resources.context)
             };
         });
       },

--- a/viewer/v2client/src/components/shared/tooltip-component.vue
+++ b/viewer/v2client/src/components/shared/tooltip-component.vue
@@ -28,7 +28,7 @@ export default {
     },
     translatedText() {
       if (this.translation === 'labelByLang') {
-        return StringUtil.getLabelByLang(this.tooltipText, this.settings.language, this.resources.vocab, this.settings.vocabPfx, this.resources.context);
+        return StringUtil.getLabelByLang(this.tooltipText, this.settings.language, this.resources.vocab, this.resources.context);
       } else if (this.translation === 'translatePhrase') {
         return StringUtil.getUiPhraseByLang(this.tooltipText, this.settings.language);
       }

--- a/viewer/v2client/src/main.js
+++ b/viewer/v2client/src/main.js
@@ -19,7 +19,7 @@ Vue.use(Vuex);
 Vue.component('field', Field);
 
 Vue.filter('labelByLang', (label) => {
-  return StringUtil.getLabelByLang(label, store.getters.user.settings.language, store.getters.resources.vocab, store.getters.settings.vocabPfx, store.getters.resources.context);
+  return StringUtil.getLabelByLang(label, store.getters.user.settings.language, store.getters.resources.vocab, store.getters.resources.context);
 });
 
 Vue.filter('asAppPath', (path) => {

--- a/viewer/v2client/src/store/store.js
+++ b/viewer/v2client/src/store/store.js
@@ -68,7 +68,6 @@ const store = new Vuex.Store({
     settings: {
       title: 'Libris Katalogisering',
       language: 'sv',
-      vocabPfx: 'https://id.kb.se/vocab/',
       environment: getEnvironment(),
       version: process.env.VERSION,
       apiPath: process.env.API_PATH,

--- a/viewer/v2client/src/utils/display.js
+++ b/viewer/v2client/src/utils/display.js
@@ -51,7 +51,7 @@ function getValueByLang(item, propertyId, displayDefs, langCode, context) {
   return translatedValue;
 }
 
-export function getProperties(typeInput, level, displayDefs, settings) {
+export function getProperties(typeInput, level, displayDefs) {
   if (!typeInput || typeof typeInput === 'undefined') {
     throw new Error('getProperties was called with an undefined type.');
   }
@@ -72,7 +72,7 @@ export function getProperties(typeInput, level, displayDefs, settings) {
     if (props.length > 0) {
       return props;
     } else if (level === 'cards') { // Try fallback to chip level
-      props = getProperties(type, 'chips', displayDefs, settings);
+      props = getProperties(type, 'chips', displayDefs);
       if (props.length > 0) {
         return props;
       }
@@ -108,10 +108,10 @@ export function getDisplayObject(item, level, displayDefs, quoted, vocab, settin
     return {};
   }
   if (properties.length === 0) { // If none were found, traverse up inheritance tree
-    const baseClasses = VocabUtil.getBaseClassesFromArray(trueItem['@type'], vocab, settings.vocabPfx, context);
+    const baseClasses = VocabUtil.getBaseClassesFromArray(trueItem['@type'], vocab, context);
     for (let i = 0; i < baseClasses.length; i++) {
       if (typeof baseClasses[i] !== 'undefined') {
-        properties = getProperties(baseClasses[i].replace(settings.vocabPfx, ''), level, displayDefs, settings);
+        properties = getProperties(StringUtil.getCompactUri(baseClasses[i], context), level, displayDefs, settings);
         if (properties.length > 0) {
           usedLensType = baseClasses[i];
           break;
@@ -142,7 +142,6 @@ export function getDisplayObject(item, level, displayDefs, quoted, vocab, settin
         let value = valueOnItem;
         if (_.isObject(value) && !_.isArray(value)) {
           value = getItemLabel(value, displayDefs, quoted, vocab, settings, context);
-          // value = getDisplayObject(value, 'chips', displayDefs, quoted, vocab, vocabPfx);
         } else if (_.isArray(value)) {
           const newArray = [];
           for (const arrayItem of value) {
@@ -161,7 +160,7 @@ export function getDisplayObject(item, level, displayDefs, quoted, vocab, settin
         }
         result[properties[i]] = value;
       } else if (properties.length < 3 && i === 0) {
-        const rangeOfMissingProp = VocabUtil.getRange(trueItem['@type'], properties[i], vocab, settings.vocabPfx, context);
+        const rangeOfMissingProp = VocabUtil.getRange(trueItem['@type'], properties[i], vocab, context);
         let propMissing = properties[i];
         if (rangeOfMissingProp.length > 0) {
           propMissing = rangeOfMissingProp[0];
@@ -170,7 +169,6 @@ export function getDisplayObject(item, level, displayDefs, quoted, vocab, settin
           propMissing, // Get the first one just to show something
           settings.language,
           vocab,
-          settings.vocabPfx,
           context
         );
         result[properties[i]] = `{${expectedClassName} saknas}`;
@@ -219,7 +217,7 @@ export function getItemSummary(item, displayDefs, quoted, vocab, settings, conte
 export function getItemLabel(item, displayDefs, quoted, vocab, settings, context) {
   const displayObject = getChip(item, displayDefs, quoted, vocab, settings, context);
   let rendered = StringUtil.extractStrings(displayObject).trim();
-  if (item['@type'] && VocabUtil.isSubClassOf(item['@type'], 'Identifier', vocab, settings.vocabPfx, context)) {
+  if (item['@type'] && VocabUtil.isSubClassOf(item['@type'], 'Identifier', vocab, context)) {
     rendered = `${item['@type']} ${rendered}`;
   }
   return rendered;
@@ -234,7 +232,7 @@ export function getCard(item, displayDefs, quoted, vocab, settings, context) {
 }
 
 export function getFormattedSelectOption(term, settings, vocab, context) {
-  const labelByLang = StringUtil.getLabelByLang(term.id, settings.language, vocab, settings.vocabPfx, context);
+  const labelByLang = StringUtil.getLabelByLang(term.id, settings.language, vocab, context);
   const abstractIndicator = ` {${StringUtil.getUiPhraseByLang('Abstract', settings.language)}}`;
   const prefix = Array((term.depth) + 1).join(' •');
   return `${prefix} ${labelByLang} ${term.abstract ? abstractIndicator : ''}`;

--- a/viewer/v2client/src/utils/record.js
+++ b/viewer/v2client/src/utils/record.js
@@ -276,30 +276,29 @@ export function getNewCopy(id) {
   });
 }
 
-export function getEmptyForm(type, vocab, display, settings) {
+export function getEmptyForm(type, vocab, display, context) {
+  // TODO: Is this used?
   console.log('Type', type);
   const formObj = { '@type': type };
-  let inputKeys = DisplayUtil.getProperties(type, 'cards', display, settings);
+  let inputKeys = DisplayUtil.getProperties(type, 'cards', display);
   if (inputKeys.length === 0) {
     const baseClasses = VocabUtil.getBaseClassesFromArray(
       type,
       vocab,
-      settings.vocabPfx
     );
     console.log('baseClasses for', type, 'is', JSON.stringify(baseClasses));
     for (const baseClass of baseClasses) {
       inputKeys = DisplayUtil.getProperties(
-        baseClass.replace(settings.vocabPfx, ''),
+        StringUtil.getCompactUri(baseClass, context),
         'cards',
         display,
-        settings
       );
       if (inputKeys.length > 0) {
         break;
       }
     }
     if (inputKeys.length === 0) {
-      inputKeys = DisplayUtil.getProperties('Resource', 'cards', display, settings);
+      inputKeys = DisplayUtil.getProperties('Resource', 'cards', display);
     }
   }
   inputKeys = ['@type'].concat(inputKeys);
@@ -307,7 +306,7 @@ export function getEmptyForm(type, vocab, display, settings) {
     if (inputKey === '@type') {
       formObj[inputKey] = type;
     } else {
-      const keyRange = VocabUtil.getRange(type, inputKey, vocab, settings.vocabPfx, context);
+      const keyRange = VocabUtil.getRange(type, inputKey, vocab, context);
       if (keyRange.length === 0 || keyRange[0].split(':')[1] === 'Literal') {
         formObj[inputKey] = '';
       } else {

--- a/viewer/v2client/src/utils/string.js
+++ b/viewer/v2client/src/utils/string.js
@@ -124,7 +124,7 @@ export function getLabelFromObject(object, language) {
   return label;
 }
 
-export function getLabelByLang(string, lang, vocab, vocabPfx, context) {
+export function getLabelByLang(string, lang, vocab, context) {
   if (!string) {
     return '{FAILED LABEL}';
   }
@@ -134,7 +134,7 @@ export function getLabelByLang(string, lang, vocab, vocabPfx, context) {
       JSON.stringify(string)
     );
   }
-  let item = VocabUtil.getTermObject(string, vocab, vocabPfx, context);
+  let item = VocabUtil.getTermObject(string, vocab, context);
   let note = '';
   let labelByLang = '';
   if (typeof item !== 'undefined') {
@@ -187,7 +187,7 @@ export function getFormattedEntries(list, vocab, settings, context) {
   for (const entry of list) {
     if (translateable(entry.property)) {
       formatted = formatted.concat(entry.value.map((obj) => {
-        return getLabelByLang(obj, settings.language, vocab, settings.vocabPfx, context);
+        return getLabelByLang(obj, settings.language, vocab, context);
       }));
     } else {
       formatted = formatted.concat(entry.value);

--- a/viewer/v2client/src/utils/vocab.js
+++ b/viewer/v2client/src/utils/vocab.js
@@ -255,7 +255,7 @@ export function getValuesFrom(entityType, property, vocab, vocabPfx, context) {
     throw new Error('getValuesFrom was called with an object as property id (should be a string)');
   }
   let result = [];
-  const baseClasses = getBaseClasses(StringUtil.convertToVocabKey(StringUtil.convertToBaseUri(entityType, context), context), vocab, vocabPfx, context);
+  const baseClasses = getBaseClasses(StringUtil.getCompactUri(entityType, context), vocab, vocabPfx, context);
   baseClasses.forEach(baseClass => {
     const vocabEntry = vocab.get(baseClass);
     if (vocabEntry.hasOwnProperty('subClassOf')) {
@@ -268,7 +268,7 @@ export function getValuesFrom(entityType, property, vocab, vocabPfx, context) {
         }
         if (embellishedObj.hasOwnProperty('@type') &&
         embellishedObj['@type'] === 'Restriction' &&
-        embellishedObj.onProperty['@id'] === StringUtil.convertToVocabKey(StringUtil.convertToBaseUri(property, context), context)) {
+        embellishedObj.onProperty['@id'] === StringUtil.getCompactUri(property, context)) {
           let key = '';
           if (embellishedObj.hasOwnProperty('someValuesFrom')) {
             key = 'someValuesFrom';


### PR DESCRIPTION
* More consistency when handling terms and translating to compact uri:s.
* Remove all use of the vocabPfx parameter and setting. This is now taken from the context file instead.