### PR TITLE
Fix unsavedChanges warning flow

### DIFF
--- a/viewer/v2client/src/components/Inspector.vue
+++ b/viewer/v2client/src/components/Inspector.vue
@@ -125,6 +125,7 @@ export default {
     loadDocument() {
       this.$store.dispatch('setInspectorStatusValue', { property: 'isNew', value: false });
       this.$store.dispatch('setInspectorStatusValue', { property: 'editing', value: false });
+      this.$store.dispatch('setInspectorStatusValue', { property: 'unsavedChanges', value: false });
       this.fetchDocument();
     },
     loadNewDocument() {
@@ -134,6 +135,7 @@ export default {
         this.$router.go(-1);
         console.warn('New document called without input data, routing user back.')
       } else {
+        this.$store.dispatch('setInspectorStatusValue', { property: 'unsavedChanges', value: false });
         this.$store.dispatch('setInspectorData', RecordUtil.splitJson(insertData));
         this.$store.dispatch('setInspectorStatusValue', { 
           property: 'editing', 
@@ -201,8 +203,6 @@ export default {
     },   
     saveItem(done=false) {
       this.$store.dispatch('setInspectorStatusValue', { property: 'saving', value: true });
-      this.$store.dispatch('setInspectorStatusValue', { property: 'isNew', value: false });
-      this.$store.dispatch('setInspectorStatusValue', { property: 'unsavedChanges', value: false });
 
       const RecordId = this.inspector.data.record['@id'];
       const obj = this.getPackagedItem();
@@ -241,6 +241,8 @@ export default {
           }
         }
         this.$store.dispatch('setInspectorStatusValue', { property: 'saving', value: false });
+        this.$store.dispatch('setInspectorStatusValue', { property: 'unsavedChanges', value: false });
+        this.$store.dispatch('setInspectorStatusValue', { property: 'isNew', value: false });
       }, (error) => {
         this.$store.dispatch('setInspectorStatusValue', { property: 'saving', value: false });
         this.$store.dispatch('pushNotification', { color: 'red', message: `${StringUtil.getUiPhraseByLang('Something went wrong', this.settings.language)} - ${error}` });

--- a/viewer/v2client/src/components/Inspector.vue
+++ b/viewer/v2client/src/components/Inspector.vue
@@ -42,7 +42,7 @@ export default {
   methods: {
     initializeWarnBeforeUnload() {
       window.addEventListener("beforeunload", (e) => {
-        if (!this.inspector.status.editing) {
+        if (!this.inspector.status.editing || !this.inspector.status.unsavedChanges) {
           return undefined;
         }
         const confirmationMessage = StringUtil.getUiPhraseByLang('You have unsaved changes. Do you want to leave the page?', this.settings.language);

--- a/viewer/v2client/src/components/Inspector.vue
+++ b/viewer/v2client/src/components/Inspector.vue
@@ -240,7 +240,6 @@ export default {
             this.$store.dispatch('setInspectorStatusValue', { property: 'editing', value: false });
           }
         }
-        this.$store.dispatch('setInspectorStatusValue', { property: 'dirty', value: false });
         this.$store.dispatch('setInspectorStatusValue', { property: 'saving', value: false });
       }, (error) => {
         this.$store.dispatch('setInspectorStatusValue', { property: 'saving', value: false });

--- a/viewer/v2client/src/resources/json/i18n.json
+++ b/viewer/v2client/src/resources/json/i18n.json
@@ -110,6 +110,7 @@
     "This entity may have active links": "Den här entiteten kan ha aktiva länkningar",
     "The entity was removed": "Entiteten blev raderad",
     "You have unsaved changes. Do you want to leave the page?": "Du har osparade ändringar. Vill du lämna sidan?",
+    "You have unsaved changes. Do you want to cancel?": "Du har osparade ändringar. Vill du avbryta redigeringen?",
     "Choose type": "Välj typ",
     "Fetching results": "Hämtar Resultat",
     "Linking was successful": "Länkning lyckades",

--- a/viewer/v2client/src/store/store.js
+++ b/viewer/v2client/src/store/store.js
@@ -36,7 +36,6 @@ const store = new Vuex.Store({
       insertData: {},
       title: '',
       status: {
-        dirty: false,
         saving: false,
         opening: false,
         lastAdded: '',


### PR DESCRIPTION
* Removed old status property `dirty`
* Correctly reset `unsavedChanges` and `isNew`
* Add a missing translation
* Use `unsavedChanges` bool when unloading window (not just when router is changing)