### PR TITLE
Feature/shortcut keys

### DIFF
--- a/viewer/helpdocs/editor-short-cuts.md
+++ b/viewer/helpdocs/editor-short-cuts.md
@@ -18,7 +18,7 @@ För att underlätta arbetet har vi integrerat ett antal kortkommandon för PC r
 | Kopiera, skapa identisk kopia av post 				|Ctrl+Shift+ C  								    |
 | Redigera, gå till postens redigeringsvy 						|Ctrl+E  				  							    |
 | Lägg till nytt fält							|  																  Alt+F 														  |
-| Ångra dina senaste ändringar i redigeringsläge	| 			Ctrl+Z		  |  
+| Ångra dina senaste ändringar i redigeringsläge	| 			Alt+Z		  |  
 | Spara, spara post utan att lämna redigeringsläget   | Ctrl+S |
 | Klar, spara post och gå till visningsläge | Ctrl+D |
 | Expandera alla fält i post 		|						Alt(+)+                 |
@@ -38,7 +38,7 @@ För att underlätta arbetet har vi integrerat ett antal kortkommandon för PC r
 | Kopiera, skapa identisk kopia av post  				| ⌘+Shift+C  								|
 | Redigera, gå till postens redigeringsvy  | ⌘+E   |
 | Lägg till nytt fält | Alt+F  |
-| Ångra dina senaste ändringar i redigeringsläge | ⌘+Z |
+| Ångra dina senaste ändringar i redigeringsläge | Alt+Z |
 | Spara post utan att lämna redigeringsläget   | ⌘+S |
 | Klar, spara post och gå till visningsläge | ⌘+D |
 | Expandera alla fält i post 		|						Alt(+)+                 |

--- a/viewer/v2client/src/components/Inspector.vue
+++ b/viewer/v2client/src/components/Inspector.vue
@@ -283,11 +283,6 @@ export default {
             return;
         }
       }
-    }
-  },
-  events: {
-    'toggle-editor-focus'() {
-      this.toggleEditorFocus();
     },
   },
   created: function () {
@@ -321,6 +316,10 @@ export default {
   },
   mounted() {
     this.$nextTick(() => {
+      this.$store.dispatch('setStatusValue', { 
+        property: 'keybindState', 
+        value: 'overview' 
+      });
       if (!this.postLoaded) {
         this.initializeRecord();
       }

--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -316,8 +316,6 @@ export default {
         } else {
           currentValue.push(obj);
         }
-        
-
       }
       this.$store.dispatch('updateInspectorData', {
           path: `${this.path}`,
@@ -376,6 +374,7 @@ export default {
 
 <template>
   <div class="EntityAdder" :class="{'is-innerAdder': isPlaceholder, 'is-fillWidth': addEmbedded}">
+    <!-- Adds another empty field of the same type -->
     <div class="EntityAdder-add"
       v-if="isPlaceholder && !addEmbedded" 
       v-on:click="add()" 
@@ -393,6 +392,7 @@ export default {
       </span>
     </div>
 
+    <!-- Add entity within field -->
     <div class="EntityAdder-add action-button" 
       v-if="!isPlaceholder && !addEmbedded" 
       tabindex="0"
@@ -403,7 +403,7 @@ export default {
       <i class="EntityAdder-addIcon fa fa-fw fa-plus plus-icon" aria-hidden="true">
         <tooltip-component 
           :show-tooltip="showToolTip" 
-          tooltip-text="Add" 
+          :tooltip-text="'Add'" 
           translation="translatePhrase"></tooltip-component>
       </i>
       <span class="EntityAdder-addLabel label-text">{{ addLabel | labelByLang | capitalize }}</span>

--- a/viewer/v2client/src/components/inspector/field-adder.vue
+++ b/viewer/v2client/src/components/inspector/field-adder.vue
@@ -27,6 +27,7 @@ export default {
     editingObject: '',
     entityType: '',
     inToolbar: false,
+    forceActive: false
   },
   data() {
     return {
@@ -149,7 +150,7 @@ export default {
         if (!this.filteredResults[this.selectedIndex].added) {
           this.addField(this.filteredResults[this.selectedIndex], false);
         } else {
-          console.warn("already added, should be handled");
+          console.warn("Already added, should be handled");
         }
       }
     },
@@ -158,7 +159,7 @@ export default {
         if (!this.filteredResults[this.selectedIndex].added) {
           this.addField(this.filteredResults[this.selectedIndex], true);
         } else {
-          console.warn("already added, should be handled");
+          console.warn("Already added, should be handled");
         }
       }
     },
@@ -261,6 +262,13 @@ export default {
       this.selectedIndex = -1;
     },
   },
+  watch: {
+    forceActive: function(newVal, oldVal) {
+      if (newVal != oldVal) {
+        this.active = true;
+      }
+    } 
+  },
   mounted() {
     this.$nextTick(() => { // TODO: Fix proper scroll tracking. This is just an ugly solution using document.onscroll here and window.scroll in editorcontrols.vue
     });
@@ -296,7 +304,7 @@ export default {
       @mouseleave="showToolTip = false">
       <i class="FieldAdder-icon fa fa-plus plus-icon" aria-hidden="true">
         <tooltip-component 
-          :tooltip-text="modalTitle"
+          tooltip-text="Add field"
           :show-tooltip="showToolTip" 
           translation="translatePhrase"></tooltip-component>
       </i>

--- a/viewer/v2client/src/components/inspector/field-adder.vue
+++ b/viewer/v2client/src/components/inspector/field-adder.vue
@@ -48,7 +48,7 @@ export default {
       'status',
     ]),
     modalTitle() {
-      const title = StringUtil.getUiPhraseByLang('Add field', this.settings.language);
+      const title = StringUtil.getUiPhraseByLang('Add field in', this.settings.language);
       const contextString = StringUtil.getLabelByLang(
         this.entityType, 
         this.settings.language, 
@@ -283,10 +283,10 @@ export default {
       <i class="FieldAdder-innerIcon fa fa-plus plus-icon" aria-hidden="true">
         <tooltip-component 
           :show-tooltip="showToolTip" 
-          tooltip-text="Add field" 
+          :tooltip-text="modalTitle" 
           translation="translatePhrase"></tooltip-component>
       </i>
-      <span class="FieldAdder-innerLabel">{{ "Field" | translatePhrase }}</span>
+      <span class="FieldAdder-innerLabel">{{ "Add field" | translatePhrase }}</span>
     </span>
 
     <button v-if="!inner" class="FieldAdder-add btn btn-default toolbar-button" 
@@ -295,11 +295,12 @@ export default {
       @mouseenter="showToolTip = true" 
       @mouseleave="showToolTip = false">
       <i class="FieldAdder-icon fa fa-plus plus-icon" aria-hidden="true">
-        <tooltip-component tooltip-text="Add field"
+        <tooltip-component 
+          :tooltip-text="modalTitle"
           :show-tooltip="showToolTip" 
           translation="translatePhrase"></tooltip-component>
       </i>
-      <span v-if="!inToolbar" class="FieldAdder-label"> {{ "Field" | translatePhrase }}</span>
+      <span v-if="!inToolbar" class="FieldAdder-label"> {{ "Add field" | translatePhrase }}</span>
     </button>
 
     <modal-component @close="hide" v-if="active" class="FieldAdder-modal FieldAdderModal">

--- a/viewer/v2client/src/components/inspector/field.vue
+++ b/viewer/v2client/src/components/inspector/field.vue
@@ -568,13 +568,13 @@ export default {
       border-top: 1px solid #666666;
       top: 16px;
       width: 15px;
-      height: 0;
+      height: 2px;
     }
 
     &:after {
       border-left: 1px solid #666666;
       height: 100%;
-      width: 0px;
+      width: 2px;
       top: 0px;
     }
 

--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -310,26 +310,6 @@ export default {
     this.$on('collapse-item', this.collapse);
     this.$on('expand-item', this.expand);
   },
-  events: {
-    'focus-new-item'(index) {
-      if (this.index === index) {
-        this.expand();
-        this.isNewlyAdded = true;
-
-        // Scroll to item
-        const windowHeight = window.innerHeight || document.documentElement.clientHeight || document.getElementsByTagName('body')[0].clientHeight;
-        const scrollPos = this.$el.offsetTop - (windowHeight * 0.2);
-        LayoutUtil.scrollTo(scrollPos, 1000, 'easeInOutQuad', () => {
-          setTimeout(() => {
-            this.isNewlyAdded = false;
-          }, 3000);
-        });
-      }
-    },
-    'set-copy-title'(bool) {
-      this.copyTitle = bool;
-    },
-  },
   mounted() {
     this.$nextTick(() => {
     });
@@ -348,7 +328,7 @@ export default {
 
 <template>
   <div class="ItemLocal js-itemLocal"
-    :class="{'highlight': isNewlyAdded, 'is-expanded': expanded}"
+    :class="{'is-highlighted': isNewlyAdded, 'is-expanded': expanded}"
     tabindex="0">
    
    <strong class="ItemLocal-heading">

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -277,26 +277,6 @@ export default {
     this.$on('collapse-item', this.collapse);
     this.$on('expand-item', this.expand);
   },
-  events: {
-    'focus-new-item'(index) {
-      if (this.index === index) {
-        this.expand();
-        this.isNewlyAdded = true;
-
-        // Scroll to item
-        const windowHeight = window.innerHeight || document.documentElement.clientHeight || document.getElementsByTagName('body')[0].clientHeight;
-        const scrollPos = this.$el.offsetTop - (windowHeight * 0.2);
-        LayoutUtil.scrollTo(scrollPos, 1000, 'easeInOutQuad', () => {
-          setTimeout(() => {
-            this.isNewlyAdded = false;
-          }, 3000);
-        });
-      }
-    },
-    'set-copy-title'(bool) {
-      this.copyTitle = bool;
-    },
-  },
   mounted() {
     this.$nextTick(() => {
     });
@@ -316,7 +296,7 @@ export default {
 <template>
   <div class="ItemSibling js-itemLocal"
     tabindex="0"
-    :class="{'highlight': isNewlyAdded, 'is-expanded': expanded}">
+    :class="{'is-highlighted': isNewlyAdded, 'is-expanded': expanded}">
    
    <strong class="ItemSibling-heading">
       <i class="ItemSibling-arrow fa fa-chevron-right " 
@@ -500,7 +480,7 @@ export default {
       cursor: pointer;
     }
   }
-  &.highlight {
+  &.is-highlighted {
     transition: 0s ease;
     transition-property: outline, box-shadow;
     outline: 2px solid @highlight-color;

--- a/viewer/v2client/src/components/inspector/toolbar.vue
+++ b/viewer/v2client/src/components/inspector/toolbar.vue
@@ -21,6 +21,9 @@ import { mapGetters } from 'vuex';
 
 export default {
   mixins: [clickaway, LensMixin],
+  props: {
+    fieldAdderOpen: false,
+  },
   data() {
     return {
       showAdminInfoDetails: false,
@@ -35,7 +38,8 @@ export default {
       showCancel: false,
       showFieldAdderTooltip: false,
       showClarifySave: false,
-      showMarcPreview: false
+      showMarcPreview: false,
+      fieldAdderActive: false
     };
   },
   watch: {
@@ -44,8 +48,43 @@ export default {
         this.loadingEdit = false;
       }
     },
+    'inspector.event'(val, oldVal) {
+      if (val.name === 'form-control') {
+        switch(val.value) {
+          case 'duplicate-item':
+            this.handleCopy();
+            break;
+          case 'edit-item':
+            this.edit();
+            break;
+          case 'open-field-adder':
+            this.openFieldAdder();
+            break;
+          case 'navigate-change-history':
+            this.undo();
+          case 'cancel-edit':
+            this.cancel();
+          case 'save-item':
+            this.postControl('save-record');
+          case 'save-item-done':
+            this.postControl('save-record-done');
+          default:
+            return;
+        }
+      }
+    },
+    'status.keyActions'(value) {
+      this.formControl(value[value.length-1]);
+    },
   },
   methods: {
+    openFieldAdder() {
+      if (!this.fieldAdderActive) {
+        this.fieldAdderActive = true;
+      } else {
+        this.fieldAdderActive = false;
+      }
+    },
     showOtherFormatMenu() {
       this.otherFormatMenuActive = true;
     },
@@ -370,7 +409,8 @@ export default {
       :allowed="allowedProperties" 
       :path="inspector.status.focus" 
       :editing-object="inspector.status.focus"
-      :in-toolbar="true"></field-adder>
+      :in-toolbar="true"
+      :force-active="fieldAdderActive"></field-adder>
 
     <button class="Toolbar-btn btn btn-default toolbar-button" 
       :disabled="inspector.changeHistory.length === 0" 

--- a/viewer/v2client/src/components/layout/navbar.vue
+++ b/viewer/v2client/src/components/layout/navbar.vue
@@ -59,7 +59,7 @@ export default {
                 <div class="MainNav-iconWrap" aria-hidden="true">
                   <i class="fa fa-question-circle"></i>
                 </div>
-                <span>{{"Help" | translatePhrase}}</span>
+                <span class="MainNav-linkText">{{"Help" | translatePhrase}}</span>
               </router-link>
             </li>
             <li class="MainNav-item">
@@ -67,7 +67,7 @@ export default {
                 <div class="MainNav-iconWrap" aria-hidden="true">
                   <i class="fa fa-search"></i>
                 </div>
-                <span>{{"Search" | translatePhrase}}</span>
+                <span class="MainNav-linkText">{{"Search" | translatePhrase}}</span>
               </router-link>
             </li>
               <li class="MainNav-item" v-if="user.isLoggedIn">
@@ -75,7 +75,7 @@ export default {
                 <div class="MainNav-iconWrap" aria-hidden="true">
                   <i class="fa fa-file-text"></i>
                 </div>
-                <span>{{"Create new" | translatePhrase}}</span>
+                <span class="MainNav-linkText">{{"Create new" | translatePhrase}}</span>
               </router-link>
             </li>
             <li class="MainNav-item" v-if="user.isLoggedIn">
@@ -83,7 +83,9 @@ export default {
                 <div class="MainNav-iconWrap MainNav-iconWrap--userSettings">
                   <img class="MainNav-gravatar" :src="`https://www.gravatar.com/avatar/${user.emailHash}?d=mm&s=32`" alt="Avatar"/>
                 </div>
+                <span class="MainNav-linkText">
                 {{ user.fullName }} <span v-cloak class="sigelLabel">({{ user.settings.activeSigel }})</span>
+                </span>
               </router-link>
             </li>
             <li class="MainNav-item" v-if="!user.isLoggedIn">
@@ -91,7 +93,7 @@ export default {
                 <div class="MainNav-iconWrap" aria-hidden="true">
                   <i class="fa fa-fw fa-sign-in"></i>
                 </div>
-                <span>{{"Log in" | translatePhrase}}</span>
+                <span class="MainNav-linkText">{{"Log in" | translatePhrase}}</span>
               </a>
             </li>
           </ul>
@@ -176,19 +178,22 @@ export default {
   border-top: 1px solid @black;
   width: 100%;
   list-style: none;
-  padding: 0;
+  padding: 5px 0 0;
   margin: 5px 0 5px;
 
   @media (min-width: 992px) {
     float: right;
-    border-top: 1px solid @white;
+    border-top: 0;
     margin: 0;
+    padding: 0;
     text-align: right;
   }
 
   &-item {
     text-transform: none;
     display: inline-block;
+    max-height: 60px;
+    margin-top: -2px;
       
     @media screen and (max-width: @screen-sm-min) {
       display: inline;
@@ -197,18 +202,17 @@ export default {
 
   &-iconWrap {
     display: inline-block;
-    width: 32px;
-    height: 32px;
+    width: 30px;
+    height: 24px;
     border-radius: 50%;
-    line-height: 2em;
-    margin-right: .25em;
+    line-height: 1;
+    margin-right: 5px;
     text-align: center;
     width: .8em;
 
     &--userSettings {
-      height: 32px;   
-      width: 32px;
-      line-height: 20px;
+      height: 30px;   
+      width: 30px;
     }
   }
 
@@ -227,6 +231,7 @@ export default {
     &:hover, 
     &:focus {
       background-color: @bg-navbar-hover;
+      text-decoration: none;
     }
 
     i {
@@ -234,7 +239,13 @@ export default {
     }
 
     @media (min-width: 992px) {
-      padding: 15px;
+      padding: 16px;
+    }
+  }
+
+  &-linkText {
+    .MainNav-link:hover & {
+      text-decoration: underline;
     }
   }
 

--- a/viewer/v2client/src/components/layout/navbar.vue
+++ b/viewer/v2client/src/components/layout/navbar.vue
@@ -239,7 +239,7 @@ export default {
     }
 
     @media (min-width: 992px) {
-      padding: 16px;
+      padding: 20px 15px 12px;
     }
   }
 

--- a/viewer/v2client/src/resources/json/i18n.json
+++ b/viewer/v2client/src/resources/json/i18n.json
@@ -39,6 +39,7 @@
     "Loading marc" : "Laddar MARC21",
     "Add entity" : "Lägg till entitet",
     "Add field" : "Lägg till fält",
+    "Add field in" : "Lägg till fält inom",
     "Entity": "Entitet",
     "Unnamed entity": "Namnlös entitet",
     "Link entity": "Länka entitet",

--- a/viewer/v2client/src/resources/json/keybindings.json
+++ b/viewer/v2client/src/resources/json/keybindings.json
@@ -1,12 +1,12 @@
 {
   "overview": {
-    "mod+s": "save-item|false",
-    "mod+d": "save-item",
+    "mod+s": "save-item",
+    "mod+d": "save-item-done",
     "mod+e": "edit-item",
     "alt+q": "cancel-edit",
-    "mod+z": "navigate-change-history|back",
-    "alt+plus": "form-control|expand-item",
-    "alt+minus": "form-control|collapse-item",
+    "alt+z": "navigate-change-history",
+    "alt+plus": "expand-item",
+    "alt+minus": "collapse-item",
     "alt+f": "open-field-adder",
     "mod+shift+c": "duplicate-item"
   },

--- a/viewer/v2client/src/store/store.js
+++ b/viewer/v2client/src/store/store.js
@@ -332,6 +332,7 @@ const store = new Vuex.Store({
       commit('updateInspectorData', payload);
     },
     pushKeyAction({ commit }, keyAction) {
+      console.log(keyAction);
       commit('pushKeyAction', keyAction);
     },
     pushInspectorEvent({ commit }, payload) {


### PR DESCRIPTION
- Changed shortcut for undo from `ctrl/cmd+z` to `alt+z`, because these are VERY much default keybindings in the OS and should not be hijacked IMO
- Added keybind state for inspector
- Added minor typo changes for labels
- Added watcher to make entity adder window listen for keybindings
- Removed som deprecated code
- Added CSS which _I think_ might fix another issue concerning a graphical bug (stumbled upon this one, hoping for the best)