### PR TITLE
Work as sibling + composing of several form-changes at once

### DIFF
--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -306,9 +306,13 @@ export default {
       }
       this.$store.dispatch('addToQuoted', obj);
       this.$store.dispatch('updateInspectorData', {
-          path: `${this.path}`,
-          value: currentValue,
-          addToHistory: true,
+        changeList: [
+          {
+            path: `${this.path}`,
+            value: currentValue,
+          }
+        ],
+        addToHistory: true,
       });
       this.hide();
     },
@@ -329,9 +333,31 @@ export default {
         }
       }
       this.$store.dispatch('updateInspectorData', {
-          path: `${this.path}`,
-          value: currentValue,
-          addToHistory: true,
+        changeList: [
+          {
+            path: `${this.path}`,
+            value: currentValue,
+          }
+        ],
+        addToHistory: true,
+      });
+    },
+    addSibling(obj) {
+      const linkObj = { '@id': `${this.inspector.data.record['@id']}#work` };
+      const workObj = obj;
+      workObj['@id'] = linkObj['@id'];
+      this.$store.dispatch('updateInspectorData', {
+        changeList: [
+          {
+            path: `${this.path}`,
+            value: linkObj,
+          },
+          {
+            path: 'work',
+            value: workObj,
+          }
+        ],
+        addToHistory: true,
       });
     },
     addEmpty(typeId) {
@@ -341,7 +367,11 @@ export default {
       if (StructuredValueTemplates.hasOwnProperty(shortenedType)) {
         obj = _.cloneDeep(StructuredValueTemplates[shortenedType]);
       }
-      this.addItem(obj);
+      if (this.fieldKey === 'instanceOf') {
+        this.addSibling(obj);
+      } else {
+        this.addItem(obj);
+      }
     },
     addType(typeId) {
       const shortenedType = StringUtil.convertToPrefix(typeId, this.resources.context);

--- a/viewer/v2client/src/components/inspector/field-adder.vue
+++ b/viewer/v2client/src/components/inspector/field-adder.vue
@@ -224,8 +224,12 @@ export default {
         const propLastPart = splitProp[splitProp.length-1];
         const key = StringUtil.convertToPrefix(prop.item['@id'], this.resources.context);
         this.$store.dispatch('updateInspectorData', {
-          path: `${this.path}.${key}`,
-          value: this.getEmptyFieldValue(key, prop.item),
+          changeList: [
+            {
+              path: `${this.path}.${key}`,
+              value: this.getEmptyFieldValue(key, prop.item),
+            }
+          ],
           addToHistory: true,
         });
         this.$store.dispatch('setInspectorStatusValue', { property: 'unsavedChanges', value: true });

--- a/viewer/v2client/src/components/inspector/field.vue
+++ b/viewer/v2client/src/components/inspector/field.vue
@@ -277,8 +277,12 @@ export default {
       delete parentData[this.fieldKey];
       setTimeout(() => {
         this.$store.dispatch('updateInspectorData', {
-          path: this.parentPath,
-          value: parentData,
+          changeList: [
+            {
+              path: this.parentPath,
+              value: parentData,
+            }
+          ],
           addToHistory: true,
         });
         this.$store.dispatch('setInspectorStatusValue', { 

--- a/viewer/v2client/src/components/inspector/item-boolean.vue
+++ b/viewer/v2client/src/components/inspector/item-boolean.vue
@@ -64,8 +64,12 @@ export default {
     selected(value, oldValue) {
       if (value !== oldValue) {
         this.$store.dispatch('updateInspectorData', {
-          path: this.path,
-          value: value,
+          changeList: [
+            {
+              path: this.path,
+              value: value,
+            }
+          ],
           addToHistory: true,
         });
         this.$store.dispatch('setInspectorStatusValue', { 

--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -222,8 +222,12 @@ export default {
       const newValue = { '@id': value['@id'] };
       this.$store.dispatch('addToQuoted', value);
       this.$store.dispatch('updateInspectorData', {
-        path: `${this.path}`,
-        value: newValue,
+        changeList: [
+          {
+            path: `${this.path}`,
+            value: newValue,
+          }
+        ],
         addToHistory: false,
       });
       this.$store.dispatch('pushNotification', { color: 'green', message: `${StringUtil.getUiPhraseByLang('Linking was successful', this.settings.language)}` });

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -160,6 +160,24 @@ export default {
     },
   },
   methods: {
+    removeThis() {
+      const changeList = [
+        {
+          path: `${this.parentPath}`,
+          value: null,
+        }
+      ];
+      if (this.fieldKey === 'instanceOf') {
+        changeList.push({
+          path: 'work',
+          value: null,
+        });
+      }
+      this.$store.dispatch('updateInspectorData', {
+        addToHistory: true,
+        changeList: changeList,
+      });
+    },
     highlightItem(event) {
       let item = event.target;
       while ((item = item.parentElement) && !item.classList.contains('js-itemLocal'));
@@ -253,16 +271,21 @@ export default {
     replaceWith(value) {
       const newValue = { '@id': value['@id'] };
       this.$store.dispatch('addToQuoted', value);
+      const changeList = [
+        {
+          // Remove the link
+          path: `${this.parentPath}`,
+          value: newValue,
+        },
+        {
+          // Remove the #work
+          path: `${this.getPath}`,
+          value: null,
+        }
+      ];
       this.$store.dispatch('updateInspectorData', {
-        path: `${this.parentPath}`,
-        value: newValue,
-        addToHistory: false,
-      });
-      // Remove the #work
-      this.$store.dispatch('updateInspectorData', {
-        path: `${this.getPath}`,
-        value: null,
-        addToHistory: false,
+        addToHistory: true,
+        changeList: changeList,
       });
       this.$store.dispatch('pushNotification', { color: 'green', message: `${StringUtil.getUiPhraseByLang('Linking was successful', this.settings.language)}` });
       this.closeExtractDialog();

--- a/viewer/v2client/src/components/inspector/item-value.vue
+++ b/viewer/v2client/src/components/inspector/item-value.vue
@@ -48,19 +48,16 @@ export default {
       },
       set: _.debounce(function(newValue) {
         this.$store.dispatch('updateInspectorData', {
-          path: this.path,
-          value: newValue,
+          changeList: [
+            {
+              path: this.path,
+              value: newValue,
+            }
+          ],
           addToHistory: true,
         });
         this.$store.dispatch('setInspectorStatusValue', { property: 'unsavedChanges', value: true });
       }, 1000)
-      // set(newValue) {
-      //   this.$store.dispatch('updateInspectorData', {
-      //     path: this.path,
-      //     value: newValue,
-      //     addToHistory: true,
-      //   });
-      // }
     }
   },
   mounted() {

--- a/viewer/v2client/src/components/inspector/item-vocab.vue
+++ b/viewer/v2client/src/components/inspector/item-vocab.vue
@@ -67,8 +67,12 @@ export default {
     selected(value, oldValue) {
       if (value !== oldValue) {
         this.$store.dispatch('updateInspectorData', {
-          path: this.path,
-          value: value,
+          changeList: [
+            {
+              path: this.path,
+              value: value,
+            }
+          ],
           addToHistory: true,
         });
         this.$store.dispatch('setInspectorStatusValue', { 

--- a/viewer/v2client/src/components/mixins/item-mixin.vue
+++ b/viewer/v2client/src/components/mixins/item-mixin.vue
@@ -30,15 +30,23 @@ export default {
         this.removed = true;
         setTimeout(() => {
           this.$store.dispatch('updateInspectorData', {
-            path: `${this.parentPath}`,
-            value: parentValue,
+            changeList: [
+              {
+                path: `${this.parentPath}`,
+                value: parentValue,
+              }
+            ],
             addToHistory: true,
           });
         }, 500);
       } else {
         this.$store.dispatch('updateInspectorData', {
-          path: `${this.parentPath}`,
-          value: parentValue,
+          changeList: [
+            {
+              path: `${this.parentPath}`,
+              value: parentValue,
+            }
+          ],
           addToHistory: true,
         });
       }

--- a/viewer/v2client/src/store/store.js
+++ b/viewer/v2client/src/store/store.js
@@ -206,17 +206,23 @@ const store = new Vuex.Store({
       state.inspector.status.updating = true;
       // Clone inspectorData so we can manipulate it before setting it
       const inspectorData = _.cloneDeep(state.inspector.data);
+
       // Push old value to history
       if (payload.addToHistory) {
-        const oldValue = _.cloneDeep(_.get(inspectorData, payload.path));
-        const historyNode = { path: payload.path, value: oldValue };
-        console.log(JSON.stringify(historyNode));
-        state.inspector.changeHistory.push(historyNode);
+        const changes = [];
+        _.each(payload.changeList, (node) => {
+          const oldValue = _.cloneDeep(_.get(inspectorData, node.path));
+          const historyNode = { path: node.path, value: oldValue };
+          changes.push(historyNode);
+        });
+        state.inspector.changeHistory.push(changes);
       }
-      
-      // Set the new value
-      console.log("DATA_UPDATE:", payload);
-      _.set(inspectorData, payload.path, payload.value);
+
+      // Set the new values
+      _.each(payload.changeList, (node) => {
+        console.log("DATA_UPDATE:", JSON.stringify(node));
+        _.set(inspectorData, node.path, node.value);
+      });
       state.inspector.data = inspectorData;
     },
     setInspectorTitle(state, str) {
@@ -305,28 +311,28 @@ const store = new Vuex.Store({
     undoInspectorChange({ commit, state }) {
       const history = state.inspector.changeHistory;
       const lastNode = history[history.length-1];
-      let payload = {};
-      if (typeof lastNode.value !== 'undefined') {
-        // It had a value
-        payload = {
-          path: lastNode.path,
-          value: lastNode.value,
-          addToHistory: false,
+      let payload = { addToHistory: false, changeList: [] };
+      _.each(lastNode, (node) => {
+        if (typeof node.value !== 'undefined') {
+          // It had a value
+          payload.changeList.push({
+            path: node.path,
+            value: node.value,
+          });
+        } else {
+          // It did not have a value (ie key did not exist)
+          const pathParts = node.path.split('.');
+          const key = pathParts[pathParts.length-1];
+          pathParts.splice(pathParts.length-1, 1);
+          const path = pathParts.join('.');
+          const data = _.cloneDeep(_.get(state.inspector.data, path));
+          delete data[key];
+          payload.changeList.push({
+            path: path,
+            value: data,
+          });
         }
-      } else {
-        // It did not have a value (ie key did not exist)
-        const pathParts = lastNode.path.split('.');
-        const key = pathParts[pathParts.length-1];
-        pathParts.splice(pathParts.length-1, 1);
-        const path = pathParts.join('.');
-        const data = _.cloneDeep(_.get(state.inspector.data, path));
-        delete data[key];
-        payload = {
-          path: path,
-          value: data,
-          addToHistory: false,
-        }
-      }
+      });
       history.splice(history.length-1, 1);
       commit('updateInspectorData', payload);
     },

--- a/viewer/v2client/src/utils/record.js
+++ b/viewer/v2client/src/utils/record.js
@@ -233,7 +233,6 @@ export function prepareDuplicateFor(inspectorData, user) {
   // Removes fields that we do not want to import or copy
   const newData = _.cloneDeep(inspectorData);
   newData.record.descriptionCreator = { '@id': `https://libris.kb.se/library/${user.settings.activeSigel}` };
-  
   if (newData.mainEntity) {
     newData.mainEntity['@id'] =  `https://id.kb.se/TEMPID#it`;
     delete newData.mainEntity.sameAs;
@@ -245,6 +244,7 @@ export function prepareDuplicateFor(inspectorData, user) {
   }
   if (newData.work) {
     newData.work['@id'] = `https://id.kb.se/TEMPID#work`;
+    newData.mainEntity.instanceOf = { '@id': newData.work['@id'] };
     delete newData.work.sameAs;
   }
 


### PR DESCRIPTION
* Works can now be properly created as siblings instead of ordinary local entitites.
* Changed updateInspectorData so that it can recieve an array of data mutations (as one "change").