### PR TITLE
Sort all forms according to display

### DIFF
--- a/viewer/v2client/src/components/Inspector.vue
+++ b/viewer/v2client/src/components/Inspector.vue
@@ -330,6 +330,7 @@ export default {
       }
       this.initializeWarnBeforeUnload();
       this.initJsonOutput();
+
       let self = this;
       window.addEventListener('resize', function() {
         self.initToolbarFloat();

--- a/viewer/v2client/src/components/Inspector.vue
+++ b/viewer/v2client/src/components/Inspector.vue
@@ -92,6 +92,7 @@ export default {
     },
     initializeRecord() {
       this.postLoaded = false;
+      this.$store.dispatch('flushChangeHistory');
       this.$store.dispatch('setInspectorStatusValue', { property: 'focus', value: 'mainEntity' });
       if (this.$route.name === 'Inspector') {
         console.log("Initializing view for existing document");

--- a/viewer/v2client/src/components/inspector/entity-form.vue
+++ b/viewer/v2client/src/components/inspector/entity-form.vue
@@ -80,82 +80,11 @@ export default {
       }
       return false;
     },
-    specialProperties() {
-      const props = [];
-      for (const prop of this.settings.specialProperties) {
-        if (this.inspector.data[this.editingObject][prop]) {
-          props.push(prop);
-        }
-      }
-      return props;
-    },
     formObj() {
       return this.formData;
     },
-    allowed() {
-      return VocabUtil.getPropertiesFromArray(
-        formObj['@type'],
-        this.resources.vocabClasses,
-        this.resources.vocabProperties,
-        this.resources.context
-      );
-    },
     formData() {
       return this.inspector.data[this.editingObject];
-    },
-    sortedFormData() {
-      const sortedForm = {};
-      for (const property of this.sortedProperties) {
-        const k = property;
-        if (typeof this.formData[k] !== 'undefined' || this.formData[k] === '') {
-          sortedForm[k] = this.formData[k];
-        }
-      }
-      return sortedForm;
-    },
-    sortedProperties() {
-      const formObj = this.formData;
-
-      // Try to get properties from type of object
-      // If none found, try baseClasses
-      let propertyList = DisplayUtil.getProperties(
-        formObj['@type'],
-        'full',
-        this.resources.display
-      );
-      if (propertyList.length === 0) { // If none were found, traverse up inheritance tree
-        const baseClasses = VocabUtil.getBaseClassesFromArray(
-          formObj['@type'],
-          this.resources.vocab,
-          this.resources.context
-        );
-        for (const baseClass of baseClasses) {
-          propertyList = DisplayUtil.getProperties(
-            StringUtil.getCompactUri(baseClass, this.resources.context),
-            'full',
-            this.resources.display
-          );
-          if (propertyList.length > 0) {
-            break;
-          }
-        }
-        if (propertyList.length === 0) {
-          propertyList = DisplayUtil.getProperties(
-            'Resource',
-            'full',
-            this.resources.display
-          );
-        }
-      }
-      _.each(formObj, (v, k) => {
-        if (!_.includes(propertyList, k)) {
-          propertyList.push(k);
-        }
-      });
-      _.remove(propertyList, (k) => {
-        return (this.settings.specialProperties.indexOf(k) !== -1);
-      });
-      return propertyList;
     },
   },
   watch: {
@@ -199,7 +128,7 @@ export default {
     <ul class="FieldList" 
       v-bind:class="{'collapsed': collapsed }">
       <field class="FieldList-item"
-        v-for="(v,k) in sortedFormData" 
+        v-for="(v,k) in filteredItem" 
         v-bind:class="{ 'locked': isLocked }" 
         :entity-type="inspector.data[editingObject]['@type']" 
         :is-inner="false" 

--- a/viewer/v2client/src/components/inspector/entity-form.vue
+++ b/viewer/v2client/src/components/inspector/entity-form.vue
@@ -121,8 +121,7 @@ export default {
       let propertyList = DisplayUtil.getProperties(
         formObj['@type'],
         'full',
-        this.resources.display,
-        this.settings
+        this.resources.display
       );
       if (propertyList.length === 0) { // If none were found, traverse up inheritance tree
         const baseClasses = VocabUtil.getBaseClassesFromArray(
@@ -133,9 +132,8 @@ export default {
         for (const baseClass of baseClasses) {
           propertyList = DisplayUtil.getProperties(
             StringUtil.getCompactUri(baseClass, this.resources.context),
-            'cards',
-            this.resources.display,
-            this.settings
+            'full',
+            this.resources.display
           );
           if (propertyList.length > 0) {
             break;
@@ -144,9 +142,8 @@ export default {
         if (propertyList.length === 0) {
           propertyList = DisplayUtil.getProperties(
             'Resource',
-            'cards',
-            this.resources.display,
-            this.settings
+            'full',
+            this.resources.display
           );
         }
       }
@@ -158,7 +155,6 @@ export default {
       _.remove(propertyList, (k) => {
         return (this.settings.specialProperties.indexOf(k) !== -1);
       });
-
       return propertyList;
     },
   },

--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -54,14 +54,6 @@ export default {
       'user',
       'status',
     ]),
-    allowed() {
-      return VocabUtil.getPropertiesFromArray(
-        [StringUtil.convertToVocabKey(StringUtil.convertToBaseUri(this.formObj['@type'], this.resources.context), this.resources.context)],
-        this.resources.vocabClasses,
-        this.resources.vocabProperties,
-        this.resources.context
-      );
-    },
     canCopyTitle() {
       if (this.isExtractable && !this.item.hasOwnProperty('hasTitle') && this.key === 'instanceOf') {
         return true;
@@ -94,13 +86,6 @@ export default {
         return `${this.parentPath}[${this.index}]`;
       }
       return this.parentPath;
-    },
-    filteredItem() {
-      const fItem = _.cloneDeep(this.item);
-      delete fItem['@type'];
-      delete fItem['@id'];
-      delete fItem['_uid'];
-      return fItem;
     },
     formObj() {
       return this.item;

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -23,12 +23,13 @@ import FieldAdder from '@/components/inspector/field-adder';
 import SearchWindow from './search-window';
 import ItemMixin from '../mixins/item-mixin';
 import LensMixin from '../mixins/lens-mixin';
+import FormMixin from '../mixins/form-mixin';
 import {mixin as clickaway} from 'vue-clickaway';
 import { mapGetters } from 'vuex';
 
 export default {
   name: 'item-sibling',
-  mixins: [ItemMixin, LensMixin, clickaway],
+  mixins: [FormMixin, ItemMixin, LensMixin, clickaway],
   props: {
     id: '',
     fieldKey: '',
@@ -96,13 +97,6 @@ export default {
     getPath() {
       return this.suffix;
     },
-    filteredItem() {
-      const fItem = _.cloneDeep(this.item);
-      delete fItem['@type'];
-      delete fItem['@id'];
-      delete fItem['_uid'];
-      return fItem;
-    },
     isEmpty() {
       let bEmpty = true;
       // Check if item has any keys besides @type and _uid. If not, we'll consider it empty.
@@ -115,48 +109,8 @@ export default {
       });
       return bEmpty;
     },
-    allowedProperties() {
-      const settings = this.settings;
-      const formObj = this.item;
-      const allowed = VocabUtil.getPropertiesFromArray(
-        [StringUtil.convertToVocabKey(StringUtil.convertToBaseUri(formObj['@type'], this.resources.context), this.resources.context)],
-        this.resources.vocabClasses,
-        this.resources.vocabProperties,
-        this.resources.context
-      );
-      // Add the "added" property
-      for (const element of allowed) {
-        const oId = StringUtil.getCompactUri(element.item['@id'], this.resources.context);
-        element.added = (formObj.hasOwnProperty(oId) && formObj[oId] !== null);
-      }
-
-      const extendedAllowed = allowed.map(property => {
-        const labelByLang = property.item.labelByLang;
-        if (typeof labelByLang !== 'undefined') {
-          // Try to get the label in the preferred language
-          let label = ((typeof labelByLang[this.settings.language] !== 'undefined') ? labelByLang[this.settings.language] : labelByLang.en);
-          // If several labels are present, use the first one
-          if (_.isArray(label)) {
-            label = label[0];
-          }
-          return {
-            added: property.added,
-            item: property.item,
-            label: label
-          };
-        } else {
-          // If no label, use @id as label
-          return {
-            added: property.added,
-            item: property.item,
-            label: property.item['@id']
-          };
-        }
-      });
-      const sortedAllowed = _.sortBy(extendedAllowed, (prop) => {
-        return prop.label.toLowerCase();
-      });
-      return sortedAllowed;
+    formObj() {
+      return this.item;
     },
   },
   methods: {

--- a/viewer/v2client/src/store/store.js
+++ b/viewer/v2client/src/store/store.js
@@ -93,7 +93,7 @@ const store = new Vuex.Store({
         'http://id.kb.se/',
         'https://id.kb.se/',
       ],
-      specialProperties: [
+      hiddenProperties: [
         '@id',
         '@type',
         'created',

--- a/viewer/v2client/src/store/store.js
+++ b/viewer/v2client/src/store/store.js
@@ -247,6 +247,9 @@ const store = new Vuex.Store({
       state.user = userObj;
       state.user.saveSettings();
     },
+    flushChangeHistory(state) {
+      state.inspector.changeHistory = [];
+    },
     logoutUser(state) {
       localStorage.removeItem('at');
       state.user = User.getUserObject();
@@ -309,6 +312,9 @@ const store = new Vuex.Store({
     }
   },
   actions: {
+    flushChangeHistory({commit}) {
+      commit('flushChangeHistory');
+    },
     undoInspectorChange({ commit, state }) {
       const history = state.inspector.changeHistory;
       const lastNode = history[history.length-1];

--- a/viewer/v2client/src/utils/display.js
+++ b/viewer/v2client/src/utils/display.js
@@ -102,9 +102,6 @@ export function getProperties(typeInput, level, displayDefs) {
       return props;
     } else if (level === 'full') { // Try fallback to card level
       props = getProperties(type, 'cards', displayDefs);
-      if (props.length > 0) {
-        return props;
-      }
     }
     if (props.length > 0) {
       return props;

--- a/viewer/v2client/src/utils/display.js
+++ b/viewer/v2client/src/utils/display.js
@@ -100,6 +100,14 @@ export function getProperties(typeInput, level, displayDefs) {
 
     if (props.length > 0) {
       return props;
+    } else if (level === 'full') { // Try fallback to card level
+      props = getProperties(type, 'cards', displayDefs);
+      if (props.length > 0) {
+        return props;
+      }
+    }
+    if (props.length > 0) {
+      return props;
     } else if (level === 'cards') { // Try fallback to chip level
       props = getProperties(type, 'chips', displayDefs);
       if (props.length > 0) {

--- a/viewer/v2client/src/utils/vocab.js
+++ b/viewer/v2client/src/utils/vocab.js
@@ -461,7 +461,21 @@ export function getPropertiesFromArray(typeArray, vocabClasses, vocabProperties,
       const p = {
         item: properties[x],
       };
-      props.push(p);
+      // TODO: Handle shorthand when format is ready
+      if (
+        p.item.hasOwnProperty('category') &&
+        (
+          p.item.category['@id'] === 'https://id.kb.se/vocab/shorthand' ||
+          p.item.category['@id'] === 'https://id.kb.se/vocab/unstable'
+        )
+      ) {
+        // Dont add (is shorthand/unstable)
+      } else if (p.item.hasOwnProperty('abstract') && p.item.abstract === true) {
+        // Dont add (is abstract)
+      } else {
+        // Do add
+        props.push(p);
+      }
     }
   }
   props = _.uniqBy(props, 'item.@id');

--- a/viewer/v2client/src/utils/vocab.js
+++ b/viewer/v2client/src/utils/vocab.js
@@ -345,7 +345,10 @@ export function getSubClassChain(classname, vocabClasses, context) {
     vocabClasses,
     context,
   ));
-  classObj.subClassChain = subClassChain;
+  const curieChain = subClassChain.map((subClass) => {
+    return StringUtil.getCompactUri(subClass, context);
+  });
+  classObj.subClassChain = curieChain;
   return subClassChain;
 }
 


### PR DESCRIPTION
* Moved a lot of form-functionality into `form-mixin`, so that it works the same between `entity-form`, `item-sibling` and `item-local`.
* Make `DisplayUtil.getProperties` respect `fresnel:super` and `fresnel:extends`.
* Add `DisplayUtil.getLensById`.
* Fixed so that `subClassChain` always contains curie:s.

Other changes:
* Renamed `specialProperties` to `hiddenProperties`.
* Added flushing of `changeHistory` on document load.
* Disallow `abstract`, `unstable` and `shorthand` properties from being added. (LXL-1097)