### PR TITLE
Make cancel restore original state of post

### DIFF
--- a/viewer/v2client/src/components/Inspector.vue
+++ b/viewer/v2client/src/components/Inspector.vue
@@ -274,7 +274,6 @@ export default {
         }
         this.$store.dispatch('setInspectorStatusValue', { property: 'saving', value: false });
         this.$store.dispatch('setInspectorStatusValue', { property: 'unsavedChanges', value: false });
-        this.$store.dispatch('flushChangeHistory');
         this.$store.dispatch('setInspectorStatusValue', { property: 'isNew', value: false });
       }, (error) => {
         this.$store.dispatch('setInspectorStatusValue', { property: 'saving', value: false });

--- a/viewer/v2client/src/components/inspector/toolbar.vue
+++ b/viewer/v2client/src/components/inspector/toolbar.vue
@@ -149,25 +149,10 @@ export default {
       this.showMarcPreview = false;
     },
     cancel() {
-     if (!this.inspector.status.isNew) {
-        if (this.inspector.status.editing && this.inspector.status.unsavedChanges) {
-          const confString = StringUtil.getUiPhraseByLang('You have unsaved changes. Do you want to cancel?', this.settings.language);
-          const answer = window.confirm(confString);
-          if (answer) {
-            this.$store.dispatch('setInspectorStatusValue', { 
-              property: 'editing', 
-              value: false 
-            });
-          } 
-        } else {
-          this.$store.dispatch('setInspectorStatusValue', { 
-            property: 'editing', 
-            value: false 
-          });
-        }
-      } else {
-        this.$router.go(-1);
-      }
+      this.$store.dispatch('pushInspectorEvent', { 
+        name: 'post-control', 
+        value: 'cancel'
+      });
     },
     undo() {
       this.$store.dispatch('undoInspectorChange');

--- a/viewer/v2client/src/store/store.js
+++ b/viewer/v2client/src/store/store.js
@@ -34,6 +34,7 @@ const store = new Vuex.Store({
     inspector: {
       data: {},
       insertData: {},
+      originalData: {},
       title: '',
       status: {
         saving: false,
@@ -192,6 +193,9 @@ const store = new Vuex.Store({
           state.status.notifications.splice(i, 1);
         }
       }
+    },
+    setOriginalData(state, data) {
+      state.inspector.originalData = data;
     },
     setInspectorData(state, data) {
       state.inspector.data = data;
@@ -358,6 +362,9 @@ const store = new Vuex.Store({
     },
     setSettings({ commit }, settingsObj) {
       commit('setSettings', settingsObj);
+    },
+    setOriginalData({ commit }, data) {
+      commit('setOriginalData', data);
     },
     setInspectorData({ commit }, data) {
       commit('setInspectorData', data);


### PR DESCRIPTION
* Move cancel event into inspector.
* Add `originalData` property and actions to store.
* Added `onPostLoaded()` where we flush the history and put the loaded data into `originalData`.