### PR TITLE
Fix non-repeatable being forced to arrays

### DIFF
--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -362,7 +362,7 @@ export default {
     },
     addEmpty(typeId) {
       this.closeSearch();
-      const shortenedType = StringUtil.convertToPrefix(typeId, this.resources.context);
+      const shortenedType = StringUtil.getCompactUri(typeId, this.resources.context);
       let obj = {'@type': shortenedType};
       if (StructuredValueTemplates.hasOwnProperty(shortenedType)) {
         obj = _.cloneDeep(StructuredValueTemplates[shortenedType]);

--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -319,7 +319,7 @@ export default {
     addItem(obj) {
       let currentValue = _.cloneDeep(_.get(this.inspector.data, this.path));
       if (currentValue === null) {
-        currentValue = [obj];
+        currentValue = obj;
       } else if (!_.isArray(currentValue)) {
         currentValue = [currentValue];
         currentValue.push(obj);


### PR DESCRIPTION
* When adding object, set value to object instead of setting value to object in array.
* switched out `convertToPrefix` to `getCompactUri` function, for consistency.