### PR TITLE
Make Chips/Cards show missing property instead of range if range is a literal

### DIFF
--- a/viewer/v2client/src/utils/display.js
+++ b/viewer/v2client/src/utils/display.js
@@ -196,7 +196,10 @@ export function getDisplayObject(item, level, displayDefs, quoted, vocab, settin
       } else if (properties.length < 3 && i === 0) {
         const rangeOfMissingProp = VocabUtil.getRange(trueItem['@type'], properties[i], vocab, context);
         let propMissing = properties[i];
-        if (rangeOfMissingProp.length > 0) {
+        if (
+          rangeOfMissingProp.length > 1 ||
+          (rangeOfMissingProp.length === 1 && rangeOfMissingProp[0] !== 'http://www.w3.org/2000/01/rdf-schema#Literal')
+        ) {
           propMissing = rangeOfMissingProp[0];
         }
         const expectedClassName = StringUtil.getLabelByLang(


### PR DESCRIPTION
# Example:
Chip for `TitlePart` expects `partName` and `partNumber`. It only has `partName`.

## Result before this change:
If `partName` is missing it would return
`{Missing http://www.w3.org/2000/01/rdf-schema#Literal}`
or (if we used the compact version, which we don't ;) )
`{Missing Literal}`

## Result after this change:
If `partName` is missing it will return `{Missing partName}`

# Why was the old code like that?
The old code didn't care if it was a literal or not. And we only handled missing entities. We will still handle entities this way:
If the range isn't a literal, we will try to say what the type of the expected entity is. This makes it return:
`{Missing Title}`
instead of
`{Missing hasTitle}`
Which is a bit more informative.