### PR TITLE
Fixed entity-adder not resetting previous search when adding from the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.1.0] - ????-??-??
 
+### Fixed
+- Fixed entity adder modal not correctly resetting previous search.
+
 ## [Released]
 
 ## [1.0.10] - 2018-06-15

--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -23,12 +23,10 @@ export default {
   mixins: [clickaway, LensMixin],
   data() {
     return {
-      searchOpen: false,
       searchResult: [],
       keyword: '',
       loading: false,
       debounceTimer: 500,
-      chooseLocalType: false,
       showToolTip: false,
       rangeInfo: false,
       selectedType: '',
@@ -75,7 +73,7 @@ export default {
       if (val.name === 'modal-control') {
         switch(val.value) {
           case 'close-entity-adder':
-            this.closeSearch();
+            this.hide();
             return true;
             break;
           default:
@@ -85,7 +83,7 @@ export default {
       if (val.name === 'form-control') {
         switch(val.value) {
           case 'close-modals':
-            this.closeSearch();
+            this.hide();
             return true;
             break;
           default:
@@ -222,8 +220,6 @@ export default {
   },
   mounted() {
     this.addEmbedded = (this.valueList.length === 0 && this.onlyEmbedded && this.getFullRange.length > 1);
-    this.searchOpen = false;
-    this.currentSearchTypes = this.getRange;
   },
   methods: {
     actionHighlight(active, event) {
@@ -292,6 +288,7 @@ export default {
       }
     },
     show() {
+      this.resetSearch();
       LayoutUtil.scrollLock(true);
       this.active = true;
       this.$nextTick(() => {
@@ -311,18 +308,10 @@ export default {
         value: 'overview' 
       });
     },
-    openSearch() {
+    resetSearch() {
       this.keyword = '';
-      this.searchOpen = true;
-    },
-    closeSearch() {
-      this.searchOpen = false;
-      this.keyword = '';
+      this.currentSearchTypes = this.getRange;
       this.searchResult = [];
-      this.pagesFetched = 0;
-      this.allFetched = false;
-      this.chooseLocalType = false;
-      this.hide();
     },
     addLinkedItem(obj) {
       let currentValue = _.cloneDeep(_.get(this.inspector.data, this.path));
@@ -393,7 +382,7 @@ export default {
       });
     },
     addEmpty(typeId) {
-      this.closeSearch();
+      this.hide();
       const shortenedType = StringUtil.getCompactUri(typeId, this.resources.context);
       let obj = {'@type': shortenedType};
       if (StructuredValueTemplates.hasOwnProperty(shortenedType)) {
@@ -520,11 +509,11 @@ export default {
       </select>
     </div>
 
-    <modal-component v-if="active" class="EntityAdder-modal EntityAdderModal" @close="closeSearch">
+    <modal-component v-if="active" class="EntityAdder-modal EntityAdderModal" @close="hide">
       <template slot="modal-header">
         {{ "Add entity" | translatePhrase }} | {{ addLabel | labelByLang }}
         <span class="ModalComponent-windowControl">
-          <i @click="closeSearch" tabindex="0" @keyup.enter="closeSearch" class="fa fa-close"></i>
+          <i @click="hide" tabindex="0" @keyup.enter="hide" class="fa fa-close"></i>
         </span>
       </template>
 

--- a/viewer/v2client/src/components/inspector/search-window.vue
+++ b/viewer/v2client/src/components/inspector/search-window.vue
@@ -84,6 +84,18 @@ export default {
         this.hide();
       }
     },
+    'inspector.event'(val, oldVal) {
+      if (val.name === 'form-control') {
+        switch(val.value) {
+          case 'close-modals':
+            this.hide();
+            return true;
+            break;
+          default:
+            return;
+        }
+      }
+    },
   },
   computed: {
     ...mapGetters([

--- a/viewer/v2client/src/components/inspector/search-window.vue
+++ b/viewer/v2client/src/components/inspector/search-window.vue
@@ -81,7 +81,7 @@ export default {
       if(value) {
         this.show();
       } else {
-        this.closeSearch();
+        this.hide();
       }
     },
   },
@@ -160,6 +160,7 @@ export default {
       }
     },
     show() {
+      this.resetSearch();
       LayoutUtil.scrollLock(true);
       this.active = true;
       this.$nextTick(() => {
@@ -180,12 +181,10 @@ export default {
         value: 'overview' 
       });
     },
-    closeSearch() {
+    resetSearch() {
       this.keyword = '';
+      this.currentSearchTypes = this.getRange;
       this.searchResult = [];
-      this.pagesFetched = 0;
-      this.allFetched = false;
-      this.hide();
     },
     loadResults(result) {
       this.searchResult = result.items;
@@ -202,7 +201,6 @@ export default {
       const totalItems = self.searchResult.length;
       self.currentPage = pageNumber;
       self.loading = true;
-      console.log('fetching page', this.currentPage);
       this.getItems(this.keyword).then((result) => {
         self.loadResults(result);
       }, (error) => {
@@ -245,7 +243,7 @@ export default {
     <modal-component
       :title="'Link entity' | translatePhrase"
       v-if="active"
-      @close="closeSearch()"
+      @close="hide()"
       class="SearchWindow-modal">
       <template slot="modal-body">
         <div class="SearchWindow-header search-header">
@@ -333,7 +331,7 @@ export default {
           </ul>
           <modal-pagination v-if="!loading && searchResult.length > 0" @go="go" :numberOfPages="numberOfPages" :currentPage="currentPage"></modal-pagination>
           <div class="SearchWindow-searchStatusContainer"
-            v-show="extracting || keyword.length === 0 || loading || foundNoResult || fetchingMore || allFetched">
+            v-show="extracting || keyword.length === 0 || loading || foundNoResult">
             <div class="SearchWindow-searchStatus">
               <span v-show="keyword.length === 0 && !extracting">
                 {{ "Search for existing linked entities" | translatePhrase }}...
@@ -341,12 +339,6 @@ export default {
               <span v-show="loading">
                 <i class="fa fa-circle-o-notch fa-spin"></i>
                 {{ "Searching" | translatePhrase }}...
-              </span>
-              <span class="EntitySearchResult-fetchMore" v-show="fetchingMore">
-                {{"Fetching more results" | translatePhrase }} <i class="fa fa-circle-o-notch fa-spin"></i><br/>
-              </span>
-              <span class="EntitySearchResult-fetchMore" v-show="allFetched && searchResult.length > 0">
-                {{'No more results found' | translatePhrase }}
               </span>
               <span v-show="foundNoResult">
                 <strong>{{ "No results" | translatePhrase }}</strong>

--- a/viewer/v2client/src/utils/display.js
+++ b/viewer/v2client/src/utils/display.js
@@ -268,7 +268,11 @@ export function getCard(item, displayDefs, quoted, vocab, settings, context) {
 }
 
 export function getFormattedSelectOption(term, settings, vocab, context) {
-  const labelByLang = StringUtil.getLabelByLang(term.id, settings.language, vocab, context);
+  const maxLength = 40;
+  let labelByLang = StringUtil.getLabelByLang(term.id, settings.language, vocab, context);
+  if (labelByLang.length > maxLength) {
+    labelByLang = labelByLang.substr(0, maxLength-2) + '...';
+  }
   const abstractIndicator = ` {${StringUtil.getUiPhraseByLang('Abstract', settings.language)}}`;
   const prefix = Array((term.depth) + 1).join(' •');
   return `${prefix} ${labelByLang} ${term.abstract ? abstractIndicator : ''}`;


### PR DESCRIPTION
Moved all the reset functionality into one method.

* Removed `searchOpen` property (was unused)
* Removed `chooseLocalType` property (was unused)
* Removed `closeSearch` method (use `hide`)
* Removed `openSearch` method (use `show`)
* Added `resetSearch` method (called in `show`)

Also:
* Removed some scattered code from old pagination