### PR TITLE
save user's remote databases

### DIFF
--- a/viewer/v2client/src/components/search/remote-databases.vue
+++ b/viewer/v2client/src/components/search/remote-databases.vue
@@ -49,7 +49,11 @@ export default {
     },
     q() {
       return this.remoteSearch.q;
-    }
+    },
+    user() {
+      const user = this.$store.getters.user;
+      return user.isLoggedIn ? user : false;
+    },
   },
   events: {
     'set-import'(data){
@@ -66,6 +70,7 @@ export default {
           property: 'remoteDatabases', 
           value: val
         });
+        this.user && this.updateUserDbs(val);
       }
     },
   },
@@ -92,6 +97,8 @@ export default {
         'YALE'
       ];
 
+      const defaultDbs = this.user ? this.user.settings.defaultDatabases : [];
+
       this.remoteDatabases.state = 'loading';
       this.remoteDatabases.debug = '';
       this.fetchDatabases().then((dbs) => {
@@ -100,6 +107,9 @@ export default {
           const obj = { item: dbs[i], active: false, disabled: false };
           if (disabled.includes(dbs[i].database)) {
             obj.disabled = true;
+          }
+          if (defaultDbs.includes(dbs[i].database)) {
+            obj.active = true;
           }
           newDbList.push(obj);
         }
@@ -144,6 +154,11 @@ export default {
       this.importData = response.items;
       this.remoteResult.state = 'complete';
     },
+    updateUserDbs(dbs) {
+      const userObj = this.user;
+      userObj.settings.defaultDatabases = dbs
+      this.$store.dispatch('setUser', userObj);
+    }
   },
   components: {
     'result-list': ResultList,

--- a/viewer/v2client/src/models/user.js
+++ b/viewer/v2client/src/models/user.js
@@ -14,6 +14,7 @@ export class User {
       appTech: false,
       activeSigel: '',
       language: 'sv',
+      defaultDatabases: ['OCLC'],
     };
   }
 


### PR DESCRIPTION
Targets [LXL-1344](https://jira.kb.se/browse/LXL-1344)

* Logged in user's selected remote databases are stored in new settings property `defaultDatabases`.
* `defaultDatabases` is set to `OCLC` by default.
* For non-logged in users nothing is stored or selected by default (maybe a later todo?)

