### PR TITLE
Highlight when adding local entity

### DIFF
--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -364,6 +364,10 @@ export default {
           currentValue.push(obj);
         }
       }
+      this.$store.dispatch('setInspectorStatusValue', { 
+        property: 'lastAdded', 
+        value: `${this.path}[${currentValue.length -1}]`
+      });
       this.$store.dispatch('updateInspectorData', {
         changeList: [
           {

--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -37,7 +37,6 @@ export default {
     return {
       inEdit: false,
       showCardInfo: false,
-      isNewlyAdded: false,
       extractDialogActive: false,
       extracting: false,
       expanded: false,
@@ -101,6 +100,12 @@ export default {
         }
       });
       return bEmpty;
+    },
+    isLastAdded() {
+      if (this.inspector.status.lastAdded === this.getPath) {
+        return true;
+      }
+      return false;
     },
   },
   methods: {
@@ -252,6 +257,12 @@ export default {
     this.$nextTick(() => {
       this.expandOnNew();
     });
+    
+    if (this.isLastAdded) {
+      setTimeout(()=> {
+        this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+      }, 1000)
+    } 
   },
  
   components: {
@@ -267,7 +278,7 @@ export default {
 
 <template>
   <div class="ItemLocal js-itemLocal"
-    :class="{'is-highlighted': isNewlyAdded, 'is-expanded': expanded}"
+    :class="{'is-highlighted': isLastAdded, 'is-expanded': expanded}"
     tabindex="0">
    
    <strong class="ItemLocal-heading">
@@ -368,7 +379,7 @@ export default {
   border-radius: 4px;
   position: relative;
   flex: 1 100%;
-  transition: background-color .2s ease;
+  transition: background-color .5s ease;
 
   &-heading {
     display: block;
@@ -452,6 +463,10 @@ export default {
     &::before {
       vertical-align: sub;
     }
+  }
+
+  &.is-highlighted {
+    background-color: @sec;
   }
 }
 </style>


### PR DESCRIPTION
Target issue [LXL-1558](https://jira.kb.se/browse/LXL-1558)

* To create highlight, inspector's `lastAdded` property is now also set when a local entity is added
* Using the index to match `item-local.vue`'s  `getPath` property seems to be the best option since they can be identical and have no other unique identifiers... 🤔

i.e `${this.path}[${currentValue.length -1}]` === `${this.parentPath}[${this.index}]`