### PR TITLE
Update 866 in item template and snippet

### DIFF
--- a/viewer/v2client/src/resources/json/structuredValueTemplates.json
+++ b/viewer/v2client/src/resources/json/structuredValueTemplates.json
@@ -87,8 +87,8 @@
     { 
       "@type": "marc:TextualHoldingsBasicBibliographicUnit", 
       "marc:textualString": "",
-      "marc:holdingsLevel": " ",
-      "marc:typeOfNotation": " "
+      "marc:cataloguersNote": [""],
+      "marc:publicNote": [""]
     } 
   ],
   "SeriesMembership": [

--- a/viewer/v2client/src/utils/record.js
+++ b/viewer/v2client/src/utils/record.js
@@ -151,8 +151,8 @@ export function getItemObject(itemOf, heldBy, instance) {
         {
           '@type': 'marc:TextualHoldingsBasicBibliographicUnit',
           'marc:textualString': '',
-          'marc:holdingsLevel': ' ',
-          'marc:typeOfNotation': ' '
+          'marc:cataloguersNote': [''],
+          'marc:publicNote': ['']
         }
       ]
     },


### PR DESCRIPTION
When marc-default is added to 866 in MarcFrame the indicators become obsolete and need to be removed from the templates. This Update removes them and adds instead fields for cataloguersNote and publicNote.