### PR TITLE
Fix chip hover z-index issue

### DIFF
--- a/viewer/v2client/src/components/inspector/field.vue
+++ b/viewer/v2client/src/components/inspector/field.vue
@@ -371,11 +371,11 @@ export default {
 <template>
   <li class="Field js-field" 
     :id="`field-${getPath}`" 
-    v-bind:class="{'is-mainField': isMainField, 'Field--inner': !asColumns, 'is-lastAdded': isLastAdded, 'is-removed': removed, 'is-hovered': shouldShowActionButtons}" 
+    v-bind:class="{'is-mainField': isMainField, 'Field--inner': !asColumns, 'is-lastAdded': isLastAdded, 'is-removed': removed}" 
     @mouseover="handleMouseEnter()" 
     @mouseleave="handleMouseLeave()">
 
-    <div class="Field-labelContainer" v-if="!isInner" :class="{'is-wide': inspector.status.editing || user.settings.appTech}">
+    <div class="Field-labelContainer" v-if="!isInner" :class="{'is-wide': inspector.status.editing || user.settings.appTech, 'is-hovered': shouldShowActionButtons}">
       <div class="Field-labelWrapper">
         <div v-if="this.inspector.status.editing" class="Field-actions">
           <div class="Field-action Field-remove" 
@@ -600,10 +600,6 @@ export default {
     background-color: @add;
   }
 
-  &.is-hovered {
-    z-index: 1;
-  }
-
   @media (min-width: 768px) {
     display: flex;
   }
@@ -666,6 +662,10 @@ export default {
 
     &.is-wide {
       flex-basis: 300px;
+    }
+
+    &.is-hovered {
+      z-index: 1;
     }
 
     pre {


### PR DESCRIPTION
`Position: sticky` on the field labels caused help popups to break:

![bug1](https://user-images.githubusercontent.com/22232928/45423168-c5835880-b692-11e8-9d6b-cee1d83beca8.png)

The fix for that caused the chip popup to break:

![bug2](https://user-images.githubusercontent.com/22232928/45423246-08ddc700-b693-11e8-88d8-87fd0c5c27a2.png)

This fixes both 🙂