### PR TITLE
Print Marc21 IE

### DIFF
--- a/viewer/v2client/src/components/Inspector.vue
+++ b/viewer/v2client/src/components/Inspector.vue
@@ -468,7 +468,7 @@ export default {
     <div v-if="!postLoaded && !loadFailure" class="Inspector-spinner text-center">
       <vue-simple-spinner size="large" :message="'Loading document' | translatePhrase"></vue-simple-spinner>
     </div>
-    <div class="Inspector col-sm-12" :class="{'col-md-11': !status.panelOpen, 'col-md-7': status.panelOpen }" ref="Inspector">
+    <div class="Inspector col-sm-12" :class="{'col-md-11': !status.panelOpen, 'col-md-7': status.panelOpen, 'hideOnPrint': marcPreview.active}" ref="Inspector">
       <div v-if="!postLoaded && loadFailure">
         <h2>{{loadFailure.status}}</h2>
         <p v-if="loadFailure.status === 404">
@@ -581,6 +581,12 @@ export default {
     padding: 10px 20px;
     background-color: @white;
     border: 1px solid @gray-lighter;
+  }
+
+  &.hideOnPrint {
+    @media print {
+      display: none;
+    }
   }
 }
 

--- a/viewer/v2client/src/components/inspector/marc-preview.vue
+++ b/viewer/v2client/src/components/inspector/marc-preview.vue
@@ -82,12 +82,12 @@ export default {
 </script>
 
 <template>
-  <panel-component class=""
+  <panel-component class="MarcPreview"
     @close="hide" 
     origin="Preview MARC21"
     title="Preview MARC21">
     <template slot="panel-body">
-      <div class="MarcPreview">
+      <div class="">
         <div class="MarcPreview-body">
           <div class="MarcPreview-status" v-if="marcObj === null">
             <p v-show="error === null" >
@@ -141,7 +141,6 @@ export default {
 
   &-body {
     width: 100%;
-    overflow-y: scroll;
     padding-bottom: 30px;
   }
 
@@ -154,7 +153,6 @@ export default {
   &-table {
     width: 100%;
     height: 100%;
-    overflow: scroll;
     margin: 0 0 20px 0; // Make sure last field is fully visible
     font-family: monospace;
     border: 1px solid #a1a1a1;
@@ -180,6 +178,15 @@ export default {
 
     tbody td, tbody th {
       vertical-align: top;
+    }
+  }
+
+  & .PanelComponent-container {
+    @media print {
+      display: block;
+      position: static;
+      width: 100%;
+      height: auto;
     }
   }
 }

--- a/viewer/v2client/src/components/shared/panel-component.vue
+++ b/viewer/v2client/src/components/shared/panel-component.vue
@@ -207,13 +207,6 @@ export default {
       .full-view();
     }
 
-    @media print {
-      .full-view();
-      height: auto;
-      position: absolute;
-      background-color: @white!important;
-    }
-
     &.full-view {
       top: 0px;
       left: 0px;


### PR DESCRIPTION
Hopefully a better implementation of printing the Marc21 preview, since IE and Edge doesn't support `background-color` prop in `@media print`.

This hides the form completely when the printing the page with Marc preview panel open. Also some refactoring.