### PR TITLE
Post of type 'välj typ' bug

### DIFF
--- a/viewer/v2client/src/components/create/creation-card.vue
+++ b/viewer/v2client/src/components/create/creation-card.vue
@@ -54,7 +54,7 @@ export default {
         <div class="CreationCard-descr card-descr">Innehåller de vanligaste fälten för vald typ.</div>
       </div>
       <div class="card-link">
-        <select class="CreationCard-select customSelect" @change="useBase($event)" @keyup.enter="useBase($event)">
+        <select class="CreationCard-select customSelect" @change="useBase($event)">
           <option class="CreationCard-option" selected disabled>
             {{'Choose type' | translatePhrase}}
           </option>


### PR DESCRIPTION
Create new view: Prevents user from creating a new post of type 'välj typ' when tabbing to the select menu and pressing enter.

Keyboard navigation is now working as it should, i.e tabbing -> space (opens select) -> up or down arrows -> enter.

