### PR TITLE
Null links in footer fix

### DIFF
--- a/viewer/v2client/src/components/layout/footer.vue
+++ b/viewer/v2client/src/components/layout/footer.vue
@@ -19,7 +19,9 @@ export default {
       _.each(translationEls, function (translationEl) {
         const originalText = translationEl.getAttribute('data-translateable');
         const newText = StringUtil.getUiPhraseByLang(originalText, langCode);
-        translationEl.innerHTML = newText;
+        if (newText) {
+          translationEl.innerHTML = newText;
+        }
       });
     }
   },


### PR DESCRIPTION
[LXL-1505](https://jira.kb.se/browse/LXL-1505)

Was caused by translate function setting a prop as `innerHTML`, even when it wasn't found, ie `null`.
However, was only rendered by IE & Edge, Chrome skipped it.