### PR TITLE
IE scrollbar overlap fix

### DIFF
--- a/viewer/v2client/src/less/main.less
+++ b/viewer/v2client/src/less/main.less
@@ -79,6 +79,8 @@ body {
   height: 100vh;
   display: flex;
   flex-direction: column;
+  -ms-overflow-style: scrollbar;
+  
   .facet-container {
     opacity: 1;
     transition: 0.3s ease width 0s, 0.3s ease opacity 0.3s;


### PR DESCRIPTION
[LXL-1892](https://jira.kb.se/browse/LXL-1892) Sidepanel and page scrollbars are on top of each other in IE, blocking one of them from being used. Seems to be a common problem with a common [fix](https://stackoverflow.com/questions/17045132/scrollbar-overlay-in-ie10-how-do-you-stop-that).
