### PR TITLE
Blogposts on landingpage

### DIFF
--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -107,6 +107,12 @@ def get_release_feed():
     return requests.get('https://github.com/libris/lxlviewer/releases.atom').content
 
 ##
+# Setup blog feed
+@app.route('/blogfeed', methods=['GET'])
+def get_blog_feed():
+    return requests.get('http://librisbloggen.kb.se/wp-json/wp/v2/posts/?categories=8&per_page=4').content
+
+##
 # Setup basic views
 
 @app.route('/assets/<path:path>.<suffix>')

--- a/viewer/v2client/src/components/LandingPage.vue
+++ b/viewer/v2client/src/components/LandingPage.vue
@@ -3,6 +3,7 @@ import ServiceWidgetSettings from '@/resources/json/serviceWidgetSettings.json';
 import SearchForm from '@/components/search/search-form';
 import DatasetObservations from '@/components/search/dataset-observations';
 import LinkCardComponent from '@/components/search/link-card';
+import BlogPanel from '@/components/search/blog-panel';
 import Copy from '@/resources/json/copy.json';
 
 export default {
@@ -38,6 +39,7 @@ export default {
     'dataset-observations': DatasetObservations,
     'intro-component': LinkCardComponent,
     'link-card': LinkCardComponent,
+    'blog-panel': BlogPanel,
   },
 }
 </script>
@@ -56,12 +58,13 @@ export default {
           :text="copy['about-xl'].text" 
           :link-text="copy['about-xl'].linkText" 
           :link-url="copy['about-xl'].linkUrl"></link-card>
-        <link-card v-if="widgetShouldBeShown('link-blog')" 
-          :image="copy['blog'].image" 
-          :header="copy['blog'].header" 
+        <blog-panel v-if="widgetShouldBeShown('link-blog')"
+          :image="copy['blog'].image"
+          :header="copy['blog'].header"
           :text="copy['blog'].text" 
           :link-text="copy['blog'].linkText" 
-          :link-url="copy['blog'].linkUrl"></link-card>
+          :link-url="copy['blog'].linkUrl"
+        />
         <link-card v-if="widgetShouldBeShown('link-studies')" 
           :image="copy['studies'].image" 
           :header="copy['studies'].header" 

--- a/viewer/v2client/src/components/search/blog-panel.vue
+++ b/viewer/v2client/src/components/search/blog-panel.vue
@@ -1,0 +1,171 @@
+<script>
+import moment from 'moment';
+import * as StringUtil from '@/utils/string';
+import { mapGetters } from 'vuex';
+
+export default {
+  name: 'blog-panel',
+  props: [
+    "image",
+    "linkUrl",
+    "linkText",
+    "header",
+    "text",
+    "html",
+  ],
+  data() {
+    return {
+      feed: null,
+    }
+  },
+  methods: {
+    getFeed() {
+      fetch(`${this.settings.apiPath}/blogfeed`).then((result) => {
+        if (result.status == 200) {
+          result.json().then((body) => {
+            this.feed = body;
+          });
+        }
+      }, (error) => {
+        console.log(error);
+      });
+    },
+    getTimeAgoString(date) {
+      const today = moment().startOf('day');
+      if (today.isSame(date, 'day')) {
+        return StringUtil.getUiPhraseByLang('Today', this.user.settings.language).toLowerCase();
+      }
+      return moment(date, "YYYY-MM-DD").from(moment().startOf('day'));
+    },
+  },
+  computed: {
+    ...mapGetters([
+      'user',
+      'settings',
+    ]),
+    resolvedImage() {
+      return require(`@/assets/img/${this.image}`)
+    },
+  },
+  components: {
+  },
+  watch: {
+  },
+  mounted() { 
+    this.$nextTick(() => {
+      this.getFeed();
+    });
+  },
+};
+</script>
+
+
+<template>
+  <div class="panel panel-default BlogPanel">
+    <img v-if="image" :src="resolvedImage" class="LinkCard-img"/>
+    <div class="BlogPanel-content card-content" v-if="feed !== null">
+      <span class="BlogPanel-title card-title">{{ header }}</span>
+      <div class="BlogPanel-postList">
+        <div class="BlogPanel-post" v-for="post in feed" :key="post.id">
+          <a :href="post.link">{{ post.title.rendered }}</a>
+          <span class="date">{{ 'Posted' | translatePhrase }} {{ getTimeAgoString(post.date) }}</span>
+        </div>
+      </div>
+    </div>
+    <div class="BlogPanel-content card-content" v-if="feed === null">
+      <div class="BlogPanel-text card-text">
+        <span class="BlogPanel-title card-title">{{ header }}</span>
+        <div v-if="html" class="BlogPanel-html card-descr" v-html="html">{{ html }}</div>
+        <div class="BlogPanel-descr card-descr">{{ text }}</div>
+      </div>
+      <a v-if="linkUrl" :href="linkUrl" class="card-link BlogPanel-link">{{ linkText }}</a>
+    </div>
+  </div>
+</template>
+
+<style lang="less">
+.BlogPanel {
+  flex-basis: 100%; // To parent
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0;
+
+  @media (min-width: 768px) {
+    flex-basis: 49%; 
+  }
+
+  @media (min-width: 992px) {
+    flex-basis: 24%; 
+  }
+
+  &-postList {
+    flex-grow: 1;
+  }
+  &-post {
+    padding: 0 0.5em 0 0.5em;
+    width: 100%;
+    a {
+      font-weight: 600;
+      display: block;
+      font-size: 11pt;
+    }
+    .date {
+      font-size: 10pt;
+      width: 100%;
+      display: block;
+    }
+  }
+
+  &-img {
+    width: 100%;
+    flex-shrink: 0; // Prevent weird image sizing behaviour in IE11
+    border: solid #f1f1f1;
+    border-width: 0px 0px 1px 0px;
+  }
+
+  &-content {
+    .LinkCard--large & {
+      padding: 1em;
+      @media (min-width: 768px) {
+        flex-basis: 45%;
+      }
+    }
+  }
+
+  &-link {
+  }
+
+  &-text {
+  }
+
+  &-descr,
+  &-html {
+    @media (min-width: 768px) {
+      display: flex;
+    }
+  }
+
+  &-html {
+    display: block;
+  }
+
+  &-title {
+  }
+
+  &.no-link {
+    padding-bottom: 1em;
+  }
+
+  &--large {
+    display: block;
+    justify-content: space-between;
+    flex-direction: row;
+    align-items: inherit;
+
+    @media (min-width: 768px) {
+      display: flex;
+    }
+  }
+}
+</style>

--- a/viewer/v2client/src/resources/json/i18n.json
+++ b/viewer/v2client/src/resources/json/i18n.json
@@ -62,6 +62,7 @@
     "Link entity": "Länka entitet",
     "Post": "Post",
     "Unknown": "Okänd",
+    "Posted": "Publicerad",
     "Field": "Fält",
     "Show technical application details": "Visa applikationstekniska detaljer",
     "On": "På",


### PR DESCRIPTION
Try to fetch blog posts, if not successful it will show the ordinary panel with a link to the blog.

If success, will show a list of the latest 4 posts from the category "Libristjänster" (this can be adjusted to a tag or something else).

<img width="1159" alt="screen shot 2018-09-27 at 17 17 58" src="https://user-images.githubusercontent.com/3618525/46156772-805a4b80-c27a-11e8-840e-e4e9aced6771.png">
