### PR TITLE
Remove unused keybinding logic

### DIFF
--- a/viewer/client/static/resources/json/keybindings.json
+++ b/viewer/client/static/resources/json/keybindings.json
@@ -14,13 +14,9 @@
   },
   "field-adder": {
     "esc": "close-modals",
-    "down": "select-next",
-    "up": "select-prev",
-    "enter": "add-field-single",
-    "mod+enter": "add-field-multiple"
   },
   "entity-adder": {
-    "esc": "close-modals"
+    "esc": "close-modals",
   },
   "release-notes": {
     "esc": "close-modals",
@@ -34,8 +30,4 @@
   "help-window": {
     "esc": "close-modals",
   },
-  "entity-search-list": {
-    "down": "select-next",
-    "up": "select-prev"
-  }
 }

--- a/viewer/v2client/src/components/inspector/field-adder.vue
+++ b/viewer/v2client/src/components/inspector/field-adder.vue
@@ -35,8 +35,6 @@ export default {
       buttonFixed: true,
       buttonPos: -1,
       filterKey: '',
-      selectedIndex: -1,
-      fieldListBottom: false,
       showToolTip: false,
     };
   },
@@ -118,60 +116,6 @@ export default {
         let item = event.target;
         while ((item = item.parentElement) && !item.classList.contains('js-itemLocal'));
           item.classList.remove('is-marked');
-      }
-    },
-    selectNext() {
-      if (this.active) {
-        if (this.selectedIndex < this.filteredResults.length - 1) {
-          if (this.selectedIndex >= 0) {
-            const fieldList = document.getElementsByClassName('js-fieldlist')[0];
-            const threshold =
-              fieldList.getBoundingClientRect().top +
-              fieldList.getBoundingClientRect().height;
-            const selectedElement = document.getElementsByClassName('selected')[0];
-            const selectedPosition =
-              selectedElement.getBoundingClientRect().top +
-              selectedElement.getBoundingClientRect().height * 2;
-            if (selectedPosition > threshold) {
-              fieldList.scrollTop += selectedElement.getBoundingClientRect().height * 2;
-            }
-          }
-          this.selectedIndex += 1;
-        }
-      }
-    },
-    selectPrev() {
-      if (this.active) {
-        if (this.selectedIndex > 0) {
-          this.selectedIndex -= 1;
-          const fieldList = document.getElementsByClassName('js-fieldlist')[0];
-          const threshold = fieldList.getBoundingClientRect().top;
-          const selectedElement = document.getElementsByClassName('selected')[0];
-          const selectedPosition =
-            selectedElement.getBoundingClientRect().top -
-            selectedElement.getBoundingClientRect().height;
-          if (selectedPosition < threshold) {
-            fieldList.scrollTop -= selectedElement.getBoundingClientRect().height * 2;
-          }
-        }
-      }
-    },
-    addFieldMultiple() {
-      if (this.active) {
-        if (!this.filteredResults[this.selectedIndex].added) {
-          this.addField(this.filteredResults[this.selectedIndex], false);
-        } else {
-          console.warn("Already added, should be handled");
-        }
-      }
-    },
-    addFieldSingle() {
-      if (this.active) {
-        if (!this.filteredResults[this.selectedIndex].added) {
-          this.addField(this.filteredResults[this.selectedIndex], true);
-        } else {
-          console.warn("Already added, should be handled");
-        }
       }
     },
     closeModals() {
@@ -273,11 +217,6 @@ export default {
       this.active = false;
       this.filterKey = '';
       this.$store.dispatch('setStatusValue', { property: 'keybindState', value: 'overview' });
-      this.resetSelectIndex();
-    },
-    resetSelectIndex() {
-      this.fieldListBottom = false;
-      this.selectedIndex = -1;
     },
   },
   watch: {
@@ -289,20 +228,8 @@ export default {
     'inspector.event'(val, oldVal) {
       if (val.name === 'form-control') {
         switch (val.value) { 
-          case 'select-next':
-            this.selectNext();
-            break;
-          case 'select-prev':
-            this.selectPrev();
-            break;
           case 'close-modals':
             this.hide();
-            break;
-          case 'add-field-single':
-            this.addFieldSingle();
-            break;
-          case 'add-field-multiple':
-            this.addFieldMultiple();
             break;
           default:
             return;
@@ -368,7 +295,6 @@ export default {
             type="text" 
             ref="input"
             class="FieldAdderPanel-filterInput customInput form-control mousetrap" 
-            @input="resetSelectIndex()" 
             :placeholder="'Filter by' | translatePhrase"
             v-model="filterKey">
         </div>
@@ -399,10 +325,8 @@ export default {
           <ul class="FieldAdderPanel-fieldList js-fieldlist">
             <li
               class="FieldAdderPanel-fieldItem PanelComponent-listItem"
-              @focus="selectedIndex = index"
-              @mouseover="selectedIndex = index" 
-              v-bind:class="{ 'is-added': prop.added, 'available': !prop.added, 'selected': index == selectedIndex }" 
-              v-for="(prop, index) in filteredResults" 
+              v-bind:class="{ 'is-added': prop.added, 'available': !prop.added }" 
+              v-for="(prop) in filteredResults" 
               @click="addField(prop, false)"
               @keyup.enter="addField(prop, false)" 
               :key="prop['@id']">

--- a/viewer/v2client/src/components/search/entity-search-list.vue
+++ b/viewer/v2client/src/components/search/entity-search-list.vue
@@ -20,8 +20,6 @@ export default {
     return {
       keyword: '',
       active: false,
-      selectedIndex: -1,
-      fieldListBottom: false,
     }
   },
   methods: {
@@ -38,44 +36,6 @@ export default {
     addItem(item) {
       this.$emit('add-item', item);
     },
-    select(index) {
-      this.selectedIndex = index;
-    },
-    selectNext() {
-      if (this.active) {
-        if (this.selectedIndex >= 0) {
-          const fieldList = document.getElementsByClassName('js-field-list')[0];
-          const threshold =
-            fieldList.getBoundingClientRect().top +
-            fieldList.getBoundingClientRect().height;
-          
-          const selectedElement = document.getElementsByClassName('is-selected')[0];
-          const selectedPosition =
-            selectedElement.getBoundingClientRect().top +
-            selectedElement.getBoundingClientRect().height * 2;
-          if (selectedPosition > threshold) {
-            fieldList.scrollTop += selectedElement.getBoundingClientRect().height * 2;
-          }
-        } 
-        this.selectedIndex += 1;
-      }
-    },
-    selectPrev() {
-      if (this.active) {
-        if (this.selectedIndex > 0) {
-          this.selectedIndex -= 1;
-          const fieldList = document.getElementsByClassName('js-field-list')[0];
-          const threshold = fieldList.getBoundingClientRect().top;
-          const selectedElement = document.getElementsByClassName('is-selected')[0];
-          const selectedPosition =
-            selectedElement.getBoundingClientRect().top -
-            selectedElement.getBoundingClientRect().height;
-          if (selectedPosition < threshold) {
-            fieldList.scrollTop -= selectedElement.getBoundingClientRect().height * 2;
-          }
-        }
-      }
-    },
   },
   computed: {
     ...mapGetters([
@@ -90,20 +50,11 @@ export default {
     'entity-search-item': EntitySearchItem,
   },
   watch: {
-    'status.keyActions'(value) {
-      this.$emit(value[value.length-1]);
-    }
   },
   events: {
   },
   mounted: function () {
     this.active = true;
-    this.$store.dispatch('setStatusValue', { 
-      property: 'keybindState', 
-      value: 'entity-search-list' 
-    });
-    this.$on('select-next', () => this.selectNext());
-    this.$on('select-prev', () => this.selectPrev());
   }
 };
 </script>
@@ -113,9 +64,6 @@ export default {
     <ul class="EntitySearchResult-list js-field-list" v-show="results.length > 0" >
       <entity-search-item
         v-for="(item, index) in results" 
-        :class="{'is-selected': index == selectedIndex }" 
-        @mouseover.native="select(index)"
-        @focus.native="select(index)"
         :is-replaced="isReplaced(item)"
         :focus-data="item" 
         :is-disabled="itemIsAdded(item)" 


### PR DESCRIPTION
If we decide to only go with tabbing through side panels: 
This removes the old keybindings including its `selectNext` functions etc 

+ fixes console reference errors
+ fixes unexpected behaviour such as panel closing (caused by old keybindings colliding)
+ Field adder emits a lot less events