### PR TITLE
Cursor focus on newly added input

### DIFF
--- a/viewer/v2client/src/components/inspector/field.vue
+++ b/viewer/v2client/src/components/inspector/field.vue
@@ -565,6 +565,7 @@ export default {
           :field-key="fieldKey" 
           :index="index" 
           :parent-path="getPath" 
+          :gparent-path="parentPath"
           :show-action-buttons="actionButtonsShown"
           :is-expanded="isExpanded"></item-value>
       </div>
@@ -815,7 +816,7 @@ export default {
       padding: 0 0 0 10px;
     }
 
-     @media (min-width: 768px) {
+    @media (min-width: 768px) {
       border-left: 1px solid;
       border-color: @form-border;
       border-color: @form-border-alt;

--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -277,6 +277,7 @@ export default {
   },
   mounted() {
     if (this.isLastAdded) {
+      this.toggleExpanded();
       setTimeout(()=> {     
         if (this.isEmpty) {
           this.$el.getElementsByClassName('js-expandable')[0].classList.add('is-inactive');
@@ -287,7 +288,7 @@ export default {
       }, 1000)
     } 
   },
- 
+
   components: {
     'processed-label': ProcessedLabel,
     'item-entity': ItemEntity,
@@ -306,9 +307,9 @@ export default {
     @keyup.enter="checkFocus()"
     @focus="addFocus()"
     @blur="removeFocus()">
-   
-   <strong class="ItemLocal-heading">
-     <div class="ItemLocal-label js-expandable">
+
+    <strong class="ItemLocal-heading">
+      <div class="ItemLocal-label js-expandable">
         <i class="ItemLocal-arrow fa fa-chevron-right " 
           :class="{'down': expanded}" 
           @click="toggleExpanded()"></i>
@@ -404,7 +405,7 @@ export default {
         :show-action-buttons="showActionButtons"
         :is-expanded="expanded"></field> 
     </ul>
-       
+
     <search-window 
       :isActive="extractDialogActive" 
       :can-copy-title="canCopyTitle" 

--- a/viewer/v2client/src/components/inspector/item-value.vue
+++ b/viewer/v2client/src/components/inspector/item-value.vue
@@ -24,6 +24,8 @@ export default {
     isRemovable: false,
     showActionButtons: false,
     isExpanded: false,
+    parentPath: false,
+    gparentPath: false,
   },
   watch: {
     isLocked(val) {
@@ -35,7 +37,7 @@ export default {
       if (val) {
         this.initializeTextarea();
       }
-    }
+    },
   },
   data() {
     return {
@@ -67,12 +69,22 @@ export default {
     },
     newWindowText() {
       return StringUtil.getUiPhraseByLang('Opens in new window', this.user.settings.language);
-    }
+    },
+    shouldFocus() {
+      let lastAdded = this.inspector.status.lastAdded;
+      if (lastAdded === this.path || lastAdded === this.parentPath || lastAdded === this.gparentPath) {
+        return true;
+      }
+      return false;
+    },
   },
   mounted() {
     this.$nextTick(() => {
       if (!this.isLocked) {
         this.initializeTextarea();
+        if (!this.status.isNew && this.shouldFocus) {
+          this.addFocus();
+        }
       }
     });
   },
@@ -121,6 +133,9 @@ export default {
       // TODO: Is the item empty?
       return false;
     },
+    addFocus() {
+      this.$refs.textarea.focus();
+    },
   },
   components: {
     'processed-label': ProcessedLabel,
@@ -131,28 +146,29 @@ export default {
 
 <template>
   <div class="ItemValue js-value" v-bind:class="{'is-locked': isLocked, 'unlocked': !isLocked, 'is-removed': removed}">
-    <textarea class="ItemValue-input js-itemValueInput" 
-      rows="1" 
-      v-model="value" 
+    <textarea class="ItemValue-input js-itemValueInput"
+      rows="1"
+      v-model="value"
       @blur="update($event.target.value)"
-      @keydown="handleKeys" 
-      v-if="!isLocked"></textarea>
-    <span class="ItemValue-text" 
+      @keydown="handleKeys"
+      v-if="!isLocked"
+      ref="textarea"></textarea>
+    <span class="ItemValue-text"
       v-if="isLocked && !shouldLink">{{fieldValue}}</span>
-    <a class="ItemValue-text" 
+    <a class="ItemValue-text"
       v-if="isLocked && shouldLink"
       :href="fieldValue" target="_blank" :title="`${fieldValue} (${newWindowText})`">{{fieldValue}} <i class="fa fa-external-link" aria-hidden="true"></i></a>
-    <div class="ItemValue-remover" 
-      v-show="!isLocked && isRemovable" 
-      v-on:click="removeThis()" 
-      @focus="removeHover = true, removeHighlight(true)" 
+    <div class="ItemValue-remover"
+      v-show="!isLocked && isRemovable"
+      v-on:click="removeThis()"
+      @focus="removeHover = true, removeHighlight(true)"
       @blur="removeHover = false, removeHighlight(false)"
-      @mouseover="removeHover = true, removeHighlight(true)" 
+      @mouseover="removeHover = true, removeHighlight(true)"
       @mouseout="removeHover = false, removeHighlight(false)">
       <i class="fa fa-trash-o icon icon--sm">
-        <tooltip-component 
-          :show-tooltip="removeHover" 
-          tooltip-text="Remove" 
+        <tooltip-component
+          :show-tooltip="removeHover"
+          tooltip-text="Remove"
           translation="translatePhrase"></tooltip-component>
       </i>
     </div>


### PR DESCRIPTION
Reinstates [previously removed](https://github.com/libris/lxlviewer/pull/170) functionality, but without the autoscrolling bug.

Old solution simply added focus to _all_ textarea inputs (except if record was created from scratch) = to the last added one, but also to the last textarea on the page if switching from instance and metadata view for example.

This time `item-value` uses the `inspector.status.lastAdded` prop, and only applies focus if the last added component is 1) itself (when adding plain textarea), 2) its parent (when adding a new field containing a textarea) or 3) its grandparent (adding an item-local containing a field-with-a-textarea 🤪)