### PR TITLE
Change click area on create-new-cards

### DIFF
--- a/viewer/v2client/src/components/create/creation-card.vue
+++ b/viewer/v2client/src/components/create/creation-card.vue
@@ -67,17 +67,16 @@ export default {
         </select>
       </div>
     </div>
-    <div v-if="!isBase" class="CreationCard-content card-content" 
-      @click="useTemplate(template.value)">
+    <div v-if="!isBase" class="CreationCard-content card-content">
       <div class="card-text">
         <h2 class="CreationCard-title card-title">{{template.label}}</h2>
         <div class="CreationCard-descr card-descr">{{template.description}}</div>
       </div>
       <div class="card-link">
-        <button class="CreationCard-select btn btn-primary btn--md" tabindex="0" v-show="!isActive" @keyup.enter="useTemplate(template.value)">
+        <button class="CreationCard-select btn btn-primary btn--md" tabindex="0" v-show="!isActive" @keyup.enter="useTemplate(template.value)" @click="useTemplate(template.value)">
           {{ 'Choose' | translatePhrase }}
         </button>
-        <a class="CreationCard-select" tabindex="0" v-show="isActive" @keyup.enter="useTemplate(template.value)">
+        <a class="CreationCard-select" tabindex="0" v-show="isActive" @keyup.enter="useTemplate(template.value)" @click="useTemplate(template.value)">
           {{ 'Chosen' | translatePhrase }}
         </a>
       </div>


### PR DESCRIPTION
Change click area on create-new-cards to be only on button instead of whole item.

Fixes [LXL-1906](https://jira.kb.se/browse/LXL-1906)