### PR TITLE
Move main loading indicator

### DIFF
--- a/viewer/v2client/src/App.vue
+++ b/viewer/v2client/src/App.vue
@@ -3,22 +3,19 @@
     <global-message />
     <navbar-component />
     <main class="MainContent" :class="{ 'container': !status.panelOpen, 'container-fluid': status.panelOpen }" role="main">
-      <div v-if="!resourcesLoaded" class="text-center MainContent-spinner">
-        <vue-simple-spinner size="large" :message="'Loading application' | translatePhrase"></vue-simple-spinner>
-      </div>
-      <transition name="fade">
+        <div v-if="status.loadingIndicators.length > 0" class="text-center MainContent-spinner">
+          <vue-simple-spinner size="large" :message="status.loadingIndicators[0] | translatePhrase"></vue-simple-spinner>
+        </div>
+        <div v-if="resourcesLoadingError" class="ResourcesLoadingError">
+          <i class="fa fa-warning fa-4x text-danger"></i>
+          <div>
+            <h2>Kunde inte hämta nödvändiga resurser</h2>
+            <p>Testa att ladda om sidan.</p>
+            <p>Om felet kvarstår, kontakta <a href="mailto:libris@kb.se">libris@kb.se</a>.</p>
+          </div>
+        </div>
         <router-view v-if="resourcesLoaded" />
-      </transition>
     </main>
-    <modal-component title="Error" modal-type="danger" class="ResourceLoadingErrorModal"
-      :closeable="false" 
-      v-if="resourcesLoadingError">
-      <div slot="modal-body" class="ResourceLoadingErrorModal-body">
-        <p>Kunde inte hämta nödvändiga resurser.</p>
-        <p>Testa att ladda om sidan.</p>
-        <p>Om felet kvarstår, kontakta <a href="mailto:libris@kb.se">libris@kb.se</a>.</p>
-      </div>
-    </modal-component>
     <portal-target name="sidebar" multiple />
     <footer-component></footer-component>
     <notification-list></notification-list>
@@ -94,10 +91,12 @@ export default {
   .fade-enter, .fade-leave-active {
     opacity: 0
   }
-  .ResourceLoadingErrorModal {
-    &-body {
-      text-align: center;
-      padding: 2em;
+  .ResourcesLoadingError {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    i {
+      margin-right: 0.5em;
     }
   }
 }

--- a/viewer/v2client/src/components/Inspector.vue
+++ b/viewer/v2client/src/components/Inspector.vue
@@ -17,7 +17,6 @@ import ModalComponent from '@/components/shared/modal-component';
 import ReverseRelations from '@/components/inspector/reverse-relations';
 import MarcPreview from '@/components/inspector/marc-preview';
 import TabMenu from '@/components/shared/tab-menu';
-import VueSimpleSpinner from 'vue-simple-spinner';
 import { mapGetters } from 'vuex';
 
 export default {
@@ -177,6 +176,7 @@ export default {
       });
     },
     initializeRecord() {
+      this.$store.dispatch('pushLoadingIndicator', 'Loading document');
       this.postLoaded = false;
       this.$store.dispatch('flushChangeHistory');
       this.$store.dispatch('setInspectorStatusValue', { property: 'focus', value: 'mainEntity' });
@@ -268,6 +268,7 @@ export default {
       this.$store.dispatch('setOriginalData', this.inspector.data);
       this.$store.dispatch('flushChangeHistory');
       this.postLoaded = true;
+      this.$store.dispatch('removeLoadingIndicator', 'Loading document');
     },
     doCancel() {
       this.$store.dispatch('setInspectorStatusValue', { 
@@ -489,7 +490,6 @@ export default {
     'breadcrumb': Breadcrumb,
     'marc-preview': MarcPreview,
     'tab-menu': TabMenu,
-    'vue-simple-spinner': VueSimpleSpinner,
   },
   mounted() {
     this.$nextTick(() => {
@@ -506,9 +506,6 @@ export default {
 </script>
 <template>
   <div class="row">
-    <div v-if="!postLoaded && !loadFailure" class="Inspector-spinner text-center">
-      <vue-simple-spinner size="large" :message="'Loading document' | translatePhrase"></vue-simple-spinner>
-    </div>
     <div class="Inspector col-sm-12" :class="{'col-md-11': !status.panelOpen, 'col-md-7': status.panelOpen, 'hideOnPrint': marcPreview.active}" ref="Inspector">
       <div v-if="!postLoaded && loadFailure">
         <h2>{{loadFailure.status}}</h2>

--- a/viewer/v2client/src/main.js
+++ b/viewer/v2client/src/main.js
@@ -69,14 +69,17 @@ new Vue({
   created() {
     this.initWarningFunc();
     this.fetchHelpDocs();
+    store.dispatch('pushLoadingIndicator', 'Loading application');
     Promise.all(this.getLdDependencies()).then((resources) => {
       store.dispatch('setContext', resources[2]['@context']);
       store.dispatch('setupVocab', resources[0]['@graph']);
       store.dispatch('setDisplay', resources[1]);
       store.dispatch('changeResourcesStatus', true);
+      store.dispatch('removeLoadingIndicator', 'Loading application');
     }, (error) => {
       window.lxlWarning(`🔌 The API (at ${this.settings.apiPath}) might be offline!`);
       store.dispatch('changeResourcesLoadingError', true);
+      store.dispatch('removeLoadingIndicator', 'Loading application');
     });
   },
   watch: {

--- a/viewer/v2client/src/store/store.js
+++ b/viewer/v2client/src/store/store.js
@@ -59,6 +59,7 @@ const store = new Vuex.Store({
       resultList: {
         loading: false
       },
+      loadingIndicators: [],
       notifications: [],
       helpSection: 'none',
       remoteDatabases: [],
@@ -375,6 +376,27 @@ const store = new Vuex.Store({
       });
       history.splice(history.length-1, 1);
       commit('updateInspectorData', payload);
+    },
+    pushLoadingIndicator({ commit, state }, indicatorString) {
+      const loaders = state.status.loadingIndicators;
+      loaders.push(indicatorString);
+      commit('setStatusValue', {
+        property: 'loadingIndicators',
+        value: loaders
+      });
+    },
+    removeLoadingIndicator({ commit, state }, indicatorString) {
+      const loaders = state.status.loadingIndicators;
+      for (let i = 0; i < loaders.length; i++) {
+        if (loaders[i] === indicatorString) {
+          loaders.splice(i, 1);
+          break;
+        }
+      }
+      commit('setStatusValue', {
+        property: 'loadingIndicators',
+        value: loaders
+      });
     },
     pushKeyAction({ commit }, keyAction) {
       commit('pushKeyAction', keyAction);


### PR DESCRIPTION
Main loading indicator (like for "Loading application" and "Loading document") is now moved out of the 
router view-element so that it always appears on top of everything. This solves a situation where the loading indicator would show "below the fold" and confusing the user.

When you need to use the loading indicator you can use
"pushLoadingIndicator" and "removeLoadingIndicator" in the store. It takes a string as argument (the string you want to be displayed. The indicator component will try to translate the string, so use english labels in the code.