### PR TITLE
Restrict entity-summary 

### DIFF
--- a/viewer/v2client/src/components/inspector/entity-header.vue
+++ b/viewer/v2client/src/components/inspector/entity-header.vue
@@ -79,7 +79,7 @@ export default {
 <template>
   <div class="EntityHeader HeaderComponent">
     <div class="EntityHeader-body HeaderComponent-body is-full">
-      <entity-summary :focus-data="focusData" :should-link="false"></entity-summary>
+      <entity-summary :focus-data="focusData" :should-link="false" :valueDisplayLimit=3></entity-summary>
     </div>
     <div class="EntityHeader-body HeaderComponent-body is-compact">
       <div class="compact-header" :class="{ 'show-compact': showCompact }">

--- a/viewer/v2client/src/components/inspector/entity-header.vue
+++ b/viewer/v2client/src/components/inspector/entity-header.vue
@@ -79,7 +79,7 @@ export default {
 <template>
   <div class="EntityHeader HeaderComponent">
     <div class="EntityHeader-body HeaderComponent-body is-full">
-      <entity-summary :focus-data="focusData" :should-link="false" :lines="full ? 6 : 3"></entity-summary>
+      <entity-summary :focus-data="focusData" :should-link="false"></entity-summary>
     </div>
     <div class="EntityHeader-body HeaderComponent-body is-compact">
       <div class="compact-header" :class="{ 'show-compact': showCompact }">

--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -438,7 +438,7 @@ export default {
   }
 
   &-label {
-    margin-right: 90px;
+    margin-right: 120px;
     
     &.is-inactive {
       pointer-events: none;

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -432,7 +432,7 @@ export default {
   }
 
   &-label {
-    margin-right: 90px;
+    margin-right: 120px;
     
     &.is-inactive {
       pointer-events: none;

--- a/viewer/v2client/src/components/inspector/search-window.vue
+++ b/viewer/v2client/src/components/inspector/search-window.vue
@@ -433,7 +433,6 @@ export default {
             <entity-summary 
               :action-settings="localEntitySettings" 
               :focus-data="itemInfo" 
-              :lines="4"
               :should-link="false"></entity-summary>
             <summary-action 
               v-show="!extracting" 

--- a/viewer/v2client/src/components/inspector/search-window.vue
+++ b/viewer/v2client/src/components/inspector/search-window.vue
@@ -433,7 +433,8 @@ export default {
             <entity-summary 
               :action-settings="localEntitySettings" 
               :focus-data="itemInfo" 
-              :should-link="false"></entity-summary>
+              :should-link="false"
+              :valueDisplayLimit=1></entity-summary>
             <summary-action 
               v-show="!extracting" 
               :options="localEntitySettings" 
@@ -517,7 +518,6 @@ export default {
       border: 1px solid @gray-lighter;
       max-height: inherit;
       max-height: fit-content;
-      resize: vertical;
       overflow: auto;
     }
   }

--- a/viewer/v2client/src/components/search/panel-search-item.vue
+++ b/viewer/v2client/src/components/search/panel-search-item.vue
@@ -81,7 +81,8 @@ export default {
         :focus-data="focusData" 
         :should-link="true" 
         :is-compact="isCompact"
-        :shouldOpenTab="true">
+        :shouldOpenTab="true"
+        :valueDisplayLimit=1>
       </entity-summary>
     </div>
   </li>

--- a/viewer/v2client/src/components/search/panel-search-item.vue
+++ b/viewer/v2client/src/components/search/panel-search-item.vue
@@ -80,7 +80,6 @@ export default {
       <entity-summary 
         :focus-data="focusData" 
         :should-link="true" 
-        :lines="4"
         :is-compact="isCompact"
         :shouldOpenTab="true">
       </entity-summary>

--- a/viewer/v2client/src/components/search/result-list-item.vue
+++ b/viewer/v2client/src/components/search/result-list-item.vue
@@ -54,7 +54,8 @@ export default {
       :is-import="isImport" 
       :import-item="importItem" 
       :add-link="true" 
-      @import-this="importThis()">
+      @import-this="importThis()"
+      :valueDisplayLimit=3>
     </entity-summary>
     <div class="ResultItem-relationsContainer"
       v-if="this.$route.params.perimeter !== 'remote'">

--- a/viewer/v2client/src/components/search/result-list-item.vue
+++ b/viewer/v2client/src/components/search/result-list-item.vue
@@ -54,8 +54,7 @@ export default {
       :is-import="isImport" 
       :import-item="importItem" 
       :add-link="true" 
-      @import-this="importThis()"
-      :lines="4">
+      @import-this="importThis()">
     </entity-summary>
     <div class="ResultItem-relationsContainer"
       v-if="this.$route.params.perimeter !== 'remote'">

--- a/viewer/v2client/src/components/shared/card-component.vue
+++ b/viewer/v2client/src/components/shared/card-component.vue
@@ -68,7 +68,6 @@ export default {
       :focus-data="focusData" 
       :is-extractable="isExtractable" 
       :add-link="hasUri" 
-      :lines="5" 
       :actions="!floating && !isLocked" 
       :is-local="isLocal"></entity-summary>
   </div>

--- a/viewer/v2client/src/components/shared/card-component.vue
+++ b/viewer/v2client/src/components/shared/card-component.vue
@@ -69,7 +69,8 @@ export default {
       :is-extractable="isExtractable" 
       :add-link="hasUri" 
       :actions="!floating && !isLocked" 
-      :is-local="isLocal"></entity-summary>
+      :is-local="isLocal"
+      :valueDisplayLimit=3></entity-summary>
   </div>
 </template>
 

--- a/viewer/v2client/src/components/shared/entity-summary.vue
+++ b/viewer/v2client/src/components/shared/entity-summary.vue
@@ -8,7 +8,6 @@ export default {
   name: 'entity-summary',
   props: {
     focusData: {},
-    lines: Number,
     actions: false,
     isLocal: false,
     isExtractable: false,
@@ -71,6 +70,7 @@ export default {
       const info = this.getSummary.info.concat(this.getSummary.sub);
       const infoObj = {};
       _.each(info, (node) => {
+        // console.log(node.value);
         infoObj[node.property] = node.value.join(', ');
       });
       return infoObj;
@@ -98,11 +98,6 @@ export default {
         this.settings, 
         this.resources.context
       );
-      if (identifiersList.length > this.lines) {
-        const diff = identifiersList.length - this.lines;
-        identifiersList.splice((this.lines - 1), diff+1);
-        identifiersList.push(`+ ${diff+1} identifierare`);
-      }
       return identifiersList;
     },
     info() {

--- a/viewer/v2client/src/components/shared/entity-summary.vue
+++ b/viewer/v2client/src/components/shared/entity-summary.vue
@@ -22,7 +22,11 @@ export default {
     isCompact: {
       default: false,
       type: Boolean
-    } 
+    },
+    valueDisplayLimit: {
+      default: 5,
+      type: Number
+    }, 
   },
   data() {
     return {
@@ -70,8 +74,9 @@ export default {
       const info = this.getSummary.info.concat(this.getSummary.sub);
       const infoObj = {};
       _.each(info, (node) => {
-        // console.log(node.value);
-        infoObj[node.property] = node.value.join(', ');
+        let remainder = node.value.length > this.valueDisplayLimit ? ` (+${node.value.length - this.valueDisplayLimit})` : '';
+        let trimmed = node.value.slice(0, this.valueDisplayLimit).join(', ') + remainder;
+        infoObj[node.property] = trimmed;
       });
       return infoObj;
     },
@@ -190,14 +195,14 @@ export default {
         v-show="v.length !== 0" 
         v-for="(v, k) in infoWithKeys" 
         :key="k">
-        <div v-if="isReplacedBy === ''">
+        <span v-if="isReplacedBy === ''">
           <span  class="EntitySummary-detailsKey uppercaseHeading--bold">{{ k | labelByLang }}:</span>
           <span class="EntitySummary-detailsValue">{{ v }}</span>
-        </div>
-        <div v-if="isReplacedBy !== ''">
+        </span>
+        <span v-if="isReplacedBy !== ''">
           <span  class="EntitySummary-detailsKey uppercaseHeading--bold">Ersatt av:</span>
           <span class="EntitySummary-detailsValue">{{ v }}</span>
-        </div>
+        </span>
       </li>
     </ul>
   </div>
@@ -287,7 +292,6 @@ export default {
   }
 
   &-details {
-    display: inline;
     list-style-type: none;
     margin: 0;
     padding: 0px;
@@ -300,7 +304,7 @@ export default {
   }
 
   &-detailsItem {
-    display: inline-block;
+    display: inline;
     margin-right: 10px;
   }
 

--- a/viewer/v2client/src/components/shared/entity-summary.vue
+++ b/viewer/v2client/src/components/shared/entity-summary.vue
@@ -295,6 +295,7 @@ export default {
     list-style-type: none;
     margin: 0;
     padding: 0px;
+    max-height: 175px;
   }
 
   &-id {

--- a/viewer/v2client/src/components/shared/entity-summary.vue
+++ b/viewer/v2client/src/components/shared/entity-summary.vue
@@ -74,7 +74,7 @@ export default {
       const info = this.getSummary.info.concat(this.getSummary.sub);
       const infoObj = {};
       _.each(info, (node) => {
-        let remainder = node.value.length > this.valueDisplayLimit ? ` (+${node.value.length - this.valueDisplayLimit})` : '';
+        let remainder = node.value.length > this.valueDisplayLimit ? ` <span class="badge">+${node.value.length - this.valueDisplayLimit}</span>` : '';
         let trimmed = node.value.slice(0, this.valueDisplayLimit).join(', ') + remainder;
         infoObj[node.property] = trimmed;
       });
@@ -189,7 +189,7 @@ export default {
         <span class="EntitySummary-detailsKey EntitySummary-id uppercaseHeading--bold">
         {{ identifiers[0] }}</span>
         <span class="EntitySummary-detailsValue EntitySummary-idInfo" 
-          v-if="identifiers.length > 1">(+{{ identifiers.length-1 }})</span>
+          v-if="identifiers.length > 1"><span class="badge">+{{ identifiers.length-1 }}</span></span>
       </li>
       <li class="EntitySummary-detailsItem" 
         v-show="v.length !== 0" 
@@ -197,7 +197,7 @@ export default {
         :key="k">
         <span v-if="isReplacedBy === ''">
           <span  class="EntitySummary-detailsKey uppercaseHeading--bold">{{ k | labelByLang }}:</span>
-          <span class="EntitySummary-detailsValue">{{ v }}</span>
+          <span class="EntitySummary-detailsValue" v-html="v"></span>
         </span>
         <span v-if="isReplacedBy !== ''">
           <span  class="EntitySummary-detailsKey uppercaseHeading--bold">Ersatt av:</span>
@@ -315,6 +315,10 @@ export default {
   &-detailsValue {
     font-size: 16px;
     font-size: 1.6rem;
+    .badge {
+      background-color: @gray-lighter;
+      color: @gray-darker;
+    }
   }
 
   &-icon {

--- a/viewer/v2client/src/components/shared/panel-component.vue
+++ b/viewer/v2client/src/components/shared/panel-component.vue
@@ -217,6 +217,7 @@ export default {
     display: flex;
     flex-wrap: nowrap;
     flex-direction: column;
+    flex-shrink: 0;
     background-color: @panel-header-bg;
     border-bottom: 1px solid @gray-lighter;
     padding: 20px 15px 0 15px;


### PR DESCRIPTION
Issue [LXL-1970](https://jira.kb.se/browse/LXL-1970), prevent entity-summary from having too much content, filling up the entire sidebar for example.

* Removed old unused `lines` prop, added `valueDisplayLimit` prop. This can be used to limit the number of values rendered on each property. For example `valueDisplayLimit=1` turns "Language: swedish, italian, norwegian" into "Language: swedish (+2)". This means different instances of entity-summary can show different amounts of data. Feel free to change the values I set for them.

* max-height on container and other css-fixes