### PR TITLE
Filter-select IE fix

### DIFF
--- a/viewer/v2client/src/components/shared/filter-select.vue
+++ b/viewer/v2client/src/components/shared/filter-select.vue
@@ -126,19 +126,10 @@ export default {
       event.preventDefault();
       if (event.target.classList.contains('js-filterSelect') || 
       event.target.classList.contains('js-createSelect')) {
-        const input = event.target.getElementsByClassName('js-filterSelectInput')[0];
-        this.simulateClick(input);
+        const input = this.$refs.filterselectInput;
+        input.click();
         input.focus();
       }
-    },
-    simulateClick(elem) {
-      let evt = new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-        view: window
-      });
-      
-      let canceled = !elem.dispatchEvent(evt);
     },
     clear() {
       let allObj = {};
@@ -194,6 +185,7 @@ export default {
       @keyup="filter()"
       @keyup.space="checkInput($event)"
       @click="filterVisible = !filterVisible"
+      ref="filterselectInput"
       :tabindex="-1">
     <ul class="FilterSelect-dropdown js-filterSelectDropdown"
       :class="{'is-visible': filterVisible}">


### PR DESCRIPTION
Trying another way of simulating click since `new MouseEvent` is not supported in IE.