### PR TITLE
Fix missing 'limit' param in remote search

### DIFF
--- a/viewer/v2client/src/components/search/result-controls.vue
+++ b/viewer/v2client/src/components/search/result-controls.vue
@@ -59,11 +59,12 @@ export default {
       return '';
     },
     limit() {
-      if (this.pageData.first) {
-        return StringUtil.getParamValueFromUrl(this.pageData.first['@id'], '_limit');
+      const limitFromUrl = StringUtil.getParamValueFromUrl(this.pageData.first['@id'], '_limit');
+      if (limitFromUrl !== null) {
+        return limitFromUrl;
+      } else {
+        return 20;
       }
-      console.warn('Search details is missing limit parameter');
-      return '';
     },
     pageList() {
       const list = [];


### PR DESCRIPTION
Fix missing 'limit' param in remote search (caused "too many hits" message every time)

[LXL-2007](https://jira.kb.se/browse/LXL-2007)