### PR TITLE
Feature/expand new entities part 2

### DIFF
--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -422,7 +422,14 @@ export default {
     addSibling(obj) {
       const linkObj = { '@id': `${this.inspector.data.record['@id']}#work` };
       const workObj = obj;
+      const workType = workObj['@type'];
       workObj['@id'] = linkObj['@id'];
+
+      this.$store.dispatch('setInspectorStatusValue', { 
+        property: 'lastAdded', 
+        value: 'work'
+      });
+
       this.$store.dispatch('updateInspectorData', {
         changeList: [
           {

--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -97,11 +97,16 @@ export default {
       return this.item;
     },
     isEmpty() {
+      this.$el.getElementsByClassName('js-expandable')[0].classList.add('is-inactive');
+      this.$el.classList.remove('is-expanded');
+
       let bEmpty = true;
       // Check if item has any keys besides @type and _uid. If not, we'll consider it empty.
       _.each(this.item, (value, key) => {
         if (key !== '@type' && key !== '_uid') {
           if (typeof value !== 'undefined') {
+            this.$el.getElementsByClassName('js-expandable')[0].classList.remove('is-inactive');
+            this.$el.classList.add('is-expanded');
             bEmpty = false;
           }
         }
@@ -243,7 +248,12 @@ export default {
     cloneThis() {      
       let parentData = _.cloneDeep(_.get(this.inspector.data, this.parentPath));
       parentData.push(this.item);
-      
+
+      this.$store.dispatch('setInspectorStatusValue', { 
+        property: 'lastAdded', 
+        value: `${this.parentPath}[${parentData.length-1}]`
+      });
+
       setTimeout(() => {
         this.$store.dispatch('updateInspectorData', {
           changeList: [
@@ -258,15 +268,6 @@ export default {
     },
   },
   watch: {
-    isEmpty(val) {
-      if (val) {
-        this.$el.getElementsByClassName('js-expandable')[0].classList.add('is-inactive');
-        this.$el.classList.remove('is-expanded');
-      } else {
-        this.$el.getElementsByClassName('js-expandable')[0].classList.remove('is-inactive');
-        this.$el.classList.add('is-expanded');
-      }
-    },
     'inspector.event'(val, oldVal) {
       this.$emit(`${val.value}`);
     }
@@ -277,11 +278,11 @@ export default {
   },
   mounted() {
     if (this.isLastAdded) {
-      this.toggleExpanded();
       const fieldAdder = this.$refs.fieldAdder;
       setTimeout(() => {
         if (this.isEmpty) {
           this.$el.getElementsByClassName('js-expandable')[0].classList.add('is-inactive');
+          this.collapse();
           LayoutUtil.enableTabbing();
           fieldAdder.$refs.adderButton.focus();
         } else {

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -281,15 +281,12 @@ export default {
   },
   mounted() {
     if (this.isLastAdded) {
-      //const fieldAdder = this.$refs.fieldAdder;
-      setTimeout(() => {
-        console.log(this.$el);
+      const fieldAdder = this.$refs.fieldAdder;
+      setTimeout(()=> {
         if (this.isEmpty) {
           this.$el.getElementsByClassName('js-expandable')[0].classList.add('is-inactive');
-          
-          this.collapse();
           LayoutUtil.enableTabbing();
-          //fieldAdder.$refs.adderButton.focus();
+          fieldAdder.$refs.adderButton.focus();
         } else {
           this.expand();
         }
@@ -346,7 +343,7 @@ export default {
             tooltip-text="Link entity" 
             translation="translatePhrase"></tooltip-component>
         </i>
-        <field-adder class="ItemSibling-action"
+        <field-adder ref="fieldAdder" class="ItemSibling-action"
           v-if="!isLocked" 
           :entity-type="item['@type']" 
           :allowed="allowedProperties" 

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -99,17 +99,30 @@ export default {
       }
       return false;
     },
+    isLastAdded() {
+      if (this.inspector.status.lastAdded === this.getPath) {
+        return true;
+      }
+      return false;
+    },
     getPath() {
       return this.suffix;
     },
-     isEmpty() {
+    isEmpty() {
+      this.$el.getElementsByClassName('js-expandable')[0].classList.add('is-inactive');
+      this.$el.classList.remove('is-expanded');
       let bEmpty = true;
       // Check if item has any keys besides @type and _uid. If not, we'll consider it empty.
       _.each(this.item, (value, key) => {
         if (key !== '@type' && key !== '_uid') {
-          if (typeof value !== 'undefined') {
-            bEmpty = false;
+          if (key !== '@id') {
+            if (typeof value !== 'undefined') {
+              this.$el.getElementsByClassName('js-expandable')[0].classList.remove('is-inactive');
+              this.$el.classList.add('is-expanded');
+              bEmpty = false;
+            }
           }
+        
         }
       });
       return bEmpty;
@@ -258,15 +271,6 @@ export default {
     },
   },
   watch: {
-    isEmpty(val) {
-      if (val) {
-        this.$el.getElementsByClassName('js-expandable')[0].classList.add('is-inactive');
-        this.$el.classList.remove('is-expanded');
-      } else {
-        this.$el.getElementsByClassName('js-expandable')[0].classList.remove('is-inactive');
-        this.$el.classList.add('is-expanded');
-      }
-    },
     'inspector.event'(val, oldVal) {
       this.$emit(`${val.value}`);
     }
@@ -277,10 +281,15 @@ export default {
   },
   mounted() {
     if (this.isLastAdded) {
-      this.toggleExpanded();
-      setTimeout(()=> {
+      //const fieldAdder = this.$refs.fieldAdder;
+      setTimeout(() => {
+        console.log(this.$el);
         if (this.isEmpty) {
           this.$el.getElementsByClassName('js-expandable')[0].classList.add('is-inactive');
+          
+          this.collapse();
+          LayoutUtil.enableTabbing();
+          //fieldAdder.$refs.adderButton.focus();
         } else {
           this.expand();
         }


### PR DESCRIPTION
- Removed fieldAdder focus method for item-sibling because $refs is empty on this item object
- Added isLastAdded-check for item-sibling
- Create similar expand functionality to item-sibling as item-local has
- Check for isEmpty within computed prop instead of adding watcher