### PR TITLE
Inactive arrow refactor

### DIFF
--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -97,16 +97,12 @@ export default {
       return this.item;
     },
     isEmpty() {
-      this.$el.getElementsByClassName('js-expandable')[0].classList.add('is-inactive');
-      this.$el.classList.remove('is-expanded');
 
       let bEmpty = true;
       // Check if item has any keys besides @type and _uid. If not, we'll consider it empty.
       _.each(this.item, (value, key) => {
         if (key !== '@type' && key !== '_uid') {
           if (typeof value !== 'undefined') {
-            this.$el.getElementsByClassName('js-expandable')[0].classList.remove('is-inactive');
-            this.$el.classList.add('is-expanded');
             bEmpty = false;
           }
         }
@@ -300,8 +296,6 @@ export default {
       this.highLightLastAdded();
       const fieldAdder = this.$refs.fieldAdder;
         if (this.isEmpty) {
-          this.$el.getElementsByClassName('js-expandable')[0].classList.add('is-inactive');
-          this.collapse();
           LayoutUtil.enableTabbing();
           fieldAdder.$refs.adderButton.focus();
         } else {
@@ -326,16 +320,17 @@ export default {
 
 <template>
   <div class="ItemLocal js-itemLocal"
-    :class="{'is-highlighted': isLastAdded, 'is-expanded': expanded, 'is-extractable': isExtractable}"
-    tabindex="0" 
+    :class="{'is-highlighted': isLastAdded, 'is-expanded': expanded && !isEmpty, 'is-extractable': isExtractable}"
+    :tabindex="isEmpty ? -1 : 0"
     @keyup.enter="checkFocus()"
     @focus="addFocus()"
     @blur="removeFocus()">
 
     <strong class="ItemLocal-heading">
-      <div class="ItemLocal-label js-expandable">
-        <i class="ItemLocal-arrow fa fa-chevron-right " 
-          :class="{'down': expanded}" 
+      <div class="ItemLocal-label"
+        :class="{'is-inactive': isEmpty}">
+        <i class="ItemLocal-arrow fa fa-chevron-right" 
+          :class="{'icon is-disabled' : isEmpty}"
           @click="toggleExpanded()"></i>
         <span class="ItemLocal-type" 
           @click="toggleExpanded($event)" 
@@ -478,12 +473,6 @@ export default {
     transition: all 0.2s ease;
     padding: 0 2px;
     cursor: pointer;
-
-    .is-inactive & {
-      color: @gray-light;
-      pointer-events: none;
-      cursor: not-allowed;
-    }
   }
 
   &-list {

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -109,16 +109,12 @@ export default {
       return this.suffix;
     },
     isEmpty() {
-      this.$el.getElementsByClassName('js-expandable')[0].classList.add('is-inactive');
-      this.$el.classList.remove('is-expanded');
       let bEmpty = true;
       // Check if item has any keys besides @type and _uid. If not, we'll consider it empty.
       _.each(this.item, (value, key) => {
         if (key !== '@type' && key !== '_uid') {
           if (key !== '@id') {
             if (typeof value !== 'undefined') {
-              this.$el.getElementsByClassName('js-expandable')[0].classList.remove('is-inactive');
-              this.$el.classList.add('is-expanded');
               bEmpty = false;
             }
           }
@@ -303,7 +299,6 @@ export default {
       this.highLightLastAdded();
       const fieldAdder = this.$refs.fieldAdder;
       if (this.isEmpty) {
-        this.$el.getElementsByClassName('js-expandable')[0].classList.add('is-inactive');
         LayoutUtil.enableTabbing();
         fieldAdder.$refs.adderButton.focus();
       } else {
@@ -328,16 +323,17 @@ export default {
 
 <template>
   <div class="ItemSibling js-itemLocal"
-    tabindex="0"
-    :class="{'is-highlighted': isNewlyAdded, 'is-expanded': expanded, 'is-extractable': isExtractable}"
+    :class="{'is-highlighted': isNewlyAdded, 'is-expanded': expanded && !isEmpty, 'is-extractable': isExtractable}"
+    :tabindex="isEmpty ? -1 : 0"
     @keyup.enter="checkFocus()" 
     @focus="addFocus()"
     @blur="removeFocus()">
-   
-   <strong class="ItemSibling-heading">
-      <div class="ItemSibling-label js-expandable">
-        <i class="ItemSibling-arrow fa fa-chevron-right " 
-          :class="{'down': expanded}"
+
+    <strong class="ItemSibling-heading">
+      <div class="ItemSibling-label"
+        :class="{'is-inactive': isEmpty}">
+        <i class="ItemSibling-arrow fa fa-chevron-right" 
+          :class="{'icon is-disabled' : isEmpty}"
           @click="toggleExpanded()"></i>
         <span class="ItemSibling-type" 
           @click="toggleExpanded($event)" 
@@ -411,7 +407,7 @@ export default {
         :key="k" 
         :show-action-buttons="showActionButtons"></field>
     </ul>
-       
+
     <search-window 
       :isActive="extractDialogActive" 
       :can-copy-title="canCopyTitle" 
@@ -463,12 +459,6 @@ export default {
     padding: 0 2px;
     margin: 0 0 0 1px;
     cursor: pointer;
-
-    .is-inactive & {
-      color: @gray-light;
-      pointer-events: none;
-      cursor: not-allowed;
-    }
   }
 
   &-list {

--- a/viewer/v2client/src/less/_variables.less
+++ b/viewer/v2client/src/less/_variables.less
@@ -134,7 +134,7 @@
 @icon-primary--hover: @link-hover-color;
 
 @icon-added: @gray-light;
-@icon-disabled: @gray-lighter;
+@icon-disabled: @gray-lighter-transparent;
 
 @icon-sm: 16px;
 @icon-md: 20px;


### PR DESCRIPTION
[LXL-1573](https://jira.kb.se/browse/LXL-1573)
* Refactored this functionality, v-binding classes directly to `isEmpty` prop making it more reactive
* This fixes previously non-working case described in issue above