### PR TITLE
Highlight local entity fix

### DIFF
--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -405,9 +405,13 @@ export default {
           currentValue.push(obj);
         }
       }
+      let index = '';
+      if (currentValue.length) {
+        index = `[${currentValue.length -1}]`;
+      }
       this.$store.dispatch('setInspectorStatusValue', { 
         property: 'lastAdded', 
-        value: `${this.path}[${currentValue.length -1}]`
+        value: `${this.path}${index}`
       });
       this.$store.dispatch('updateInspectorData', {
         changeList: [

--- a/viewer/v2client/src/components/shared/tooltip-component.vue
+++ b/viewer/v2client/src/components/shared/tooltip-component.vue
@@ -178,6 +178,7 @@ export default {
     transition-delay: 0.2s;
     visibility: visible;
     display:block;
+    z-index: 4;
   }
 }
 

--- a/viewer/v2client/src/less/_variables.less
+++ b/viewer/v2client/src/less/_variables.less
@@ -97,7 +97,8 @@
 @panel-border-radius: 3px;
 @topbar-color: @white;
 
-@sec: rgba(135, 170, 187, 0.3);
+// @sec: rgba(135, 170, 187, 0.3);
+@sec: #e0e9ee;
 @sec-contrast: #74aac3;
 
 @sec-alter: #629fbc;


### PR DESCRIPTION
A fix so that new item highlighting works in case described in [LXL-1964](https://jira.kb.se/browse/LXL-1964). As a bonus, adder (+) focus also works.

Was caused by an index value always being appended to the path, even if it was a single (empty) object, resulting in a path like `somePath[isNaN]`. Fix does a check to prevent this.