### PR TITLE
Download compiled Marc in Edge

### DIFF
--- a/viewer/v2client/src/components/inspector/toolbar.vue
+++ b/viewer/v2client/src/components/inspector/toolbar.vue
@@ -213,10 +213,11 @@ export default {
         focusId = this.inspector.data.mainEntity.itemOf['@id'].split('#')[0];
       }
       const element = document.createElement('a');
-      element.setAttribute('href', 'data:application/octet-stream,' + encodeURIComponent(text));
+      let blob = new Blob([`${text}`], { type: 'text/plain'});
+      element.href = window.URL.createObjectURL(blob);
       const splitIdParts = focusId.split('/');
       const id = splitIdParts[splitIdParts.length-1];
-      element.setAttribute('download', id);
+      element.download = id;
       element.style.display = 'none';
       document.body.appendChild(element);
       element.click();


### PR DESCRIPTION
[LXL-1894](https://jira.kb.se/browse/LXL-1894).

This probably has to do with Edge limiting the length of href URL:s, a long standing issue with data URI:s, see [here](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4282810/)

Implemented Microsoft's recommendation to create a [URL from a blob](https://textslashplain.com/2018/08/06/script-generated-download-files/) instead, although I can't compare the output in local env - just empty files. Thoughts are welcome 🙂