### PR TITLE
Move type select with portal

### DIFF
--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -563,133 +563,133 @@ export default {
       </i>
       <span class="EntityAdder-addLabel label-text">{{ addLabel | labelByLang | capitalize }}</span>
     </div>
-
-    <div class="EntityAdder-typeChooser" 
-      v-if="addEmbedded" 
-      v-on-clickaway="dismissTypeChooser">
-      <select class="EntityAdder-typeSelect customSelect" 
-        v-model="selectedType" 
-        ref="adderTypeSelect"
-        @change="addType(selectedType, true)">
-        <option disabled value="">{{"Choose type" | translatePhrase}}</option>
-        <option v-for="(term, index) in getClassTree"  
-          v-html="getFormattedSelectOption(term, settings, resources.vocab, resources.context)"
-          :disabled="term.abstract" 
-          :key="`${term.id}-${index}`" 
-          :value="term.id"></option>
-      </select>
-    </div>
+    <portal :to="`typeSelect-${path}`">
+      <div class="EntityAdder-typeChooser" 
+        v-if="addEmbedded">
+        <select class="EntityAdder-typeSelect customSelect" 
+          v-model="selectedType" 
+          ref="adderTypeSelect"
+          @change="addType(selectedType, true)">
+          <option disabled value="">{{"Choose type" | translatePhrase}}</option>
+          <option v-for="(term, index) in getClassTree"  
+            v-html="getFormattedSelectOption(term, settings, resources.vocab, resources.context)"
+            :disabled="term.abstract" 
+            :key="`${term.id}-${index}`" 
+            :value="term.id"></option>
+        </select>
+      </div>
+    </portal>
     <portal to="sidebar" v-if="active">
-    <panel-component class="EntityAdder-panel EntityAdderPanel" 
-      v-if="active"
-      :title="computedTitle"
-      @close="hide">
-      <template slot="panel-header-info">
-        <div 
-          class="PanelComponent-headerInfo" 
-          v-if="getFullRange.length > 0" 
-          @mouseleave="rangeInfo = false">
-          <i class="fa fa-info-circle icon icon--md" @mouseenter="rangeInfo = true"></i>
-          <div class="PanelComponent-headerInfoBox" v-show="rangeInfo">
-            <p class="header">
-              {{ "Allowed types" | translatePhrase }}:
-            </p>
-            <span v-for="(range, index) in getFullRange" :key="index">
-              • {{range | labelByLang}}
-            </span>
-          </div>
-        </div>
-      </template>
-      <template slot="panel-header-extra">
-        <!-- <div class="EntityAdder-panelBody"> -->
-        <div class="EntityAdder-controls">
-          <div class="EntityAdder-controlForm">
-            <div class="EntityAdder-search">
-              <label for="entityKeywordInput" class="EntityAdder-searchLabel">{{ "Search" | translatePhrase }}</label>
-              <div class="EntityAdder-searchInputContainer panel">
-                <input class="EntityAdder-searchInput entity-search-keyword-input customInput form-control"
-                  name="entityKeywordInput"
-                  v-model="keyword"
-                  ref="input"
-                  placeholder="Sök"
-                  autofocus />
-                  <filter-select class="EntityAdder-filterSearchInput FilterSelect--insideInput"
-                    :class-name="'js-filterSelect'"
-                    :custom-placeholder="'All types:'"
-                    :options="selectOptions"
-                    :options-all="getRange"
-                    :is-filter="true"
-                    :options-selected="''"
-                    v-on:filter-selected="setFilter($event, keyword)"></filter-select>
-              </div>
+      <panel-component class="EntityAdder-panel EntityAdderPanel" 
+        v-if="active"
+        :title="computedTitle"
+        @close="hide">
+        <template slot="panel-header-info">
+          <div 
+            class="PanelComponent-headerInfo" 
+            v-if="getFullRange.length > 0" 
+            @mouseleave="rangeInfo = false">
+            <i class="fa fa-info-circle icon icon--md" @mouseenter="rangeInfo = true"></i>
+            <div class="PanelComponent-headerInfoBox" v-show="rangeInfo">
+              <p class="header">
+                {{ "Allowed types" | translatePhrase }}:
+              </p>
+              <span v-for="(range, index) in getFullRange" :key="index">
+                • {{range | labelByLang}}
+              </span>
             </div>
           </div>
-          
-        </div>
-      </template>
-      <template slot="panel-body">
-        <panel-search-list class="EntityAdder-searchResult"
-          v-if="!loading && keyword.length > 0" 
-          :path="path" 
-          :results="searchResult" 
-          :disabled-ids="alreadyAdded"
-          :is-compact="isCompact"
-          icon="plus"
-          text="Add"
-          :has-action="true"
-          @use-item="addLinkedItem">
-        </panel-search-list>
-        <div class="PanelComponent-searchStatus" v-if="!loading && keyword.length === 0" >
-          {{ "Start writing to begin search" | translatePhrase }}...
-        </div>
-        <div v-if="loading" class="PanelComponent-searchStatus">
-          <vue-simple-spinner size="large" :message="'Searching' | translatePhrase"></vue-simple-spinner>
-        </div>
-        <div class="PanelComponent-searchStatus"
-          v-if="!loading && searchResult.length === 0 && keyword.length > 0 && searchMade">
-          {{ "No results" | translatePhrase }}
-        </div>
-      <!-- </div> -->
-      </template>
-      <template slot="panel-footer">
-        
-        <div class="EntityAdder-resultControls" v-if="!loading && searchResult.length > 0">
-          <modal-pagination
-            @go="go" 
-            :numberOfPages="numberOfPages" 
-            :currentPage="currentPage">
-          </modal-pagination>
-          <div class="EntityAdder-listTypes">
-            <i class="fa fa-th-list icon icon--sm"
-              @click="isCompact = false"
-              @keyup.enter="isCompact = false"
-              :class="{'icon--primary' : !isCompact}"
-              :title="'Detailed view' | translatePhrase"
-              tabindex="0"></i>
-            <i class="fa fa-list icon icon--sm"
-              @click="isCompact = true"
-              @keyup.enter="isCompact = true"
-              :class="{'icon--primary' : isCompact}"
-              :title="'Compact view' | translatePhrase"
-              tabindex="0"></i>
+        </template>
+        <template slot="panel-header-extra">
+          <!-- <div class="EntityAdder-panelBody"> -->
+          <div class="EntityAdder-controls">
+            <div class="EntityAdder-controlForm">
+              <div class="EntityAdder-search">
+                <label for="entityKeywordInput" class="EntityAdder-searchLabel">{{ "Search" | translatePhrase }}</label>
+                <div class="EntityAdder-searchInputContainer panel">
+                  <input class="EntityAdder-searchInput entity-search-keyword-input customInput form-control"
+                    name="entityKeywordInput"
+                    v-model="keyword"
+                    ref="input"
+                    placeholder="Sök"
+                    autofocus />
+                    <filter-select class="EntityAdder-filterSearchInput FilterSelect--insideInput"
+                      :class-name="'js-filterSelect'"
+                      :custom-placeholder="'All types:'"
+                      :options="selectOptions"
+                      :options-all="getRange"
+                      :is-filter="true"
+                      :options-selected="''"
+                      v-on:filter-selected="setFilter($event, keyword)"></filter-select>
+                </div>
+              </div>
+            </div>
+            
           </div>
-        </div>
-        <div class="EntityAdder-create">
-          <button class="EntityAdder-createBtn btn btn-primary btn--sm"
-            v-if="hasSingleRange" 
-            v-on:click="addEmpty(getFullRange[0])">{{ "Create local entity" | translatePhrase }}
-          </button>
-           <filter-select
-            v-if="!hasSingleRange" 
-            :class-name="'js-createSelect'"
-            :options="selectOptions"
-            :options-all="getRange"
-            :is-filter="false"
-            :custom-placeholder="'Create local entity:'"
-            v-on:filter-selected="addType($event.value)"></filter-select>
-        </div>
-      </template>
-    </panel-component>
+        </template>
+        <template slot="panel-body">
+          <panel-search-list class="EntityAdder-searchResult"
+            v-if="!loading && keyword.length > 0" 
+            :path="path" 
+            :results="searchResult" 
+            :disabled-ids="alreadyAdded"
+            :is-compact="isCompact"
+            icon="plus"
+            text="Add"
+            :has-action="true"
+            @use-item="addLinkedItem">
+          </panel-search-list>
+          <div class="PanelComponent-searchStatus" v-if="!loading && keyword.length === 0" >
+            {{ "Start writing to begin search" | translatePhrase }}...
+          </div>
+          <div v-if="loading" class="PanelComponent-searchStatus">
+            <vue-simple-spinner size="large" :message="'Searching' | translatePhrase"></vue-simple-spinner>
+          </div>
+          <div class="PanelComponent-searchStatus"
+            v-if="!loading && searchResult.length === 0 && keyword.length > 0 && searchMade">
+            {{ "No results" | translatePhrase }}
+          </div>
+        <!-- </div> -->
+        </template>
+        <template slot="panel-footer">
+          
+          <div class="EntityAdder-resultControls" v-if="!loading && searchResult.length > 0">
+            <modal-pagination
+              @go="go" 
+              :numberOfPages="numberOfPages" 
+              :currentPage="currentPage">
+            </modal-pagination>
+            <div class="EntityAdder-listTypes">
+              <i class="fa fa-th-list icon icon--sm"
+                @click="isCompact = false"
+                @keyup.enter="isCompact = false"
+                :class="{'icon--primary' : !isCompact}"
+                :title="'Detailed view' | translatePhrase"
+                tabindex="0"></i>
+              <i class="fa fa-list icon icon--sm"
+                @click="isCompact = true"
+                @keyup.enter="isCompact = true"
+                :class="{'icon--primary' : isCompact}"
+                :title="'Compact view' | translatePhrase"
+                tabindex="0"></i>
+            </div>
+          </div>
+          <div class="EntityAdder-create">
+            <button class="EntityAdder-createBtn btn btn-primary btn--sm"
+              v-if="hasSingleRange" 
+              v-on:click="addEmpty(getFullRange[0])">{{ "Create local entity" | translatePhrase }}
+            </button>
+            <filter-select
+              v-if="!hasSingleRange" 
+              :class-name="'js-createSelect'"
+              :options="selectOptions"
+              :options-all="getRange"
+              :is-filter="false"
+              :custom-placeholder="'Create local entity:'"
+              v-on:filter-selected="addType($event.value)"></filter-select>
+          </div>
+        </template>
+      </panel-component>
     </portal>
   </div>
 </template>
@@ -740,13 +740,10 @@ export default {
   }
 
   &-typeChooser {
-    text-align: center;
+    // text-align: center;
   }
 
   &-typeSelect {
-    position: absolute;
-    left: 20px;
-    z-index: 1;
     max-width: 150px;
   }
 

--- a/viewer/v2client/src/components/inspector/field.vue
+++ b/viewer/v2client/src/components/inspector/field.vue
@@ -155,10 +155,10 @@ export default {
       return `${this.parentPath}.${this.fieldKey}`;
     },
     isChild() {
-     if (this.parentPath !== 'mainEntity') {
-       return true;
-     }
-     return false;
+      if (this.parentPath !== 'mainEntity') {
+        return true;
+      }
+      return false;
     },
     propertyTypes() {
       return VocabUtil.getPropertyTypes(
@@ -342,13 +342,9 @@ export default {
         if (this.fieldValue === null || (_.isArray(this.fieldValue) && this.fieldValue.length === 0 )) {
           const entityAdder = this.$refs.entityAdder;
           this.$nextTick(() => {
-            if (entityAdder) {
+            if (entityAdder.$refs.adderFocusElement) {
               LayoutUtil.enableTabbing();
-              if (entityAdder.$refs.adderTypeSelect) {
-                entityAdder.$refs.adderTypeSelect.focus();
-              } else {
-                entityAdder.$refs.adderFocusElement.focus();
-              }
+              entityAdder.$refs.adderFocusElement.focus();
             }
           });
         }

--- a/viewer/v2client/src/components/inspector/field.vue
+++ b/viewer/v2client/src/components/inspector/field.vue
@@ -349,22 +349,11 @@ export default {
           });
         }
         let element = this.$el;
-        let topOfElement = LayoutUtil.getPosition(element).y;
-        if (topOfElement > 0) {
-          const windowHeight = window.innerHeight || 
-          document.documentElement.clientHeight || 
-          document.getElementsByTagName('body')[0].clientHeight;
-          const scrollPos = LayoutUtil.getPosition(this.$el).y - (windowHeight * 0.2);
-          LayoutUtil.scrollTo(scrollPos, 1000, 'easeInOutQuad', () => {
-            setTimeout(() => {
-              this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-            }, 1000)
-          });
-        } else {
+        LayoutUtil.scrollToElement(element, 1000, () => {
           setTimeout(() => {
             this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-          }, 1000)
-        }
+          }, 1000);
+        });
       }
     }
   },

--- a/viewer/v2client/src/components/inspector/field.vue
+++ b/viewer/v2client/src/components/inspector/field.vue
@@ -549,6 +549,7 @@ export default {
           :show-action-buttons="actionButtonsShown"
           :parent-path="getPath"></item-sibling>
       </div>
+      <portal-target :name="`typeSelect-${getPath}`" />
     </div>
 
     <div class="Field-content is-endOfTree js-endOfTree" 
@@ -592,6 +593,7 @@ export default {
           :show-action-buttons="actionButtonsShown"
           :is-expanded="isExpanded"></item-value>
       </div>
+      <portal-target :name="`typeSelect-${getPath}`" />
     </div>
   </li>
 </template>

--- a/viewer/v2client/src/components/inspector/item-entity.vue
+++ b/viewer/v2client/src/components/inspector/item-entity.vue
@@ -100,22 +100,11 @@ export default {
       if(this.inspector.status.lastAdded === this.fullPath) {
         setTimeout(() => {
           let element = this.$el;
-          let topOfElement = LayoutUtil.getPosition(element).y;
-          if (topOfElement > 0) {
-            const windowHeight = window.innerHeight || 
-            document.documentElement.clientHeight || 
-            document.getElementsByTagName('body')[0].clientHeight;
-            const scrollPos = LayoutUtil.getPosition(this.$el).y - (windowHeight * 0.2);
-            LayoutUtil.scrollTo(scrollPos, 900, 'easeInOutQuad', () => {
-              setTimeout(() => {
-                this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-              }, 1000)
-            });
-          } else {
+          LayoutUtil.scrollToElement(element, 1000, () => {
             setTimeout(() => {
-                this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-              }, 1000)
-          }
+              this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+            }, 1000);
+          });
         }, 200);
       }
     });

--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -123,22 +123,11 @@ export default {
   methods: {
     highLightLastAdded() {
       let element = this.$el;
-      let topOfElement = LayoutUtil.getPosition(element).y;
-      if (topOfElement > 0) {
-        const windowHeight = window.innerHeight || 
-        document.documentElement.clientHeight || 
-        document.getElementsByTagName('body')[0].clientHeight;
-        const scrollPos = LayoutUtil.getPosition(this.$el).y - (windowHeight * 0.2);
-        LayoutUtil.scrollTo(scrollPos, 1000, 'easeInOutQuad', () => {
-          setTimeout(() => {
-            this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-          }, 1000)
-        });
-      } else {
+      LayoutUtil.scrollToElement(element, 1000, () => {
         setTimeout(() => {
           this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-        }, 1000)
-      }
+        }, 1000);
+      });
     },
     actionHighlight(active, event) {
       if (active) {

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -134,22 +134,11 @@ export default {
   methods: {
     highLightLastAdded() {
       let element = this.$el;
-      let topOfElement = LayoutUtil.getPosition(element).y;
-      if (topOfElement > 0) {
-        const windowHeight = window.innerHeight || 
-        document.documentElement.clientHeight || 
-        document.getElementsByTagName('body')[0].clientHeight;
-        const scrollPos = LayoutUtil.getPosition(this.$el).y - (windowHeight * 0.2);
-        LayoutUtil.scrollTo(scrollPos, 1000, 'easeInOutQuad', () => {
-          setTimeout(() => {
-            this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-          }, 1000)
-        });
-      } else {
+      LayoutUtil.scrollToElement(element, 1000, () => {
         setTimeout(() => {
           this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-        }, 1000)
-      }
+        }, 1000);
+      });
     },
     removeThis() {
       const changeList = [

--- a/viewer/v2client/src/components/inspector/item-value.vue
+++ b/viewer/v2client/src/components/inspector/item-value.vue
@@ -122,22 +122,11 @@ export default {
     highLightLastAdded() {
       if (this.isLastAdded === true) {
         let element = this.$el;
-        let topOfElement = LayoutUtil.getPosition(element).y;
-        if (topOfElement > 0) {
-          const windowHeight = window.innerHeight || 
-          document.documentElement.clientHeight || 
-          document.getElementsByTagName('body')[0].clientHeight;
-          const scrollPos = LayoutUtil.getPosition(this.$el).y - (windowHeight * 0.2);
-          LayoutUtil.scrollTo(scrollPos, 1000, 'easeInOutQuad', () => {
-            setTimeout(() => {
-              this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-            }, 1000)
-          });
-        } else {
+        LayoutUtil.scrollToElement(element, 1000, () => {
           setTimeout(() => {
             this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-          }, 1000)
-        }
+          }, 1000);
+        });
       }
     },
     initializeTextarea() {

--- a/viewer/v2client/src/components/inspector/toolbar.vue
+++ b/viewer/v2client/src/components/inspector/toolbar.vue
@@ -370,18 +370,24 @@ export default {
         v-show="otherFormatMenuActive"
         @click="hideOtherFormatMenu" >
         <li class="Toolbar-menuItem">
-          <a class="Toolbar-menuLink" :href="focusData['@id']">Formell resurs</a>
+          <a class="Toolbar-menuLink" :href="focusData['@id']" target="_blank">
+            <i class="fa fa-fw fa-external-link" aria-hidden="true"></i>
+            Formell resurs</a>
         </li>
         <li class="Toolbar-menuItem">
-          <a class="Toolbar-menuLink" :href="getOtherDataFormat('jsonld')">JSON-LD</a>
+          <a class="Toolbar-menuLink" :href="getOtherDataFormat('jsonld')" target="_blank">
+            <i class="fa fa-fw fa-external-link" aria-hidden="true"></i>
+            JSON-LD</a>
         </li>
         <li class="Toolbar-menuItem">
-          <a class="Toolbar-menuLink" :href="getOtherDataFormat('ttl')">Turtle</a>
+          <a class="Toolbar-menuLink" :href="getOtherDataFormat('ttl')" target="_blank">
+            <i class="fa fa-fw fa-external-link" aria-hidden="true"></i>
+            Turtle</a>
         </li>
         <li class="Toolbar-menuItem">
           <a class="Toolbar-menuLink" :href="getOtherDataFormat('rdf')">
-          <i class="fa fa-fw fa-download" aria-hidden="true"></i>
-          RDF/XML</a>
+            <i class="fa fa-fw fa-download" aria-hidden="true"></i>
+            RDF/XML</a>
         </li>
       </ul>
     </div>
@@ -644,6 +650,7 @@ export default {
       }
       & a {
         display: flex;
+        align-items: center;
         padding: 5px 15px;
         color: @grey-darker;
       }

--- a/viewer/v2client/src/components/inspector/type-select.vue
+++ b/viewer/v2client/src/components/inspector/type-select.vue
@@ -29,14 +29,7 @@ export default {
     },
     scrollToEl(){
       let element = this.$el;
-      let topOfElement = LayoutUtil.getPosition(element).y;
-      if (topOfElement > 0) {
-        const windowHeight = window.innerHeight || 
-        document.documentElement.clientHeight || 
-        document.getElementsByTagName('body')[0].clientHeight;
-        const scrollPos = LayoutUtil.getPosition(this.$el).y - (windowHeight * 0.2);
-        LayoutUtil.scrollTo(scrollPos, 1000, 'easeInOutQuad', ()=>{});
-      }
+      LayoutUtil.scrollToElement(element, 1000, () => {});
     },
   },
   computed: {

--- a/viewer/v2client/src/components/inspector/type-select.vue
+++ b/viewer/v2client/src/components/inspector/type-select.vue
@@ -1,0 +1,105 @@
+<script>
+import * as LayoutUtil from '@/utils/layout';
+
+export default {
+  name: 'type-select',
+  props: {
+    classTree: {
+      type: Array
+    },
+    options: {
+      type: Array
+    },
+    removeable: {
+      type: Boolean,
+    }
+  },
+  data() {
+    return {
+      selectedType: '',
+      highlight: false,
+    }
+  },
+  methods: {
+    handleChange(){
+      this.$emit('selected', this.selectedType);
+    },
+    dismiss(){
+      this.$emit('dismiss')
+    },
+    scrollToEl(){
+      let element = this.$el;
+      let topOfElement = LayoutUtil.getPosition(element).y;
+      if (topOfElement > 0) {
+        const windowHeight = window.innerHeight || 
+        document.documentElement.clientHeight || 
+        document.getElementsByTagName('body')[0].clientHeight;
+        const scrollPos = LayoutUtil.getPosition(this.$el).y - (windowHeight * 0.2);
+        LayoutUtil.scrollTo(scrollPos, 1000, 'easeInOutQuad', ()=>{});
+      }
+    },
+  },
+  computed: {
+  },
+  components: {
+  },
+  watch: {
+  },
+  mounted() {
+    this.$nextTick(() => {
+      this.scrollToEl();
+      LayoutUtil.enableTabbing();
+      this.$refs.adderTypeSelect.focus();
+    });
+  },
+};
+</script>
+
+<template>
+  <div class="TypeSelect"
+    :class="{'is-removeable': highlight}">
+    <select class="customSelect" 
+      v-model="selectedType"
+      ref="adderTypeSelect"
+      @change="handleChange()">
+      <option disabled value="">{{"Choose type" | translatePhrase}}</option>
+      <option v-for="(term, index) in classTree"  
+        v-html="options[index].label"
+        :disabled="term.abstract" 
+        :key="`${term.id}-${index}`" 
+        :value="term.id"></option>
+    </select>
+    <div class="TypeSelect-dismissBtn" v-if="removeable">
+      <i class="fa fa-times-circle icon icon--sm" 
+        role="button"
+        tabindex="0"
+        @click="dismiss()"
+        @keyup.enter="dismiss()"
+        @mouseover="highlight = true"
+        @mouseout="highlight = false"
+        @focus="highlight = true"
+        @blur="highlight = false">
+      </i>
+      </div>
+  </div>
+</template>
+
+<style lang="less">
+.TypeSelect {
+  max-width: 200px;
+  padding: 5px;
+  display: flex;
+  border-radius: 4px;
+  transition: background-color .3s ease;
+
+  &-dismissBtn {
+    margin-left: 10px;
+    align-items: center;
+    display: flex;
+  }
+
+  &.is-removeable {
+    background-color: @remove;
+  }
+}
+</style>

--- a/viewer/v2client/src/main.js
+++ b/viewer/v2client/src/main.js
@@ -107,7 +107,6 @@ new Vue({
         
             this.combokeys.bindGlobal(key.toString(), (e) => {
               this.$store.dispatch('pushKeyAction', value);
-              console.log(value);
               return false;
             });
           }

--- a/viewer/v2client/src/utils/layout.js
+++ b/viewer/v2client/src/utils/layout.js
@@ -108,12 +108,17 @@ export function scrollTo(position, duration = 200, easing = 'linear', callback) 
   const windowHeight = window.innerHeight || document.documentElement.clientHeight || document.getElementsByTagName('body')[0].clientHeight;
   const destination = documentHeight - properPosition < windowHeight ? documentHeight - windowHeight : properPosition;
 
+  function reachedBottom() {
+    if (body.scrollHeight - body.scrollTop - body.clientHeight === 0) return true;
+    return false;
+  }
+
   function scroll() {
     const now = Date.now();
     const time = Math.min(1, ((now - startTime) / duration));
     const timeFunction = easings[easing](time);
     body.scrollTop = (timeFunction * (destination - start)) + start;
-    if (Math.floor(body.scrollTop) > destination - 10 && Math.floor(body.scrollTop) < destination + 10) {
+    if (Math.floor(body.scrollTop) > destination - 10 && Math.floor(body.scrollTop) < destination + 10 || reachedBottom() ) {
       callback();
       return;
     }

--- a/viewer/v2client/src/utils/layout.js
+++ b/viewer/v2client/src/utils/layout.js
@@ -33,6 +33,19 @@ function handleMouseDownOnce() {
   window.addEventListener('keydown', handleFirstTab);
 }
 
+export function scrollToElement($el, duration, callback) {
+  let topOfElement = getPosition($el).y;
+  if (topOfElement > 0) {
+    const windowHeight = window.innerHeight || 
+    document.documentElement.clientHeight || 
+    document.getElementsByTagName('body')[0].clientHeight;
+    const scrollPos = getPosition($el).y - (windowHeight * 0.2);
+    scrollTo(scrollPos, duration, 'easeInOutQuad', callback);
+  } else {
+    callback();
+  }
+}
+
 export function scrollTo(position, duration = 200, easing = 'linear', callback) {
   let properPosition = Math.floor(position);
   if (properPosition < 0) {


### PR DESCRIPTION
[LXL-1987](https://jira.kb.se/browse/LXL-1987): Move the select menu that lets you choose what type of property to add. Today it's absolute positioned on top of entity adder. We want to make it a placeholder where the new item will be placed.

Doing this with dynamically named portals do send the right select menu to the right place. This, in turn requires some extra functionality:

* We want to autofocus it, i.e need to know when it's mounted -> refactored it into own component `<type-select>`
* Possible long distance from (+) button to menu -> implemented autoscroll 
* New solution works badly with clickaway -> added 'remove' button instead. Remove is not available when the field is empty. 