### PR TITLE
Throttle scroll events

### DIFF
--- a/viewer/v2client/src/components/inspector/entity-header.vue
+++ b/viewer/v2client/src/components/inspector/entity-header.vue
@@ -63,11 +63,11 @@ export default {
     },
   },
   beforeDestroy() {
-    window.removeEventListener('scroll', this.handleScroll);
+    window.removeEventListener('scroll', _.throttle(this.handleScroll, 300));
   },
   mounted() {
     this.$nextTick(() => {
-      window.addEventListener('scroll', this.handleScroll);
+    window.addEventListener('scroll', _.throttle(this.handleScroll, 300));
     });
   },
   components: {


### PR DESCRIPTION
I think we should throttle scroll events. Scrolling a medium expanded post fires 100-300 function calls. With throttling (interval of 300ms) this is reduced to 10-30.

Entity header is somewhat less responsive, but should benefit overall performance :)