### PR TITLE
Fix "from file" so that it removes and modifies fields that should not be copied

### DIFF
--- a/viewer/v2client/src/components/Create.vue
+++ b/viewer/v2client/src/components/Create.vue
@@ -148,7 +148,8 @@ export default {
     },
     'droppedFile': function(val) {
       if (val.hasOwnProperty('@graph')) {
-        this.thingData = val;
+        const inspectorObject = RecordUtil.splitJson(val);
+        this.thingData = RecordUtil.prepareDuplicateFor(inspectorObject, this.user, this.settings);
       } else {
         this.invalidFile = true;
       }


### PR DESCRIPTION
* Pipe "files" through `prepareDuplicateFor` function so that IDs and similar are cleaned

In other words it will now take the same path into the application as all other templates.

You can test this by downloading an existing JSON-LD file and creating a new post from it with "from file". Before this, it would include the IDs and the old descriptionCreator, now it cleans this and sets TEMPID as it should.

Run `getJsonOutput()` in console to see the raw data in the app.

If you check this result against the same operation on DEV, you should get different results.