### PR TITLE
Fix bug regarding multiple siblings

### DIFF
--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -456,7 +456,7 @@ export default {
         };
       }
 
-      if (this.fieldKey === 'instanceOf') {
+      if (this.path === 'mainEntity.instanceOf') {
         this.addSibling(obj);
       } else {
         this.addItem(obj);

--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -249,7 +249,6 @@ export default {
   },
   mounted() {
     this.addEmbedded = (this.valueList.length === 0 && this.onlyEmbedded && this.getFullRange.length > 1);
-
   },
   methods: {
     actionHighlight(active, event) {


### PR DESCRIPTION
Fixes [LXL-1980](https://jira.kb.se/browse/LXL-1980)

The code was acting under the impression that there would never be more than one "instanceOf" per document. When adding a new value to more than of these, they would be mirrored to each other.

This caused updates in one of the values to be mirrored (or cloned) to the other one.