### PR TITLE
Minor design restoration

### DIFF
--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -381,20 +381,22 @@ export default {
       </div>
       
       <div class="ItemLocal-actions">
-        <i class="ItemLocal-action fa fa-link icon icon--sm"
-          v-if="inspector.status.editing && isExtractable"
-          @click="openExtractDialog(), expand()" 
-          @focus="showLinkAction = true, actionHighlight(true, $event)"
-          @blur="showLinkAction = false, actionHighlight(false, $event)"
-          @mouseover="showLinkAction = true, actionHighlight(true, $event)" 
-          @mouseout="showLinkAction = false, actionHighlight(false, $event)"
-          @keyup.enter="openExtractDialog()"
-          tabindex="0">
-          <tooltip-component 
-            :show-tooltip="showLinkAction" 
-            tooltip-text="Link entity" 
-            translation="translatePhrase"></tooltip-component>
-        </i>
+        <div class="ItemLocal-action">
+          <i class="fa fa-link icon icon--sm"
+            v-if="inspector.status.editing && isExtractable"
+            @click="openExtractDialog(), expand()" 
+            @focus="showLinkAction = true, actionHighlight(true, $event)"
+            @blur="showLinkAction = false, actionHighlight(false, $event)"
+            @mouseover="showLinkAction = true, actionHighlight(true, $event)" 
+            @mouseout="showLinkAction = false, actionHighlight(false, $event)"
+            @keyup.enter="openExtractDialog(), expand()"
+            tabindex="0">
+            <tooltip-component 
+              :show-tooltip="showLinkAction" 
+              tooltip-text="Link entity" 
+              translation="translatePhrase"></tooltip-component>
+          </i>
+        </div>
 
         <div class="ItemLocal-action" 
           v-if="!isLocked && inArray">
@@ -421,21 +423,23 @@ export default {
           :path="getPath">
         </field-adder>
 
-        <i class="ItemLocal-action fa fa-trash-o icon icon--sm" 
-          v-if="!isLocked" 
-          :class="{'show-icon': showActionButtons}" 
-          v-on:click="removeThis(true)" 
-          @keyup.enter="removeThis(true)"
-          tabindex="0"
-          @focus="removeHover = true, removeHighlight(true, $event)"
-          @blur="removeHover = false, removeHighlight(false, $event)"
-          @mouseover="removeHover = true, removeHighlight(true, $event)"
-          @mouseout="removeHover = false, removeHighlight(false, $event)">
-          <tooltip-component 
-            :show-tooltip="removeHover" 
-            tooltip-text="Remove" 
-            translation="translatePhrase"></tooltip-component>
-        </i>
+        <div class="ItemLocal-action">
+          <i class="fa fa-trash-o icon icon--sm" 
+            v-if="!isLocked" 
+            :class="{'show-icon': showActionButtons}" 
+            v-on:click="removeThis(true)" 
+            @keyup.enter="removeThis(true)"
+            tabindex="0"
+            @focus="removeHover = true, removeHighlight(true, $event)"
+            @blur="removeHover = false, removeHighlight(false, $event)"
+            @mouseover="removeHover = true, removeHighlight(true, $event)"
+            @mouseout="removeHover = false, removeHighlight(false, $event)">
+            <tooltip-component 
+              :show-tooltip="removeHover" 
+              tooltip-text="Remove" 
+              translation="translatePhrase"></tooltip-component>
+          </i>
+        </div>
       </div>
     </strong>
   

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -344,20 +344,23 @@ export default {
       </div>
       
       <div class="ItemSibling-actions">
-        <i class="ItemSibling-action fa fa-link icon icon--sm"
-          v-if="inspector.status.editing && isExtractable"
-          @click="openExtractDialog(), expand()" 
-          tabindex="0"
-          @keyup.enter="openExtractDialog()"
-          @focus="showLinkAction = true, actionHighlight(true)" 
-          @blur="showLinkAction = false, actionHighlight(false)"
-          @mouseover="showLinkAction = true, actionHighlight(true)" 
-          @mouseout="showLinkAction = false, actionHighlight(false)">
-          <tooltip-component 
-            :show-tooltip="showLinkAction" 
-            tooltip-text="Link entity" 
-            translation="translatePhrase"></tooltip-component>
-        </i>
+        <div class="ItemSibling-action">
+          <i class="fa fa-link icon icon--sm"
+            v-if="inspector.status.editing && isExtractable"
+            @click="openExtractDialog(), expand()" 
+            tabindex="0"
+            @keyup.enter="openExtractDialog(), expand()"
+            @focus="showLinkAction = true, actionHighlight(true)" 
+            @blur="showLinkAction = false, actionHighlight(false)"
+            @mouseover="showLinkAction = true, actionHighlight(true)" 
+            @mouseout="showLinkAction = false, actionHighlight(false)">
+            <tooltip-component 
+              :show-tooltip="showLinkAction" 
+              tooltip-text="Link entity" 
+              translation="translatePhrase"></tooltip-component>
+          </i>
+        </div>
+
         <field-adder ref="fieldAdder" class="ItemSibling-action"
           v-if="!isLocked" 
           :entity-type="item['@type']" 
@@ -365,21 +368,23 @@ export default {
           :inner="true" 
           :path="getPath">
         </field-adder>
-        <i class="ItemSibling-action fa fa-trash-o icon icon--sm" 
-          v-if="!isLocked" 
-          :class="{'show-icon': showActionButtons}" 
-          v-on:click="removeThis(true)"
-          @keyup.enter="removeThis(true)"
-          tabindex="0"
-          @focus="removeHover = true, removeHighlight(true)" 
-          @blur="removeHover = false, removeHighlight(false)"
-          @mouseover="removeHover = true, removeHighlight(true)" 
-          @mouseout="removeHover = false, removeHighlight(false)">
-          <tooltip-component 
-            :show-tooltip="removeHover" 
-            tooltip-text="Remove" 
-            translation="translatePhrase"></tooltip-component>
-        </i>
+        <div class="ItemSibling-action">
+          <i class="fa fa-trash-o icon icon--sm" 
+            v-if="!isLocked" 
+            :class="{'show-icon': showActionButtons}" 
+            v-on:click="removeThis(true)"
+            @keyup.enter="removeThis(true)"
+            tabindex="0"
+            @focus="removeHover = true, removeHighlight(true)" 
+            @blur="removeHover = false, removeHighlight(false)"
+            @mouseover="removeHover = true, removeHighlight(true)" 
+            @mouseout="removeHover = false, removeHighlight(false)">
+            <tooltip-component 
+              :show-tooltip="removeHover" 
+              tooltip-text="Remove" 
+              translation="translatePhrase"></tooltip-component>
+          </i>
+        </div>
       </div>
     </strong>
   

--- a/viewer/v2client/src/components/inspector/toolbar.vue
+++ b/viewer/v2client/src/components/inspector/toolbar.vue
@@ -619,6 +619,10 @@ export default {
     width: 50px;
     height: 50px;
     position: relative;
+
+    &:disabled {
+      opacity: 0.65;
+    }
   }
 
   &-menuLink {

--- a/viewer/v2client/src/components/shared/round-button.vue
+++ b/viewer/v2client/src/components/shared/round-button.vue
@@ -65,7 +65,7 @@ export default {
 
 <template>
   <button class="RoundButton btn"
-    :class="{'btn-gray is-disabled' : disabled, 'default': !indicator && !disabled, 'btn-primary': indicator && !disabled}"
+    :class="{'btn-gray disabled' : disabled, 'default': !indicator && !disabled, 'btn-primary': indicator && !disabled}"
     @click="action()"
     @mouseover="mouseOver = true"
     @mouseout="mouseOver = false">
@@ -107,7 +107,7 @@ export default {
     color: @white;
   }
 
-  &.is-disabled {
+  &.disabled { //can't be SUIT-ified because inherits from Bootstrap .disabled
     color: @white;
     border: none;
   }

--- a/viewer/v2client/src/less/button-links-chip.less
+++ b/viewer/v2client/src/less/button-links-chip.less
@@ -10,6 +10,10 @@ body a {
   }
 }
 
+a:focus {
+  outline: none;
+}
+
 // ----------- BUTTON ----------------
 
 .btn,
@@ -17,6 +21,11 @@ body a {
   border: 0;
   box-shadow: @shadow-panel;
   transition: background-color 0.1s ease;
+}
+
+.btn:focus,
+.btn:active:focus {
+  outline: 0;
 }
 
 .btn[disabled],

--- a/viewer/v2client/src/less/form.less
+++ b/viewer/v2client/src/less/form.less
@@ -10,15 +10,16 @@
       color: @brand-primary;
     }
 
-    &:focus + .customCheckbox-icon {
-      background: @gray-lighter;
-      background: @gray-lighter-transparent;
+    .user-is-tabbing &:focus + .customCheckbox-icon {
+      outline: 2px solid #8cc9c9; //fallback for IE & Edge
+      outline: auto darkcyan;
     }
   }
 
   &-icon {
     padding: 0 3px;
     margin-left: -3px;
+    display: inline-block;
 
     &::before {
       content: "\f096";

--- a/viewer/v2client/src/less/main.less
+++ b/viewer/v2client/src/less/main.less
@@ -186,5 +186,6 @@ button {
   outline: none;
 }
 .user-is-tabbing *:focus {
+  outline: 2px solid #8cc9c9; //fallback for IE & Edge
   outline: auto darkcyan;
 }


### PR DESCRIPTION
 This PR wishes to restore some minor design stuff that has broken during recent development etc:

* Restore disabled look of buttons in sidepanel
* Restore disabled look of undo button in toolbar
* Disable blue outline on focus (since we apply our own .user-is-tabbing outline)
* Make .user-is-tabbing outline show in in Explorer & Edge
* Consistent tabbing outline for our custom checkbox & icons in form
