### PR TITLE
Use publication.year in facets

### DIFF
--- a/viewer/dataaccess.py
+++ b/viewer/dataaccess.py
@@ -81,7 +81,7 @@ sites = {
                     "sortOrder":"asc",
                     "size":100
                 },
-                "publication.date":{
+                "publication.year.keyword":{
                     "sort":"key",
                     "sortOrder":"desc",
                     "size":50

--- a/viewer/v2client/src/store/store.js
+++ b/viewer/v2client/src/store/store.js
@@ -174,9 +174,9 @@ const store = new Vuex.Store({
           sv: 'Verksspråk',
           en: 'Language of work',
         },
-        'publication.date': {
-          sv: 'Utgivningsdatum',
-          en: 'Publication date',
+        'publication.year.keyword': {
+          sv: 'Utgivningsår',
+          en: 'Publication year',
         },
       },
       availableUserSettings: {


### PR DESCRIPTION
This replaces publication.date, since that field tends to include
additional information.