### PR TITLE
Clear facets on new search

### DIFF
--- a/viewer/v2client/src/components/search/search-form.vue
+++ b/viewer/v2client/src/components/search/search-form.vue
@@ -200,17 +200,17 @@ export default {
         if (typeof this.resultData.search !== 'undefined') {
             this.resultData.search.mapping.forEach(item => {
             if (item.variable !== 'q') {
-                let filter = '';
-                if (typeof item.object !== 'undefined') {
-                  if (item.variable === '@type') {
-                    filter = item.object['@id'];
-                  } else {
-                    filter = item.object['@id'].replace('https://id.kb.se/', '');
-                  }
+              let filter = '';
+              if (typeof item.object !== 'undefined') {
+                if (item.variable === '@type') {
+                  filter = item.object['@id'];
                 } else {
-                  filter = item.value;
+                  filter = item.object['@id'].replace('https://id.kb.se/', '');
                 }
-                filters.push(filter);
+              } else {
+                filter = item.value;
+              }
+              filters.push(filter);
             }
           });
         }
@@ -272,9 +272,11 @@ export default {
     },
     resultData: function(newVal, oldVal) {
       if (typeof newVal !== 'undefined' && Object.keys(newVal).length) {
-        if (this.usedFilters !== '') {
-          this.inputData.ids = this.usedFilters;
-        }
+
+        // don't include filters from facets on new search
+        // if (this.usedFilters !== '') {
+          // this.inputData.ids = this.usedFilters;
+        // }
 
         if (this.usedTextInput !== '') {
           const newObj = {};


### PR DESCRIPTION
[LXL-2071](https://jira.kb.se/browse/LXL-2071) - Can't reset facet filters on new search.

I think the most straightforward solution (currently) is to disregard the facet filters on new search and only look for the checkbox filters. Since the search query remains in the box, a new search would be an equivalent to having a "clear filters" button. I also think this is the expected behavior, as opposed to the facets still restricting the search. Please correct me if i'm wrong :)