### PR TITLE
Feature/input resets bug

### DIFF
--- a/viewer/v2client/src/components/inspector/item-value.vue
+++ b/viewer/v2client/src/components/inspector/item-value.vue
@@ -97,13 +97,18 @@ export default {
           item.classList.remove('is-removeable');
       }
     },
-    handleKeys(e) {
-      this.$store.dispatch('setInspectorStatusValue', { property: 'updating', value: true });
-      if (e.keyCode === 13) { // Handle enter
-        e.target.blur();
-        e.preventDefault();
-        return false;
-      }
+    // no one seems to watch inspector.status.updating anyway?
+    // handleKeys(e) {
+    //   this.$store.dispatch('setInspectorStatusValue', { property: 'updating', value: true });
+    //   if (e.keyCode === 13) { // Handle enter
+    //     e.target.blur();
+    //     e.preventDefault();
+    //     return false;
+    //   }
+    // },
+    handleEnter(e) {
+      e.target.blur();
+      return false;
     },
     update(newValue) {
       const oldValue = _.cloneDeep(_.get(this.inspector.data, this.path));
@@ -131,7 +136,7 @@ export default {
     },
     initializeTextarea() {
       this.$nextTick(() => {
-        let textarea = this.$el.querySelector('textarea');
+        let textarea = this.$refs.textarea;
         AutoSize(textarea);
         AutoSize.update(textarea);
       })
@@ -169,7 +174,7 @@ export default {
       rows="1" 
       v-model="value"
       @blur="update($event.target.value)"
-      @keydown="handleKeys"
+      @keydown.enter.prevent="handleEnter"
       v-if="!isLocked"
       ref="textarea"></textarea>
     <span class="ItemValue-text"

--- a/viewer/v2client/src/components/inspector/item-value.vue
+++ b/viewer/v2client/src/components/inspector/item-value.vue
@@ -127,8 +127,10 @@ export default {
     highLightLastAdded() {
       if (this.isLastAdded === true) {
         let element = this.$el;
+        element.classList.add('is-lastAdded');
         LayoutUtil.scrollToElement(element, 1000, () => {
           setTimeout(() => {
+            element.classList.remove('is-lastAdded');
             this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
           }, 1000);
         });
@@ -169,7 +171,7 @@ export default {
 
 <template>
   <div class="ItemValue js-value" 
-    v-bind:class="{'is-locked': isLocked, 'unlocked': !isLocked, 'is-removed': removed, 'is-lastAdded': isLastAdded}">
+    v-bind:class="{'is-locked': isLocked, 'unlocked': !isLocked, 'is-removed': removed}">
     <textarea class="ItemValue-input js-itemValueInput" 
       rows="1" 
       v-model="value"


### PR DESCRIPTION
[LXL-2088](https://jira.kb.se/browse/LXL-2088) - Newly added input field resets after 1 sec

Probably caused by `lastAdded` in the parent being updated after 1000ms, sending new props and causing `item-value` to update. In the process, the field also displays the un-updated value of prop `fieldValue` for a brief moment (ie nothing), which is then again recorded and displayed, overwriting everything that was typed up until that point.

Avoiding this by removing the direct class binding of the component to `lastAdded`.

Also the removed the listener which updates the `inspector.status.updating` on every keystroke, since it seems unused. Hopefully good for performance.