### PR TITLE
Focus on first input

### DIFF
--- a/viewer/v2client/src/components/inspector/field.vue
+++ b/viewer/v2client/src/components/inspector/field.vue
@@ -40,6 +40,7 @@ export default {
     entityType: '',
     showActionButtons: '',
     isExpanded: false,
+    expandChildren: false,
   },
   data() {
     return {
@@ -553,6 +554,7 @@ export default {
           :index="index" 
           :parent-path="getPath" 
           :in-array="valueIsArray" 
+          :should-expand="expandChildren"
           :show-action-buttons="actionButtonsShown"></item-local>
 
         <item-sibling
@@ -565,6 +567,7 @@ export default {
           :index="index"
           :in-array="valueIsArray"
           :show-action-buttons="actionButtonsShown"
+          :should-expand="expandChildren"
           :parent-path="getPath"></item-sibling>
       </div>
       <portal-target :name="`typeSelect-${getPath}`" />
@@ -607,7 +610,6 @@ export default {
           :field-key="fieldKey" 
           :index="index" 
           :parent-path="getPath" 
-          :gparent-path="parentPath"
           :show-action-buttons="actionButtonsShown"
           :is-expanded="isExpanded"></item-value>
       </div>

--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -318,7 +318,10 @@ export default {
       this.$nextTick(this.focusFirstInput);
     },
     focusFirstInput() {
-      this.$el.querySelector('.js-itemValueInput').focus();
+      const firstInput = this.$el.querySelector('.js-itemValueInput')
+      if (firstInput) {
+        firstInput.focus();
+      }
     },
   },
   watch: {

--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -36,6 +36,7 @@ export default {
       type: Array,
       default: () => [],
     },
+    shouldExpand: false,
   },
   data() {
     return {
@@ -48,6 +49,7 @@ export default {
       cloneHover: false,
       showLinkAction: false,
       copyTitle: false,
+      expandChildren: false,
       cloned: false
     };
   },
@@ -311,15 +313,23 @@ export default {
         });
       }, 500);
     },
-    expandOnNew() {
-      if (this.inspector.status.isNew) {
-        this.expand();
-      }
-    }
+    expandAllChildren() {
+      this.expandChildren = true;
+      this.$nextTick(this.focusFirstInput);
+    },
+    focusFirstInput() {
+      this.$el.querySelector('.js-itemValueInput').focus();
+    },
   },
   watch: {
     'inspector.event'(val, oldVal) {
       this.$emit(`${val.value}`);
+    },
+    shouldExpand(val) {
+      if (val) {
+        this.expand();
+        this.expandChildren = true;
+      }
     }
   },
   beforeDestroy() {
@@ -338,12 +348,15 @@ export default {
           fieldAdder.$refs.adderButton.focus();
         } else {
           this.expand();
+          this.expandAllChildren();
         }
       setTimeout(() => {
         this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
       }, 1000)
-    } 
-    this.expandOnNew();
+    }
+    if (this.inspector.status.isNew) {
+      this.expand();
+    }
   },
 
   components: {
@@ -461,6 +474,7 @@ export default {
         :field-value="v"
         :key="k" 
         :show-action-buttons="showActionButtons"
+        :expand-children="expandChildren"
         :is-expanded="expanded"></field> 
     </ul>
 

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -39,6 +39,7 @@ export default {
     showActionButtons: false,
     parentPath: '',
     inArray: false,
+    shouldExpand: false,
   },
   data() {
     return {
@@ -51,6 +52,7 @@ export default {
       removeHover: false,
       showLinkAction: false,
       copyTitle: false,
+      expandChildren: false,
     };
   },
   computed: {
@@ -277,15 +279,23 @@ export default {
       });
       this.closeExtractDialog();
     },
-    expandOnNew() {
-      if (this.inspector.status.isNew) {
-        this.expand();
-      }
-    }
+    expandAllChildren() {
+      this.expandChildren = true;
+      this.$nextTick(this.focusFirstInput);
+    },
+    focusFirstInput() {
+      this.$el.querySelector('.js-itemValueInput').focus();
+    },
   },
   watch: {
     'inspector.event'(val, oldVal) {
       this.$emit(`${val.value}`);
+    },
+    shouldExpand(val) {
+      if (val) {
+        this.expand();
+        this.expandChildren = true;
+      }
     }
   },
   created: function () {
@@ -301,12 +311,15 @@ export default {
         fieldAdder.$refs.adderButton.focus();
       } else {
         this.expand();
+        this.expandAllChildren();
       }
       setTimeout(()=> {
       this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
     }, 1000)
     }
-    this.expandOnNew();
+    if (this.inspector.status.isNew) {
+      this.expand();
+    }
   },
 
   components: {
@@ -404,6 +417,7 @@ export default {
         :field-key="k" 
         :field-value="v" 
         :key="k" 
+        :expand-children="expandChildren"
         :show-action-buttons="showActionButtons"></field>
     </ul>
 

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -284,7 +284,10 @@ export default {
       this.$nextTick(this.focusFirstInput);
     },
     focusFirstInput() {
-      this.$el.querySelector('.js-itemValueInput').focus();
+      const firstInput = this.$el.querySelector('.js-itemValueInput')
+      if (firstInput) {
+        firstInput.focus();
+      }
     },
   },
   watch: {

--- a/viewer/v2client/src/components/inspector/item-value.vue
+++ b/viewer/v2client/src/components/inspector/item-value.vue
@@ -26,7 +26,6 @@ export default {
     showActionButtons: false,
     isExpanded: false,
     parentPath: false,
-    gparentPath: false,
   },
   watch: {
     isLocked(val) {
@@ -73,7 +72,7 @@ export default {
     },
     shouldFocus() {
       let lastAdded = this.inspector.status.lastAdded;
-      if (lastAdded === this.path || lastAdded === this.parentPath || lastAdded === this.gparentPath) {
+      if (lastAdded === this.path || lastAdded === this.parentPath) {
         return true;
       }
       return false;


### PR DESCRIPTION
[LXL-2077](https://jira.kb.se/browse/LXL-2077) - Focus the **first** input when adding an item with several inputs (a snippet for example). Today the last input is focused because of rendering order.

For this to work we need to expand all the subitems of a newly added `item-local` or `item-sibling`.

Doing this by passing down a `should-expand` prop via `fields` to nested `items-siblings` and `locals`. Then, on the the top level, focusing on the first child input element via `querySelector`.