### PR TITLE
Inconsistent adder focus fix

### DIFF
--- a/viewer/v2client/src/components/inspector/field.vue
+++ b/viewer/v2client/src/components/inspector/field.vue
@@ -381,7 +381,9 @@ export default {
         let element = this.$el;
         LayoutUtil.scrollToElement(element, 1000, () => {
           setTimeout(() => {
-            this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+            if (this.isLastAdded) {
+              this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+            }
           }, 1000);
         });
       }

--- a/viewer/v2client/src/components/inspector/item-entity.vue
+++ b/viewer/v2client/src/components/inspector/item-entity.vue
@@ -102,7 +102,9 @@ export default {
           let element = this.$el;
           LayoutUtil.scrollToElement(element, 1000, () => {
             setTimeout(() => {
-              this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+              if (this.isNewlyAdded) {
+                this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+              }
             }, 1000);
           });
         }, 200);

--- a/viewer/v2client/src/components/inspector/item-local.vue
+++ b/viewer/v2client/src/components/inspector/item-local.vue
@@ -158,11 +158,7 @@ export default {
   methods: {
     highLightLastAdded() {
       let element = this.$el;
-      LayoutUtil.scrollToElement(element, 1000, () => {
-        setTimeout(() => {
-          this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-        }, 1000);
-      });
+      LayoutUtil.scrollToElement(element, 1000, () => {});
     },
     actionHighlight(active, event) {
       if (active) {
@@ -354,7 +350,9 @@ export default {
           this.expandAllChildren();
         }
       setTimeout(() => {
-        this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+        if (this.isLastAdded) {
+          this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+        }
       }, 1000)
     }
     if (this.inspector.status.isNew) {

--- a/viewer/v2client/src/components/inspector/item-sibling.vue
+++ b/viewer/v2client/src/components/inspector/item-sibling.vue
@@ -132,11 +132,7 @@ export default {
   methods: {
     highLightLastAdded() {
       let element = this.$el;
-      LayoutUtil.scrollToElement(element, 1000, () => {
-        setTimeout(() => {
-          this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-        }, 1000);
-      });
+      LayoutUtil.scrollToElement(element, 1000, () => {});
     },
     removeThis() {
       const changeList = [
@@ -317,8 +313,10 @@ export default {
         this.expandAllChildren();
       }
       setTimeout(()=> {
-      this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
-    }, 1000)
+        if (this.isLastAdded) {
+          this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+        }
+      }, 1000)
     }
     if (this.inspector.status.isNew) {
       this.expand();

--- a/viewer/v2client/src/components/inspector/item-value.vue
+++ b/viewer/v2client/src/components/inspector/item-value.vue
@@ -121,7 +121,9 @@ export default {
         LayoutUtil.scrollToElement(element, 1000, () => {
           setTimeout(() => {
             element.classList.remove('is-lastAdded');
-            this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+            if (this.isLastAdded) {
+              this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+            }
           }, 1000);
         });
       }

--- a/viewer/v2client/src/less/button-links-chip.less
+++ b/viewer/v2client/src/less/button-links-chip.less
@@ -110,7 +110,7 @@ a:focus {
   line-height: 1.6;
   padding: 3px 5px 3px 10px;
   margin: 2px 5px 5px 0px;
-  transition: .3s ease;
+  transition: .3s ease, background-color 0.3s ease;
   max-width: 300px;
 
   &-label {


### PR DESCRIPTION
[LXL-2053](https://jira.kb.se/browse/LXL-2053)
Today a newly added item always resets the `inspector.status.lastAdded` after 1 sec. This can screw up the match of some other component that has been added in the meantime, resulting in jittery highlight & unreliable button focus.

Fix is to add another check of `lastAdded` inside `setTimeout`.

Also removed some duplicate code.