### PR TITLE
Added contitional ref

### DIFF
--- a/viewer/v2client/src/components/inspector/entity-adder.vue
+++ b/viewer/v2client/src/components/inspector/entity-adder.vue
@@ -553,7 +553,7 @@ export default {
         class="EntityAdder-addIcon fa fa-plus-circle icon icon--sm"
         :class="{'is-disabled': addEmbedded}" 
         :tabindex="addEmbedded ? -1 : 0"
-        ref="adderFocusElement"
+        :ref="addEmbedded ? '' : 'adderFocusElement'"
         v-on:click="add($event)" 
         @keyup.enter="add($event)"
         @mouseenter="showToolTip = true, actionHighlight(true, $event)" 


### PR DESCRIPTION
A late buggfix for [this](https://github.com/libris/lxlviewer/pull/251) PR, preventing autofocus of a disabled adder-icon instead of the type select.