### PR TITLE
Feature/redesign facets

### DIFF
--- a/viewer/dataaccess.py
+++ b/viewer/dataaccess.py
@@ -69,22 +69,22 @@ sites = {
                 "instanceOf.language.@id":{
                     "sort":"value",
                     "sortOrder":"desc",
-                    "size":10
+                    "size":100
                 },
                 "carrierType":{
                     "sort":"value",
                     "sortOrder":"desc",
-                    "size":10
+                    "size":100
                 },
                 "instanceOf.@type":{
-                    "sort":"key",
-                    "sortOrder":"asc",
+                    "sort":"value",
+                    "sortOrder":"desc",
                     "size":100
                 },
                 "publication.year.keyword":{
                     "sort":"key",
                     "sortOrder":"desc",
-                    "size":50
+                    "size":500
                 },
                 "@type":{
                     "sort":"key",

--- a/viewer/vue-client/src/App.vue
+++ b/viewer/vue-client/src/App.vue
@@ -166,7 +166,8 @@ h4 {
 }
 
 // ----------- LINKS ----------------
-body a {
+body a,
+.link {
   color: @link-color;
   text-decoration: none;
   cursor: pointer;

--- a/viewer/vue-client/src/App.vue
+++ b/viewer/vue-client/src/App.vue
@@ -451,6 +451,13 @@ body {
     }
 }
 
+// ------------- BADGE ----------------
+
+.badge {
+  background-color: @gray-lighter;
+  color: @gray-darker;
+}
+
 // ---------- TYPOGRAPHY -------------
 // ----------- HEADINGS ----------------
 h1, h2, h3, h4 {

--- a/viewer/vue-client/src/components/inspector/reverse-relations.vue
+++ b/viewer/vue-client/src/components/inspector/reverse-relations.vue
@@ -1,6 +1,7 @@
 <script>
 import { each } from 'lodash-es';
 import * as VocabUtil from '../../utils/vocab';
+import * as MathUtil from '@/utils/math';
 import CreateItemButton from './create-item-button';
 import RelationsList from '@/components/inspector/relations-list';
 import RoundButton from '@/components/shared/round-button.vue';
@@ -125,19 +126,7 @@ export default {
       'status',
     ]),
     numberOfRelationsCircle() {
-      const no = this.numberOfRelations;
-      let compact = '';
-      let compactNo = 0;
-      if (no > 999 && no < 1000000) {
-        compactNo = parseInt(no / 1000);
-        compact = `${compactNo}k`;
-      } else if (no > 999999) {
-        compactNo = Math.round(no / 1000000);
-        compact = `${compactNo}M`;
-      } else {
-        compact = `${no}`;
-      }
-      return compact;
+      return MathUtil.getCompactNumber(this.numberOfRelations);
     },
     hasRelation() {
       return this.myHolding !== null;

--- a/viewer/vue-client/src/components/search/facet-controls.vue
+++ b/viewer/vue-client/src/components/search/facet-controls.vue
@@ -8,6 +8,7 @@ export default {
   },
   data() {
     return {
+      numOfExpanded: 3,
     };
   },
   methods: {
@@ -46,9 +47,10 @@ export default {
 <template>
   <div class="FacetControls">
     <facet-group
-      v-for="(dimensionValue, dimensionKey) in sortedFacets"
+      v-for="(dimensionValue, dimensionKey, index) in sortedFacets"
       :key="dimensionKey"
-      :group="dimensionValue"/>
+      :group="dimensionValue"
+      :expanded="index < numOfExpanded"/>
   </div>
 </template>
 

--- a/viewer/vue-client/src/components/search/facet-controls.vue
+++ b/viewer/vue-client/src/components/search/facet-controls.vue
@@ -1,5 +1,5 @@
 <script>
-import Facet from './facet.vue';
+import FacetGroup from './facet-group.vue';
 
 export default {
   name: 'facet-controls',
@@ -11,37 +11,18 @@ export default {
     };
   },
   methods: {
-    isRangeFacet(dimensionKey) {
-      return dimensionKey === 'publication.date';
-    },
-    facetLabelByLang(facetType) {
-      return this.settings.propertyChains[facetType][this.user.settings.language];
-    },
-    expandFacets($event) {
-      const el = $event.target;
-      const list = el.nextSibling.nextSibling;
-      el.classList.toggle('is-open');
-      list.classList.toggle('is-open');
-    },
   },
   computed: {
-    user() {
-      return this.$store.getters.user;
-    },
-    settings() {
-      return this.$store.getters.settings;
-    },
   },
   events: {
   },
   components: {
-    facet: Facet,
+    'facet-group': FacetGroup,
   },
   watch: {
   },
-  ready() { // Ready method is deprecated in 2.0, switch to "mounted"
+  mounted() {
     this.$nextTick(() => {
-      // Do stuff
     });
   },
 };
@@ -49,23 +30,10 @@ export default {
 
 <template>
   <div class="FacetControls">
-    <nav class="FacetControls-listNav" 
-      :aria-labelledby="facetLabelByLang(dimensionValue.dimension)"
-      v-for="(dimensionValue, dimensionKey) in result.stats.sliceByDimension" 
-      :key="dimensionKey">
-      <h4 class="FacetControls-listTitle js-listTitle uppercaseHeading--bold" 
-        @click="expandFacets($event)"
-        :id="facetLabelByLang(dimensionValue.dimension)">
-        {{facetLabelByLang(dimensionValue.dimension) | capitalize}}
-      </h4>
-      <!--<range-input v-if="isRangeFacet(dimensionKey)"></range-input>-->
-      <ul class="FacetControls-list js-list">
-        <facet class="FacetControls-listItem"
-        v-for="observation in dimensionValue.observation" 
-        :observation="observation" 
-        :key="observation.label"></facet>
-      </ul>
-    </nav>
+    <facet-group
+      v-for="(dimensionValue, dimensionKey) in result.stats.sliceByDimension"
+      :key="dimensionKey"
+      :slice="dimensionValue"/>
   </div>
 </template>
 
@@ -75,59 +43,6 @@ export default {
 
   @media (min-width: @screen-md) {
     padding: 0;
-  }
-
-  &-listTitle {
-    margin: 10px 0 5px 0;
-    padding: 0px;
-    cursor: pointer;
-    display: inline-block;
-
-    &:before {
-      font-family: FontAwesome;
-      content: "\F054";
-      display: inline-block;
-      margin-right: 3px;
-      transition: transform 0.1s ease;
-    }
-
-    @media (min-width: 992px) {
-      cursor: default;
-      pointer-events: none;
-
-      &:before {
-        content: '';
-        margin: -2px;
-      }
-    }
-
-    &.is-open {
-      &:before {
-        transform: rotate(90deg);
-      }
-    }
-  }
-
-  &-listNav {
-    margin: 0px 0 0;
-  }
-
-  &-list {
-    list-style: none;
-    padding: 0;
-    display: none;
-
-    @media (min-width: 992px) {
-      display: block;
-    }
-
-    &.is-open {
-      display: block;     
-    }
-  }
-
-  &-listItem {
-    line-height: 27px;
   }
 }
 </style>

--- a/viewer/vue-client/src/components/search/facet-controls.vue
+++ b/viewer/vue-client/src/components/search/facet-controls.vue
@@ -33,7 +33,7 @@ export default {
     <facet-group
       v-for="(dimensionValue, dimensionKey) in result.stats.sliceByDimension"
       :key="dimensionKey"
-      :slice="dimensionValue"/>
+      :group="dimensionValue"/>
   </div>
 </template>
 

--- a/viewer/vue-client/src/components/search/facet-controls.vue
+++ b/viewer/vue-client/src/components/search/facet-controls.vue
@@ -13,6 +13,21 @@ export default {
   methods: {
   },
   computed: {
+    facetSettings() {
+      return this.$store.getters.settings.propertyChains;
+    },
+    sortedFacets() {
+      const unordered = this.result.stats.sliceByDimension;
+      const ordered = Object
+        .keys(unordered)
+        .sort((a, b) => this.facetSettings[unordered[a].dimension].facet.order 
+            - this.facetSettings[unordered[b].dimension].facet.order)
+        .reduce((_sortedObj, key) => ({
+          ..._sortedObj, 
+          [key]: unordered[key],
+        }), {});
+      return ordered;
+    },
   },
   events: {
   },
@@ -31,7 +46,7 @@ export default {
 <template>
   <div class="FacetControls">
     <facet-group
-      v-for="(dimensionValue, dimensionKey) in result.stats.sliceByDimension"
+      v-for="(dimensionValue, dimensionKey) in sortedFacets"
       :key="dimensionKey"
       :group="dimensionValue"/>
   </div>

--- a/viewer/vue-client/src/components/search/facet-group.vue
+++ b/viewer/vue-client/src/components/search/facet-group.vue
@@ -26,13 +26,6 @@ export default {
     toggleExpanded() {
       this.isExpanded = !this.isExpanded;
     },
-    sortObservations(arr) {
-      const sortFunc = this.settings.propertyChains[this.group.dimension].facet.sortBy;
-      if (!sortFunc) {
-        return arr;
-      }
-      return arr.sort(sortFunc);
-    },
   },
   computed: {
     settings() {
@@ -43,12 +36,11 @@ export default {
     },
     slicedObservations() {
       let limit = this.revealLevels[this.currentLevel];
-      const sortedObs = this.sortObservations(this.group.observation);
 
       if (this.group.observation.length - limit === 1) {
         limit = false; // if only one remains hidden we might as well show all
       }
-      return limit ? sortedObs.slice(0, limit) : sortedObs;
+      return limit ? this.group.observation.slice(0, limit) : this.group.observation;
     },
     revealText() {
       if (this.slicedObservations.length >= this.group.observation.length) {

--- a/viewer/vue-client/src/components/search/facet-group.vue
+++ b/viewer/vue-client/src/components/search/facet-group.vue
@@ -1,0 +1,100 @@
+<script>
+import Facet from './facet.vue';
+
+export default {
+  name: 'facet-group',
+  props: {
+    slice: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      isExpanded: true,
+    };
+  },
+  methods: {
+    facetLabelByLang(facetType) {
+      return this.settings.propertyChains[facetType][this.user.settings.language];
+    },
+    toggleExpanded() {
+      this.isExpanded = !this.isExpanded;
+    },
+  },
+  computed: {
+    settings() {
+      return this.$store.getters.settings;
+    },
+    user() {
+      return this.$store.getters.user;
+    },
+  },
+  components: {
+    facet: Facet,
+  },
+  mounted() {
+    this.$nextTick(() => {
+    });
+  },
+};
+</script>
+
+<template>
+  <nav class="FacetGroup" 
+    :aria-labelledby="facetLabelByLang(slice.dimension)">
+    <h4 class="FacetGroup-title uppercaseHeading--bold"
+      :class="{'is-expanded' : isExpanded}"
+      @click="toggleExpanded()"
+      :id="facetLabelByLang(slice.dimension)">
+      {{facetLabelByLang(slice.dimension) | capitalize}}
+    </h4>
+    <ul class="FacetGroup-list"
+      :class="{'is-expanded' : isExpanded}">
+      <facet v-for="observation in slice.observation" 
+      :observation="observation" 
+      :key="observation.label"></facet>
+    </ul>
+  </nav>
+</template>
+
+<style lang="less">
+.FacetGroup {
+  width: 200px;
+  margin: 0px 0 0;
+
+  &-title {
+    margin: 10px 0 5px 0;
+    padding: 0px;
+    cursor: pointer;
+    display: inline-block;
+
+    &:before {
+      font-family: FontAwesome;
+      content: "\F054";
+      font-weight: normal;
+      color: @brand-primary;
+      display: inline-block;
+      margin-right: 5px;
+      transition: transform 0.1s ease;
+    }
+
+    &.is-expanded {
+      &:before {
+        transform: rotate(90deg);
+      }
+    }
+  }
+
+  &-list {
+    list-style: none;
+    padding: 0;
+    display: none;
+
+    &.is-expanded {
+      margin-top: 5px;
+      display: block;     
+    }
+  }
+}
+</style>

--- a/viewer/vue-client/src/components/search/facet-group.vue
+++ b/viewer/vue-client/src/components/search/facet-group.vue
@@ -4,7 +4,7 @@ import Facet from './facet.vue';
 export default {
   name: 'facet-group',
   props: {
-    slice: {
+    group: {
       type: Object,
       required: true,
     },
@@ -12,6 +12,8 @@ export default {
   data() {
     return {
       isExpanded: true,
+      currentLevel: 0,
+      revealLevels: [5, 15, false],
     };
   },
   methods: {
@@ -29,6 +31,20 @@ export default {
     user() {
       return this.$store.getters.user;
     },
+    slicedObservations() {
+      const limit = this.revealLevels[this.currentLevel];
+      return limit ? this.group.observation.slice(0, limit) : this.group.observation;
+    },
+    revealText() {
+      if (this.slicedObservations.length >= this.group.observation.length) {
+        return false;
+      } 
+      if (this.revealLevels[this.currentLevel + 1] 
+        && this.revealLevels[this.currentLevel + 1] < this.group.observation.length) {
+        return 'Show more';
+      } 
+      return 'Show all';
+    },
   },
   components: {
     facet: Facet,
@@ -42,25 +58,30 @@ export default {
 
 <template>
   <nav class="FacetGroup" 
-    :aria-labelledby="facetLabelByLang(slice.dimension)">
+    :aria-labelledby="facetLabelByLang(group.dimension)">
     <h4 class="FacetGroup-title uppercaseHeading--bold"
       :class="{'is-expanded' : isExpanded}"
       @click="toggleExpanded()"
-      :id="facetLabelByLang(slice.dimension)">
-      {{facetLabelByLang(slice.dimension) | capitalize}}
+      :id="facetLabelByLang(group.dimension)">
+      {{facetLabelByLang(group.dimension) | capitalize}}
     </h4>
     <ul class="FacetGroup-list"
       :class="{'is-expanded' : isExpanded}">
-      <facet v-for="observation in slice.observation" 
+      <facet v-for="observation in slicedObservations"
       :observation="observation" 
       :key="observation.label"></facet>
+      <span 
+        v-if="revealText" 
+        class="FacetGroup-reveal link" 
+        @click="currentLevel++">{{ revealText | translatePhrase }}...</span>
     </ul>
+
   </nav>
 </template>
 
 <style lang="less">
 .FacetGroup {
-  width: 200px;
+  width: 230px;
   margin: 0px 0 0;
 
   &-title {
@@ -88,13 +109,20 @@ export default {
 
   &-list {
     list-style: none;
-    padding: 0;
+    padding: 0 15px 0 0;
     display: none;
+    max-height: 450px;
+    overflow-y: scroll;
 
     &.is-expanded {
       margin-top: 5px;
-      display: block;     
+      display: block;
     }
+  }
+
+  &-reveal {
+    font-size: 14px;
+    line-height: 30px;
   }
 }
 </style>

--- a/viewer/vue-client/src/components/search/facet-group.vue
+++ b/viewer/vue-client/src/components/search/facet-group.vue
@@ -8,10 +8,13 @@ export default {
       type: Object,
       required: true,
     },
+    expanded: {
+      type: Boolean,
+    },
   },
   data() {
     return {
-      isExpanded: true,
+      isExpanded: this.expanded,
       currentLevel: 0,
       revealLevels: [5, 15, false],
     };
@@ -23,6 +26,13 @@ export default {
     toggleExpanded() {
       this.isExpanded = !this.isExpanded;
     },
+    sortObservations(arr) {
+      const sortFunc = this.settings.propertyChains[this.group.dimension].facet.sortBy;
+      if (!sortFunc) {
+        return arr;
+      }
+      return arr.sort(sortFunc);
+    },
   },
   computed: {
     settings() {
@@ -33,10 +43,12 @@ export default {
     },
     slicedObservations() {
       let limit = this.revealLevels[this.currentLevel];
+      const sortedObs = this.sortObservations(this.group.observation);
+
       if (this.group.observation.length - limit === 1) {
         limit = false; // if only one remains hidden we might as well show all
       }
-      return limit ? this.group.observation.slice(0, limit) : this.group.observation;
+      return limit ? sortedObs.slice(0, limit) : sortedObs;
     },
     revealText() {
       if (this.slicedObservations.length >= this.group.observation.length) {
@@ -54,11 +66,6 @@ export default {
   },
   components: {
     facet: Facet,
-  },
-  mounted() {
-    this.$nextTick(() => {
-      this.isExpanded = this.settings.propertyChains[this.group.dimension].facet.expanded;
-    });
   },
 };
 </script>

--- a/viewer/vue-client/src/components/search/facet.vue
+++ b/viewer/vue-client/src/components/search/facet.vue
@@ -1,4 +1,5 @@
 <script>
+import * as MathUtil from '@/utils/math';
 
 export default {
   name: 'facet',
@@ -37,6 +38,9 @@ export default {
       const idArray = object['@id'].split('/');
       return `${idArray[idArray.length - 1]} (has no label)`;
     },
+    getCompactNumber() {
+      return MathUtil.getCompactNumber(this.observation.totalItems);
+    },
   },
   components: {
   },
@@ -53,11 +57,10 @@ export default {
     <router-link class="Facet-link"
       :to="observation.view['@id'] | asAppPath" 
       :title="determinedLabel | capitalize">
-      <span class="Facet-label"
-        :title="determinedLabel | capitalize">
-        {{determinedLabel | capitalize}} 
-        ({{observation.totalItems}})
-      </span>
+        <span class="Facet-label"
+          :title="determinedLabel | capitalize">
+          {{determinedLabel | capitalize}}</span>
+        <span class="Facet-badge badge">{{getCompactNumber}}</span>
     </router-link>
   </li>
 </template>
@@ -65,24 +68,34 @@ export default {
 <style lang="less">
 
 .Facet {
-  width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 2;
 
   &-link {
-    font-size: 16px;
-    font-size: 1.6rem;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: nowrap;
 
     &:hover {
-      color: inherit;
+      text-decoration: none;
+      & .Facet-label {
+        text-decoration: underline;
+      }
     }
+  }
+
+  &-badge {
   }
 
   &-label {
     cursor: pointer;
     color: @black;
+    line-height: 1.8em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 

--- a/viewer/vue-client/src/components/shared/entity-summary.vue
+++ b/viewer/vue-client/src/components/shared/entity-summary.vue
@@ -335,10 +335,6 @@ export default {
   &-detailsValue {
     font-size: 16px;
     font-size: 1.6rem;
-    .badge {
-      background-color: @gray-lighter;
-      color: @gray-darker;
-    }
   }
 
   &-icon {

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -244,6 +244,8 @@
     "GDPR compliance": "Om dataskydd (GDPR)",
     "National Library of Sweden on Youtube": "Kungliga biblioteket på Youtube",
     "LibrisNytt on Twitter": "LibrisNytt på Twitter",
-    "LibrisNytt on Facebook": "LibrisNytt på Facebook"
+    "LibrisNytt on Facebook": "LibrisNytt på Facebook",
+    "Show more": "Visa fler",
+    "Show all": "Visa alla"
   }
 }

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -157,7 +157,7 @@ const store = new Vuex.Store({
           en: 'Type',
           facet: {
             order: 3,
-            expanded: false,
+            sortBy: false,
           },
         },
         carrierType: {
@@ -165,7 +165,7 @@ const store = new Vuex.Store({
           en: 'Carrier type',
           facet: {
             order: false,
-            expanded: false,
+            sortBy: false,
           },
         },
         issuanceType: {
@@ -173,7 +173,7 @@ const store = new Vuex.Store({
           en: 'Issuance type',
           facet: {
             order: false,
-            expanded: false,
+            sortBy: false,
           },
         },
         'instanceOf.@type': {
@@ -181,7 +181,7 @@ const store = new Vuex.Store({
           en: 'Type of work',
           facet: {
             order: 0,
-            expanded: true,
+            sortBy: (a, b) => b.totalItems - a.totalItems,
           },
         },
         'instanceOf.contentType': {
@@ -189,7 +189,7 @@ const store = new Vuex.Store({
           en: 'Content type of work',
           facet: {
             order: false,
-            expanded: false,
+            sortBy: false,
           },
         },
         'instanceOf.language': {
@@ -197,7 +197,7 @@ const store = new Vuex.Store({
           en: 'Language of work',
           facet: {
             order: 1,
-            expanded: true,
+            sortBy: false,
           },
         },
         'publication.year.keyword': {
@@ -205,7 +205,7 @@ const store = new Vuex.Store({
           en: 'Publication year',
           facet: {
             order: 2,
-            expanded: true,
+            sortBy: false,
           },
         },
       },

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -157,7 +157,6 @@ const store = new Vuex.Store({
           en: 'Type',
           facet: {
             order: 3,
-            sortBy: false,
           },
         },
         carrierType: {
@@ -165,7 +164,6 @@ const store = new Vuex.Store({
           en: 'Carrier type',
           facet: {
             order: false,
-            sortBy: false,
           },
         },
         issuanceType: {
@@ -173,7 +171,6 @@ const store = new Vuex.Store({
           en: 'Issuance type',
           facet: {
             order: false,
-            sortBy: false,
           },
         },
         'instanceOf.@type': {
@@ -181,7 +178,6 @@ const store = new Vuex.Store({
           en: 'Type of work',
           facet: {
             order: 0,
-            sortBy: (a, b) => b.totalItems - a.totalItems,
           },
         },
         'instanceOf.contentType': {
@@ -189,7 +185,6 @@ const store = new Vuex.Store({
           en: 'Content type of work',
           facet: {
             order: false,
-            sortBy: false,
           },
         },
         'instanceOf.language': {
@@ -197,7 +192,6 @@ const store = new Vuex.Store({
           en: 'Language of work',
           facet: {
             order: 1,
-            sortBy: false,
           },
         },
         'publication.year.keyword': {
@@ -205,7 +199,6 @@ const store = new Vuex.Store({
           en: 'Publication year',
           facet: {
             order: 2,
-            sortBy: false,
           },
         },
       },

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -155,30 +155,58 @@ const store = new Vuex.Store({
         '@type': {
           sv: 'Typ',
           en: 'Type',
+          facet: {
+            order: 3,
+            expanded: false,
+          },
         },
         carrierType: {
           sv: 'Bärartyp',
           en: 'Carrier type',
+          facet: {
+            order: false,
+            expanded: false,
+          },
         },
         issuanceType: {
           sv: 'Utgivningssätt',
           en: 'Issuance type',
+          facet: {
+            order: false,
+            expanded: false,
+          },
         },
         'instanceOf.@type': {
           sv: 'Verkstyp',
           en: 'Type of work',
+          facet: {
+            order: 0,
+            expanded: true,
+          },
         },
         'instanceOf.contentType': {
           sv: 'Verksinnehållstyp',
           en: 'Content type of work',
+          facet: {
+            order: false,
+            expanded: false,
+          },
         },
         'instanceOf.language': {
-          sv: 'Verksspråk',
+          sv: 'Språk',
           en: 'Language of work',
+          facet: {
+            order: 1,
+            expanded: true,
+          },
         },
         'publication.year.keyword': {
           sv: 'Utgivningsår',
           en: 'Publication year',
+          facet: {
+            order: 2,
+            expanded: true,
+          },
         },
       },
       availableUserSettings: {

--- a/viewer/vue-client/src/utils/math.js
+++ b/viewer/vue-client/src/utils/math.js
@@ -12,3 +12,19 @@ export function getNewRandom(randomArray) {
   }
   return rand;
 }
+
+export function getCompactNumber(number) {
+  const no = number;
+  let compact = '';
+  let compactNo = 0;
+  if (no > 999 && no < 1000000) {
+    compactNo = parseInt(no / 1000);
+    compact = `${compactNo}k`;
+  } else if (no > 999999) {
+    compactNo = Math.round(no / 1000000);
+    compact = `${compactNo}M`;
+  } else {
+    compact = `${no}`;
+  }
+  return compact;
+}


### PR DESCRIPTION
Display more facets + new facet design: [LXL-2226](https://jira.kb.se/browse/LXL-2226), [LXL-2258](https://jira.kb.se/browse/LXL-2258), [LXL-2233](https://jira.kb.se/browse/LXL-2233), [LXL-2133](https://jira.kb.se/browse/LXL-2133)

Design changes include:
* Facet groups are expandable/toggleable, first 3 expanded by default.
* Numbers in badges including compact format ('30k')
* 'show more'-indicators when lots of results, and scrollbar at a certain point.
* Ability to set order of facet groups

App changes:
* Facet limit increase in dataaccess.py
* Refactored into new component `facet-group`
* Settings for facets in store
* function `getCompactNumber` moved to mathUtil file.