### PR TITLE
Feature/translate arrays

### DIFF
--- a/viewer/vue-client/src/components/inspector/create-item-button.vue
+++ b/viewer/vue-client/src/components/inspector/create-item-button.vue
@@ -133,12 +133,9 @@ export default {
             class="Toolbar-tooltipContainer"
             :show-tooltip="true" 
             position="left"
-            :tooltip-text="hasHolding ? 'has holding' : 'Add holding for'" 
-            :literalString="{
-              position: hasHolding ? 'before' : 'after',
-              text: user.settings.activeSigel
-            }"
-            translation="translatePhrase"></tooltip-component>
+            :tooltip-text="hasHolding ? 
+              [user.settings.activeSigel, 'has holding'] : 
+              ['Add holding for', user.settings.activeSigel]"></tooltip-component>
         </template>
       </round-button>
     </template>

--- a/viewer/vue-client/src/components/inspector/field-adder.vue
+++ b/viewer/vue-client/src/components/inspector/field-adder.vue
@@ -282,8 +282,7 @@ export default {
         @blur="showToolTip = false, actionHighlight(false, $event)">
         <tooltip-component 
           :show-tooltip="showToolTip" 
-          :tooltip-text="modalTitle" 
-          translation="translatePhrase"></tooltip-component>
+          :tooltip-text="modalTitle"></tooltip-component>
       </i>
       <span class="FieldAdder-innerLabel">{{ "Add field" | translatePhrase }}</span>
     </span>

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -516,8 +516,7 @@ export default {
               @mouseout="removeHover = false, removeHighlight(false, $event)">
               <tooltip-component 
                 :show-tooltip="removeHover" 
-                tooltip-text="Remove" 
-                translation="translatePhrase"></tooltip-component>
+                tooltip-text="Remove"></tooltip-component>
             </i>
           </div>
           <entity-adder class="Field-entityAdder Field-action"
@@ -554,8 +553,7 @@ export default {
               @mouseout="pasteHover = false, actionHighlight(false, $event)">
               <tooltip-component 
                 :show-tooltip="pasteHover" 
-                tooltip-text="Paste entity" 
-                translation="translatePhrase"></tooltip-component>
+                tooltip-text="Paste entity"></tooltip-component>
             </i>
           </div>
         </div>
@@ -606,7 +604,7 @@ export default {
             @blur="removeHover = false, removeHighlight(false, $event)" 
             @mouseover="removeHover = true, removeHighlight(true, $event)" 
             @mouseout="removeHover = false, removeHighlight(false, $event)"  >
-            <tooltip-component translation="translatePhrase"
+            <tooltip-component
               :show-tooltip="removeHover" 
               tooltip-text="Remove"></tooltip-component>
           </i>
@@ -624,8 +622,7 @@ export default {
             @mouseout="pasteHover = false, actionHighlight(false, $event)">
             <tooltip-component 
               :show-tooltip="pasteHover" 
-              tooltip-text="Paste entity" 
-              translation="translatePhrase"></tooltip-component>
+              tooltip-text="Paste entity"></tooltip-component>
           </i>
         </div>
       </div>

--- a/viewer/vue-client/src/components/inspector/item-entity.vue
+++ b/viewer/vue-client/src/components/inspector/item-entity.vue
@@ -131,8 +131,7 @@ export default {
 
           <tooltip-component 
             :show-tooltip="removeHover" 
-            tooltip-text="Remove" 
-            translation="translatePhrase"></tooltip-component>
+            tooltip-text="Remove"></tooltip-component>
         </i>
       </div>
     </div>

--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -421,8 +421,7 @@ export default {
             tabindex="0">
             <tooltip-component 
               :show-tooltip="showLinkAction" 
-              tooltip-text="Link entity" 
-              translation="translatePhrase"></tooltip-component>
+              tooltip-text="Link entity"></tooltip-component>
           </i>
           <i class="fa fa-link fa-fw icon icon--sm is-disabled"
             v-else-if="inspector.status.editing && isExtractable && !extractedMainEntity"
@@ -450,8 +449,7 @@ export default {
             @mouseout="removeHover = false, removeHighlight(false, $event)">
             <tooltip-component 
               :show-tooltip="removeHover" 
-              tooltip-text="Remove" 
-              translation="translatePhrase"></tooltip-component>
+              tooltip-text="Remove"></tooltip-component>
           </i>
         </div>
 
@@ -468,8 +466,7 @@ export default {
             @mouseout="manageHover = false, actionHighlight(false, $event)">
             <tooltip-component 
               :show-tooltip="manageHover" 
-              tooltip-text="Manage" 
-              translation="translatePhrase"></tooltip-component>
+              tooltip-text="Manage"></tooltip-component>
           </i>
         </div>
         <div class="dropdown ManagerMenu" v-on-clickaway="closeManagerMenu" v-if="managerMenuOpen"

--- a/viewer/vue-client/src/components/inspector/item-sibling.vue
+++ b/viewer/vue-client/src/components/inspector/item-sibling.vue
@@ -377,8 +377,7 @@ export default {
             @mouseout="showLinkAction = false, actionHighlight($event, false)">
             <tooltip-component 
               :show-tooltip="showLinkAction" 
-              tooltip-text="Link entity" 
-              translation="translatePhrase"></tooltip-component>
+              tooltip-text="Link entity"></tooltip-component>
           </i>
           <i class="fa fa-link fa-fw icon icon--sm is-disabled"
             v-else-if="inspector.status.editing && isExtractable && !extractedMainEntity"
@@ -405,8 +404,7 @@ export default {
             @mouseout="removeHover = false, removeHighlight($event, false)">
             <tooltip-component 
               :show-tooltip="removeHover" 
-              tooltip-text="Remove" 
-              translation="translatePhrase"></tooltip-component>
+              tooltip-text="Remove"></tooltip-component>
           </i>
         </div>
       </div>

--- a/viewer/vue-client/src/components/inspector/item-value.vue
+++ b/viewer/vue-client/src/components/inspector/item-value.vue
@@ -201,8 +201,7 @@ export default {
       <i class="fa fa-trash-o icon icon--sm">
         <tooltip-component
           :show-tooltip="removeHover"
-          tooltip-text="Remove"
-          translation="translatePhrase"></tooltip-component>
+          tooltip-text="Remove"></tooltip-component>
       </i>
     </div>
   </div>

--- a/viewer/vue-client/src/components/inspector/reverse-relations.vue
+++ b/viewer/vue-client/src/components/inspector/reverse-relations.vue
@@ -256,8 +256,7 @@ export default {
               class="Toolbar-tooltipContainer"
               position="left"
               :show-tooltip="true"
-              :tooltip-text="totalRelationTooltipText" 
-              translation="translatePhrase"></tooltip-component>
+              :tooltip-text="totalRelationTooltipText"></tooltip-component>
           </template>
         </round-button>
       </span>
@@ -304,8 +303,7 @@ export default {
               position="left"
               :active="true"
               :show-tooltip="true"
-              :tooltip-text="totalRelationTooltipText" 
-              translation="translatePhrase"></tooltip-component>
+              :tooltip-text="totalRelationTooltipText"></tooltip-component>
           </template>
         </round-button>
       </div>

--- a/viewer/vue-client/src/components/inspector/summary-action.vue
+++ b/viewer/vue-client/src/components/inspector/summary-action.vue
@@ -79,8 +79,7 @@ export default {
             class="Toolbar-tooltipContainer"
             position="right"
             :show-tooltip="true"
-            :tooltip-text="getTooltipText" 
-            translation="translatePhrase"></tooltip-component>
+            :tooltip-text="getTooltipText"></tooltip-component>
         </template>
       </round-button>
     </div>

--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -385,8 +385,7 @@ export default {
             class="Toolbar-tooltipContainer"
             :show-tooltip="showDisplayAs" 
             position="left"
-            tooltip-text="Show as" 
-            translation="translatePhrase"></tooltip-component>
+            tooltip-text="Show as"></tooltip-component>
         </i>
         <span class="Toolbar-caret caret"></span>
       </button>
@@ -429,8 +428,7 @@ export default {
             class="Toolbar-tooltipContainer"
             :show-tooltip="showTools" 
             position="left"
-            tooltip-text="Tools" 
-            translation="translatePhrase"></tooltip-component>
+            tooltip-text="Tools"></tooltip-component>
         </i>
         <span class="Toolbar-caret caret"></span>
       </button>
@@ -526,8 +524,7 @@ export default {
           :show-tooltip="showUndo" 
           position="left"
           tooltip-text="Undo" 
-          keybind-name="undo"
-          translation="translatePhrase"></tooltip-component>
+          keybind-name="undo"></tooltip-component>
       </i>
     </button>
 
@@ -542,8 +539,7 @@ export default {
           :show-tooltip="showCancel" 
           position="left"
           tooltip-text="Cancel" 
-          keybind-name="cancel-edit"
-          translation="translatePhrase"></tooltip-component>
+          keybind-name="cancel-edit"></tooltip-component>
       </i>
     </button>
 
@@ -558,8 +554,7 @@ export default {
           :show-tooltip="showSave" 
           position="left"
           tooltip-text="Save" 
-          keybind-name="save-item"
-          translation="translatePhrase"></tooltip-component>
+          keybind-name="save-item"></tooltip-component>
       </i>
     </button>
     <button class="Toolbar-btn btn btn-primary" id="saveButton" 
@@ -572,15 +567,13 @@ export default {
         <tooltip-component 
           class="Toolbar-tooltipContainer"
           tooltip-text="Save and stop editing" 
-          keybind-name="save-item-done" 
-          translation="translatePhrase"
+          keybind-name="save-item-done"
           position="left"
           v-if="!isNewRecord"
           :show-tooltip="showClarifySave"></tooltip-component>
         <tooltip-component 
           tooltip-text="Create record" 
-          keybind-name="save-item"  
-          translation="translatePhrase"
+          keybind-name="save-item"
           position="left"
           class="Toolbar-tooltipContainer"
           v-if="isNewRecord"
@@ -599,7 +592,6 @@ export default {
         tooltip-text="Edit" 
         position="left"
         keybind-name="edit-item" 
-        translation="translatePhrase"
         :show-tooltip="showEdit"></tooltip-component></i>
       <i class="fa fa-fw fa-circle-o-notch fa-spin" v-show="inspector.status.opening"></i>
     </button>

--- a/viewer/vue-client/src/components/search/remote-databases.vue
+++ b/viewer/vue-client/src/components/search/remote-databases.vue
@@ -243,8 +243,7 @@ export default {
           class="RemoteDatabases-tooltip"
           :show-tooltip="clearTooltip" 
           tooltip-text="Clear all"
-          position="top" 
-          translation="translatePhrase">
+          position="top">
         </tooltip-component>
         <i class="fa fa-times-circle icon icon--lg"></i>
       </div>
@@ -260,8 +259,7 @@ export default {
           class="RemoteDatabases-tooltip"
           :show-tooltip="addTooltip" 
           :tooltip-text="'Add'"
-          position="top" 
-          translation="translatePhrase">
+          position="top">
         </tooltip-component>
         <i class="fa fa-plus-circle icon icon--primary icon--lg"></i>
       </div>

--- a/viewer/vue-client/src/components/shared/tooltip-component.vue
+++ b/viewer/vue-client/src/components/shared/tooltip-component.vue
@@ -10,7 +10,7 @@ export default {
   },
   props: {
     tooltipText: {
-      type: String,
+      type: [String, Array],
       default: '',
     },
     translation: {
@@ -20,13 +20,6 @@ export default {
     showTooltip: {
       type: Boolean,
       default: false,
-    },
-    literalString: {
-      type: Object,
-      default: () => ({
-        position: 'before',
-        text: '',
-      }),
     },
     keybindName: {
       type: String,
@@ -54,23 +47,12 @@ export default {
     translatedText() {
       if (this.translation === 'labelByLang') {
         return StringUtil.getLabelByLang(this.tooltipText, this.settings.language, this.resources.vocab, this.resources.context);
-      } if (this.translation === 'translatePhrase') {
-        return StringUtil.getUiPhraseByLang(this.tooltipText, this.settings.language);
       } 
-      return this.tooltipText;
-    },
-    totalText() {
-      let text = '';
-      if (this.literalString.position === 'before') {
-        text += this.literalString.text;
-        text += ' ';
-        text += this.translatedText;
-      } else {
-        text += this.translatedText;
-        text += ' ';
-        text += this.literalString.text;
-      }
-      return text + this.keybindingText;
+      // if (this.translation === 'translatePhrase') {
+      //   return StringUtil.getUiPhraseByLang(this.tooltipText, this.settings.language);
+      // } 
+      // return this.tooltipText;
+      return StringUtil.getUiPhraseByLang(this.tooltipText, this.settings.language);
     },
     keybindingText() {
       let str = '';
@@ -93,7 +75,7 @@ export default {
     @mouseover="hoverTooltip = true" 
     @mouseleave="hoverTooltip = false">
     <div class="tooltip-container-inner">
-      {{ totalText }}
+      {{ translatedText + keybindingText }}
     </div>
   </div>
 </template>

--- a/viewer/vue-client/src/components/shared/tooltip-component.vue
+++ b/viewer/vue-client/src/components/shared/tooltip-component.vue
@@ -13,10 +13,6 @@ export default {
       type: [String, Array],
       default: '',
     },
-    translation: {
-      type: String,
-      default: '',
-    },
     showTooltip: {
       type: Boolean,
       default: false,
@@ -45,13 +41,6 @@ export default {
       return !this.hoverTooltip && this.showTooltip;
     },
     translatedText() {
-      if (this.translation === 'labelByLang') {
-        return StringUtil.getLabelByLang(this.tooltipText, this.settings.language, this.resources.vocab, this.resources.context);
-      } 
-      // if (this.translation === 'translatePhrase') {
-      //   return StringUtil.getUiPhraseByLang(this.tooltipText, this.settings.language);
-      // } 
-      // return this.tooltipText;
       return StringUtil.getUiPhraseByLang(this.tooltipText, this.settings.language);
     },
     keybindingText() {

--- a/viewer/vue-client/src/utils/string.js
+++ b/viewer/vue-client/src/utils/string.js
@@ -76,8 +76,17 @@ export function convertToVocabKey(str, context) {
 }
 
 export function getUiPhraseByLang(phrase, langcode) {
-  if (translationsFile[langcode] && translationsFile[langcode][phrase]) {
-    return translationsFile[langcode][phrase];
+  if (typeof phrase === 'string') {
+    if (translationsFile[langcode] && translationsFile[langcode][phrase]) {
+      return translationsFile[langcode][phrase];
+    }
+  } else if (Array.isArray(phrase)) {
+    const translated = phrase.map((el) => {
+      if (translationsFile[langcode] && translationsFile[langcode][el]) {
+        return translationsFile[langcode][el];
+      } return el;
+    });
+    return translated.join(' ');
   }
   return phrase;
 }


### PR DESCRIPTION
Rewrote `getUiPhraseByLang` function a bit so that it accepts arrays and translate elements separately before joining them. This means tooltip component's `literalString` etc (which seemed overly complicated anyway) is no longer needed. 

Maybe in the long run we can avoid translation file to grow out of hand by reusing/constructing phrases out of smaller pieces.

Also removed tooltip's `translation` prop altoghether since translatePhrase is always used anyway.