### PR TITLE
Fix path for extractions and block Concept chain from extraction

### DIFF
--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -224,7 +224,7 @@ export default {
       // TODO: Remove this when Summary isn't broken
       const hackedObject = this.extractedItem;
       delete hackedObject['@graph'][1].summary;
-      this.doCreateRequest(httpUtil.post, hackedObject, this.settings.apiPath);
+      this.doCreateRequest(httpUtil.post, hackedObject, `${this.settings.apiPath}/data`);
     },
     doCreateRequest(requestMethod, obj, url) {
       requestMethod({ url, token: this.user.token, activeSigel: this.user.settings.activeSigel }, obj).then((result) => {

--- a/viewer/vue-client/src/components/inspector/item-sibling.vue
+++ b/viewer/vue-client/src/components/inspector/item-sibling.vue
@@ -211,7 +211,7 @@ export default {
       // TODO: Remove this when Summary isn't broken
       const hackedObject = this.extractedItem;
       delete hackedObject['@graph'][1].summary;
-      this.doCreateRequest(httpUtil.post, hackedObject, this.settings.apiPath);
+      this.doCreateRequest(httpUtil.post, hackedObject, `${this.settings.apiPath}/data`);
     },
     doCreateRequest(requestMethod, obj, url) {
       requestMethod({ url, token: this.user.token, activeSigel: this.user.settings.activeSigel }, obj).then((result) => {

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -100,7 +100,8 @@ const store = new Vuex.Store({
       extractableTypes: [
         'Item',
         'Instance',
-        'Identity',
+        'Agent',
+        'Work',
       ],
       removeOnDuplication: [
         'record.controlNumber',


### PR DESCRIPTION
- Removed baseclass `Identity` from extractable classes, this removes `Concept`, `Agent`, `Work` from extraction
- Add `Agent` and `Work` to extractable classes.

- Add `/data` to apiPath when making extraction calls.