### PR TITLE
Re-enable link icon

### DIFF
--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -411,7 +411,7 @@ export default {
       <div class="ItemLocal-actions">
         <div class="ItemLocal-action">
           <i class="fa fa-link fa-fw icon icon--sm"
-            v-if="inspector.status.editing && isExtractable && extractedMainEntity"
+            v-if="inspector.status.editing && isExtractable"
             @click="openExtractDialog(), expand()" 
             @focus="showLinkAction = true, actionHighlight(true, $event)"
             @blur="showLinkAction = false, actionHighlight(false, $event)"
@@ -423,9 +423,6 @@ export default {
               :show-tooltip="showLinkAction" 
               tooltip-text="Link entity"></tooltip-component>
           </i>
-          <i class="fa fa-link fa-fw icon icon--sm is-disabled"
-            v-else-if="inspector.status.editing && isExtractable && !extractedMainEntity"
-            tabindex="-1"></i>
         </div>
 
         <field-adder ref="fieldAdder" class="ItemLocal-action"

--- a/viewer/vue-client/src/components/inspector/search-window.vue
+++ b/viewer/vue-client/src/components/inspector/search-window.vue
@@ -404,15 +404,15 @@ export default {
             </ul>
           </div> -->
           <div class="PanelComponent-searchStatus" v-show="keyword.length === 0 && !extracting">
-            <p>1. {{ "Search for existing linked entities to replace your local entity" | translatePhrase }}.</p>
-            <p>2. {{ "If you can't find an existing link, you can create one using your local entity below" | translatePhrase }}.</p>
+            <p> {{ "Search for existing linked entities to replace your local entity" | translatePhrase }}.</p>
+            <p v-if="itemInfo"> {{ "If you can't find an existing link, you can create one using your local entity below" | translatePhrase }}.</p>
           </div>
           <div class="PanelComponent-searchStatus" v-show="loading">
             <vue-simple-spinner size="large" :message="'Searching' | translatePhrase"></vue-simple-spinner>
           </div>
           <div class="PanelComponent-searchStatus" v-show="foundNoResult">
             <p>{{ "Your search gave no results" | translatePhrase }}.</p>
-            <p>{{ "Try again" | translatePhrase }} {{ "or create a link from your local data below" | translatePhrase }}.</p>
+            <p v-if="itemInfo">{{ "Try again" | translatePhrase }} {{ "or create a link from your local data below" | translatePhrase }}.</p>
           </div>
           <div class="PanelComponent-searchStatus" v-show="extracting">
             <vue-simple-spinner size="large" :message="'Creating link' | translatePhrase"></vue-simple-spinner>
@@ -440,7 +440,7 @@ export default {
                 tabindex="0"></i>
               </div>
             </div>
-          <div class="SearchWindow-footerContainer">
+          <div class="SearchWindow-footerContainer" v-if="itemInfo">
             <p class="preview-entity-text uppercaseHeading">{{ "Create link from local entity" | translatePhrase }}:</p>
             <div class="SearchWindow-summaryContainer">
               <summary-action 

--- a/viewer/vue-client/src/components/shared/panel-component.vue
+++ b/viewer/vue-client/src/components/shared/panel-component.vue
@@ -294,7 +294,8 @@ export default {
     color: @grey;
 
     & > * {
-      max-width: 100%;
+      max-width: 500px;
+      text-align: center;
     }
   }
 


### PR DESCRIPTION
[LXL-2240](https://jira.kb.se/browse/LXL-2240) - A feature that seems to come across as a bug (i.e empty entities cannot be extracted, therefore disabling link icon)

Proposing the following to tackle this instead: Don't render the extract-and-link box in sidepanel if the local entity is empty. But still allowing to search-and-replace.