### PR TITLE
Feature/axe validation

### DIFF
--- a/viewer/vue-client/public/index.html
+++ b/viewer/vue-client/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="sv_SE">
+<html lang="sv">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/viewer/vue-client/src/App.vue
+++ b/viewer/vue-client/src/App.vue
@@ -488,6 +488,7 @@ h1 {
       font-size: 12px;
       font-size: 1.2rem;
       color: @gray-dark;
+      color: @gray-dark-transparent;
     }
 
     &--bold {

--- a/viewer/vue-client/src/App.vue
+++ b/viewer/vue-client/src/App.vue
@@ -558,6 +558,7 @@ h1 {
   font-size: 20px;
   font-size: 2rem;
   line-height: 1.2;
+  color: @black;
   border: 1px solid @gray-light;
   border-radius: 4px;
 

--- a/viewer/vue-client/src/App.vue
+++ b/viewer/vue-client/src/App.vue
@@ -185,7 +185,7 @@ a:focus {
 // ----------- BUTTON ----------------
 
 button, .btn-primary, .btn-primary:hover, .btn-primary:focus {
-    color: #ffffff;
+    color: @white;
 }
 
 button {
@@ -226,14 +226,15 @@ button {
   }
 
   &.btn-primary {
-    background-color: fadeout(@brand-primary, 35%);
+    background-color: fadeout(@btn-primary, 35%);
   }
 }
 
 .btn-primary {
+  background-color: @btn-primary;
   &:hover {
-    background-color: @link-hover-color;
-    border-color: @link-hover-color;
+    background-color: @btn-primary--hover;
+    border-color: @btn-primary--hover;
   }
 }
 
@@ -404,21 +405,21 @@ body {
 
 // ------------- ICONS ----------------
 .icon {
-    color: @icon-default;
-    color: @icon-alt;
+    color: @gray;
+    color: @gray-transparent;
     cursor: pointer;
     transition: color .2s ease, background-color .2s ease;
 
     &:hover {
-        color: @icon-default--hover;
-        color: @icon-alt--hover;
+        color: @gray-darker;
+        color: @gray-darker-transparent;
     }
 
     &--primary {
-        color: @icon-primary;
+        color: @btn-primary;
 
         &:hover {
-            color: @icon-primary--hover;
+            color: @btn-primary--hover;
         }
     }
 
@@ -430,24 +431,24 @@ body {
     }
 
     &--sm {
-        font-size: @icon-sm;
+        font-size: 16px;
     }
 
     &--md {
-        font-size: @icon-md;
+        font-size: 20px;
     }
     
     &--lg {
-        font-size: @icon-lg;
+        font-size: 30px;
     }
 
     &.is-disabled {
-        color: @icon-disabled;
+        color: @gray-lighter-transparent;
         cursor: not-allowed;
     }
 
     &.is-added {
-        color: @icon-added;
+        color: @gray-light;
         cursor: not-allowed;
     }
 }

--- a/viewer/vue-client/src/components/create/creation-card.vue
+++ b/viewer/vue-client/src/components/create/creation-card.vue
@@ -52,8 +52,10 @@ export default {
         <div class="CreationCard-descr card-descr">Innehåller de vanligaste fälten för vald typ.</div>
       </div>
       <div class="card-link">
-        <select class="CreationCard-select customSelect" @change="useBase($event)">
-          <option class="CreationCard-option" selected disabled>
+        <select class="CreationCard-select customSelect" 
+          @change="useBase($event)"
+          aria-labelledby="CreationCard-selectLabel">
+          <option id="CreationCard-selectLabel" class="CreationCard-option" selected disabled>
             {{'Choose type' | translatePhrase}}
           </option>
           <option class="CreationCard-option"

--- a/viewer/vue-client/src/components/create/file-adder.vue
+++ b/viewer/vue-client/src/components/create/file-adder.vue
@@ -120,14 +120,23 @@ export default {
       Notera att interna @ID-värden behöver matcha posten du vill skriva över.<br>
       Du behöver även spara posten i nästa steg för att operationen ska slutföras.
     </div>
-    <button class="btn btn-primary" @click="openPicker">{{ 'Choose file' | translatePhrase }}</button>
-    <input type="file" class="FilePicker" ref="FilePicker" accept=".jsonld,application/ld+json,text/*" />
+    <button class="btn btn-primary btn--lg" 
+      @click="openPicker">{{ 'Choose file' | translatePhrase }}</button>
+    <input type="file" 
+      class="FilePicker" 
+      ref="FilePicker" 
+      accept=".jsonld,application/ld+json,text/*"
+      aria-labelledby="Dropzone-description"/>
     <hr/>{{ 'or' | translatePhrase }}<hr/>
     <div class="Dropzone" :class="{'is-active': userIsDropping, 'is-invalid': invalidFile}">
       <div class="Dropzone-mask" ref="dropzone"></div>
       <div class="Dropzone-container">
-        <div class="Dropzone-description" v-show="!invalidFile">{{'Drop your file here' | translatePhrase}}</div>
-        <div class="Dropzone-description" v-show="invalidFile">{{'Invalid file' | translatePhrase}}</div>
+        <div id="Dropzone-description" 
+          class="Dropzone-description" 
+          v-if="!invalidFile">{{'Drop your file here' | translatePhrase}}</div>
+        <div id="Dropzone-description" 
+          class="Dropzone-description" 
+          v-else-if="invalidFile">{{'Invalid file' | translatePhrase}}</div>
       </div>
     </div>
   </div>

--- a/viewer/vue-client/src/components/inspector/create-item-button.vue
+++ b/viewer/vue-client/src/components/inspector/create-item-button.vue
@@ -127,6 +127,9 @@ export default {
       <round-button 
         :icon="hasHolding ? 'check' : 'plus'"
         :indicator="hasHolding"
+        :label="hasHolding ? 
+              [user.settings.activeSigel, 'has holding'] : 
+              ['Add holding for', user.settings.activeSigel]"
         @click="performItemAction()">
         <template slot="tooltip">
           <tooltip-component 

--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -541,10 +541,11 @@ export default {
     <!-- Adds another empty field of the same type -->
     <div class="EntityAdder-add"
       v-if="isPlaceholder">
-        <i class="fa fa-plus-circle icon icon--sm"
+        <i class="fa fa-plus-circle fa-fw icon icon--sm"
           v-if="!addEmbedded"
           tabindex="0"
-          aria-hidden="true"
+          role="button"
+          :aria-label="tooltipText | translatePhrase"
           ref="adderFocusElement"
           @click="add($event)" 
           @keyup.enter="add($event)"
@@ -556,7 +557,7 @@ export default {
             :show-tooltip="showToolTip" 
             :tooltip-text="tooltipText"></tooltip-component>
         </i>
-        <i class="fa fa-plus-circle icon icon--sm is-disabled"
+        <i class="fa fa-plus-circle fa-fw icon icon--sm is-disabled"
           v-else-if="addEmbedded"
           tabindex="-1"
           aria-hidden="true">
@@ -566,10 +567,12 @@ export default {
     <!-- Add entity within field -->
     <div class="EntityAdder-add action-button" v-if="!isPlaceholder">
       <i 
-        class="EntityAdder-addIcon fa fa-plus-circle icon icon--sm"
+        class="fa fa-fw fa-plus-circle icon icon--sm"
         v-if="!addEmbedded"
         tabindex="0"
+        role="button"
         ref="adderFocusElement"
+        :aria-label="tooltipText | translatePhrase"
         v-on:click="add($event)" 
         @keyup.enter="add($event)"
         @mouseenter="showToolTip = true, actionHighlight(true, $event)" 
@@ -581,7 +584,7 @@ export default {
           :tooltip-text="tooltipText"></tooltip-component>
       </i>
       <i
-        class="EntityAdder-addIcon fa fa-plus-circle icon icon--sm is-disabled"
+        class="fa fa-plus-circle fa-fw icon icon--sm is-disabled"
         v-else-if="addEmbedded"
         tabindex="-1">
       </i>
@@ -750,10 +753,6 @@ export default {
     &:hover {
       color: @black;
     }
-  }
-
-  &-addIcon {
-    width: 16px;
   }
 
   &-addLabel {

--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -631,7 +631,8 @@ export default {
                     name="entityKeywordInput"
                     v-model="keyword"
                     ref="input"
-                    placeholder="Sök"
+                    :aria-label="'Sök' | translatePhrase"
+                    :placeholder="'Sök' | translatePhrase"
                     autofocus />
                 </div>
                 <div class="EntityAdder-filterSearchContainer">
@@ -684,12 +685,14 @@ export default {
             </modal-pagination>
             <div class="EntityAdder-listTypes">
               <i class="fa fa-th-list icon icon--sm"
+                role="button"
                 @click="isCompact = false"
                 @keyup.enter="isCompact = false"
                 :class="{'icon--primary' : !isCompact}"
                 :title="'Detailed view' | translatePhrase"
                 tabindex="0"></i>
               <i class="fa fa-list icon icon--sm"
+                role="button"
                 @click="isCompact = true"
                 @keyup.enter="isCompact = true"
                 :class="{'icon--primary' : isCompact}"

--- a/viewer/vue-client/src/components/inspector/entity-form.vue
+++ b/viewer/vue-client/src/components/inspector/entity-form.vue
@@ -212,7 +212,7 @@ export default {
     width: 100%;
     min-height: 60px;
     box-shadow: none;
-    transition: box-shadow ease-out 0.2s;
+    // transition: box-shadow ease-out 0.2s;
 
     &:hover:not(.locked) {
       >.actions {

--- a/viewer/vue-client/src/components/inspector/entity-header.vue
+++ b/viewer/vue-client/src/components/inspector/entity-header.vue
@@ -132,7 +132,7 @@ export default {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        background: @brand-primary;
+        background: @brand-darker;
         color: @white;
         padding: 0.5em;
         box-shadow: 0 2px 5px rgba(0,0,0,.26);

--- a/viewer/vue-client/src/components/inspector/field-adder.vue
+++ b/viewer/vue-client/src/components/inspector/field-adder.vue
@@ -318,6 +318,7 @@ export default {
             ref="input"
             class="FieldAdderPanel-filterInput customInput form-control mousetrap" 
             :placeholder="'Filter by' | translatePhrase"
+            :aria-label="'Filter by' | translatePhrase"
             v-model="filterKey">
         </div>
         <div class="FieldAdderPanel-filterInfo uppercaseHeading">
@@ -357,7 +358,8 @@ export default {
                   :tabindex="prop.added ? -1 : 0"
                   :icon="prop.added ? 'check' : 'plus'"
                   :indicator="true"
-                  :disabled="prop.added"/>
+                  :disabled="prop.added"
+                  :label="prop.added ? 'Added' : 'Add'"/>
               </span>
               <span class="FieldAdderPanel-fieldLabel" :title="prop.label | capitalize">
                 {{prop.label | capitalize }}
@@ -418,7 +420,7 @@ export default {
   }
 
   &-filterInfo {
-    color: @gray;
+    color: @gray-darker;
     margin-bottom: 10px;
   }
 

--- a/viewer/vue-client/src/components/inspector/field-adder.vue
+++ b/viewer/vue-client/src/components/inspector/field-adder.vue
@@ -271,9 +271,11 @@ export default {
   <div class="FieldAdder">
     <span v-if="inner" class="FieldAdder-innerAdd">
       <i 
-        class="FieldAdder-innerIcon fa fa-plus-circle fa-fw icon icon--sm" 
+        class="FieldAdder-innerIcon fa fa-plus-circle fa-fw icon icon--sm"
+        role="button"
         tabindex="0"
         ref="adderButton"
+        :aria-label="modalTitle | translatePhrase"
         @click="show(), expand()" 
         @keyup.enter="show"
         @mouseenter="showToolTip = true, actionHighlight(true, $event)" 
@@ -292,7 +294,8 @@ export default {
       ref="adderButton"
       @keyup.enter="show"
       @mouseenter="showToolTip = true" 
-      @mouseleave="showToolTip = false">
+      @mouseleave="showToolTip = false"
+      :aria-label="modalTitle | translatePhrase">
       <i class="FieldAdder-icon fa fa-plus plus-icon" aria-hidden="true">
         <tooltip-component 
           class="Toolbar-tooltipContainer"

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -526,7 +526,9 @@ export default {
           <div class="Field-action Field-remove" 
             v-show="!locked" 
             :class="{'disabled': activeModal}">
-            <i class="fa fa-trash-o action-button icon icon--sm"
+            <i class="fa fa-trash-o fa-fw action-button icon icon--sm"
+              role="button"
+              :aria-label="'Remove' | translatePhrase"
               tabindex="0"
               v-on:click="removeThis(true)"
               @keyup.enter="removeThis(true)"
@@ -561,7 +563,7 @@ export default {
           <div v-else class="Field-action placeholder"></div> 
 
           <div class="Field-comment" v-if="propertyComment && !locked" >
-            <i class="fa fa-question-circle Field-comment icon icon--sm"></i>
+            <i class="fa fa-question-circle fa-fw icon icon--sm"></i>
             <span class="Field-commentText">{{ propertyComment }}</span>
           </div>
           <div v-else class="Field-action placeholder"></div> 
@@ -569,7 +571,9 @@ export default {
           <div class="Field-action Field-clipboardPaster"
             v-if="!locked && (isRepeatable || isEmptyObject) && clipboardHasValidObject" 
             ref="clipboardPaster">
-            <i tabindex="0" class="fa fa-paste action-button icon icon--sm"
+            <i tabindex="0" class="fa fa-paste fa-fw action-button icon icon--sm"
+              role="button"
+              :aria-label="'Paste entity' | translatePhrase"
               @click="pasteClipboardItem"
               @keyup.enter="pasteClipboardItem"
               @focus="pasteHover = true, actionHighlight(true, $event)" 
@@ -600,7 +604,7 @@ export default {
       <!-- Is inner -->
       <div class="Field-actions is-nested">
         <div class="Field-action Field-comment" v-if="propertyComment && !locked" >
-          <i class="fa fa-question-circle icon icon--sm"></i>
+          <i class="fa fa-question-circle fa-fw icon icon--sm"></i>
           <span class="Field-commentText">{{ propertyComment }}</span>
         </div>
         <entity-adder class="Field-action Field-entityAdder"
@@ -626,8 +630,10 @@ export default {
         <div class="Field-action Field-remove" 
           v-show="!locked" 
           :class="{'disabled': activeModal}">
-          <i class="fa fa-trash-o action-button icon icon--sm"
+          <i class="fa fa-trash-o fa-fw action-button icon icon--sm"
             tabindex="0"
+            role="button"
+            :aria-label="'Remove' | translatePhrase"
             v-on:click="removeThis(true)"
             @keyup.enter="removeThis(true)"
             @focus="removeHover = true, removeHighlight(true, $event)" 
@@ -643,7 +649,9 @@ export default {
         <div class="Field-action Field-clipboardPaster"
           v-if="!locked && (isRepeatable || isEmptyObject) && clipboardHasValidObject" 
           ref="clipboardPaster">
-          <i tabindex="0" class="fa fa-paste action-button icon icon--sm"
+          <i tabindex="0" class="fa fa-paste fa-fw action-button icon icon--sm"
+            role="button"
+            :aria-label="'Paste entity' | translatePhrase"
             @click="pasteClipboardItem"
             @keyup.enter="pasteClipboardItem"
             @focus="pasteHover = true, actionHighlight(true, $event)" 
@@ -1067,7 +1075,6 @@ export default {
     }
 
     .Field--inner & {
-      display: inline-block;
       font-size: 16px;
       font-size: 1.6rem;
       margin: 0 0 0 10px;

--- a/viewer/vue-client/src/components/inspector/item-boolean.vue
+++ b/viewer/vue-client/src/components/inspector/item-boolean.vue
@@ -93,7 +93,11 @@ export default {
 <template>
   <div class="ItemBoolean" v-bind:class="{'is-locked': isLocked, 'is-unlocked': !isLocked, 'distinguish-removal': removeHover, 'removed': removed}">
     <div v-if="!isLocked">
-      <input type="checkbox" class="customCheckbox-input" v-model="selected" :disabled="isLocked" />
+      <input type="checkbox" 
+        class="customCheckbox-input" 
+        v-model="selected" 
+        :disabled="isLocked"
+        :aria-label="fieldKey | labelByLang" />
       <div class="customCheckbox-icon"></div>
     </div>
     <span class="ItemVocab-text" 

--- a/viewer/vue-client/src/components/inspector/item-entity.vue
+++ b/viewer/vue-client/src/components/inspector/item-entity.vue
@@ -124,6 +124,7 @@ export default {
           v-if="!isLocked"
           role="button"
           tabindex="0"
+          :aria-label="'Remove' | translatePhrase"
           @click="removeThis(true)"
           @keyup.enter="removeThis(true)"
           @mouseover="removeHover = true, showCardInfo = false"

--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -435,13 +435,15 @@ export default {
         <div class="ItemLocal-action">
           <i class="fa fa-link fa-fw icon icon--sm"
             v-if="inspector.status.editing && isExtractable"
+            role="button"
+            tabindex="0"
+            :aria-label="'Link entity' | translatePhrase"
             @click="openExtractDialog(), expand()" 
             @focus="showLinkAction = true, actionHighlight(true, $event)"
             @blur="showLinkAction = false, actionHighlight(false, $event)"
             @mouseover="showLinkAction = true, actionHighlight(true, $event)" 
             @mouseout="showLinkAction = false, actionHighlight(false, $event)"
-            @keyup.enter="openExtractDialog(), expand()"
-            tabindex="0">
+            @keyup.enter="openExtractDialog(), expand()">
             <tooltip-component 
               :show-tooltip="showLinkAction" 
               tooltip-text="Link entity"></tooltip-component>
@@ -457,12 +459,14 @@ export default {
         </field-adder>
 
         <div class="ItemLocal-action">
-          <i class="fa fa-trash-o fa-fw icon icon--sm" 
+          <i class="fa fa-trash-o fa-fw icon icon--sm"
             v-if="!isLocked" 
-            :class="{'show-icon': showActionButtons}" 
+            :class="{'show-icon': showActionButtons}"
+            role="button"
+            tabindex="0"
+            :aria-label="'Remove' | translatePhrase"
             v-on:click="removeThis(true)" 
             @keyup.enter="removeThis(true)"
-            tabindex="0"
             @focus="removeHover = true, removeHighlight(true, $event)"
             @blur="removeHover = false, removeHighlight(false, $event)"
             @mouseover="removeHover = true, removeHighlight(true, $event)"
@@ -477,9 +481,11 @@ export default {
           <i class="icon icon--sm fa fa-fw fa-ellipsis-v"
             v-if="!isLocked"
             :class="{'show-icon': showActionButtons}" 
+            role="button"
+            tabindex="0"
+            :aria-label="'Manage' | translatePhrase"
             v-on:click="managerMenuOpen ? closeManagerMenu() : openManagerMenu()" 
             @keyup.enter="managerMenuOpen ? closeManagerMenu() : openManagerMenu()"
-            tabindex="0"
             @focus="manageHover = true, actionHighlight(true, $event)"
             @blur="manageHover = false, actionHighlight(false, $event)"
             @mouseover="manageHover = true, actionHighlight(true, $event)"

--- a/viewer/vue-client/src/components/inspector/item-sibling.vue
+++ b/viewer/vue-client/src/components/inspector/item-sibling.vue
@@ -386,12 +386,14 @@ export default {
       
       <div class="ItemSibling-actions">
         <div class="ItemSibling-action">
-          <i class="fa fa-link icon icon--sm"
-            v-if="inspector.status.editing && isExtractable"
-            @click="openExtractDialog(), expand()" 
+          <i class="fa fa-link fa-fw icon icon--sm"
+            role="button"
+            :aria-label="'Link entity' | translatePhrase"
             tabindex="0"
+            v-if="inspector.status.editing && isExtractable"
+            @click="openExtractDialog(), expand()"
             @keyup.enter="openExtractDialog(), expand()"
-            @focus="showLinkAction = true, actionHighlight($event, true)" 
+            @focus="showLinkAction = true, actionHighlight($event, true)"
             @blur="showLinkAction = false, actionHighlight($event, false)"
             @mouseover="showLinkAction = true, actionHighlight($event, true)" 
             @mouseout="showLinkAction = false, actionHighlight($event, false)">
@@ -409,12 +411,14 @@ export default {
           :path="getPath">
         </field-adder>
         <div class="ItemSibling-action">
-          <i class="fa fa-trash-o icon icon--sm" 
+          <i class="fa fa-trash-o fa-fw icon icon--sm" 
             v-if="!isLocked" 
-            :class="{'show-icon': showActionButtons}" 
+            :class="{'show-icon': showActionButtons}"
+            role="button"
+            tabindex="0"
+            :aria-label="'Remove' | translatePhrase"
             v-on:click="removeThis(true)"
             @keyup.enter="removeThis(true)"
-            tabindex="0"
             @focus="removeHover = true, removeHighlight($event, true)" 
             @blur="removeHover = false, removeHighlight($event, false)"
             @mouseover="removeHover = true, removeHighlight($event, true)" 
@@ -423,6 +427,9 @@ export default {
               :show-tooltip="removeHover" 
               tooltip-text="Remove"></tooltip-component>
           </i>
+        </div>
+        <div class="ItemSibling-action">
+          <div class="ItemSibling-placeHolder"></div>
         </div>
       </div>
     </strong>
@@ -533,8 +540,10 @@ export default {
 
   &-action {
     display: inline-block;
-    min-width: 20px;
-    margin-right: 5px;
+  }
+
+  &-placeHolder {
+    width: 20px;
   }
 
   &-collapsedLabel {

--- a/viewer/vue-client/src/components/inspector/item-sibling.vue
+++ b/viewer/vue-client/src/components/inspector/item-sibling.vue
@@ -612,7 +612,7 @@ export default {
       display: flex;
       align-items: center;
       padding: 5px 0;
-      background: @topbar-color;
+      background: @white;
       white-space: nowrap;
       overflow: hidden;
       cursor: pointer;

--- a/viewer/vue-client/src/components/inspector/item-value.vue
+++ b/viewer/vue-client/src/components/inspector/item-value.vue
@@ -177,6 +177,7 @@ export default {
     <textarea class="ItemValue-input js-itemValueInput" 
       rows="1" 
       v-model="value"
+      :aria-label="fieldKey | labelByLang"
       @blur="update($event.target.value)"
       @keydown.enter.prevent="handleEnter"
       v-if="!isLocked"
@@ -193,6 +194,8 @@ export default {
     </a>
     <div class="ItemValue-remover"
       v-show="!isLocked && isRemovable"
+      role="button"
+      :aria-label="'Remove' | translatePhrase"
       v-on:click="removeThis()"
       @focus="removeHover = true, removeHighlight($event, true)"
       @blur="removeHover = false, removeHighlight($event, false)"

--- a/viewer/vue-client/src/components/inspector/item-vocab.vue
+++ b/viewer/vue-client/src/components/inspector/item-vocab.vue
@@ -116,10 +116,13 @@ export default {
 <template>
   <div class="ItemVocab" :id="`formPath-${path}`" v-bind:class="{'is-locked': isLocked, 'is-unlocked': !isLocked, 'distinguish-removal': removeHover, 'removed': removed}">
     <div v-if="!isLocked && possibleValues.length > 0">
-      <select v-model="selected" class="ItemVocab-select customSelect">
+      <select 
+        v-model="selected" 
+        class="ItemVocab-select customSelect" 
+        :aria-label="fieldKey | labelByLang">
         <option 
           v-for="option in possibleValues" 
-          :key="option" 
+          :key="option"
           v-bind:value="option">{{ option | labelByLang }}</option>
       </select>
     </div>

--- a/viewer/vue-client/src/components/inspector/reverse-relations.vue
+++ b/viewer/vue-client/src/components/inspector/reverse-relations.vue
@@ -239,6 +239,7 @@ export default {
           :disabled="numberOfRelations === 0 || isNaN(numberOfRelations)"
           :indicator="numberOfRelations > 0"
           :icon="isNaN(numberOfRelations) ? 'exclamation' : false"
+          :active="relationsListOpen"
           @click="showPanel()">
           <template slot="tooltip">
             <tooltip-component 
@@ -285,6 +286,7 @@ export default {
           :disabled="!numberOfRelations || isNaN(numberOfRelations)"
           :indicator="numberOfRelations > 0"
           :icon="isNaN(numberOfRelations) ? 'exclamation' : false"
+          :active="relationsListOpen"
           @click="showPanel()">
           <template slot="tooltip">
             <tooltip-component 

--- a/viewer/vue-client/src/components/inspector/reverse-relations.vue
+++ b/viewer/vue-client/src/components/inspector/reverse-relations.vue
@@ -240,6 +240,7 @@ export default {
           :indicator="numberOfRelations > 0"
           :icon="isNaN(numberOfRelations) ? 'exclamation' : false"
           :active="relationsListOpen"
+          :label="totalRelationTooltipText"
           @click="showPanel()">
           <template slot="tooltip">
             <tooltip-component 
@@ -287,6 +288,7 @@ export default {
           :indicator="numberOfRelations > 0"
           :icon="isNaN(numberOfRelations) ? 'exclamation' : false"
           :active="relationsListOpen"
+          :label="totalRelationTooltipText"
           @click="showPanel()">
           <template slot="tooltip">
             <tooltip-component 

--- a/viewer/vue-client/src/components/inspector/search-window.vue
+++ b/viewer/vue-client/src/components/inspector/search-window.vue
@@ -244,7 +244,7 @@ export default {
           this.$nextTick(() => {
             this.active = true;
             this.$nextTick(() => {
-              let cleanedChipString = DisplayUtil.getItemLabel(this.itemInfo, this.resources.display, this.inspector.data.quoted, this.resources.vocab, this.settings, this.resources.context).replace(' • ', ' ');
+              const cleanedChipString = DisplayUtil.getItemLabel(this.itemInfo, this.resources.display, this.inspector.data.quoted, this.resources.vocab, this.settings, this.resources.context).replace(' • ', ' ');
               this.keyword = cleanedChipString;
               this.search();
               if (this.$refs.input) {
@@ -382,7 +382,8 @@ export default {
                   v-model="keyword"
                   ref="input"
                   autofocus
-                  :placeholder="'Search' | translatePhrase">
+                  :placeholder="'Search' | translatePhrase"
+                  :aria-label="'Search' | translatePhrase">
               </div>
               <div class="SearchWindow-filterSearchContainer">
                 <span class="SearchWindow-filterSearchLabel">{{ 'Show' | translatePhrase }}</span>
@@ -449,12 +450,14 @@ export default {
             </modal-pagination>
             <div class="SearchWindow-listTypes">
               <i class="fa fa-th-list icon icon--sm"
+                role="button"
                 @click="isCompact = false"
                 @keyup.enter="isCompact = false"
                 :class="{'icon--primary' : !isCompact}"
                 :title="'Detailed view' | translatePhrase"
                 tabindex="0"></i>
               <i class="fa fa-list icon icon--sm"
+                role="button"
                 @click="isCompact = true"
                 @keyup.enter="isCompact = true"
                 :class="{'icon--primary' : isCompact}"

--- a/viewer/vue-client/src/components/inspector/summary-action.vue
+++ b/viewer/vue-client/src/components/inspector/summary-action.vue
@@ -71,7 +71,8 @@ export default {
         :disabled="disabled || replaced || extracting"
         :color="options.styling"
         :icon="getIcon"
-        :indicator="!disabled || !replaced" 
+        :indicator="!disabled || !replaced"
+        :label="getTooltipText" 
         @click="action()"
         @keyup.enter="action()">
         <template slot="tooltip" v-if="getTooltipText">

--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -368,7 +368,7 @@ export default {
 
 <template>
   <div class="Toolbar" id="editor-container">
-    <input type="file" class="FilePicker" ref="FilePicker" accept=".jsonld,application/ld+json,text/*" />
+    <input type="file" class="FilePicker" ref="FilePicker" accept=".jsonld,application/ld+json,text/*" aria-hidden="true"/>
     <div class="dropdown Toolbar-menu OtherFormatMenu"
       v-if="!inspector.status.editing" 
       v-on-clickaway="hideOtherFormatMenu">

--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -379,7 +379,8 @@ export default {
         @focus="showDisplayAs = true"
         @blur="showDisplayAs = false"
         @mouseover="showDisplayAs = true" 
-        @mouseout="showDisplayAs = false">
+        @mouseout="showDisplayAs = false"
+        :aria-label="'Show as' | translatePhrase">
         <i class="fa fa-fw fa-eye" aria-hidden="true">
           <tooltip-component 
             class="Toolbar-tooltipContainer"
@@ -422,7 +423,8 @@ export default {
         aria-haspopup="true" 
         aria-expanded="true" 
         @mouseover="showTools = true" 
-        @mouseout="showTools = false">
+        @mouseout="showTools = false"
+        :aria-label="'Tools' | translatePhrase">
         <i class="fa fa-fw fa-wrench" aria-hidden="true">
           <tooltip-component 
             class="Toolbar-tooltipContainer"
@@ -517,7 +519,8 @@ export default {
       v-show="inspector.status.editing" 
       @click="undo" 
       @mouseover="showUndo = true" 
-      @mouseout="showUndo = false">
+      @mouseout="showUndo = false"
+      :aria-label="'Undo' | translatePhrase">
       <i class="fa fa-undo" aria-hidden="true">
         <tooltip-component 
           class="Toolbar-tooltipContainer"
@@ -532,7 +535,8 @@ export default {
       v-show="inspector.status.editing" 
       @click="cancel" 
       @mouseover="showCancel = true" 
-      @mouseout="showCancel = false">
+      @mouseout="showCancel = false"
+      :aria-label="'Cancel' | translatePhrase">
       <i class="fa fa-close" aria-hidden="true">
         <tooltip-component 
           class="Toolbar-tooltipContainer"
@@ -546,7 +550,9 @@ export default {
     <button class="Toolbar-btn btn btn-default" id="saveButton" 
       @click="postControl('save-record')"
       v-if="inspector.status.editing && !isNewRecord" 
-      @mouseover="showSave = true" @mouseout="showSave = false">
+      @mouseover="showSave = true" 
+      @mouseout="showSave = false"
+      :aria-label="'Save' | translatePhrase">
       <i class="fa fa-fw fa-circle-o-notch fa-spin" v-show="inspector.status.saving"></i>
       <i class="fa fa-fw fa-save" v-show="!inspector.status.saving">
         <tooltip-component 
@@ -561,7 +567,8 @@ export default {
       @click="postControl('save-record-done')"
       v-if="inspector.status.editing"
       @mouseover="showClarifySave = true"
-      @mouseout="showClarifySave = false">
+      @mouseout="showClarifySave = false"
+      :aria-label="'Save and stop editing' | translatePhrase">
       <i class="fa fa-fw fa-circle-o-notch fa-spin" v-show="inspector.status.saving"></i>
       <i class="fa fa-fw fa-check" v-show="!inspector.status.saving">
         <tooltip-component 
@@ -585,7 +592,8 @@ export default {
       v-on:click="edit()" 
       v-show="user.isLoggedIn && !inspector.status.editing && canEditThisType" 
       @mouseover="showEdit = true" 
-      @mouseout="showEdit = false">
+      @mouseout="showEdit = false"
+      :aria-label="'Edit' | translatePhrase">
       <i class="fa fa-fw fa-pencil-square-o" v-show="!inspector.status.opening">
         <tooltip-component 
         class="Toolbar-tooltipContainer"

--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -563,7 +563,7 @@ export default {
           keybind-name="save-item"></tooltip-component>
       </i>
     </button>
-    <button class="Toolbar-btn btn btn-primary" id="saveButton" 
+    <button class="Toolbar-btn btn btn-primary" id="saveDoneButton" 
       @click="postControl('save-record-done')"
       v-if="inspector.status.editing"
       @mouseover="showClarifySave = true"

--- a/viewer/vue-client/src/components/inspector/type-select.vue
+++ b/viewer/vue-client/src/components/inspector/type-select.vue
@@ -54,7 +54,8 @@ export default {
     <select class="customSelect" 
       v-model="selectedType"
       ref="adderTypeSelect"
-      @change="handleChange()">
+      @change="handleChange()"
+      :aria-label="'Choose type' | translatePhrase">
       <option disabled value="">{{"Choose type" | translatePhrase}}</option>
       <option v-for="(term, index) in classTree"  
         v-html="options[index].label"
@@ -66,6 +67,7 @@ export default {
       <i class="fa fa-times-circle icon icon--sm" 
         role="button"
         tabindex="0"
+        :aria-label="'Remove' | translatePhrase"
         @click="dismiss()"
         @keyup.enter="dismiss()"
         @mouseover="highlight = true"

--- a/viewer/vue-client/src/components/layout/navbar.vue
+++ b/viewer/vue-client/src/components/layout/navbar.vue
@@ -46,11 +46,11 @@ export default {
 </script>
 
 <template>
-  <nav class="NavBar" aria-labelledby="service-name">
+  <nav class="NavBar" role="navigation" aria-labelledby="service-name">
     <div class="NavBar-container container">
       <div class="row">
         <div class="col-xs-12 col-sm-5">
-          <div class="NavBar-brand" role="banner">
+          <div class="NavBar-brand">
             <router-link to="/" class="NavBar-brandLink">
               <img class="NavBar-brandLogo" src="~kungbib-styles/dist/assets/kb_logo_black.svg" alt="Kungliga Bibliotekets logotyp">
             </router-link>

--- a/viewer/vue-client/src/components/mixins/item-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/item-mixin.vue
@@ -78,7 +78,7 @@ export default {
       if (isArray(parentValue)) {
         return `${this.parentPath}[${this.index}]`;
       } 
-      return this.parentPath;
+      return `${this.parentPath}[0]`;
     },
     recordType() {
       return VocabUtil.getRecordType(this.item['@type'], this.vocab, this.settings);

--- a/viewer/vue-client/src/components/search/facet-group.vue
+++ b/viewer/vue-client/src/components/search/facet-group.vue
@@ -69,6 +69,8 @@ export default {
     <h4 class="FacetGroup-title uppercaseHeading--bold"
       :class="{'is-expanded' : isExpanded}"
       @click="toggleExpanded()"
+      @keyup.enter="toggleExpanded()"
+      tabindex="0"
       :id="facetLabelByLang(group.dimension)">
       {{facetLabelByLang(group.dimension) | capitalize}}
     </h4>
@@ -77,19 +79,20 @@ export default {
       <facet v-for="observation in slicedObservations"
       :observation="observation" 
       :key="observation.label"></facet>
-      <span 
-        v-if="revealText" 
-        class="FacetGroup-reveal link" 
-        @click="currentLevel++">{{ revealText | translatePhrase }}...</span>
     </ul>
-
+    <span 
+      v-if="revealText && isExpanded" 
+      class="FacetGroup-reveal link"
+      tabindex="0"
+      @click="currentLevel++"
+      @keyup.enter="currentLevel++">{{ revealText | translatePhrase }}...</span>
   </nav>
 </template>
 
 <style lang="less">
 .FacetGroup {
   width: 230px;
-  margin: 0px 0 0;
+  margin-bottom: 5px;
 
   &-title {
     margin: 10px 0 5px 0;
@@ -116,6 +119,7 @@ export default {
 
   &-list {
     list-style: none;
+    margin: 0;
     padding: 0 15px 0 0;
     display: none;
 

--- a/viewer/vue-client/src/components/search/facet.vue
+++ b/viewer/vue-client/src/components/search/facet.vue
@@ -57,10 +57,10 @@ export default {
     <router-link class="Facet-link"
       :to="observation.view['@id'] | asAppPath" 
       :title="determinedLabel | capitalize">
-        <span class="Facet-label"
-          :title="determinedLabel | capitalize">
-          {{determinedLabel | capitalize}}</span>
-        <span class="Facet-badge badge">{{getCompactNumber}}</span>
+      <span class="Facet-label"
+        :title="determinedLabel | capitalize">
+        {{determinedLabel | capitalize}}</span>
+      <span class="Facet-badge badge">{{getCompactNumber}}</span>
     </router-link>
   </li>
 </template>
@@ -87,10 +87,12 @@ export default {
   }
 
   &-badge {
+    min-width: 20px;
   }
 
   &-label {
     cursor: pointer;
+    margin-right: 5px;
     color: @black;
     line-height: 1.8em;
     white-space: nowrap;

--- a/viewer/vue-client/src/components/search/link-card.vue
+++ b/viewer/vue-client/src/components/search/link-card.vue
@@ -36,14 +36,13 @@ export default {
 
 <template>
   <div class="panel panel-default LinkCard" v-bind:class="{'no-link': !linkUrl, 'LinkCard--large': videoUrl}">
-    <img v-if="image" :src="resolvedImage" class="LinkCard-img"/>
+    <img v-if="image" :src="resolvedImage" class="LinkCard-img" :alt="header"/>
 
     <div v-else-if="videoUrl" class="LinkCard-videoWrap">
       <div class="LinkCard-video Video">
-        <iframe :src="videoUrl" frameborder="0" allowfullscreen></iframe>
+        <iframe :src="videoUrl" frameborder="0" allowfullscreen :title="header"></iframe>
       </div>
     </div> 
-     
     <div class="LinkCard-content card-content">
       <div class="LinkCard-text card-text">
         <span class="LinkCard-title card-title">{{ header }}</span>

--- a/viewer/vue-client/src/components/search/remote-databases.vue
+++ b/viewer/vue-client/src/components/search/remote-databases.vue
@@ -237,6 +237,7 @@ export default {
         @keyup.enter="clearDatabases()"
         tabindex="0"
         role="button"
+        :aria-label="'Clear all' | translatePhrase"
         @mouseover="clearTooltip = true" 
         @mouseout="clearTooltip = false">
         <tooltip-component 
@@ -253,6 +254,7 @@ export default {
         @keyup.enter="showList = true, addTooltip = false"
         tabindex="0"
         role="button"
+        :aria-label="'Add' | translatePhrase"
         @mouseover="addTooltip = true" 
         @mouseout="addTooltip = false">
         <tooltip-component 
@@ -275,12 +277,13 @@ export default {
             class="RemoteDatabases-listFilterInput customInput form-control mousetrap" 
             type="text" 
             v-model="filterKey"
-            :placeholder="'Filter by' | translatePhrase "
-            autofocus >
+            :aria-label="'Filter by' | translatePhrase"
+            :placeholder="'Filter by' | translatePhrase"
+            autofocus>
         </div>
       </template>
       <template slot="panel-body">
-        <ul class="RemoteDatabases-list" aria-labelledby="remoteDbListLabel"
+        <ul class="RemoteDatabases-list"
           v-show="remoteDatabases.state == 'complete' && showList">
           <li 
             class="RemoteDatabases-listItem PanelComponent-listItem"
@@ -288,20 +291,23 @@ export default {
             v-for="(db, index) in filteredDatabases" 
             @click="toggleDatabase(db.database)"
             @keyup.enter="toggleDatabase(db.database)"
-            :key="index">
+            :key="index"
+            :aria-label="db.database">
             <div class="RemoteDatabases-addControl">
               <i v-show="db.disabled" class="fa fa-ban icon icon--lg is-disabled"></i>
               <i 
                 v-show="!db.active && !db.disabled" 
                 class="fa fa-plus-circle icon icon--lg icon--primary" 
                 :title="'Add' | translatePhrase"
-                tabindex="0">
+                tabindex="0"
+                role="button">
               </i>
               <i 
                 v-show="db.active" 
                 class="fa fa-check-circle icon icon--lg" 
                 :title="'Remove' | translatePhrase"
-                tabindex="0">
+                tabindex="0"
+                role="button">
               </i>
             </div>
             <div class="RemoteDatabases-dbInfo">
@@ -399,7 +405,7 @@ export default {
     }
 
     &.is-disabled {
-      color: @grey-light;
+      color: @gray-dark-transparent;
       cursor: initial;
     }
   }

--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -262,7 +262,7 @@ export default {
     &:hover, 
     &:focus {
       background-color: transparent;
-      color: @icon-default--hover;
+      color: @gray-darker;
     }
 
     i {
@@ -271,7 +271,7 @@ export default {
     }
 
     &.is-active {
-      color: @icon-primary;
+      color: @btn-primary;
 
       i {
         color: inherit;
@@ -311,7 +311,8 @@ export default {
     text-transform: uppercase;
     transition: color 0.2s ease;
 
-    &:hover {
+    &:hover, 
+    &:focus {
       color: @brand-primary;
       text-decoration: none;
     }

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -363,7 +363,10 @@ export default {
         id="remotePanel" 
         v-if="searchPerimeter === 'remote'">
         <div class="SearchBar-formGroup form-group panel">
-          <input type="text" class="SearchBar-input customInput form-control" placeholder="ISBN eller valfria sökord" 
+          <input type="text" 
+            class="SearchBar-input customInput form-control" 
+            placeholder="ISBN eller valfria sökord"
+            aria-label="ISBN eller valfria sökord"
             v-model="remoteSearch.q">
           <button 
             class="SearchBar-submit btn btn-primary icon icon--white icon--md"

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -375,7 +375,7 @@ export default {
           </button>
         </div>
       </div>
-      <div class="SearchBar-typeButtons" aria-label="Välj typ" 
+      <div class="SearchBar-typeButtons" :aria-label="'Choose type' | translatePhrase"
         v-if="searchPerimeter === 'libris'">
         <label class="SearchBar-typeLabel" 
           :for="filter['@id']"

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -171,6 +171,7 @@ export default {
       this.inputData.textInput.splice(1, this.inputData.textInput.length);
       this.inputData.textInput[0].value = '';
       this.inputData.textInput[0].class = 'is-searchPhrase';
+      this.$refs.librisSearch[0].focus();
     },
   },
   computed: {
@@ -337,7 +338,8 @@ export default {
                   v-model="input.value"
                   class="SearchBar-qsmartInput"
                   :placeholder="'Search' | translatePhrase"
-                  :class="input.class">
+                  :class="input.class"
+                  ref="librisSearch">
                 <datalist id="matchingParameters">
                   <option v-for="matchingParameter in validSearchTags" 
                     :key="matchingParameter" 

--- a/viewer/vue-client/src/components/shared/entity-summary.vue
+++ b/viewer/vue-client/src/components/shared/entity-summary.vue
@@ -287,7 +287,7 @@ export default {
     position: relative;
 
     .ResultList & {
-      color: @brand-primary;
+      color: @brand-darker;
     }
 
     &--imported {

--- a/viewer/vue-client/src/components/shared/filter-select.vue
+++ b/viewer/vue-client/src/components/shared/filter-select.vue
@@ -221,7 +221,8 @@ export default {
     @keyup.space="focusOnInput">
     <input class="FilterSelect-input js-filterSelectInput" 
       type="text" 
-      v-bind:placeholder="translatedPlaceholder" 
+      v-bind:placeholder="translatedPlaceholder"
+      :aria-label="translatedPlaceholder"
       @keyup.exact="filter()"
       @keyup.space="checkInput($event)"
       @click="filterVisible = !filterVisible"
@@ -264,10 +265,14 @@ export default {
     <i
       class="fa icon icon--sm FilterSelect-open"
       :class="{'fa-angle-up': filterVisible, 'fa-angle-down': !filterVisible}"
+      role="button"
+      :title="!filterVisible ? 'Expand' : 'Minimize' | translatePhrase"
       @click="filterVisible = !filterVisible"
       @keyup.enter="filterVisible = !filterVisible"></i>
     <i v-if="isFilter"
       class="fa fa-close icon icon--sm FilterSelect-clear"
+      :title="'Close' | translatePhrase"
+      role="button"
       @click="clear()"
       @keyup.enter="clear()"></i>
   </div>

--- a/viewer/vue-client/src/components/shared/filter-select.vue
+++ b/viewer/vue-client/src/components/shared/filter-select.vue
@@ -41,7 +41,6 @@ export default {
   },
   data() {
     return {
-      selectId: 'filterSelect',
       selectedObject: {},
       currentItem: -1,
       filterVisible: false,
@@ -223,7 +222,6 @@ export default {
     <input class="FilterSelect-input js-filterSelectInput" 
       type="text" 
       v-bind:placeholder="translatedPlaceholder" 
-      :id="selectId" 
       @keyup.exact="filter()"
       @keyup.space="checkInput($event)"
       @click="filterVisible = !filterVisible"

--- a/viewer/vue-client/src/components/shared/panel-component.vue
+++ b/viewer/vue-client/src/components/shared/panel-component.vue
@@ -115,7 +115,7 @@ export default {
 <template>
   <div class="PanelComponent"
   :class="{'is-fadedIn': fadedIn, 'is-danger': modalType === 'danger'}"
-  >
+  role="complementary">
     <div class="PanelComponent-container" :class="{'full-view': user.settings.forceFullViewPanel }">
       <div class="PanelComponent-headerContainer">
         <div class="PanelComponent-header">

--- a/viewer/vue-client/src/components/shared/panel-component.vue
+++ b/viewer/vue-client/src/components/shared/panel-component.vue
@@ -126,14 +126,17 @@ export default {
             </div>
             <span class="PanelComponent-windowControl">
               <i class="fullview-toggle-button fa fa-compress icon icon--md"
-                @click="toggleFullView" 
                 v-show="user.settings.forceFullViewPanel"
+                role="button"
+                @click="toggleFullView" 
                 :title="'Minimize' | translatePhrase"></i>
               <i class="fullview-toggle-button fa fa-expand icon icon--md"
+                v-show="!user.settings.forceFullViewPanel"
+                role="button"
                 @click="toggleFullView" 
-                v-show="!user.settings.forceFullViewPanel" 
                 :title="'Expand' | translatePhrase"></i>
               <i class="fa fa-close icon icon--md"
+                role="button"
                 @click="close"
                 :title="'Close' | translatePhrase"></i>
             </span>
@@ -291,7 +294,7 @@ export default {
     font-size: 20px;
     font-size: 2rem;
     font-weight: normal;
-    color: @grey;
+    color: @grey-dark;
 
     & > * {
       max-width: 500px;

--- a/viewer/vue-client/src/components/shared/round-button.vue
+++ b/viewer/vue-client/src/components/shared/round-button.vue
@@ -32,6 +32,9 @@ export default {
     icon: {
       default: false,
     },
+    active: {
+      default: false,
+    },
   },
   data() {
     return {
@@ -65,7 +68,7 @@ export default {
 
 <template>
   <button class="RoundButton btn"
-    :class="{'btn-gray disabled' : disabled, 'default': !indicator && !disabled, 'btn-primary': indicator && !disabled}"
+    :class="{'btn-gray disabled' : disabled, 'default': !indicator && !disabled, 'btn-primary': indicator && !disabled, 'is-active': active}"
     @click="action()"
     @mouseover="mouseOver = true"
     @mouseout="mouseOver = false">
@@ -92,19 +95,18 @@ export default {
 
   &.default {
   background-color: @neutral-color;
-  color: @brand-primary;
-  border: 2px solid @brand-primary;
+  color: @btn-primary;
+  border: 2px solid @btn-primary;
 
     &:hover {
-      border-color: @link-hover-color; 
-      color: @link-hover-color;
+      border-color: @btn-primary--hover; 
+      color: @btn-primary--hover;
     }
   }
 
-  .is-highlighted & {
-    background-color: @link-hover-color; 
-    border-color: @link-hover-color; 
-    color: @white;
+  &.btn-primary.is-active {
+    background-color: @btn-primary--hover; 
+    border: @btn-primary--hover;
   }
 
   &.disabled { //can't be SUIT-ified because inherits from Bootstrap .disabled

--- a/viewer/vue-client/src/components/shared/round-button.vue
+++ b/viewer/vue-client/src/components/shared/round-button.vue
@@ -38,7 +38,7 @@ export default {
       default: false,
     },
     label: {
-      type: [String, Boolean],
+      type: [String, Boolean, Array],
       default: false,
     },
   },

--- a/viewer/vue-client/src/components/shared/round-button.vue
+++ b/viewer/vue-client/src/components/shared/round-button.vue
@@ -9,6 +9,8 @@ Listen to the 'click' event in the parent as usual.
     * disabled - bool, true will not emit the action.
     * icon - pass in a fa-name, i.e 'check'. Otherwise child node will render as text content
     * indicator - true gets an 'active' look
+    * active - true gives primary a permanent 'focused' look
+    * label - (if icon) provide a string that will be translated & used as accessible label
 */
 export default {
   name: 'round-button',
@@ -33,6 +35,10 @@ export default {
       default: false,
     },
     active: {
+      default: false,
+    },
+    label: {
+      type: [String, Boolean],
       default: false,
     },
   },
@@ -71,7 +77,8 @@ export default {
     :class="{'btn-gray disabled' : disabled, 'default': !indicator && !disabled, 'btn-primary': indicator && !disabled, 'is-active': active}"
     @click="action()"
     @mouseover="mouseOver = true"
-    @mouseout="mouseOver = false">
+    @mouseout="mouseOver = false"
+    :aria-label="label | translatePhrase">
     <span v-if="icon">
       <i :class="`fa fa-${icon}`" aria-hidden="true"></i>
     </span>

--- a/viewer/vue-client/src/components/shared/user-avatar.vue
+++ b/viewer/vue-client/src/components/shared/user-avatar.vue
@@ -58,7 +58,7 @@ export default {
   flex-direction: column;
   align-items: center;
   border-radius: 50%;
-  background-color: @brand-primary;
+  background-color: @brand-darker;
 
   &-gravatar {
     line-height: 1.8em;

--- a/viewer/vue-client/src/components/shared/user-avatar.vue
+++ b/viewer/vue-client/src/components/shared/user-avatar.vue
@@ -58,7 +58,7 @@ export default {
   flex-direction: column;
   align-items: center;
   border-radius: 50%;
-  background-color: @brand-darker;
+  background-color: @brand-primary;
 
   &-gravatar {
     line-height: 1.8em;

--- a/viewer/vue-client/src/components/usersettings/user-settings.vue
+++ b/viewer/vue-client/src/components/usersettings/user-settings.vue
@@ -83,19 +83,28 @@ export default {
       <div class="UserSettings-config UserConfig">
         <form class="UserConfig-form">
           <div class="UserConfig-formGroup">
-            <label class="UserConfig-label">{{"Active sigel" | translatePhrase}}</label>
+            <label for="UserConfig-sigel" class="UserConfig-label">{{"Active sigel" | translatePhrase}}</label>
             <div class="UserConfig-selectWrap">
-              <select class="UserConfig-select customSelect" :value="user.settings.activeSigel" @change="updateSigel">
-                <option v-for="sigel in user.collections" :key="sigel.code" :value="sigel.code">{{ getSigelLabel(sigel, 50) }}</option>
+              <select id="UserConfig-sigel" 
+                class="UserConfig-select customSelect" 
+                :value="user.settings.activeSigel" 
+                @change="updateSigel">
+                <option v-for="sigel in user.collections" 
+                  :key="sigel.code" 
+                  :value="sigel.code">{{ getSigelLabel(sigel, 50) }}</option>
               </select>
             </div>
           </div>
           
           <div class="UserConfig-formGroup">
-            <label class="UserConfig-label">{{"Language" | translatePhrase}}</label>
+            <label for="UserConfig-lang" class="UserConfig-label">{{"Language" | translatePhrase}}</label>
             <div class="UserConfig-selectWrap">
-              <select class="UserConfig-select customSelect" :value="user.settings.language" @change="updateLanguage">
-                <option v-for="language in settings.availableUserSettings.languages" :key="language.value" :value="language.value">{{ language.label | translatePhrase }}</option>
+              <select id="UserConfig-lang" class="UserConfig-select customSelect" 
+                :value="user.settings.language" 
+                @change="updateLanguage">
+                <option v-for="language in settings.availableUserSettings.languages" 
+                  :key="language.value" 
+                  :value="language.value">{{ language.label | translatePhrase }}</option>
               </select>
             </div>
           </div>
@@ -111,7 +120,7 @@ export default {
           </div>
 
         </form>
-        <button class="btn btn-primary btn--lg UserSettings-logout" @click="logout">Logga ut</button>
+        <button class="btn btn-primary btn--lg UserSettings-logout" @click="logout">{{"Log out" | translatePhrase}}</button>
       </div>
     </div>
   </section>

--- a/viewer/vue-client/src/styles/_variables.less
+++ b/viewer/vue-client/src/styles/_variables.less
@@ -59,6 +59,7 @@
 @gray-transparent: rgba(0, 0, 0, 0.45);
 @gray-light-transparent: rgba(0, 0, 0, 0.25);
 @gray-lighter-transparent: rgba(0, 0, 0, 0.12);
+@gray-dark-transparent: rgba(0, 0, 0, 0.58);
 @gray-darker-transparent: rgba(0, 0, 0, 0.68);
 
 @grey-lighter: @gray-lighter;
@@ -150,7 +151,7 @@
 // SIDEBAR
 @list-item-bg-even: @bg-site;
 @list-item-bg-odd: @white;
-@list-item-bg-hover: @gray-lighter;
+@list-item-bg-hover: darken(@list-item-bg-even, 6%);
 @panel-header-bg: @bg-site;
 
 // TOOLBAR

--- a/viewer/vue-client/src/styles/_variables.less
+++ b/viewer/vue-client/src/styles/_variables.less
@@ -1,64 +1,182 @@
 // Import kb-styles colors
 @import "~bootstrap/less/variables.less";
 
-// ----------- VARIABLES ------------
+// ----------- FONTS ------------
+
 @font-family-base: 'Open Sans', sans-serif;
 
+// ----------- COLORS ------------
+
 @brand-primary: #29A1A2;
+@brand-darker: #207E7E;
+
+@brand-id: #547e91;
+
+@neutral-color: #FCFCFC;
+
+// @sec: rgba(135, 170, 187, 0.3);
+@sec: #e0e9ee;
+// @sec-contrast: #74aac3;
+// @sec-alter: #629fbc;
+// @sec-alter-contrast: #4b8faf;
+
 @brand-danger: #FF7373;
+@danger: rgba(255, 115, 115, 0.3);
+@danger-alter: #C85151;
+
+@warning: rgba(254, 212, 129, 0.5);
+@warning-alter: #CA9543;
+
 @bg-site: #F9F9F9;
 @test-color: pink;
-@bg-img: none;
-//@bg-img: url('/assets/img/bg_libris.png');
-@bg-content: @black;
-@bg-content-alt: @black;
-@bg-navbar: #ffffff;
-@bg-navbar-hover: rgba(199, 226, 224, 0.27);
-@shadow-navbar: none;
-@text-navbar: #505050;
-@text-brand: #505050;
-@text-brand-env: @brand-primary;
-@text-alt-navbar: #505050;
-@text-toolbar: fade(@white, 55%);
-@bg-sidebars: darken(@white, 5%);
-@border-navbar: @gray-light;
-@border-navbar-width: 1px;
-@shadow-footer: inset 0px 1px 0px 0px @gray;
-@text-footer: @black;
-@text-alt-footer: @black;
-@bg-jumbotron: transparent;
-@bg-jumbotron-image: none;
-@border-footer: @gray-light;
-@color-class: @gray;
-@color-prop: @brand-primary;
-@color-prop-list: @gray;
-@color-ext: #d51;
-@color-id: #c7254e;
-@link-color: @brand-primary;
-@link-hover-color: darken(@link-color,17%);
-@panel-border-radius: 3px;
-@thing-header-bg: @brand-primary;
-@thing-header-text: @white;
 
+
+@holding-color: #ac82b5;
+@bib-color: #009788;
+
+// @success: #d4edda;
+// @success-alt: #c3e6cb;
+
+// @color-headers: @brand-primary;
+// @color-headers-text: #fff;
+
+// @orange: #CA9543;
+// @green: #009788;
+// @gray-very-dark: #191913; // font-color
+
+// GRAYSCALE
 @white: #ffffff;
-@gray-lighter: #E0E6E9;
-@gray-light: #C4C7CA;
+// @black: #333;
+@black: #222;
 @gray: #949A9E;
-@gray-dark: #6F767B;
+@gray-light: #C4C7CA;
+@gray-lighter: #E0E6E9;
+// @gray-dark: #6F767B;
+@gray-dark: #6B7476;
+
 @gray-darker: #595D61;
+
+@gray-transparent: rgba(0, 0, 0, 0.45);
+@gray-light-transparent: rgba(0, 0, 0, 0.25);
+@gray-lighter-transparent: rgba(0, 0, 0, 0.12);
+@gray-darker-transparent: rgba(0, 0, 0, 0.68);
+
 @grey-lighter: @gray-lighter;
 @grey-light: @gray-light;
 @grey: @gray;
 @grey-dark: @gray-dark;
 @grey-darker: @gray-darker;
-@black: #333;
 
 
-@color-headers: @brand-primary;
-@color-headers-text: #fff;
+// ----------- GLOBAL ------------
+
+// BACKGROUNDS
+@bg-img: none;
+// @bg-content: @white;
+// @bg-content-alt: @white;
+
+// HEADERS
+// @color-headers: @brand-primary;
+// @color-headers-text: #fff;
+
+// LINKS
+@link-color: @brand-darker;
+@link-hover-color: darken(@link-color,17%);
+
+// BUTTONS
+@btn-primary: @brand-primary;
+@btn-primary--hover: darken(@btn-primary,17%);
+
+// ICONS
+// @icon-default: @gray;
+// @icon-default--hover: @gray-darker;
+
+// @icon-alt: @gray-transparent;
+// @icon-alt--hover: @gray-darker-transparent;
+
+// @icon-primary: @btn-primary;
+// @icon-primary--hover: @btn-primary--hover;
+
+// @icon-added: @gray-light;
+// @icon-disabled: @gray-lighter-transparent;
+
+// @icon-sm: 16px;
+// @icon-md: 20px;
+// @icon-lg: 30px;
+
+// CHIPS
+@chip-color: @link-color;
+@chip-color-hover: @link-hover-color;
+@chip-background: transparent;
+
+// SHADOWS
+@shadow-base: none;
+@shadow-chip: 0px 0px 5px 1px rgba(0, 0, 0, 0.15);
+@shadow-chip-elevated: 0px 5px 13px 2px rgba(0, 0, 0, 0.3);
+@shadow-card-elevated: 0px -1px 5px 2px rgba(0, 0, 0, 0.2);
+// @shadow-select: 0px 5px 13px 2px rgba(0, 0, 0, 0.3);
+@shadow-panel: 0 2px 2px 0 rgba(0,0,0,0.14), 0 1px 5px 0 rgba(0,0,0,0.12), 0 3px 1px -2px rgba(0,0,0,0.1);
+
+// MISC
+// @panel-border-radius: 3px;
+// @thing-header-bg: @brand-primary;
+// @thing-header-text: @white;
+
+// @bg-jumbotron: transparent;
+// @bg-jumbotron-image: none;
+
+// @color-id: #c7254e;
+// @color-class: @gray;
+// @color-prop: @brand-primary;
+// @color-prop-list: @gray;
+// @color-ext: #d51;
+
+// @color-local: @white;
+
+// ----------- COMPONENTS ------------
+
+// NAVBAR
+@bg-navbar: @white;
+@text-brand-env: @brand-darker;
+@text-alt-navbar: @gray-darker;
+// @bg-navbar-hover: rgba(199, 226, 224, 0.27);
+// @shadow-navbar: none;
+// @text-navbar: #505050;
+// @text-brand: #505050;
+
+// @border-navbar: @gray-light;
+// @border-navbar-width: 1px;
+
+// SIDEBAR
+@list-item-bg-even: @bg-site;
+@list-item-bg-odd: @white;
+@list-item-bg-hover: @gray-lighter;
+@panel-header-bg: @bg-site;
+
+// TOOLBAR
+// @text-toolbar: fade(@white, 55%);
+// @bg-sidebars: darken(@white, 5%);
+
+// FOOTER
+@bg-footer: @gray-darker;
+@text-footer: #fff;
+@text-alt-footer: #fff;
+// @shadow-footer: inset 0px 1px 0px 0px @gray;
+// @border-footer: @gray-light;
+
+// FORM
+@form-border: @gray-lighter;
+@form-border-alt: @gray-lighter-transparent;
+@field-path: @gray-light;
+@field-path-alt: @gray-light-transparent;
+@remove: @danger;
+@add: @sec;
+@highlight-color: @brand-primary;
+@form-field: @white;
+// @node-bg: #fafafa;
 
 
-// ----------- VARIABLES ------------
+// ----------- VALUES ------------
 
 // Z-index
 @header-z: 900;
@@ -68,139 +186,8 @@
 @active-component-z: 99;
 @backdrop-z: 950;
 
-// ---- grayscale ----
-@white: #ffffff;
-@black: #222;
-@gray: #949A9E;
-@gray-light: #C4C7CA;
-@gray-lighter: #E0E6E9;
-@gray-dark: #6F767B;
-@gray-darker: #595D61;
-
-@gray-transparent: rgba(0, 0, 0, 0.45);
-@gray-light-transparent: rgba(0, 0, 0, 0.25);
-@gray-lighter-transparent: rgba(0, 0, 0, 0.12);
-@gray-darker-transparent: rgba(0, 0, 0, 0.68);
-
-// LIBRIS colors
-@holding-color: #ac82b5;
-@bib-color: #009788;
-
-// - Color choices
-@brand-id: #547e91;
-@test-color: pink;
-@neutral-color: #FCFCFC;
-@bg-img: none;
-@bg-content: @white;
-@bg-content-alt: @white;
-@text-navbar: #505050;
-@text-brand: #505050;
-@text-brand-env: @brand-primary;
-@text-alt-navbar: #505050;
-@text-toolbar: fade(@white, 55%);
-@bg-sidebars: darken(@white, 5%);
-@bg-footer: @gray-darker;
-@text-footer: #fff;
-@text-alt-footer: #fff;
-@bg-jumbotron: transparent;
-@bg-jumbotron-image: none;
-@border-footer: @gray-light;
-@color-ext: #d51;
-@color-id: #c7254e;
-@panel-border-radius: 3px;
-@topbar-color: @white;
-
-// @sec: rgba(135, 170, 187, 0.3);
-@sec: #e0e9ee;
-@sec-contrast: #74aac3;
-
-@sec-alter: #629fbc;
-@sec-alter-contrast: #4b8faf;
-
-@success: #d4edda;
-@success-alt: #c3e6cb;
-
-@danger: rgba(255, 115, 115, 0.3);
-@danger-alter: #C85151;
-
-@warning: rgba(254, 212, 129, 0.5);
-@warning-alter: #CA9543;
-
-@color-headers: @brand-primary;
-@color-headers-text: #fff;
-
-// --------- SHADOWS AND ELEVATION --
-@shadow-base: none;
-@shadow-chip: 0px 0px 5px 1px rgba(0, 0, 0, 0.15);
-@shadow-chip-elevated: 0px 5px 13px 2px rgba(0, 0, 0, 0.3);
-@shadow-card-elevated: 0px -1px 5px 2px rgba(0, 0, 0, 0.2);
-@shadow-select: 0px 5px 13px 2px rgba(0, 0, 0, 0.3);
-@shadow-panel: 0 2px 2px 0 rgba(0,0,0,0.14), 0 1px 5px 0 rgba(0,0,0,0.12), 0 3px 1px -2px rgba(0,0,0,0.1);
-
-// --------- ICON COLOR & SIZES -----
-@icon-default: @gray;
-@icon-default--hover: @gray-darker;
-
-@icon-alt: @gray-transparent;
-@icon-alt--hover: @gray-darker-transparent;
-
-@icon-primary: @link-color;
-@icon-primary--hover: @link-hover-color;
-
-@icon-added: @gray-light;
-@icon-disabled: @gray-lighter-transparent;
-
-@icon-sm: 16px;
-@icon-md: 20px;
-@icon-lg: 30px;
-
-// --------- CHIP -------------------
-
-@chip-color: @link-color;
-@chip-color-hover: @link-hover-color;
-@chip-background: transparent;
-
-// --------- COMPONENT COLORS -------
-@color-local: @white;
-
-// --------- EDITOR SPECIFIC --------
-
-@form-field: @white;
-
-@form-border: @gray-lighter;
-@form-border-alt: @gray-lighter-transparent;
-
-@field-path: @gray-light;
-@field-path-alt: @gray-light-transparent;
-
-@remove: @danger;
-@add: @sec;
-
-@node-bg: #fafafa;
-
-@highlight-color: @brand-primary;
-
 // Column widths
 @col-label: 200px;
 @col-value: 620px;
 @col-action: 250px;
 
-// --------- MODAL/PANEL VARIABLES --------
-
-@list-item-bg-even: @bg-site;
-@list-item-bg-odd: @white;
-@list-item-bg-hover: @gray-lighter;
-@panel-header-bg: @bg-site;
-
-
-// ----------- BASE STYLES ----------
-
-@orange: #CA9543;
-@green: #009788;
-@gray-very-dark: #191913; // font-color
-
-
-// Column widths
-@col-label: 200px;
-@col-value: 620px;
-@col-action: 250px;


### PR DESCRIPTION
[LXL-836](https://jira.kb.se/browse/LXL-836): improve site accessibility and our score in various such tests 😊

Fixed following issues as pointed out by Axe accessibility add-on:
* Color contrast - new `@brand-darker` replaces `@brand-primary` on elements with text content. A darker grey color text was needed in some places.
* Aria `role` attributes should now be valid everywhere + added `role=button` for icon buttons.
* Icon buttons and form elements now all have a descriptive `aria-label` or `aria-labelledby`.
* Removed lots o duplicate element ID:s

Bonus fixes: 
* Sort & cleanup sass-variables. Outcommented for now so we see that nothing breaks.
* Restore text color in search boxes
* Form icon alignment tweaks
* Restore bg-color transition in outer fields
* etc