### PR TITLE
Fix panel esc bug

### DIFF
--- a/viewer/vue-client/src/components/shared/panel-component.vue
+++ b/viewer/vue-client/src/components/shared/panel-component.vue
@@ -78,7 +78,7 @@ export default {
   },
   watch: {
     'status.keyActions'(actions) {
-      const lastAction = actions.slice(-1);
+      const lastAction = actions.slice(-1).join();
       if (lastAction === 'close-modals') {
         this.close();
       }


### PR DESCRIPTION
`'close-modals' !== ['close-modals']`
Panel should now close with esc again.