### PR TITLE
feature/sort-class-fix

### DIFF
--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -106,11 +106,8 @@ export default {
       }
       return list;
     },
-    getRecordType() {
-      const searchTypes = this.$route.query['@type'];
-      if (typeof searchTypes === 'string') { // disable sorting when searching multiple types
-        return searchTypes;
-      } return false;
+    searchedTypes() {
+      return this.$route.query['@type'];
     },
     currentSortOrder() {
       return this.$route.query._sort;
@@ -160,9 +157,9 @@ export default {
       </div>
       <div class="ResultControls-controlWrap" v-if="showDetails && pageData.totalItems > 0">
         <sort 
-          v-if="getRecordType && $route.params.perimeter != 'remote'"
+          v-if="searchedTypes && $route.params.perimeter != 'remote'"
           :currentSort="currentSortOrder ? currentSortOrder : ''"
-          :recordType="getRecordType"
+          :recordTypes="searchedTypes"
           @change="$emit('sortChange', $event)"/>
         <div class="ResultControls-listTypes">
           <button class="ResultControls-listType icon icon--md"

--- a/viewer/vue-client/src/components/search/sort.vue
+++ b/viewer/vue-client/src/components/search/sort.vue
@@ -1,10 +1,12 @@
 <script>
+import { mapGetters } from 'vuex';
+import * as VocabUtil from '@/utils/vocab';
 
 export default {
   name: 'sort',
   props: {
-    recordType: { // Type to get sort options for (i.e 'Instance', 'Work' etc) 
-      type: String,
+    recordTypes: {
+      type: [String, Array],
       required: true,
     },
     currentSort: { // sortparam-value to set initial select option
@@ -17,15 +19,42 @@ export default {
     };
   },
   computed: {
+    ...mapGetters([
+      'inspector',
+      'resources',
+    ]),
     newSort() {
       if (this.boundVal) {
         return this.boundVal;
       } return '';
     },
     options() {
-      const sortOptions = this.$store.getters.settings.sortOptions[this.recordType];
+      const sortOptions = this.$store.getters.settings.sortOptions[this.commonBaseType];
       if (sortOptions) {
         return sortOptions;
+      }
+      return false;
+    },
+    commonBaseType() {
+      if (typeof this.recordTypes === 'string') {
+        return VocabUtil.getRecordType(
+          this.recordTypes,
+          this.resources.vocab, 
+          this.resources.context,
+        );
+      }
+      if (Array.isArray(this.recordTypes)) {
+        const baseTypes = this.recordTypes.reduce((accumulator, currType) => {
+          const baseType = VocabUtil.getRecordType(currType, this.resources.vocab, this.resources.context);
+          const length = accumulator.length;
+          if (length === 0 || accumulator[length - 1] !== baseType) {
+            accumulator.push(baseType);
+          }
+          return accumulator;
+        }, []);
+        if (baseTypes.length === 1) { // same base class -> check sort options
+          return baseTypes.join();
+        } return false; // different base classes -> disallow sort
       }
       return false;
     },


### PR DESCRIPTION
Current implementation of the sort component only allow one searched `@type` since we need to get relevant sort options/parameters for it. This completely ignored subclasses and the fact that multiple types can be a subset of Instance for example.

This fix allows an array of searched types to be sent to the sort component. It then reduces it and if they all belong to the same recordtype, we then get sort options for it.

For example: good when using the 'type' facets.

