### PR TITLE
Add workaround for IE11 when downloading Blob

### DIFF
--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -391,17 +391,21 @@ export default {
       const element = document.createElement('a');
       const json = JSON.stringify(this.getPackagedItem(true), null, 2); // 2 = json-spacing
       const blob = new Blob([`${json}`], { type: 'application/ld+json' });
-      element.href = window.URL.createObjectURL(blob);
       const splitIdParts = focusId.split('/');
       const id = splitIdParts[splitIdParts.length - 1];
       const promptInstruction = StringUtil.getUiPhraseByLang('Name your file', this.user.settings.language);
       const promptedName = prompt(promptInstruction, id);
       if (promptedName !== null) {
-        element.download = `${promptedName}.jsonld`;
-        element.style.display = 'none';
-        document.body.appendChild(element);
-        element.click();
-        document.body.removeChild(element);
+        if (this.downloadIsSupported) {
+          element.href = window.URL.createObjectURL(blob);
+          element.download = `${promptedName}.jsonld`;
+          element.style.display = 'none';
+          document.body.appendChild(element);
+          element.click();
+          document.body.removeChild(element);
+        } else {
+          window.navigator.msSaveOrOpenBlob(blob, `${promptedName}.jsonld`);
+        }
       }
     },
     getPackagedItem(keepEmpty = false) {
@@ -570,6 +574,10 @@ export default {
     },
     isItem() {
       return this.inspector.data.mainEntity['@type'] === 'Item';
+    },
+    downloadIsSupported() {
+      const a = document.createElement('a');
+      return typeof a.download !== 'undefined';
     },
     recordType() {
       return VocabUtil.getRecordType(


### PR DESCRIPTION
Same workaround has been used for `Download Compiled Marc` before. This is for the "download json" and "download json (incl unsaved changes)".

We can probably spin this branch on dev2 to check it.