### PR TITLE
Save expansion state on toggle

### DIFF
--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -125,6 +125,9 @@ export default {
           case 'close-modals':
             this.hide();
             break;
+          case 'focus-changed':
+            this.hide();
+            break;
           default:
         }
       }

--- a/viewer/vue-client/src/components/inspector/field-adder.vue
+++ b/viewer/vue-client/src/components/inspector/field-adder.vue
@@ -249,6 +249,11 @@ export default {
           case 'close-modals':
             this.hide();
             break;
+          case 'focus-changed':
+            if (!this.inToolbar) {
+              this.hide();
+            }
+            break;
           default:
         }
       }

--- a/viewer/vue-client/src/components/inspector/search-window.vue
+++ b/viewer/vue-client/src/components/inspector/search-window.vue
@@ -130,6 +130,9 @@ export default {
           case 'close-modals':
             this.hide();
             break;
+          case 'focus-changed':
+            this.hide();
+            break;
           default:
         }
       }

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -385,6 +385,7 @@ export default {
     },
     setEditorFocus(value) {
       this.$store.dispatch('setInspectorStatusValue', { property: 'focus', value: value });
+      this.$store.dispatch('pushInspectorEvent', { name: 'form-control', value: 'focus-changed' });
     },
     downloadJson() {
       const focusId = this.inspector.data.record['@id'];
@@ -648,11 +649,13 @@ export default {
           <validation-summary v-if="user.settings.appTech" />
 
           <tab-menu @go="setEditorFocus" :tabs="editorTabs" :active="this.inspector.status.focus" />
-
-          <entity-form 
-            :editing-object="inspector.status.focus" 
-            :locked="!inspector.status.editing">
-          </entity-form>
+            
+            <entity-form 
+              v-for="tab in editorTabs"
+              :editing-object="tab.id" 
+              :key="tab.id"
+              :locked="!inspector.status.editing">
+            </entity-form>
         </div>
       </div>
     </div>


### PR DESCRIPTION
[LXL-2005](https://jira.kb.se/browse/LXL-2005) - save fields' expansion state when toggling between instance/record.

Instead of saving the state of each field in vuex for example (which seemed like a lot of data for nothing _that_ important) I thought about saving their state by simply keeping the component in the DOM.

Today we render a single `<entity-form>` and fill it with different data when toggling focus. This approach renders one `<entity-form>` (incl data) per tab-item. Toggling is then merely a `v-show` switch. 

Everything seems to work as before, but we have to manually close some panels on switch since their parents are never unmounted. 

**Advantages:**
+ state is preserved
+ switching is much faster

**Disadvantages:**
???