### PR TITLE
Refactor/redesign search-form

### DIFF
--- a/viewer/vue-client/src/App.vue
+++ b/viewer/vue-client/src/App.vue
@@ -227,6 +227,7 @@ button {
 
   &.btn-primary {
     background-color: fadeout(@btn-primary, 35%);
+    box-shadow: none;
   }
 }
 

--- a/viewer/vue-client/src/components/search/facet-group.vue
+++ b/viewer/vue-client/src/components/search/facet-group.vue
@@ -92,7 +92,7 @@ export default {
 <style lang="less">
 .FacetGroup {
   width: 230px;
-  margin-bottom: 5px;
+  margin-bottom: 15px;
 
   &-title {
     margin: 10px 0 5px 0;

--- a/viewer/vue-client/src/components/search/remote-databases.vue
+++ b/viewer/vue-client/src/components/search/remote-databases.vue
@@ -104,6 +104,11 @@ export default {
       if (val !== oldVal) {
         this.filterKey = '';
       }
+      if (val) {
+        this.$nextTick(() => this.focusFilterInput());
+      } else {
+        this.$emit('panelClosed');
+      }
     },
   },
   methods: {
@@ -200,6 +205,9 @@ export default {
       userObj.settings.defaultDatabases = dbs;
       this.$store.dispatch('setUser', userObj);
     },
+    focusFilterInput() {
+      this.$refs.listFilterInput.focus();
+    },
   },
   components: {
     'panel-component': PanelComponent,
@@ -280,6 +288,7 @@ export default {
             v-model="filterKey"
             :aria-label="'Filter by' | translatePhrase"
             :placeholder="'Filter by' | translatePhrase"
+            ref="listFilterInput"
             autofocus>
         </div>
       </template>

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -170,17 +170,21 @@ export default {
       this.focusSearchInput();
     },
     getIncomingSearch() {
-      const match = PropertyMappings.filter(prop => Object.keys(prop.mappings).every(key => this.$route.query.hasOwnProperty(key)));
-      console.log(match);
+      let match = PropertyMappings
+        .filter(prop => Object.keys(prop.mappings)
+          .every(key => this.$route.query.hasOwnProperty(key)));
+
+      if (match.length > 1) { // multiple sets of matching parameters
+        const newMatch = match
+          .filter(prop => prop.mappings['identifiedBy.@type'] === this.$route.query['identifiedBy.@type']);
+        match = newMatch;
+      }
       if (match.length > 0) {
         const matchObj = match[0];
         this.$nextTick(() => {
           this.searchPhrase = this.$route.query[matchObj.searchProp];
         });
         return matchObj;
-      } if (match.length > 1) { // problem, we have multiple sets of matching parameters
-        console.log('ouch!');
-        return false;
       }
       return PropertyMappings[0];
     },

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -14,66 +14,24 @@ export default {
       default: 'libris',
       type: String,
     },
-    // resultData: {},
   },
   data() {
     return {
       vocabUrl: 'https://id.kb.se/vocab/',
-      // inputData: {
-      //   type: 'q',
-      //   q: this.$route.query.q,
-      // },
-      // searchParams: {
-      //   _limit: 20,
-      //   // currentInput: 0,
-      //   '@type': ['Instance', 'Work'],
-      // },
       staticProps: { _limit: 20 },
       searchPhrase: '',
       searchParams: PropertyMappings,
       activeSearchParam: this.getIncomingSearch(),
       activeTypes: this.getIncomingTypes(),
-      // query: (() => { // try to compose v-model bound object from route query
-      //   if (isEmpty(this.$route.query)) {
-      //     return { // else return default settings
-      //       // q: '',
-      //       // ...this.activeSearchParam,
-      //       // _limit: 20,
-      //       '@type': ['Instance'],
-      //     };
-      //   }
-      //   const currentQuery = cloneDeep(this.$route.query);
-      //   if (typeof currentQuery['@type'] === 'string') { // put a single @type into an array
-      //     currentQuery['@type'] = [currentQuery['@type']];
-      //   }
-      //   return currentQuery;
-      // })(),
-      // remoteSearch: {
-      //   q: '',
-      // },
-      // query: '',
-      // activeClass: 'is-active',
-      // currentSearchEl: null,
     };
   },
   methods: {
     focusSearchInput() {
-      // this.currentSearchEl = this.searchPerimeter === 'libris' ? this.$refs.librisSearch : this.$refs.remoteSearch;
-      // this.currentSearchEl.focus();
       this.$refs.searchBarInput.focus();
     },
     switchPerimeter(id) {
       this.$router.push({ path: `/search/${id}` });
-      // this.moveQuery(id);
     },
-    // moveQuery(toPerimeter) {
-    //   const qIndex = findIndex(this.inputData.textInput, { class: 'is-searchPhrase' });
-    //   if (toPerimeter === 'libris') {
-    //     this.inputData.textInput[qIndex].value = this.remoteSearch.q;
-    //   } else {
-    //     this.remoteSearch.q = this.inputData.textInput[qIndex].value;
-    //   }
-    // },
     removeTags(html) {
       let regexHtml = html.replace(/<h1.*>.*?<\/h1>/ig, '').replace(/<h2.*>.*?<\/h2>/ig, '');
       regexHtml = regexHtml.replace(/(<\/?(?:code|br|p)[^>]*>)|<[^>]+>/ig, '$1');
@@ -98,47 +56,9 @@ export default {
       const helpText = document.querySelector('.js-searchHelpText');
       helpText.parentElement.classList.toggle(this.activeClass);
     },
-    // addSearchField() {
-    //   const newobj = {};
-    //   newobj.value = '';
-    //   newobj.class = 'is-searchPhrase';
-    //   this.inputData.textInput.push(newobj);
-    //   this.inputData.currentInput += 1;
-    // },
-    // updateField() {
-    //   if (this.currentIsTag) {
-    //     this.currentField.class = 'is-searchTag is-valid';
-    //   } else {
-    //     this.currentField.class = 'is-searchPhrase';
-    //   }
-    // },
-    // handleFocus(focusedIndex) {
-    //   this.inputData.currentInput = focusedIndex;
-    // },
-    // handleInput(e) {
-    //   const currentElement = document.querySelector('.js-qsmartInput').children[this.inputData.currentInput];
-    //   if (e.keyCode === 13) { // Enter
-    //     e.preventDefault();
-    //     if (!this.currentIsTag) {
-    //       this.doSearch();
-    //     } else if (this.inputData.currentInput === this.inputData.textInput.length - 1) {
-    //       this.addSearchField();
-    //     } else {
-    //       this.inputData.currentInput += 1;
-    //     }
-    //   } else if (e.keyCode === 8 // Backspace
-    //   && !this.currentIsTag
-    //   && currentElement.value.slice(0, currentElement.selectionStart).length === 0
-    //   && this.inputData.textInput.length >= 2) {
-    //     e.preventDefault();
-    //     this.inputData.textInput.splice(this.inputData.currentInput - 1, 1);
-    //     this.inputData.currentInput -= 1;
-    //   }
-    // },
     composeQuery() {
       let query = '';
       if (this.searchPerimeter === 'libris') {
-        // const validTags = this.validSearchTags;
         const queryArr = [];
         Object.keys(this.mergedParams).forEach((param) => {
           if (Array.isArray(this.mergedParams[param])) {
@@ -162,10 +82,6 @@ export default {
       }
     },
     clearInputs() {
-      // this.inputData.currentInput = 0;
-      // this.inputData.textInput.splice(1, this.inputData.textInput.length);
-      // this.inputData.textInput[0].value = '';
-      // this.inputData.textInput[0].class = 'is-searchPhrase';
       this.searchPhrase = '';
       this.focusSearchInput();
     },
@@ -227,66 +143,7 @@ export default {
         label: StringUtil.getLabelByLang(term, this.settings.language, this.resources.vocab, this.resources.context) || term,
       }));
     },
-    // usedFilters() {
-    //   const filters = [];
-    //   if (typeof this.resultData.search !== 'undefined') {
-    //     this.resultData.search.mapping.forEach((item) => {
-    //       if (item.variable !== 'q') {
-    //         let filter = '';
-    //         if (typeof item.object !== 'undefined') {
-    //           if (item.variable === '@type') {
-    //             filter = item.object['@id'];
-    //           } else {
-    //             filter = item.object['@id'].replace('https://id.kb.se/', '');
-    //           }
-    //         } else {
-    //           filter = item.value;
-    //         }
-    //         filters.push(filter);
-    //       }
-    //     });
-    //   }
-    //   return filters;
-    // },
-    // usedTextInput() {
-    //   let textInput = '';
-    //   if (typeof this.resultData.search !== 'undefined') {
-    //     this.resultData.search.mapping.forEach((item) => {
-    //       if (item.variable === 'q') {
-    //         textInput = item.value;
-    //       } 
-    //     });
-    //   }
-    //   return textInput;
-    // },
-    // currentIsTag() {
-    //   const value = this.currentField.value;
-    //   return value.indexOf(':') > -1 && this.validSearchTags.indexOf(value.split(':')[0]) > -1;
-    // },
-    // currentField() {
-    //   return this.inputData.textInput[this.inputData.currentInput];
-    // },
-    // caretIsAtStart() {
-    //   const currentElement = document.querySelector('.js-qsmartInput').children[this.inputData.currentInput];
-    //   return currentElement.value.slice(0, currentElement.selectionStart).length === 0;
-    // },
-    // validSearchTags() {
-    //   const searchTags = PropertyMappings.map(property => property.key);
-    //   return searchTags;
-    // },
-    // currentComputedInput() {
-    //   return this.inputData.currentInput;
-    // },
     hasInput() {
-      // let hasInput = false;
-      // each(this.inputData.textInput, (inputField) => {
-      //   if (inputField.value !== '') {
-      //     hasInput = true;
-      //   }
-      // });
-      // return hasInput;
-
-      // value in input?
       return this.searchPhrase.length > 0;
     },
     inputPlaceholder() {
@@ -313,9 +170,6 @@ export default {
     'tab-menu': TabMenu,
   },
   watch: {
-    // currentComputedInput(newValue) {
-    //   document.querySelector('.js-qsmartInput').children[newValue].focus();
-    // },
     searchPerimeter(newVal, oldVal) {
       if (newVal !== oldVal) {
         this.$nextTick(() => {
@@ -323,24 +177,10 @@ export default {
         });
       }
     },
-    // resultData(newVal) {
-    //   if (typeof newVal !== 'undefined' && Object.keys(newVal).length) {
-    //     if (this.usedTextInput !== '') {
-    //       const newObj = {};
-    //       const usedTextInput = [];
-    //       newObj.value = this.usedTextInput;
-    //       newObj.class = 'is-searchPhrase';
-    //       usedTextInput.push(newObj);
-          
-    //       this.inputData.textInput = usedTextInput;
-    //     } 
-    //   }
-    // },
   },
   mounted() {
     this.$nextTick(() => {
       this.focusSearchInput();
-      // this.matchSearchProp();
     });
   },
 };
@@ -373,69 +213,36 @@ export default {
           <label class="SearchBar-inputLabel hidden" id="searchlabel" for="q" aria-hidden="false">
             {{"Search" | translatePhrase}}
           </label>
-          <!-- <div class="SearchBar-inputWrap" id="searchFieldContainer"> -->
-            <!-- <div class="SearchBar-input customInput form-control"> -->
-              <!-- <div class="SearchBar-qsmart js-qsmartInput" aria-labelledby="searchlabel"> -->
-                <select 
-                  v-if="searchPerimeter === 'libris'"
-                  v-model="activeSearchParam">
-                  <option 
-                    v-for="prop in searchParams"
-                    :key="prop.key"
-                    :value="prop">
-                    {{prop.key | translatePhrase}}
-                  </option>
-                </select>
-                <input type="text"
-                  class="SearchBar-input customInput form-control"
-                  v-model="searchPhrase"
-                  aria-labelledby="searchlabel"
-                  :placeholder="inputPlaceholder | translatePhrase"
-                  ref="searchBarInput">
-                <!-- <input type="text" 
-                  class="SearchBar-input customInput form-control" 
-                  placeholder="ISBN eller valfria sökord"
-                  aria-label="ISBN eller valfria sökord"
-                  v-model="inputData.q"
-                  ref="remoteSearch"> -->
-                <!-- <datalist id="matchingParameters">
-                  <option v-for="matchingParameter in validSearchTags" 
-                    :key="matchingParameter" 
-                    :value="`${matchingParameter}:`">
-                    {{matchingParameter}}:
-                  </option>
-                </datalist> -->
-              <!-- </div> -->
-              <span class="SearchBar-clear icon icon--md" v-show="hasInput" @click="clearInputs()">
-                <i class="fa fa-fw fa-close"></i>
-              </span>
-            <!-- </div> -->
-            <button 
-              class="SearchBar-submit btn btn-primary icon icon--white icon--md" 
-              :aria-label="'Search' | translatePhrase"
-              @click.prevent="doSearch"
-              :class="{'disabled': searchPerimeter === 'remote' && status.remoteDatabases.length === 0}"
-              :disabled="searchPerimeter === 'remote' && status.remoteDatabases.length === 0" >
-              <i class="fa fa-search"></i>
-            </button>
-            <!-- <button 
-              v-else-if="searchPerimeter === 'remote'"
-              class="SearchBar-submit btn btn-primary icon icon--white icon--md"
-              :aria-label="'Search' | translatePhrase"
-              v-bind:class="{'disabled': status.remoteDatabases.length === 0}"
-              :disabled="status.remoteDatabases.length === 0" 
-              v-on:click.prevent="doSearch">
+          <select
+            class="SearchBar-select form-control customSelect"
+            v-if="searchPerimeter === 'libris'"
+            v-model="activeSearchParam">
+            <option 
+              v-for="prop in searchParams"
+              :key="prop.key"
+              :value="prop">
+              {{prop.key | translatePhrase}}
+            </option>
+          </select>
+          <input type="text"
+            class="SearchBar-input customInput form-control"
+            v-model="searchPhrase"
+            aria-labelledby="searchlabel"
+            :placeholder="inputPlaceholder | translatePhrase"
+            ref="searchBarInput">
+          <span class="SearchBar-clear icon icon--md" v-show="hasInput" @click="clearInputs()">
+            <i class="fa fa-fw fa-close"></i>
+          </span>
+          <button 
+            class="SearchBar-submit btn btn-primary icon icon--white icon--md" 
+            :aria-label="'Search' | translatePhrase"
+            @click.prevent="doSearch"
+            :class="{'disabled': searchPerimeter === 'remote' && status.remoteDatabases.length === 0}"
+            :disabled="searchPerimeter === 'remote' && status.remoteDatabases.length === 0" >
             <i class="fa fa-search"></i>
-          </button> -->
-          <!-- </div> -->
+          </button>
         </div>
       </div>
-      <!-- <div 
-        class="SearchBar-formContent"
-        v-if="searchPerimeter === 'remote'">
-        <div class="SearchBar-formGroup form-group panel">
-        </div>
-      </div> -->
       <div class="SearchBar-typeButtons" 
         v-if="searchPerimeter === 'libris'"
         :aria-label="'Choose type' | translatePhrase">
@@ -529,61 +336,29 @@ export default {
   &-input {
     color: @black;
     border-width: 1px 0 1px 1px;
-    border-radius: 4px 0 0 4px;
+    border-radius: 0;
     width: 100%;
     box-shadow: none;
+    border: 1px solid @gray-light;
 
     &:focus {
       border-right: none;
     }
   }
 
-  // &-inputWrap {
-  //   display: flex;
-  //   margin-bottom: 0;
-  // }
+  &-select {
+    height: auto;
+    max-width: 90px;
+    min-width: 50px;
+    box-shadow: none;
+    border: none;
+    text-align-last: left;
+  }
 
   &-inputLabel {
     display: block;
     text-transform: uppercase;
   }
-
-  // &-qsmart {
-  //   display: flex;
-  //   flex: 8 8 98%;
-  //   flex-direction: row;
-  //   flex-wrap: nowrap;
-  //   white-space: nowrap;
-  //   overflow: hidden;
-  //   text-overflow: ellipsis;
-  // }
-
-  // &-qsmartInput {
-  //   border: 0px;
-  //   outline: none;
-  //   display: inline-block;
-
-  //   &.is-searchPhrase {
-  //     flex-grow: 1;
-  //     margin-right: 5px;
-  //     padding: 0;
-  //     outline: none;
-  //     cursor: text;
-  //     color: @black;
-  //   }
-
-  //   &.is-searchTag {
-  //     margin-right: 5px;
-  //     border-radius: 3px;
-  //     padding: 0px 5px;
-  //     outline: none;
-  //     cursor: text;
-  //   }
-          
-  //   &.is-valid {
-  //     background-color: #E0F2F1;
-  //   }
-  // }
 
   &-clear {
     align-self: center;

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -31,7 +31,7 @@ export default {
       staticProps: { _limit: 20 },
       searchPhrase: '',
       searchParams: PropertyMappings,
-      activeSearchParam: PropertyMappings[0],
+      activeSearchParam: this.getIncomingSearch(),
       activeTypes: this.getIncomingTypes(),
       // query: (() => { // try to compose v-model bound object from route query
       //   if (isEmpty(this.$route.query)) {
@@ -169,14 +169,20 @@ export default {
       this.searchPhrase = '';
       this.focusSearchInput();
     },
-    matchSearchProp() {
-      // console.log(this.$route.query);
-      this.searchParams.forEach((prop, index) => {
-        const match = Object.keys(prop.mappings).every(key => this.$route.query.hasOwnProperty(key));
-        if (match) {
-          this.activeSearchParam = this.searchParams[index];
-        }
-      });
+    getIncomingSearch() {
+      const match = PropertyMappings.filter(prop => Object.keys(prop.mappings).every(key => this.$route.query.hasOwnProperty(key)));
+      console.log(match);
+      if (match.length > 0) {
+        const matchObj = match[0];
+        this.$nextTick(() => {
+          this.searchPhrase = this.$route.query[matchObj.searchProp];
+        });
+        return matchObj;
+      } if (match.length > 1) { // problem, we have multiple sets of matching parameters
+        console.log('ouch!');
+        return false;
+      }
+      return PropertyMappings[0];
     },
     getIncomingTypes() {
       const performedQuery = cloneDeep(this.$route.query);

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -1,5 +1,5 @@
 <script>
-import { findIndex, each } from 'lodash-es';
+// import { each } from 'lodash-es';
 import PropertyMappings from '@/resources/json/propertymappings.json';
 import * as StringUtil from '@/utils/string';
 import RemoteDatabases from '@/components/search/remote-databases';
@@ -20,42 +20,40 @@ export default {
     return {
       vocabUrl: 'https://id.kb.se/vocab/',
       inputData: {
-        textInput: [
-          {
-            value: '',
-            class: 'is-searchPhrase',
-          },
-        ],
-        currentInput: 0,
-        ids: ['Instance'],
+        type: 'q',
+        q: this.$route.query.q,
       },
-      remoteSearch: {
-        q: '',
+      searchParams: {
+        _limit: 20,
+        // currentInput: 0,
+        '@type': ['Instance', 'Work'],
       },
-      query: '',
-      activeClass: 'is-active',
+      // remoteSearch: {
+      //   q: '',
+      // },
+      // query: '',
+      // activeClass: 'is-active',
+      // currentSearchEl: null,
     };
   },
   methods: {
-    focusSearchForm() {
-      if (this.searchPerimeter === 'libris') {
-        document.querySelectorAll('#librisPanel input')[0].focus();
-      } else {
-        document.querySelectorAll('#remotePanel input')[0].focus();
-      }
+    focusSearchInput() {
+      // this.currentSearchEl = this.searchPerimeter === 'libris' ? this.$refs.librisSearch : this.$refs.remoteSearch;
+      // this.currentSearchEl.focus();
+      this.$refs.searchBarInput.focus();
     },
     switchPerimeter(id) {
       this.$router.push({ path: `/search/${id}` });
-      this.moveQuery(id);
+      // this.moveQuery(id);
     },
-    moveQuery(id) {
-      const qIndex = findIndex(this.inputData.textInput, { class: 'is-searchPhrase' });
-      if (id === 'libris') {
-        this.inputData.textInput[qIndex].value = this.remoteSearch.q;
-      } else {
-        this.remoteSearch.q = this.inputData.textInput[qIndex].value;
-      }
-    },
+    // moveQuery(toPerimeter) {
+    //   const qIndex = findIndex(this.inputData.textInput, { class: 'is-searchPhrase' });
+    //   if (toPerimeter === 'libris') {
+    //     this.inputData.textInput[qIndex].value = this.remoteSearch.q;
+    //   } else {
+    //     this.remoteSearch.q = this.inputData.textInput[qIndex].value;
+    //   }
+    // },
     removeTags(html) {
       let regexHtml = html.replace(/<h1.*>.*?<\/h1>/ig, '').replace(/<h2.*>.*?<\/h2>/ig, '');
       regexHtml = regexHtml.replace(/(<\/?(?:code|br|p)[^>]*>)|<[^>]+>/ig, '$1');
@@ -80,84 +78,68 @@ export default {
       const helpText = document.querySelector('.js-searchHelpText');
       helpText.parentElement.classList.toggle(this.activeClass);
     },
-    addSearchField() {
-      const newobj = {};
-      newobj.value = '';
-      newobj.class = 'is-searchPhrase';
-      this.inputData.textInput.push(newobj);
-      this.inputData.currentInput += 1;
-    },
-    updateField() {
-      if (this.currentIsTag) {
-        this.currentField.class = 'is-searchTag is-valid';
-      } else {
-        this.currentField.class = 'is-searchPhrase';
-      }
-    },
-    handleFocus(focusedIndex) {
-      this.inputData.currentInput = focusedIndex;
-    },
-    handleInput(e) {
-      const currentElement = document.querySelector('.js-qsmartInput').children[this.inputData.currentInput];
-      if (e.keyCode === 13) { // Enter
-        e.preventDefault();
-        if (!this.currentIsTag) {
-          this.doSearch();
-        } else if (this.inputData.currentInput === this.inputData.textInput.length - 1) {
-          this.addSearchField();
-        } else {
-          this.inputData.currentInput += 1;
-        }
-      } else if (e.keyCode === 8 // Backspace
-      && !this.currentIsTag
-      && currentElement.value.slice(0, currentElement.selectionStart).length === 0
-      && this.inputData.textInput.length >= 2) {
-        e.preventDefault();
-        this.inputData.textInput.splice(this.inputData.currentInput - 1, 1);
-        this.inputData.currentInput -= 1;
-      }
-    },
+    // addSearchField() {
+    //   const newobj = {};
+    //   newobj.value = '';
+    //   newobj.class = 'is-searchPhrase';
+    //   this.inputData.textInput.push(newobj);
+    //   this.inputData.currentInput += 1;
+    // },
+    // updateField() {
+    //   if (this.currentIsTag) {
+    //     this.currentField.class = 'is-searchTag is-valid';
+    //   } else {
+    //     this.currentField.class = 'is-searchPhrase';
+    //   }
+    // },
+    // handleFocus(focusedIndex) {
+    //   this.inputData.currentInput = focusedIndex;
+    // },
+    // handleInput(e) {
+    //   const currentElement = document.querySelector('.js-qsmartInput').children[this.inputData.currentInput];
+    //   if (e.keyCode === 13) { // Enter
+    //     e.preventDefault();
+    //     if (!this.currentIsTag) {
+    //       this.doSearch();
+    //     } else if (this.inputData.currentInput === this.inputData.textInput.length - 1) {
+    //       this.addSearchField();
+    //     } else {
+    //       this.inputData.currentInput += 1;
+    //     }
+    //   } else if (e.keyCode === 8 // Backspace
+    //   && !this.currentIsTag
+    //   && currentElement.value.slice(0, currentElement.selectionStart).length === 0
+    //   && this.inputData.textInput.length >= 2) {
+    //     e.preventDefault();
+    //     this.inputData.textInput.splice(this.inputData.currentInput - 1, 1);
+    //     this.inputData.currentInput -= 1;
+    //   }
+    // },
     composeQuery() {
       let query = '';
       if (this.searchPerimeter === 'libris') {
-        const validTags = this.validSearchTags;
-        const queryText = [];
-        for (const inputElement of this.inputData.textInput) {     
-          if (inputElement.class.indexOf('is-searchTag') > -1) {
-            const tag = inputElement.value.split(':');
-            const tagKey = tag[0];
-            const tagValue = tag[1];
-            if (validTags.indexOf(tagKey) > -1) {
-              each(PropertyMappings, (obj) => {
-                if (obj.key === tagKey) {
-                  each(obj.mappings, (mappingValue, mappingKey) => {
-                    if (mappingValue === '') {
-                      queryText.push(`${mappingKey}=${tagValue}`);
-                    } else {
-                      queryText.push(`${mappingKey}=${mappingValue}`);
-                    }
-                  });
-                }
-              });
-            }
-          } else if (inputElement.value !== '') {
-            queryText.push(`q=${inputElement.value}`);
-          } else {
-            queryText.push('q=*');
-          }
-        }
-        if (queryText.length === 0) {
-          return '';
-        }
-        queryText.push('_limit=20');
-        each(this.inputData.ids, id => queryText.push(`@type=${id}`));
-        query = queryText.join('&');
+        // const validTags = this.validSearchTags;
+        const queryArr = [];
+        queryArr.push(`${this.inputData.type}=${!this.inputData.q ? '*' : this.inputData.q}`);
+        Object.keys(this.searchParams).forEach((param) => {
+          if (Array.isArray(this.searchParams[param])) {
+            console.log('im an array');
+            this.searchParams[param].forEach((el) => {
+              console.log(el);
+              queryArr.push(`${param}=${el}`);
+            });
+          } else queryArr.push(`${param}=${this.searchParams[param]}`);
+        });
+        // queryArr.push(`_limit=${this.inputData._limit}`);
+        // this.inputData.ids.forEach(id => queryArr.push(`@type=${id}`));
+        console.log(queryArr);
+        query = queryArr.join('&');
       } else {
         const databases = this.status.remoteDatabases.join();
-        const keywords = this.remoteSearch.q;
+        const keywords = this.inputData.q;
         query = `q=${keywords}&databases=${databases}`;
       }
-      return query;
+      return encodeURI(query);
     },
     doSearch() {
       this.$router.push({ path: `/search/${this.searchPerimeter}?${this.composeQuery()}` });
@@ -167,11 +149,12 @@ export default {
       }
     },
     clearInputs() {
-      this.inputData.currentInput = 0;
-      this.inputData.textInput.splice(1, this.inputData.textInput.length);
-      this.inputData.textInput[0].value = '';
-      this.inputData.textInput[0].class = 'is-searchPhrase';
-      this.$refs.librisSearch[0].focus();
+      // this.inputData.currentInput = 0;
+      // this.inputData.textInput.splice(1, this.inputData.textInput.length);
+      // this.inputData.textInput[0].value = '';
+      // this.inputData.textInput[0].class = 'is-searchPhrase';
+      this.inputData.q = '';
+      this.focusSearchInput();
     },
   },
   computed: {
@@ -231,32 +214,38 @@ export default {
       }
       return textInput;
     },
-    currentIsTag() {
-      const value = this.currentField.value;
-      return value.indexOf(':') > -1 && this.validSearchTags.indexOf(value.split(':')[0]) > -1;
-    },
-    currentField() {
-      return this.inputData.textInput[this.inputData.currentInput];
-    },
-    caretIsAtStart() {
-      const currentElement = document.querySelector('.js-qsmartInput').children[this.inputData.currentInput];
-      return currentElement.value.slice(0, currentElement.selectionStart).length === 0;
-    },
+    // currentIsTag() {
+    //   const value = this.currentField.value;
+    //   return value.indexOf(':') > -1 && this.validSearchTags.indexOf(value.split(':')[0]) > -1;
+    // },
+    // currentField() {
+    //   return this.inputData.textInput[this.inputData.currentInput];
+    // },
+    // caretIsAtStart() {
+    //   const currentElement = document.querySelector('.js-qsmartInput').children[this.inputData.currentInput];
+    //   return currentElement.value.slice(0, currentElement.selectionStart).length === 0;
+    // },
     validSearchTags() {
       const searchTags = PropertyMappings.map(property => property.key);
       return searchTags;
     },
-    currentComputedInput() {
-      return this.inputData.currentInput;
-    },
+    // currentComputedInput() {
+    //   return this.inputData.currentInput;
+    // },
     hasInput() {
-      let hasInput = false;
-      each(this.inputData.textInput, (inputField) => {
-        if (inputField.value !== '') {
-          hasInput = true;
-        }
-      });
-      return hasInput;
+      // let hasInput = false;
+      // each(this.inputData.textInput, (inputField) => {
+      //   if (inputField.value !== '') {
+      //     hasInput = true;
+      //   }
+      // });
+      // return hasInput;
+
+      // value in input?
+      return this.inputData.q.length > 0;
+    },
+    inputPlaceholder() {
+      return this.searchPerimeter === 'remote' ? 'ISBN eller valfria sökord' : 'Search';
     },
   },
   components: {
@@ -264,33 +253,33 @@ export default {
     'tab-menu': TabMenu,
   },
   watch: {
-    currentComputedInput(newValue) {
-      document.querySelector('.js-qsmartInput').children[newValue].focus();
-    },
+    // currentComputedInput(newValue) {
+    //   document.querySelector('.js-qsmartInput').children[newValue].focus();
+    // },
     searchPerimeter(newVal, oldVal) {
       if (newVal !== oldVal) {
         this.$nextTick(() => {
-          this.focusSearchForm();
+          this.focusSearchInput();
         });
       }
     },
-    resultData(newVal) {
-      if (typeof newVal !== 'undefined' && Object.keys(newVal).length) {
-        if (this.usedTextInput !== '') {
-          const newObj = {};
-          const usedTextInput = [];
-          newObj.value = this.usedTextInput;
-          newObj.class = 'is-searchPhrase';
-          usedTextInput.push(newObj);
+    // resultData(newVal) {
+    //   if (typeof newVal !== 'undefined' && Object.keys(newVal).length) {
+    //     if (this.usedTextInput !== '') {
+    //       const newObj = {};
+    //       const usedTextInput = [];
+    //       newObj.value = this.usedTextInput;
+    //       newObj.class = 'is-searchPhrase';
+    //       usedTextInput.push(newObj);
           
-          this.inputData.textInput = usedTextInput;
-        } 
-      }
-    },
+    //       this.inputData.textInput = usedTextInput;
+    //     } 
+    //   }
+    // },
   },
   mounted() {
     this.$nextTick(() => {
-      this.focusSearchForm();
+      this.focusSearchInput();
     });
   },
 };
@@ -318,84 +307,85 @@ export default {
       </div> 
     </div>
     <form id="searchForm" class="SearchBar-form">
-      <div class="SearchBar-formContent is-librisSearch" id="librisPanel"
-        v-if="searchPerimeter === 'libris'">
+      <div class="SearchBar-formContent">
         <div class="SearchBar-formGroup form-group panel">
           <label class="SearchBar-inputLabel hidden" id="searchlabel" for="q" aria-hidden="false">
             {{"Search" | translatePhrase}}
           </label>
-          <div class="SearchBar-inputWrap" id="searchFieldContainer">
-            <div class="SearchBar-input customInput form-control">
-              <div class="SearchBar-qsmart js-qsmartInput" aria-labelledby="searchlabel">
-                <input name="q"
+          <!-- <div class="SearchBar-inputWrap" id="searchFieldContainer"> -->
+            <!-- <div class="SearchBar-input customInput form-control"> -->
+              <!-- <div class="SearchBar-qsmart js-qsmartInput" aria-labelledby="searchlabel"> -->
+                <input type="text"
+                  class="SearchBar-input customInput form-control"
+                  v-model="inputData.q"
                   aria-labelledby="searchlabel"
-                  list="matchingParameters"
-                  v-for="(input, index) in inputData.textInput"
-                  :key="index"
-                  @focus="handleFocus(index)"
-                  @input="updateField"
-                  @keydown="handleInput"
-                  v-model="input.value"
-                  class="SearchBar-qsmartInput"
-                  :placeholder="'Search' | translatePhrase"
-                  :class="input.class"
-                  ref="librisSearch">
-                <datalist id="matchingParameters">
+                  :placeholder="inputPlaceholder | translatePhrase"
+                  ref="searchBarInput">
+                <!-- <input type="text" 
+                  class="SearchBar-input customInput form-control" 
+                  placeholder="ISBN eller valfria sökord"
+                  aria-label="ISBN eller valfria sökord"
+                  v-model="inputData.q"
+                  ref="remoteSearch"> -->
+                <!-- <datalist id="matchingParameters">
                   <option v-for="matchingParameter in validSearchTags" 
                     :key="matchingParameter" 
                     :value="`${matchingParameter}:`">
                     {{matchingParameter}}:
                   </option>
-                </datalist>
-              </div>
+                </datalist> -->
+              <!-- </div> -->
               <span class="SearchBar-clear icon icon--md" v-show="hasInput" @click="clearInputs()">
                 <i class="fa fa-fw fa-close"></i>
               </span>
-            </div>
-            <button class="SearchBar-submit btn btn-primary icon icon--white icon--md" 
+            <!-- </div> -->
+            <button 
+              class="SearchBar-submit btn btn-primary icon icon--white icon--md" 
               :aria-label="'Search' | translatePhrase"
-              @click.prevent="doSearch">
+              @click.prevent="doSearch"
+              :class="{'disabled': searchPerimeter === 'remote' && status.remoteDatabases.length === 0}"
+              :disabled="searchPerimeter === 'remote' && status.remoteDatabases.length === 0" >
               <i class="fa fa-search"></i>
             </button>
-          </div>
+            <!-- <button 
+              v-else-if="searchPerimeter === 'remote'"
+              class="SearchBar-submit btn btn-primary icon icon--white icon--md"
+              :aria-label="'Search' | translatePhrase"
+              v-bind:class="{'disabled': status.remoteDatabases.length === 0}"
+              :disabled="status.remoteDatabases.length === 0" 
+              v-on:click.prevent="doSearch">
+            <i class="fa fa-search"></i>
+          </button> -->
+          <!-- </div> -->
         </div>
       </div>
-      <div 
-        class="SearchBar-formContent is-remoteSearch" 
-        id="remotePanel" 
+      <!-- <div 
+        class="SearchBar-formContent"
         v-if="searchPerimeter === 'remote'">
         <div class="SearchBar-formGroup form-group panel">
-          <input type="text" 
-            class="SearchBar-input customInput form-control" 
-            placeholder="ISBN eller valfria sökord"
-            aria-label="ISBN eller valfria sökord"
-            v-model="remoteSearch.q">
-          <button 
-            class="SearchBar-submit btn btn-primary icon icon--white icon--md"
-            :aria-label="'Search' | translatePhrase"
-            v-bind:class="{'disabled': status.remoteDatabases.length === 0}"
-            :disabled="status.remoteDatabases.length === 0" 
-            v-on:click.prevent="doSearch">
-            <i class="fa fa-search"></i>
-          </button>
         </div>
-      </div>
-      <div class="SearchBar-typeButtons" :aria-label="'Choose type' | translatePhrase"
-        v-if="searchPerimeter === 'libris'">
+      </div> -->
+      <div class="SearchBar-typeButtons" 
+        v-if="searchPerimeter === 'libris'"
+        :aria-label="'Choose type' | translatePhrase">
         <label class="SearchBar-typeLabel" 
           :for="filter['@id']"
           v-for="filter in dataSetFilters" 
           :key="filter['@id']">
           <input type="checkbox" class="SearchBar-typeInput customCheckbox-input"
             :id="filter['@id']"
-            v-model="inputData.ids"
+            v-model="inputData['@type']"
             :value="filter['@id']"/>
             <span class="SearchBar-typeText customCheckbox-icon">
               {{ filter.label }}
             </span>
         </label>
       </div>
-      <remote-databases v-if="searchPerimeter === 'remote'" :remoteSearch="remoteSearch" ref="dbComponent"></remote-databases>
+      <remote-databases 
+        v-if="searchPerimeter === 'remote'" 
+        :remoteSearch="inputData.q"
+        @panelClosed="focusSearchInput"
+        ref="dbComponent"></remote-databases>
     </form>
   </div>
 </template>
@@ -469,68 +459,73 @@ export default {
     color: @black;
     border-width: 1px 0 1px 1px;
     border-radius: 4px 0 0 4px;
+    width: 100%;
+    box-shadow: none;
 
-    .is-remoteSearch & {
-      width: 100%;
+    &:focus {
+      border-right: none;
     }
   }
 
-  &-inputWrap {
-    display: flex;
-    margin-bottom: 0;
-  }
+  // &-inputWrap {
+  //   display: flex;
+  //   margin-bottom: 0;
+  // }
 
   &-inputLabel {
     display: block;
     text-transform: uppercase;
   }
 
-  &-qsmart {
-    display: flex;
-    flex: 8 8 98%;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+  // &-qsmart {
+  //   display: flex;
+  //   flex: 8 8 98%;
+  //   flex-direction: row;
+  //   flex-wrap: nowrap;
+  //   white-space: nowrap;
+  //   overflow: hidden;
+  //   text-overflow: ellipsis;
+  // }
 
-  &-qsmartInput {
-    border: 0px;
-    outline: none;
-    display: inline-block;
+  // &-qsmartInput {
+  //   border: 0px;
+  //   outline: none;
+  //   display: inline-block;
 
-    &.is-searchPhrase {
-      flex-grow: 1;
-      margin-right: 5px;
-      padding: 0;
-      outline: none;
-      cursor: text;
-      color: @black;
-    }
+  //   &.is-searchPhrase {
+  //     flex-grow: 1;
+  //     margin-right: 5px;
+  //     padding: 0;
+  //     outline: none;
+  //     cursor: text;
+  //     color: @black;
+  //   }
 
-    &.is-searchTag {
-      margin-right: 5px;
-      border-radius: 3px;
-      padding: 0px 5px;
-      outline: none;
-      cursor: text;
-    }
+  //   &.is-searchTag {
+  //     margin-right: 5px;
+  //     border-radius: 3px;
+  //     padding: 0px 5px;
+  //     outline: none;
+  //     cursor: text;
+  //   }
           
-    &.is-valid {
-      background-color: #E0F2F1;
-    }
-  }
+  //   &.is-valid {
+  //     background-color: #E0F2F1;
+  //   }
+  // }
 
   &-clear {
     align-self: center;
     flex: 1 1 2%;
+    position: absolute;
+    right: 110px;
   }
 
   &-submit {
     height: 42px;
     border: 0;
     border-radius: 0 4px 4px 0;
+    box-shadow: none;
 
     @media (min-width: @screen-sm) {
       min-width: 84px;
@@ -540,10 +535,9 @@ export default {
   &-formGroup {
     width: 100%;
     display: inline-block;
+    display: flex;
+    box-shadow: 0 1px 1px 0 rgba(0,0,0,.10), 0 1px 3px 0 rgba(0,0,0,.12), 0 2px 1px -2px rgba(0,0,0,.1)
 
-    .is-remoteSearch & {
-      display: flex;
-    }
   }
 
   &-typeLabel {

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -28,10 +28,13 @@ export default {
       //   // currentInput: 0,
       //   '@type': ['Instance', 'Work'],
       // },
-      query: (() => {
+      searchProperties: PropertyMappings,
+      selectedProperty: PropertyMappings[0].mappings,
+      query: (() => { // try to compose v-model bound object from route query
         if (isEmpty(this.$route.query)) {
-          return {
+          return { // else return default settings
             q: '',
+            // ...this.selectedProperty,
             _limit: 20,
             '@type': ['Instance'],
           };
@@ -163,6 +166,9 @@ export default {
       // this.inputData.textInput[0].class = 'is-searchPhrase';
       this.query.q = '';
       this.focusSearchInput();
+    },
+    handleTypeChange(e) {
+      console.log(e.target.value);
     },
   },
   computed: {
@@ -323,6 +329,17 @@ export default {
           <!-- <div class="SearchBar-inputWrap" id="searchFieldContainer"> -->
             <!-- <div class="SearchBar-input customInput form-control"> -->
               <!-- <div class="SearchBar-qsmart js-qsmartInput" aria-labelledby="searchlabel"> -->
+                <select 
+                  v-if="searchPerimeter === 'libris'"
+                  v-model="selectedProperty"
+                  @change="handleTypeChange($event)">
+                  <option 
+                    v-for="prop in searchProperties"
+                    :key="prop.key"
+                    :value="prop.mappings">
+                    {{prop.key | translatePhrase}}
+                  </option>
+                </select>
                 <input type="text"
                   class="SearchBar-input customInput form-control"
                   v-model="query.q"

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -262,6 +262,8 @@
     "Main title (A-Z)": "Huvudtitel (A-Ö)",
     "Main title (Z-A)": "Huvudtitel (Ö-A)",
     "Sigel (A-Z)": "Sigel (A-Ö)",
-    "Sigel (Z-A)": "Sigel (Ö-A)"
+    "Sigel (Z-A)": "Sigel (Ö-A)",
+    "Free text": "Fritext",
+    "Title": "Titel"
     }
 }

--- a/viewer/vue-client/src/resources/json/propertymappings.json
+++ b/viewer/vue-client/src/resources/json/propertymappings.json
@@ -1,12 +1,14 @@
 [
   {
     "key": "Free text",
+    "searchProp": "q",
     "mappings": {
       "q": ""
     }
   },
   {
     "key": "ISBN",
+    "searchProp": "identifiedBy.value",
     "mappings": {
       "identifiedBy.value": "",
       "identifiedBy.@type": "ISBN"
@@ -14,6 +16,7 @@
   },
   {
     "key": "ISSN",
+    "searchProp": "identifiedBy.value",
     "mappings": {
       "identifiedBy.value": "",
       "identifiedBy.@type": "ISSN"
@@ -21,6 +24,7 @@
   },
   {
     "key": "title",
+    "searchProp": "hasTitle.mainTitle",
     "mappings": {
       "hasTitle.mainTitle": ""
     }

--- a/viewer/vue-client/src/resources/json/propertymappings.json
+++ b/viewer/vue-client/src/resources/json/propertymappings.json
@@ -1,5 +1,11 @@
 [
   {
+    "key": "Free text",
+    "mappings": {
+      "q": ""
+    }
+  },
+  {
     "key": "ISBN",
     "mappings": {
       "identifiedBy.value": "",

--- a/viewer/vue-client/src/resources/json/propertymappings.json
+++ b/viewer/vue-client/src/resources/json/propertymappings.json
@@ -23,7 +23,7 @@
     }
   },
   {
-    "key": "title",
+    "key": "Title",
     "searchProp": "hasTitle.mainTitle",
     "mappings": {
       "hasTitle.mainTitle": ""

--- a/viewer/vue-client/src/views/Find.vue
+++ b/viewer/vue-client/src/views/Find.vue
@@ -157,10 +157,7 @@ export default {
 <template>
   <div class="row">
     <div class="Find col-sm-12" :class="{'col-md-12': !status.panelOpen, 'col-md-7': status.panelOpen }" ref="Find">
-      <search-form 
-        :search-perimeter="$route.params.perimeter"
-        :result-data="result">
-      </search-form>
+      <search-form :search-perimeter="$route.params.perimeter" />
     </div>
     <div v-show="searchInProgress" class="col-sm-12">
         <div class="Find-progressText">


### PR DESCRIPTION
According to [LXL-2300](https://jira.kb.se/browse/LXL-2300)

I ended up rewriting most of the `search-form` component - it can now search only one prop at a time, but should have a more user friendly UI (according to design in ticket). The component also recognizes a performed search, populating select menu, text input and select boxes with the current values.

**Bonus features:**
* 'libris' and 'remote' now share the same v-bound input, so queries are immediately reflected in both places. Means remote also gets a 'clear' btn.
* remote: cursor automatically jumps to sidebar/search field when opened/closed. 