### PR TITLE
Expand only focused fields

### DIFF
--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -374,8 +374,18 @@ export default {
     this.$store.dispatch('setValidation', { path: this.path, validates: true });
   },
   created() {
-    this.$on('collapse-item', this.collapse);
-    this.$on('expand-item', this.expand);
+    this.$on('collapse-item', () => {
+      if (this.getPath.startsWith(this.inspector.status.focus) // Only expand part of form that has focus
+          || (this.getPath.startsWith('work') && this.inspector.status.focus === 'mainEntity')) {
+        this.collapse();
+      }
+    });
+    this.$on('expand-item', () => {
+      if (this.getPath.startsWith(this.inspector.status.focus)
+          || (this.getPath.startsWith('work') && this.inspector.status.focus === 'mainEntity')) {
+        this.expand();
+      }
+    });
   },
   mounted() {
     if (this.isLastAdded) {

--- a/viewer/vue-client/src/components/inspector/item-sibling.vue
+++ b/viewer/vue-client/src/components/inspector/item-sibling.vue
@@ -335,8 +335,18 @@ export default {
     },
   },
   created() {
-    this.$on('collapse-item', this.collapse);
-    this.$on('expand-item', this.expand);
+    this.$on('collapse-item', () => {
+      if (this.getPath.startsWith(this.inspector.status.focus) // Only expand part of form that has focus
+          || (this.getPath.startsWith('work') && this.inspector.status.focus === 'mainEntity')) {
+        this.collapse();
+      }
+    });
+    this.$on('expand-item', () => {
+      if (this.getPath.startsWith(this.inspector.status.focus)
+          || (this.getPath.startsWith('work') && this.inspector.status.focus === 'mainEntity')) {
+        this.expand();
+      }
+    });
   },
   mounted() {
     if (this.isLastAdded) {


### PR DESCRIPTION
[LXL-2370](https://jira.kb.se/browse/LXL-2370)
Adds this conditional on `expand-item` & `collapse-item` events: 

`if (this.getPath.startsWith(this.inspector.status.focus) || (this.getPath.startsWith('work') && this.inspector.status.focus === 'mainEntity')) `