### PR TITLE
Tab router link

### DIFF
--- a/viewer/vue-client/src/components/layout/navbar.vue
+++ b/viewer/vue-client/src/components/layout/navbar.vue
@@ -8,9 +8,9 @@ export default {
     return {
       hasAvatar: true,
       tabs: [
-        { id: 'Search', text: 'Search' },
-        { id: 'Create new', text: 'Create new' },
-        { id: 'Directory care', text: 'Directory care' }, 
+        { id: 'Search', text: 'Search', link: '/search/libris' },
+        { id: 'Create new', text: 'Create new', link: '/create' },
+        { id: 'Directory care', text: 'Directory care', link: '/directory-care' }, 
       ],
     };
   },
@@ -50,9 +50,6 @@ export default {
     },
   },
   methods: {
-    tabChange(id) {
-      this.$router.push({ name: id });
-    },
   },
 };
 </script>
@@ -75,7 +72,8 @@ export default {
       <tab-menu
         :tabs="tabs"
         :active="$route.name"
-        @go="tabChange" />
+        :link="true"
+        />
       </div>
       <ul class="MainNav-userWrapper">
         <li class="MainNav-item">

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -29,9 +29,6 @@ export default {
     focusSearchInput() {
       this.$refs.searchBarInput.focus();
     },
-    switchPerimeter(id) {
-      this.$router.push({ path: `/search/${id}` });
-    },
     removeTags(html) {
       let regexHtml = html.replace(/<h1.*>.*?<\/h1>/ig, '').replace(/<h2.*>.*?<\/h2>/ig, '');
       regexHtml = regexHtml.replace(/(<\/?(?:code|br|p)[^>]*>)|<[^>]+>/ig, '$1');
@@ -189,9 +186,9 @@ export default {
 <template>
   <div class="SearchBar">
     <div class="SearchBar-topControl">
-      <tab-menu @go="switchPerimeter" :tabs="[
-        { 'id': 'libris', 'text': 'Libris' },
-        { 'id': 'remote', 'text': 'Other sources' },
+      <tab-menu :link="true" :tabs="[
+        { 'id': 'libris', 'text': 'Libris', link: '/search/libris'},
+        { 'id': 'remote', 'text': 'Other sources', link: '/search/remote' },
       ]" :active="searchPerimeter"></tab-menu>
       <div  v-if="searchPerimeter === 'libris'"  class="SearchBar-help" @mouseleave="hideHelp()">
         <div class="SearchBar-helpBox dropdown" >

--- a/viewer/vue-client/src/components/shared/tab-menu.vue
+++ b/viewer/vue-client/src/components/shared/tab-menu.vue
@@ -7,6 +7,8 @@
   Props:
     * Tabs    - Expects an array of tab-objects
     * Active  - Expects a string that it will match against the id on the tab-object and put as active.
+    * Link    - If true, component expects tab-objects to have a link prop. 
+                It will then render a <router-link> instead of emitting an event.
 
   Tab-Objects:
     A tab object needs two things.
@@ -39,6 +41,10 @@ export default {
     active: {
       type: String,
       default: '',
+    },
+    link: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {
@@ -105,7 +111,7 @@ export default {
 
 <template>
   <div class="TabMenu">
-    <ul class="TabMenu-tabList" role="tablist" ref="tablist">
+    <ul v-if="!link" class="TabMenu-tabList" role="tablist" ref="tablist">
       <li class="TabMenu-tab"
         v-for="item in tabs" 
         tabindex="0"
@@ -115,6 +121,16 @@ export default {
         :class="{'is-active': active === item.id }"
         role="tab">
           {{item.text | translatePhrase}}
+      </li>
+      <hr v-show="hasActive" class="TabMenu-underline" ref="underline">
+    </ul>
+    <ul v-else class="TabMenu-tabList" ref="tablist">
+      <li v-for="item in tabs" 
+        :key="item.id" 
+        class="TabMenu-tab" 
+        :class="{'is-active': active === item.id }" >
+        <router-link class="TabMenu-tabLink" :to="item.link">{{item.text | translatePhrase}}
+        </router-link>
       </li>
       <hr v-show="hasActive" class="TabMenu-underline" ref="underline">
     </ul>
@@ -178,6 +194,14 @@ export default {
       text-decoration: none;
     }
   }
-
+  &-tabLink {
+    color: inherit;
+    &:hover, 
+    &:active,
+    &:focus {
+      color: inherit;
+      text-decoration: none;
+    }
+  }
 }
 </style>

--- a/viewer/vue-client/src/components/shared/tab-menu.vue
+++ b/viewer/vue-client/src/components/shared/tab-menu.vue
@@ -126,10 +126,11 @@ export default {
     </ul>
     <ul v-else class="TabMenu-tabList" ref="tablist">
       <li v-for="item in tabs" 
-        :key="item.id" 
-        class="TabMenu-tab" 
-        :class="{'is-active': active === item.id }" >
-        <router-link class="TabMenu-tabLink" :to="item.link">{{item.text | translatePhrase}}
+        class="TabMenu-linkContainer"
+        :key="item.id">
+        <router-link class="TabMenu-tab" 
+          :class="{'is-active': active === item.id }" 
+          :to="item.link">{{item.text | translatePhrase}}
         </router-link>
       </li>
       <hr v-show="hasActive" class="TabMenu-underline" ref="underline">
@@ -163,13 +164,16 @@ export default {
     background-color: @brand-primary;
   }
 
+  &-linkContainer {
+    display: inline-block;
+  }
+
   &-tab {
     cursor: pointer;
     text-decoration: none;
     position: relative;
     display: inline-block;
     padding: 5px @tabPadding;
-    display: inline-block;
     color: @grey;
     font-weight: 600;
     font-size: 16px;
@@ -185,21 +189,14 @@ export default {
       font-size: 18px;
       font-size: 1.8rem;
     }
-    &:hover {
+
+    &:hover,
+    &:focus {
       color: @brand-primary;
       text-decoration: none;
     }
     &.is-active {
       color: @black;
-      text-decoration: none;
-    }
-  }
-  &-tabLink {
-    color: inherit;
-    &:hover, 
-    &:active,
-    &:focus {
-      color: inherit;
       text-decoration: none;
     }
   }


### PR DESCRIPTION
Adds a link option to `tab-menu `component. If true, will render a `<router-link>` to supplied path instead of emitting an event. Perks: user sees where tab leads & can open in new tab.

Implemented this in main navbar & search-form.