### PR TITLE
Fix holdings not being standard view if directory care clicked twice

### DIFF
--- a/viewer/vue-client/src/router.js
+++ b/viewer/vue-client/src/router.js
@@ -53,6 +53,10 @@ export default new Router({
       component: () => import(/* webpackChunkName: "Help" */ './views/Help.vue'),
     },
     {
+      path: '/directory-care',
+      redirect: '/directory-care/holdings',
+    },
+    {
       path: '/directory-care/:tool?',
       name: 'Directory care',
       component: () => import(/* webpackChunkName: "UserPage" */ './views/DirectoryCare.vue'),

--- a/viewer/vue-client/src/views/DirectoryCare.vue
+++ b/viewer/vue-client/src/views/DirectoryCare.vue
@@ -73,9 +73,6 @@ export default {
     },
   },
   mounted() {
-    if (this.$route.params.tool === '' || typeof this.$route.params.tool === 'undefined') {
-      this.$router.push({ path: '/directory-care/holdings' });
-    }
     this.fetchAllFlagged();
   },
 };


### PR DESCRIPTION
Use a default route instead of pushing route if no tool param