### PR TITLE
Use global loadingIndicator

### DIFF
--- a/viewer/vue-client/src/components/care/holding-mover.vue
+++ b/viewer/vue-client/src/components/care/holding-mover.vue
@@ -8,7 +8,6 @@ import * as RecordUtil from '@/utils/record';
 export default {
   name: 'holding-mover',
   components: {
-    // 'vue-simple-spinner': VueSimpleSpinner,
     'post-picker': PostPicker,
     HoldingList,
   },
@@ -16,9 +15,6 @@ export default {
     flaggedInstances: {
       type: Array,
       required: true,
-    },
-    fetchComplete: {
-      type: Boolean,
     },
     error: {
       type: String,
@@ -28,7 +24,7 @@ export default {
   data() {
     return {
       destinationId: '',
-      loadingStatus: '',
+      // loadingStatus: '',
       progress: {},
       loading: false,
     };
@@ -124,15 +120,15 @@ export default {
         name="sender"
         opposite="reciever"
         :flaggedInstances="flaggedInstances"
-        :fetchComplete="fetchComplete">
+        :expand="true">
         <p v-if="flaggedInstances.length === 0"
           class="HoldingMover-info" 
           slot="info">
-          Det finns inga instanser flaggade för katalogvård.</p>
+          {{ "There are no instances flagged for directory care" | translatePhrase }}.</p>
         <p v-else-if="!directoryCare.sender"
           class="HoldingMover-info" 
           slot="info">
-          Från den avsändande posten flyttar du bestånd till den mottagande posten.</p>
+          {{ "Holdings are moved from the sender post to the reciever post" | translatePhrase }}.</p>
       </post-picker>
       <div class="HoldingMover-separator">
         <button @click="switchInstances" class="btn btn-primary" :disabled="!canSwitchInstances">
@@ -142,8 +138,7 @@ export default {
       <post-picker 
         name="reciever"
         opposite="sender"
-        :flaggedInstances="flaggedInstances"
-        :fetchComplete="fetchComplete"/>
+        :flaggedInstances="flaggedInstances"/>
     </div>
     <div class="HoldingMover-resultListContainer">
       <HoldingList ref="sender" name="sender" :loading="loading" :lock="loading || !bothSelected" @send="doMove" :progress="progress" />

--- a/viewer/vue-client/src/components/care/post-picker.vue
+++ b/viewer/vue-client/src/components/care/post-picker.vue
@@ -1,7 +1,6 @@
 <script>
 import { mapGetters } from 'vuex';
 import EntitySummary from '@/components/shared/entity-summary';
-import VueSimpleSpinner from 'vue-simple-spinner';
 
 export default {
   name: 'post-picker',
@@ -18,17 +17,17 @@ export default {
       type: Array,
       required: true,
     },
-    fetchComplete: {
-      type: Boolean,
-    },
     info: {
       type: String,
       default: '',
     },
+    expand: {
+      type: Boolean,
+      default: false,
+    },
   },
   components: {
     'entity-summary': EntitySummary,
-    'vue-simple-spinner': VueSimpleSpinner,
   },
   data() {
     return {
@@ -71,6 +70,10 @@ export default {
       this.expanded = !this.expanded;
       this.focusInput();
     },
+    expandAndFocus() {
+      this.expanded = true;
+      this.focusInput();
+    },
     focusInput() {
       this.$nextTick(() => {
         if (this.expanded) {
@@ -92,10 +95,12 @@ export default {
     this.$watch(`directoryCare.${this.opposite}`, (newVal) => { // create dynamic watcher for opposite
       this.oppositeSelected = newVal;
       if (newVal && !this.selected) {
-        this.expanded = true;
-        this.focusInput();
+        this.expandAndFocus();
       }
     });
+    if (this.expand) {
+      this.expandAndFocus();
+    }
   },
 };
 </script>
@@ -114,13 +119,8 @@ export default {
           </span>
         </div>
         <div class="PostPicker-dropdown" v-show="expanded">
-          <vue-simple-spinner 
-            v-if="!fetchComplete" 
-            size="large" 
-            :message="'Loading' | translatePhrase"></vue-simple-spinner>
           <div class="PostPicker-inputContainer">
             <input
-              v-if="fetchComplete"
               type="text" 
               v-model="filterPhrase"
               class="PostPicker-input" 

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -289,6 +289,8 @@
     "Free text": "Fritext",
     "Title": "Titel",
     "sender": "avsändare",
-    "reciever": "mottagare"
+    "reciever": "mottagare",
+    "There are no instances flagged for directory care": "Det finns inga instanser flaggade för katalogvård",
+    "Holdings are moved from the sender post to the reciever post": "Från den avsändande posten flyttar du bestånd till den mottagande posten"
     }
 }

--- a/viewer/vue-client/src/views/DirectoryCare.vue
+++ b/viewer/vue-client/src/views/DirectoryCare.vue
@@ -63,29 +63,35 @@ export default {
       Promise.all(promiseArray).then((result) => {
         this.getMainEntities(result);
       }, (error) => {
-        this.fetchComplete = true;
         this.error = error;
+        this.allDone();
       });
     },
     getMainEntities(data) {
       this.fetchedItems = data.map(item => item.mainEntity);
-      this.fetchComplete = true;
+      this.allDone();
+    },
+    allDone() {
+      this.$store.dispatch('removeLoadingIndicator', 'Loading')
+        .then(() => {
+          this.fetchComplete = true;
+        });
     },
   },
   mounted() {
+    this.$store.dispatch('pushLoadingIndicator', 'Loading');
     this.fetchAllFlagged();
   },
 };
 </script>
 
 <template>
-  <div class="DirectoryCare">
+  <div class="DirectoryCare" v-if="fetchComplete">
     <tab-menu @go="switchTool" :tabs="tabs" :active="$route.params.tool"></tab-menu>
     <hr class="menuDivider">
     <holding-mover 
       v-if="$route.params.tool === 'holdings'"
       :flaggedInstances="flaggedInstances"
-      :fetchComplete="fetchComplete"
       :error="error" />
     <div class="" v-if="$route.params.tool === 'merge'">
       <h1>merge posts</h1>


### PR DESCRIPTION
...instead of local spinners. More consistent with how it's done in Inspector etc.
Also expanding & focusing the sender dropdown on mount. Saves a click!
