### PR TITLE
Fix filteredInstances

### DIFF
--- a/viewer/vue-client/src/components/care/post-picker.vue
+++ b/viewer/vue-client/src/components/care/post-picker.vue
@@ -1,6 +1,8 @@
 <script>
 import { mapGetters } from 'vuex';
 import EntitySummary from '@/components/shared/entity-summary';
+import * as DisplayUtil from '@/utils/display';
+import * as StringUtil from '@/utils/string';
 
 export default {
   name: 'post-picker',
@@ -40,17 +42,29 @@ export default {
   computed: {
     ...mapGetters([
       'directoryCare',
+      'resources',
+      'inspector',
+      'settings',
     ]),
     filteredInstances() {
-      return this.flaggedInstances.filter((el) => {
-        let titles = [];
-        el.hasTitle.forEach((t) => {
-          for (const val in t) {
-            if (t.hasOwnProperty(val) && typeof t[val] === 'string' && val !== '@type') { titles.push(t[val]); }
-          }
-        });
-        titles = titles.join(' • ').toLowerCase();
-        return titles.indexOf(this.filterPhrase.trim().toLowerCase()) > -1;
+      return this.flaggedInstances.filter((instance) => {
+        const headerList = DisplayUtil.getItemSummary(
+          instance, 
+          this.resources.display, 
+          this.inspector.data.quoted, 
+          this.resources.vocab, 
+          this.settings, 
+          this.resources.context,
+        ).header;
+
+        const header = StringUtil.getFormattedEntries(
+          headerList, 
+          this.resources.vocab, 
+          this.settings, 
+          this.resources.context,
+        ).join(', ').toLowerCase();
+
+        return header.indexOf(this.filterPhrase.trim().toLowerCase()) > -1;
       });
     },
   },

--- a/viewer/vue-client/src/components/care/post-picker.vue
+++ b/viewer/vue-client/src/components/care/post-picker.vue
@@ -46,8 +46,8 @@ export default {
       'inspector',
       'settings',
     ]),
-    filteredInstances() {
-      return this.flaggedInstances.filter((instance) => {
+    headers() {
+      return this.flaggedInstances.map((instance) => {
         const headerList = DisplayUtil.getItemSummary(
           instance, 
           this.resources.display, 
@@ -62,10 +62,14 @@ export default {
           this.resources.vocab, 
           this.settings, 
           this.resources.context,
-        ).join(', ').toLowerCase();
-
-        return header.indexOf(this.filterPhrase.trim().toLowerCase()) > -1;
+        ).join(', ');
+        return { '@id': instance['@id'], header };
       });
+    },
+    filteredInstances() {
+      const filteredTitles = this.headers.filter(el => el.header.toLowerCase()
+        .indexOf(this.filterPhrase.trim().toLowerCase()) > -1);
+      return this.flaggedInstances.filter(instance => filteredTitles.some(el => el['@id'] === instance['@id']));
     },
   },
   methods: {


### PR DESCRIPTION
Filter instances using properly calculated headers (using `getItemSummary` and `getFormattedEntries`).

These are stored in a separate computed `headers` array to avoid the operation being done at every keystroke. It is then filtered by the search phrase and matched with the real data object...



