### PR TITLE
Add title to userStorage

### DIFF
--- a/viewer/vue-client/src/components/care/post-picker.vue
+++ b/viewer/vue-client/src/components/care/post-picker.vue
@@ -76,7 +76,7 @@ export default {
   watch: {
     userCare(newVal) {
       if (this.selected) {
-        const selectedIsFlagged = newVal.filter(item => item === this.selected['@id']);
+        const selectedIsFlagged = newVal.filter(item => item['@id'] === this.selected['@id']);
         if (selectedIsFlagged.length === 0) {
           this.unselectThis();
         }

--- a/viewer/vue-client/src/components/shared/tag-switch.vue
+++ b/viewer/vue-client/src/components/shared/tag-switch.vue
@@ -1,18 +1,19 @@
 <script>
 /*
   Available props:
-    * documentId  - String, Which reference should be used in the list
+    * document  - The mainEntity from which to extract id and title
     * tag         - String, what tag we are operating on
 */
 import * as StringUtil from '@/utils/string';
 import { mapGetters } from 'vuex';
+import * as DisplayUtil from '@/utils/display';
 
 export default {
   name: 'tag-switch',
   props: {
-    documentId: {
-      type: String,
-      default: '',
+    document: {
+      type: Object,
+      default: () => {},
     },
     tag: {
       type: String,
@@ -36,7 +37,7 @@ export default {
       }
     },
     mark() {
-      this.$store.dispatch('mark', { tag: this.tag, documentId: this.documentId });
+      this.$store.dispatch('mark', { tag: this.tag, documentId: this.documentId, documentTitle: this.documentTitle });
     },
     unmark() {
       this.$store.dispatch('unmark', { tag: this.tag, documentId: this.documentId });
@@ -48,7 +49,23 @@ export default {
       'userStorage',
       'userCare',
       'userFavorites',
+      'settings',
+      'resources',
+      'inspector',
     ]),
+    documentId() {
+      return this.document['@id'] || '';
+    },
+    documentTitle() {
+      return DisplayUtil.getItemLabel(
+        this.document,
+        this.resources.display,
+        this.inspector.data.quoted,
+        this.resources.vocab,
+        this.settings,
+        this.resources.context,
+      );
+    },
     iconString() {
       let str = 'fa-';
       switch (this.tag) {
@@ -70,10 +87,10 @@ export default {
       let bool = false;
       switch (this.tag) {
         case 'Favorite':
-          bool = this.userFavorites.indexOf(this.documentId) >= 0;
+          bool = this.userFavorites.some(el => el['@id']) === this.documentId;
           break;
         case 'Directory care':
-          bool = this.userCare.indexOf(this.documentId) >= 0;
+          bool = this.userCare.some(el => el['@id'] === this.documentId);
           break;
         default:
           bool = false;

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -412,8 +412,8 @@ const store = new Vuex.Store({
       const list = getters.userStorage.list;
       const ids = Object.keys(list);
       for (let i = 0; i < ids.length; i++) {
-        if (list[ids[i]].indexOf('Favorite') > -1) {
-          collection.push(ids[i]);
+        if (list[ids[i]].tags.indexOf('Favorite') > -1) {
+          collection.push({ [ids[i]]: [ids[i]].label });
         }
       }
       return collection;
@@ -423,8 +423,8 @@ const store = new Vuex.Store({
       const list = getters.userStorage.list;
       const ids = Object.keys(list);
       for (let i = 0; i < ids.length; i++) {
-        if (list[ids[i]].indexOf('Directory care') > -1) {
-          collection.push(ids[i]);
+        if (list[ids[i]].tags.indexOf('Directory care') > -1) {
+          collection.push({ '@id': ids[i], label: list[ids[i]].label });
         }
       }
       return collection;
@@ -441,12 +441,14 @@ const store = new Vuex.Store({
       const userStorage = cloneDeep(state.userStorage);
       const tag = payload.tag;
       const id = payload.documentId;
+      const label = payload.documentTitle;
       if (userStorage.list.hasOwnProperty(id)) {
-        if (userStorage.list[id].indexOf(tag) < 0) {
-          userStorage.list[id].push(tag);
+        if (userStorage.list[id].tags.indexOf(tag) < 0) {
+          userStorage.list[id].tags.push(tag);
+          userStorage.list[id].label = label;
         }
       } else {
-        userStorage.list[id] = [tag];
+        userStorage.list[id] = { tags: [tag], label };
       }
       commit('setUserStorage', userStorage);
     },
@@ -455,9 +457,9 @@ const store = new Vuex.Store({
       const tag = payload.tag;
       const id = payload.documentId;
       if (userStorage.list.hasOwnProperty(id)) {
-        if (userStorage.list[id].indexOf(tag) >= 0) {
-          userStorage.list[id].splice(userStorage.list[id].indexOf(tag), 1);
-          if (userStorage.list[id].length === 0) {
+        if (userStorage.list[id].tags.indexOf(tag) >= 0) {
+          userStorage.list[id].tags.splice(userStorage.list[id].tags.indexOf(tag), 1);
+          if (userStorage.list[id].tags.length === 0) {
             delete userStorage.list[id];
           }
         }

--- a/viewer/vue-client/src/views/DirectoryCare.vue
+++ b/viewer/vue-client/src/views/DirectoryCare.vue
@@ -53,18 +53,18 @@ export default {
     switchTool(id) {
       this.$router.push({ path: `/directory-care/${id}` });
     },
-    fetchOne(id) {
+    fetchOne(item) {
       return new Promise((resolve, reject) => {
-        HttpUtil.getDocument(id, 'application/json') // Should be JSON, not JSON-LD
+        HttpUtil.getDocument(item['@id'], 'application/json') // Should be JSON, not JSON-LD
           .then((responseObject) => {
             if (responseObject.status === 200) {
               resolve(responseObject.data);
             } else if (responseObject.status === 410) {
-              this.errors.removed.push(id);
-              this.$store.dispatch('unmark', { tag: 'Directory care', documentId: id });
+              this.errors.removed.push(item);
+              this.$store.dispatch('unmark', { tag: 'Directory care', documentId: item['@id'] });
               resolve();
             } else {
-              this.errors.other.push(id);
+              this.errors.other.push(item);
               resolve();
             }
           }, (error) => {
@@ -108,7 +108,7 @@ export default {
               {
                 type: 'danger',
                 message: `${StringUtil.getUiPhraseByLang('The following resources could not be retrieved', this.user.settings.language)}: 
-                ${this.errors.other.join(', ')}`, 
+                ${this.errors.other.map(el => el.label).join(', ')}`, 
               })
               .then(() => {
                 this.errors.other = [];
@@ -147,8 +147,8 @@ export default {
         <p>{{ ['The following resources could not be retrieved', 
           'because they no longer exist. They have been removed from the directory care list'] | translatePhrase }}:</p>
         <ul>
-          <li v-for="error in errors.removed" :key="error">
-            {{error}}
+          <li v-for="error in errors.removed" :key="error['@id']">
+            {{error.label}}
           </li>
         </ul>
         <div class="DirectoryCare-modalBtnContainer">

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -672,7 +672,7 @@ export default {
             </div>
             <div class="Inspector-actions">
               <div class="TagContainer" v-if="recordType === 'Instance' && user.isLoggedIn && !inspector.status.isNew">
-                <tag-switch :document-id="inspector.data.mainEntity['@id']" :action-labels="{ on: 'Flag for', off: 'Unflag for' }" tag="Directory care" />
+                <tag-switch :document="inspector.data.mainEntity" :action-labels="{ on: 'Flag for', off: 'Unflag for' }" tag="Directory care" />
               </div>
               <reverse-relations 
                 class="Inspector-reverse" 


### PR DESCRIPTION
use `DisplayUtil.getItemLabel` to save entity's title in userCare along with its id. We then display it in case of removed/not found as a service to the user.

The object saved to `localStorage.userStorage.[hash].list` will now look like:
```
"id": {
   "tags":["Directory care"],
   "label":"title"
}
```
in store `userCare` this will convert to
```
[
   {"@id":"id", 
   "label":"title"}, ...
]
```

**Flush ye flagged items before testing, or all will fail!**