### PR TITLE
Absolute dropdown etc

### DIFF
--- a/viewer/vue-client/src/components/care/holding-list.vue
+++ b/viewer/vue-client/src/components/care/holding-list.vue
@@ -281,19 +281,34 @@ export default {
 
 .HoldingList {
   flex-basis: @directorycare-sidewidth;
+  max-width: @directorycare-sidewidth;
   padding: 0;
   display: flex;
   flex-direction: column;
+
   &-topBar {
     height: 4em;
-    padding: 20px;
+    padding: 15px;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     .btn {
       min-width: unset;
     }
+    & * {
+      margin: 5px;
+    }
+
+    & span {
+      white-space: nowrap;
+    }
+
+    @media (max-width: @screen-sm) {
+      height: auto;
+      flex-wrap: wrap;
+    }
   }
+
   &-body {
     border: solid @grey-lighter;
     border-width: 1px 0px 0px 1px;
@@ -377,6 +392,19 @@ export default {
   & .EntitySummary-title {
     font-size: 18px;
     font-size: 1.8rem;
+  }
+
+  & .EntitySummary-info {
+    word-break: break-word;
+  }
+
+  @media (max-width: @screen-sm) {
+    flex-basis: 100%;
+    max-width: 100%;
+
+    &:not(.is-sender) {
+      display: none;
+    }
   }
 }
 

--- a/viewer/vue-client/src/components/care/holding-mover.vue
+++ b/viewer/vue-client/src/components/care/holding-mover.vue
@@ -210,9 +210,9 @@ export default {
     <div class="HoldingMover-resultListContainer"
       :class="{ 'is-empty' : !anySelected}"
       v-if="flaggedInstances.length > 0">
-      <HoldingList ref="sender" name="sender" :loading="loading" :lock="loading || !bothSelected" @send="doMove" :progress="progress" />
+        <HoldingList ref="sender" name="sender" :loading="loading" :lock="loading || !bothSelected" @send="doMove" :progress="progress" />
       <div class="HoldingMover-separator"></div>
-      <HoldingList ref="reciever" :lock="true" name="reciever" />
+        <HoldingList ref="reciever" :lock="true" name="reciever" />
     </div>
     <modal-component 
       v-if="allSuccessDialog"
@@ -301,7 +301,7 @@ export default {
     margin: 80px 10px;
     
     @media (max-width: @screen-sm) {
-      margin: 20px;
+      margin: 10px;
     }
   }
 

--- a/viewer/vue-client/src/components/care/holding-mover.vue
+++ b/viewer/vue-client/src/components/care/holding-mover.vue
@@ -325,7 +325,8 @@ export default {
   }
 
   &-info {
-    margin: 20px 0 0;
+    margin: 0;
+    padding-top: 15px;
   }
 
   &-allSuccessDialog {

--- a/viewer/vue-client/src/components/care/holding-mover.vue
+++ b/viewer/vue-client/src/components/care/holding-mover.vue
@@ -125,7 +125,7 @@ export default {
       }
       return StringUtil.getUiPhraseByLang('Show instructions', this.user.settings.language);
     },
-    canSwitchInstances() {
+    anySelected() {
       return !!(this.directoryCare.sender || this.directoryCare.reciever);
     },
     bothSelected() {
@@ -196,7 +196,7 @@ export default {
       <div class="HoldingMover-separator" v-if="flaggedInstances.length > 0">
         <button class="btn btn-primary" 
           @click="switchInstances" 
-          :disabled="!canSwitchInstances"
+          :disabled="!anySelected"
           :aria-label="'Switch place' | translatePhrase">
           <i class="fa fa-fw fa-exchange"></i>
         </button>
@@ -207,7 +207,9 @@ export default {
         opposite="sender"
         :flaggedInstances="flaggedInstances"/>
     </div>
-    <div class="HoldingMover-resultListContainer" v-if="flaggedInstances.length > 0">
+    <div class="HoldingMover-resultListContainer"
+      :class="{ 'is-empty' : !anySelected}"
+      v-if="flaggedInstances.length > 0">
       <HoldingList ref="sender" name="sender" :loading="loading" :lock="loading || !bothSelected" @send="doMove" :progress="progress" />
       <div class="HoldingMover-separator"></div>
       <HoldingList ref="reciever" :lock="true" name="reciever" />
@@ -310,6 +312,12 @@ export default {
     justify-content: space-between;
     background-color: @white;
     border: 1px solid @grey-lighter;
+
+    &.is-empty {
+      background-color: unset;
+      border-color: transparent;
+      height: 30vh;
+    }
   }
   .statusItem {
     list-style: none;

--- a/viewer/vue-client/src/components/care/holding-mover.vue
+++ b/viewer/vue-client/src/components/care/holding-mover.vue
@@ -187,7 +187,7 @@ export default {
         name="sender"
         opposite="reciever"
         :flaggedInstances="flaggedInstances"
-        :expand="true">
+        :expand="false">
         <p v-if="!directoryCare.sender"
           class="HoldingMover-info" 
           slot="info">

--- a/viewer/vue-client/src/components/care/post-picker.vue
+++ b/viewer/vue-client/src/components/care/post-picker.vue
@@ -87,7 +87,10 @@ export default {
     selectThis(item) {
       if (item['@id'] !== this.oppositeSelected) {
         const changeObj = { [this.name]: item['@id'] };
-        this.$store.dispatch('setDirectoryCare', { ...this.directoryCare, ...changeObj });
+        this.$store.dispatch('setDirectoryCare', { ...this.directoryCare, ...changeObj })
+          .then(() => {
+            this.expanded = false;
+          });
       }
     },
     unselectThis() {
@@ -140,7 +143,8 @@ export default {
     <div class="PostPicker-label uppercaseHeading" 
       :class="{ 'has-selection' : selected}">
       {{ name | translatePhrase }}</div>
-    <div class="PostPicker-body" :class="{ 'has-selection' : selected}">
+    <div class="PostPicker-body" :class="{ 'has-selection' : selected, 'is-expanded' : expanded}">
+      <div class="PostPicker-dropdownWrapper">
       <div class="PostPicker-dropdownContainer" v-if="!selected && flaggedInstances.length > 0">
         <div class="PostPicker-toggle" 
           @click="toggleDropdown"
@@ -192,6 +196,7 @@ export default {
           <i class="fa fa-fw fa-close icon"></i>
         </span>
       </div>
+      </div>
       <slot name="info"></slot>
     </div>
   </div>
@@ -233,6 +238,10 @@ export default {
       background-color: @brand-faded;
       border-color: transparent;
     }
+
+    &.is-expanded {
+      z-index: 1;
+    }
   }
 
   &-dropdownContainer,
@@ -248,8 +257,19 @@ export default {
     padding: 15px;
   }
 
+  &-dropdownWrapper {
+    position: relative;
+    margin-bottom: 70px;
+
+    .has-selection & {
+      margin-bottom: 0;
+    }
+  }
+
   &-dropdownContainer {
     padding: 0;
+    position: absolute;
+    width: 100%;
   }
 
   &-toggle {

--- a/viewer/vue-client/src/components/care/post-picker.vue
+++ b/viewer/vue-client/src/components/care/post-picker.vue
@@ -229,6 +229,7 @@ export default {
   }
 
   &-body {
+    height: 100%;
     background-color: @white;
     border: 1px solid @grey-lighter;
     padding: 0 20px 20px;


### PR DESCRIPTION
In collab with @mattiasbolin, this includes following changes:

* Absolute positioned post-picker dropdown to create a more dropdown-y feel
* Don't open dropdown on mount, to make the need for selection more clear
* Align picker heights + holding container take up space, but not visible when no selection.
* Should now look ok and function across all widths. On small screen we hide the reciever holding list! 