### PR TITLE
Reset holdingsMoved

### DIFF
--- a/viewer/vue-client/src/components/care/holding-list.vue
+++ b/viewer/vue-client/src/components/care/holding-list.vue
@@ -118,6 +118,7 @@ export default {
       this.$store.dispatch('setDirectoryCare', { ...this.directoryCare, ...changeObj });
     },
     doSend() {
+      this.resetMovedStatus();
       this.$emit('send');
     },
     getStatus(holding) {


### PR DESCRIPTION
Flush `directoryCare.holdingsMoved` before moving. If already populated, `holdingsMoved` & `progress` arrays won't match in length & modal won't open.