### PR TITLE
Translate filters in result-control 

### DIFF
--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -38,24 +38,24 @@ export default {
     filters() {
       if (typeof this.pageData.search !== 'undefined') {
         return this.pageData.search.mapping.filter((item => item.variable !== 'q'))
-        .map((item)=> {
-          let label = '';
-          if (item.hasOwnProperty('value')) { // use item value get label
-            label = item.value;
-          }
-          if (item.hasOwnProperty('object')) { // use item object[@id]...
-            const match = this.pageData.stats.sliceByDimension[item.variable].observation
-              .filter(obs => obs.object['@id'] === item.object['@id'])
-            if (match.length === 1) { // ...to look for a prefLabelByLang/labelByLang prop in stats
-              const prop = match[0].object.prefLabelByLang || match[0].object.labelByLang;
-              label = prop[this.settings.language];
-            } else label = item.object['@id'];         
-          }
-          return {
-            label,
-            up: item.up['@id']
-          }
-        })
+          .map((item) => {
+            let label = '';
+            if (item.hasOwnProperty('value')) { // use item value get label
+              label = item.value;
+            }
+            if (item.hasOwnProperty('object')) { // use item object[@id]...
+              const match = this.pageData.stats.sliceByDimension[item.variable].observation
+                .filter(obs => obs.object['@id'] === item.object['@id']);
+              if (match.length === 1) { // ...to look for a prefLabelByLang/labelByLang prop in stats
+                const prop = match[0].object.prefLabelByLang || match[0].object.labelByLang;
+                label = prop[this.settings.language];
+              } else label = item.object['@id'];         
+            }
+            return {
+              label,
+              up: item.up['@id'],
+            };
+          });
       } return [];
     },
     queryText() {

--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -36,29 +36,27 @@ export default {
       return this.$store.getters.user;
     },
     filters() {
-      const filters = [];
       if (typeof this.pageData.search !== 'undefined') {
-        this.pageData.search.mapping.forEach((item) => {
-          if (item.variable !== 'q') {
-            const filterObj = {
-              label: '',
-              up: '',
-            };
-            if (typeof item.object !== 'undefined') {
-              if (item.variable === '@type') {
-                filterObj.label = StringUtil.getLabelByLang(item.object['@id'], this.settings.language, this.resources.vocab, this.resources.context);
-              } else {
-                filterObj.label = item.object['@id'].replace('https://id.kb.se/', '');
-              }
-            } else {
-              filterObj.label = item.value;
-            }
-            filterObj.up = item.up['@id'];
-            filters.push(filterObj);
+        return this.pageData.search.mapping.filter((item => item.variable !== 'q'))
+        .map((item)=> {
+          let label = '';
+          if (item.hasOwnProperty('value')) { // use item value get label
+            label = item.value;
           }
-        });
-      }
-      return filters;
+          if (item.hasOwnProperty('object')) { // use item object[@id]...
+            const match = this.pageData.stats.sliceByDimension[item.variable].observation
+              .filter(obs => obs.object['@id'] === item.object['@id'])
+            if (match.length === 1) { // ...to look for a prefLabelByLang/labelByLang prop in stats
+              const prop = match[0].object.prefLabelByLang || match[0].object.labelByLang;
+              label = prop[this.settings.language];
+            } else label = item.object['@id'];         
+          }
+          return {
+            label,
+            up: item.up['@id']
+          }
+        })
+      } return [];
     },
     queryText() {
       if (this.pageData.first) {
@@ -148,12 +146,16 @@ export default {
   <div class="ResultControls" v-if="!(!showDetails && pageData.totalItems < limit)">
     <div class="ResultControls-searchDetails" v-if="showDetails">
       <div class="ResultControls-resultDescr">
-        <p class="ResultControls-resultText" id="resultDescr">Sökning på {{ queryText }}
-          <span v-if="filters.length > 0">(filtrerat på <span v-for="(filter, index) in filters" :key="index">{{filter.label}}{{ index === (filters.length - 1) ? '' : ', ' }}</span>)</span>
-          gav {{pageData.totalItems}} träffar.
+        <p class="ResultControls-resultText" id="resultDescr">{{'Search for' | translatePhrase}} {{ queryText }}
+          <span v-if="filters.length > 0">({{ 'Filtered by' | translatePhrase | lowercase}}
+            <span v-for="(filter, index) in filters" :key="index">
+              {{ filter.label | labelByLang }}{{ index === (filters.length - 1) ? '' : ', ' }}</span>)
+          </span>
+          {{'Gave' | translatePhrase | lowercase}} {{pageData.totalItems}} {{'Hits' | translatePhrase | lowercase}}.
           <em v-if="pageData.totalItems > limit && $route.params.perimeter === 'remote'">Du har fått fler träffar än vad som kan visas, testa att göra en mer detaljerad sökning om du inte kan hitta det du letar efter.</em>
         </p>  
-        <p v-if="pageData.totalItems > limit && $route.params.perimeter != 'remote'" class="ResultControls-resultText">Visar {{ limit }} träffar per sida.</p>
+        <p v-if="pageData.totalItems > limit && $route.params.perimeter != 'remote'" class="ResultControls-resultText">
+          {{'Showing' | translatePhrase}} {{ limit }} {{['Hits', 'Per page'] | translatePhrase | lowercase}}.</p>
       </div>
       <div class="ResultControls-controlWrap" v-if="showDetails && pageData.totalItems > 0">
         <sort 

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -146,6 +146,7 @@
     "If you identify a matching linked entity, click it to replace the local entity with it": "Om du identifierar en matchande länkad entitet, klicka på den för att ersätta den lokala entiteten med den länkade",
     "If no matching linked entity is found you can create and link. This will create a linked entity containing the information in the entity chosen for linking": "Om du inte lyckas identifiera en matchande länkad entitet kan du skapa och länka. Detta kommer att skapa en länkad entitet med samma innehåll som entiteten som valts för länkning",
     "Filter by": "Filtrera",
+    "Filtered by": "Filtrerat på",
     "Filter": "Filtrera",
     "Showing": "Visar",
     "or": "eller",
@@ -310,6 +311,10 @@
     "Do you want to unmark the sender": "Vill du flagga av avsändaren",
     "Switch place": "Byt plats",
     "The following resources could not be retrieved": "Följande resurser kunde inte hämtas",
-    "because they no longer exist. They have been removed from the directory care list": "eftersom de har raderats. De har tagits bort från listan för katalogvård"
+    "because they no longer exist. They have been removed from the directory care list": "eftersom de har raderats. De har tagits bort från listan för katalogvård",
+    "Gave": "Gav",
+    "Hits": "Träffar",
+    "Per page": "Per sida",
+    "Search for": "Sökning på"
     }
 }


### PR DESCRIPTION
[LXL-2349](https://jira.kb.se/browse/LXL-2349)

Result-control `filters` now tries very hard to find a translatable label, either by straight up translating the `value` prop, or (in the case of languages for example), look in the facet data for a `labelByLang` or `prefLabelByLang` key.

Also translated some stuff in component markup, it should look ok in english now too...