### PR TITLE
Space separate collapsedText

### DIFF
--- a/viewer/vue-client/src/components/mixins/lens-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/lens-mixin.vue
@@ -34,6 +34,11 @@ export default {
       for (const key of Object.keys(this.getChip)) {
         labelArray.push(this.getChip[key]);
       }
+      labelArray.forEach((el, i) => {
+        if (Array.isArray(el) && (el.length > 1)) {
+          labelArray[i] = labelArray[i].join(', ');
+        }
+      });
       return labelArray.join(' • ');
     },
     getChip() {


### PR DESCRIPTION
[LXL-2426](https://jira.kb.se/browse/LXL-2426)

Modifies the `getItemLabel` function so that it, if an element is an array, returns it as a comma separated string to be displayed as collapsed text:

![nospace](https://user-images.githubusercontent.com/22232928/54434183-edc93e00-472d-11e9-82d5-091e3b2184f6.png)
![space](https://user-images.githubusercontent.com/22232928/54434189-ef930180-472d-11e9-8719-d8a2ebd99304.png)

More readable + prevents layout havoc as described in issue.