### PR TITLE
Modal esc

### DIFF
--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -210,6 +210,7 @@ export default {
     },
     postControl(control) {
       // if (!this.inspector.status.updating) {
+      this.hideToolsMenu();
       this.$store.dispatch('pushInspectorEvent', { 
         name: 'post-control', 
         value: control, 

--- a/viewer/vue-client/src/components/shared/modal-component.vue
+++ b/viewer/vue-client/src/components/shared/modal-component.vue
@@ -65,6 +65,7 @@ export default {
   computed: {
     ...mapGetters([
       'user',
+      'status',
     ]),
     translatedTitle() {
       let title = '';
@@ -92,6 +93,14 @@ export default {
     this.$nextTick(() => {
       LayoutUtil.scrollLock(false);
     });
+  },
+  watch: {
+    'status.keyActions'(actions) {
+      const lastAction = actions.slice(-1).join();
+      if (lastAction === 'close-modals') {
+        this.close();
+      }
+    }, 
   },
 };
 </script>

--- a/viewer/vue-client/src/components/shared/panel-component.vue
+++ b/viewer/vue-client/src/components/shared/panel-component.vue
@@ -185,7 +185,7 @@ export default {
   &-container {
     opacity: 0;
     transition: opacity 0.5s ease;
-    z-index: @modal-z;
+    z-index: @popover-z;
     box-shadow: @shadow-card-elevated;
     position: fixed;
     width: 35%;


### PR DESCRIPTION
* Added a watcher for `close-modals` event in Modal-component
* Z-index fix so that modals are on top of side panel
* Close toolbar tools menu in more cases (for example when clicking 'remove post')