### PR TITLE
[WIP] Update templates and snippets containing local entities of inScheme:

### DIFF
--- a/viewer/vue-client/src/resources/json/combinedTemplates.json
+++ b/viewer/vue-client/src/resources/json/combinedTemplates.json
@@ -159,7 +159,7 @@
               "@type": "Classification",
               "code": "",
               "inScheme": {
-                "@type": "ConceptScheme",
+                "@type": "ClassificationScheme",
                 "@id": "https://id.kb.se/term/kssb/8",
                 "code": "kssb",
                 "version": "8"
@@ -343,7 +343,7 @@
               "@type": "Classification",
               "code": "",
               "inScheme": {
-                "@type": "ConceptScheme",
+                "@type": "ClassificationScheme",
                 "@id": "https://id.kb.se/term/kssb/8",
                 "code": "kssb",
                 "version": "8"
@@ -523,7 +523,7 @@
               "@type": "Classification",
               "code": "",
               "inScheme": {
-                "@type": "ConceptScheme",
+                "@type": "ClassificationScheme",
                 "@id": "https://id.kb.se/term/kssb/8",
                 "code": "kssb",
                 "version": "8"
@@ -741,7 +741,7 @@
               "@type": "Classification",
               "code": "",
               "inScheme": {
-                "@type": "ConceptScheme",
+                "@type": "ClassificationScheme",
                 "@id": "https://id.kb.se/term/kssb/8",
                 "code": "kssb",
                 "version": "8"
@@ -919,7 +919,7 @@
               "@type": "Classification",
               "code": "",
               "inScheme": {
-                "@type": "ConceptScheme",
+                "@type": "ClassificationScheme",
                 "@id": "https://id.kb.se/term/kssb/8",
                 "code": "kssb",
                 "version": "8"
@@ -1320,7 +1320,7 @@
               "@type": "Classification",
               "code": "",
               "inScheme": {
-                "@type": "ConceptScheme",
+                "@type": "ClassificationScheme",
                 "@id": "https://id.kb.se/term/kssb/8",
                 "code": "kssb",
                 "version": "8"
@@ -1471,7 +1471,7 @@
               "@type": "Classification",
               "code": "",
               "inScheme": {
-                "@type": "ConceptScheme",
+                "@type": "ClassificationScheme",
                 "@id": "https://id.kb.se/term/kssb/8",
                 "code": "kssb",
                 "version": "8"
@@ -1725,7 +1725,7 @@
               "@type": "Classification",
               "code": "",
               "inScheme": {
-                "@type": "ConceptScheme",
+                "@type": "ClassificationScheme",
                 "@id": "https://id.kb.se/term/kssb/8",
                 "code": "kssb",
                 "version": "8"
@@ -1735,7 +1735,7 @@
               "@type": "Classification",
               "code": "",
               "inScheme": {
-                "@type": "ConceptScheme",
+                "@type": "ClassificationScheme",
                 "@id": "https://id.kb.se/term/kssb/8",
                 "code": "kssb",
                 "version": "8"
@@ -2167,7 +2167,7 @@
               "@type": "Classification",
               "code": "",
               "inScheme": {
-                "@type": "ConceptScheme",
+                "@type": "ClassificationScheme",
                 "@id": "https://id.kb.se/term/kssb/8",
                 "code": "kssb",
                 "version": "8"
@@ -2400,7 +2400,7 @@
             "@type": "GenreForm",
             "inScheme": {
               "@id": "https://id.kb.se/term/lcsh",
-              "@type": "ConceptScheme",
+              "@type": "TopicScheme",
               "code": "lcsh"
             },
             "prefLabel": "",
@@ -2451,7 +2451,7 @@
           "closeMatch": [],
           "inScheme": {
             "@id": "https://id.kb.se/term/sao",
-            "@type": "ConceptScheme",
+            "@type": "TopicScheme",
             "notation": "sao"
           },
           "scopeNote": [""]
@@ -2509,7 +2509,7 @@
               "@type": "ClassificationDdc",
               "code": "",
               "inScheme": {
-                "@type": "ConceptScheme",
+                "@type": "ClassificationScheme",
                 "@id": "http://dewey.info/scheme/edition/e23/swe/",
                 "version": "23",
                 "language": "swe"
@@ -2518,7 +2518,7 @@
             {
               "@type": "Topic",
               "inScheme": {
-                "@type": "ConceptScheme",
+                "@type": "TopicScheme",
                 "@id": "https://id.kb.se/term/lcsh",
                 "code": "lcsh"
               },

--- a/viewer/vue-client/src/resources/json/structuredValueTemplates.json
+++ b/viewer/vue-client/src/resources/json/structuredValueTemplates.json
@@ -374,7 +374,7 @@
     "code": "",
     "inScheme": {
       "@id": "https://id.kb.se/term/kssb/8/",
-      "@type": "ConceptScheme",
+      "@type": "ClassificationScheme",
       "code": "kssb",
       "version": "8"
     }


### PR DESCRIPTION
- Change the type of inScheme to appropriate subClass of ConceptScheme

This only affects local entities of ClassificationScheme. We need to discuss if this should be merged together with https://github.com/libris/definitions/pull/103 or if we should wait until we change mapping of ConceptScheme i marcframe?