### PR TITLE
LXL-2432 Removable filter

### DIFF
--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -110,6 +110,17 @@ export default {
     currentSortOrder() {
       return this.$route.query._sort;
     },
+    resultRange() {
+      if (this.$route.params.perimeter === 'remote') {
+        return `1-${this.limit}`;
+      } 
+      const first = this.pageData.itemOffset + 1;
+      let last = this.pageData.itemOffset + this.pageData.itemsPerPage;
+      if (last > this.pageData.totalItems) {
+        last = this.pageData.totalItems;
+      }
+      return `${first}-${last}`;
+    },
   },
   methods: {
     setCompact() {
@@ -146,16 +157,23 @@ export default {
   <div class="ResultControls" v-if="!(!showDetails && pageData.totalItems < limit)">
     <div class="ResultControls-searchDetails" v-if="showDetails">
       <div class="ResultControls-resultDescr">
-        <p class="ResultControls-resultText" id="resultDescr">{{'Search for' | translatePhrase}} {{ queryText }}
+        <!-- <p class="ResultControls-resultText" id="resultDescr">{{'Search for' | translatePhrase}} {{ queryText }}
           <span v-if="filters.length > 0">({{ 'Filtered by' | translatePhrase | lowercase}}
             <span v-for="(filter, index) in filters" :key="index">
               {{ filter.label | labelByLang }}{{ index === (filters.length - 1) ? '' : ', ' }}</span>)
           </span>
           {{'Gave' | translatePhrase | lowercase}} {{pageData.totalItems}} {{'Hits' | translatePhrase | lowercase}}.
           <em v-if="pageData.totalItems > limit && $route.params.perimeter === 'remote'">Du har fått fler träffar än vad som kan visas, testa att göra en mer detaljerad sökning om du inte kan hitta det du letar efter.</em>
-        </p>  
-        <p v-if="pageData.totalItems > limit && $route.params.perimeter != 'remote'" class="ResultControls-resultText">
-          {{'Showing' | translatePhrase}} {{ limit }} {{['Hits', 'Per page'] | translatePhrase | lowercase}}.</p>
+        </p>   -->
+        <p class="ResultControls-resultText" id="resultDescr">
+          <span v-if="pageData.totalItems > 0"> {{['Showing', resultRange, 'of'] | translatePhrase }} </span>
+          <span class="ResultControls-numTotal"> {{pageData.totalItems}} {{'Hits' | translatePhrase | lowercase}}</span>
+        </p>
+        <p class="ResultControls-resultText" v-if="$route.params.perimeter === 'remote' && pageData.totalItems > limit">
+          Du har fått fler träffar än vad som kan visas.
+        </p>
+        <!-- <p v-if="pageData.totalItems > limit && $route.params.perimeter != 'remote'" class="ResultControls-resultText">
+          {{'Showing' | translatePhrase}} {{ limit }} {{['Hits', 'Per page'] | translatePhrase | lowercase}}.</p> -->
       </div>
       <div class="ResultControls-controlWrap" v-if="showDetails && pageData.totalItems > 0">
         <sort 
@@ -229,6 +247,8 @@ export default {
     align-items: baseline;
     width: 100%;
     color: @gray-dark;
+    border-bottom: 1px solid @gray-lighter;
+    padding-bottom: 10px;
 
     @media (max-width: @screen-sm) {
       flex-direction: column;
@@ -242,6 +262,10 @@ export default {
   &-resultText {
     font-weight: 600;
     padding-right: 20px;
+  }
+
+  &-numTotal {
+    color: @black;
   }
 
   &-controlWrap {

--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -157,23 +157,13 @@ export default {
   <div class="ResultControls" v-if="!(!showDetails && pageData.totalItems < limit)">
     <div class="ResultControls-searchDetails" v-if="showDetails">
       <div class="ResultControls-resultDescr">
-        <!-- <p class="ResultControls-resultText" id="resultDescr">{{'Search for' | translatePhrase}} {{ queryText }}
-          <span v-if="filters.length > 0">({{ 'Filtered by' | translatePhrase | lowercase}}
-            <span v-for="(filter, index) in filters" :key="index">
-              {{ filter.label | labelByLang }}{{ index === (filters.length - 1) ? '' : ', ' }}</span>)
-          </span>
-          {{'Gave' | translatePhrase | lowercase}} {{pageData.totalItems}} {{'Hits' | translatePhrase | lowercase}}.
-          <em v-if="pageData.totalItems > limit && $route.params.perimeter === 'remote'">Du har fått fler träffar än vad som kan visas, testa att göra en mer detaljerad sökning om du inte kan hitta det du letar efter.</em>
-        </p>   -->
         <p class="ResultControls-resultText" id="resultDescr">
           <span v-if="pageData.totalItems > 0"> {{['Showing', resultRange, 'of'] | translatePhrase }} </span>
           <span class="ResultControls-numTotal"> {{pageData.totalItems}} {{'Hits' | translatePhrase | lowercase}}</span>
         </p>
         <p class="ResultControls-resultText" v-if="$route.params.perimeter === 'remote' && pageData.totalItems > limit">
-          Du har fått fler träffar än vad som kan visas.
+          {{ 'The search gave more results than can be displayed' | translatePhrase }}.
         </p>
-        <!-- <p v-if="pageData.totalItems > limit && $route.params.perimeter != 'remote'" class="ResultControls-resultText">
-          {{'Showing' | translatePhrase}} {{ limit }} {{['Hits', 'Per page'] | translatePhrase | lowercase}}.</p> -->
       </div>
       <div class="ResultControls-controlWrap" v-if="showDetails && pageData.totalItems > 0">
         <sort 
@@ -195,6 +185,15 @@ export default {
             <i class="fa fa-list"></i>
           </button>
         </div>
+      </div>
+    </div>
+    <div class="ResultControls-filterWrapper" v-if="showDetails && filters.length > 0">
+      <div class="ResultControls-filterBadge" v-for="(filter, index) in filters" :key="index">
+        <span>{{filter.label | labelByLang }}</span>
+        <router-link class="ResultControls-pagLink"
+          :to="filter.up | asAppPath">
+          <i class="fa fa-fw fa-close icon"></i>
+        </router-link>
       </div>
     </div>
     <nav v-if="hasPagination && showPages">
@@ -244,11 +243,9 @@ export default {
   &-searchDetails {
     display: flex;
     justify-content: space-between;
-    align-items: baseline;
+    align-items: center;
     width: 100%;
     color: @gray-dark;
-    border-bottom: 1px solid @gray-lighter;
-    padding-bottom: 10px;
 
     @media (max-width: @screen-sm) {
       flex-direction: column;
@@ -281,6 +278,7 @@ export default {
   &-listType {
     background-color: transparent;
     height: 20px;
+    margin-bottom: 10px;
 
     &:hover, 
     &:focus {
@@ -300,6 +298,30 @@ export default {
         color: inherit;
       }
     }
+  }
+
+  &-filterWrapper {
+    padding-top: 5px;
+    display: flex;
+    flex-wrap: wrap;
+    border-top: 1px solid @gray-lighter;
+  }
+
+  &-filterBadge {
+    background-color: #364a4c;
+    color: @white;
+    font-weight: 600;
+    font-size: 1.4rem;
+    padding: 2px 10px;
+    margin: 5px 5px 0 0;
+    border-radius: 4px;
+    white-space: nowrap;
+
+    & i,
+    & i:hover {
+      color: @white;
+    }
+
   }
 
   &-pagDecor {

--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -2,6 +2,7 @@
 import * as StringUtil from '@/utils/string';
 import * as httpUtil from '@/utils/http';
 import Sort from '@/components/search/sort';
+// import { pickBy } from 'lodash-es';
 
 export default {
   name: 'result-controls',
@@ -52,6 +53,7 @@ export default {
             } else if (item.hasOwnProperty('object')) label = item.object['@id']; // else try to translate object[@id]...
             return {
               label,
+              variable: item.variable,
               up: item.up['@id'],
             };
           });
@@ -145,6 +147,11 @@ export default {
       });
       this.$dispatch('newresult', resultPromise);
     },
+    // clearAllFilters() { // introduce when we have 'type' radio buttons
+    //   const currentQuery = Object.assign({}, this.$route.query);
+    //   const clearedQuery = pickBy(currentQuery, (value, key) => this.filters.every(el => el.variable !== key));
+    //   this.$router.push({ query: clearedQuery });
+    // },
   },
   components: {
     sort: Sort,
@@ -195,6 +202,12 @@ export default {
           <i class="fa fa-fw fa-close icon"></i>
         </router-link>
       </div>
+      <!-- <button class="ResultControls-filterBadge clear-all" // introduce when we have 'type' radio buttons
+        v-if="filters.length > 1"
+        @click="clearAllFilters">
+        {{ 'Clear all' | translatePhrase }}
+        <i class="fa fa-fw fa-close icon"></i>
+      </button> -->
     </div>
     <nav v-if="hasPagination && showPages">
       <ul class="ResultControls-pagList">
@@ -223,7 +236,7 @@ export default {
             v-if="pageData.next" :to="pageData.next['@id'] | asAppPath">{{'Next' | translatePhrase}}</router-link>
           <a class="ResultControls-pagLink" v-if="!pageData.next">{{'Next' | translatePhrase}}</a>
         </li>
-        <li class="ResultControls-pagItem" 
+        <li class="ResultControls-pagItem"
           v-bind:class="{ 'is-disabled': !pageData.last || pageData['@id'] === pageData.last['@id'] }">
           <router-link class="ResultControls-pagLink" 
             v-if="pageData.last" :to="pageData.last['@id'] | asAppPath">{{'Last' | translatePhrase}}</router-link>
@@ -309,6 +322,7 @@ export default {
 
   &-filterBadge {
     background-color: #364a4c;
+    border: 1px solid #364a4c;
     color: @white;
     font-weight: 600;
     font-size: 1.4rem;
@@ -320,6 +334,17 @@ export default {
     & i,
     & i:hover {
       color: @white;
+    }
+
+    &.clear-all {
+      color: inherit;
+      background-color: @white;
+      border: 1px solid @grey-lighter;
+
+      & i,
+      & i:hover {
+        color: inherit;
+      }
     }
 
   }

--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -328,7 +328,7 @@ export default {
     color: @white;
     font-weight: 600;
     font-size: 1.4rem;
-    padding: 2px 10px;
+    padding: 2px 5px 2px 10px;
     margin: 5px 5px 0 0;
     border-radius: 4px;
     white-space: nowrap;
@@ -416,10 +416,6 @@ export default {
       &:hover {
         color: @black;
       }
-    }
-
-    i {
-      padding: 0 5px 0 5px;
     }
   }
 }

--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -24,6 +24,7 @@ export default {
   data() {
     return {
       keyword: '',
+      excludeFilters: ['q', 'identifiedBy.value', 'identifiedBy.@type', 'hasTitle.mainTitle'],
     };
   },
   computed: {
@@ -38,7 +39,8 @@ export default {
     },
     filters() {
       if (typeof this.pageData.search !== 'undefined') {
-        return this.pageData.search.mapping.filter((item => item.variable !== 'q'))
+        // remove search-by filters, ISBN etc
+        return this.pageData.search.mapping.filter(item => this.excludeFilters.every(el => el !== item.variable))
           .map((item) => {
             let label = '';
             if (item.hasOwnProperty('value')) { // Try to use item value to get label

--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -40,17 +40,16 @@ export default {
         return this.pageData.search.mapping.filter((item => item.variable !== 'q'))
           .map((item) => {
             let label = '';
-            if (item.hasOwnProperty('value')) { // use item value get label
+            if (item.hasOwnProperty('value')) { // Try to use item value to get label
               label = item.value;
-            }
-            if (item.hasOwnProperty('object')) { // use item object[@id]...
+            } else if (item.hasOwnProperty('object') && this.pageData.hasOwnProperty('stats')) { // else look for preflabel in stats (if there are results)
               const match = this.pageData.stats.sliceByDimension[item.variable].observation
                 .filter(obs => obs.object['@id'] === item.object['@id']);
-              if (match.length === 1) { // ...to look for a prefLabelByLang/labelByLang prop in stats
+              if (match.length === 1) {
                 const prop = match[0].object.prefLabelByLang || match[0].object.labelByLang;
                 label = prop[this.settings.language];
-              } else label = item.object['@id'];         
-            }
+              } else label = item.object['@id'];        
+            } else if (item.hasOwnProperty('object')) label = item.object['@id']; // else try to translate object[@id]...
             return {
               label,
               up: item.up['@id'],
@@ -159,7 +158,8 @@ export default {
       <div class="ResultControls-resultDescr">
         <p class="ResultControls-resultText" id="resultDescr">
           <span v-if="pageData.totalItems > 0"> {{['Showing', resultRange, 'of'] | translatePhrase }} </span>
-          <span class="ResultControls-numTotal"> {{pageData.totalItems}} {{'Hits' | translatePhrase | lowercase}}</span>
+          <span v-if="pageData.totalItems > 0" class="ResultControls-numTotal"> {{pageData.totalItems}} {{'Hits' | translatePhrase | lowercase}}</span>
+          <span v-else class="ResultControls-numTotal">{{'No hits' | translatePhrase }}</span>
         </p>
         <p class="ResultControls-resultText" v-if="$route.params.perimeter === 'remote' && pageData.totalItems > limit">
           {{ 'The search gave more results than can be displayed' | translatePhrase }}.

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -176,6 +176,9 @@ export default {
         });
       }
     },
+    '$route.fullPath'() {
+      this.activeTypes = this.getIncomingTypes();
+    },
   },
   mounted() {
     this.$nextTick(() => {

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -178,7 +178,7 @@ export default {
     },
     '$route.fullPath'() {
       this.activeTypes = this.getIncomingTypes();
-      this.getIncomingSearch();
+      this.activeSearchParam = this.getIncomingSearch();
     },
   },
   mounted() {

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -178,6 +178,7 @@ export default {
     },
     '$route.fullPath'() {
       this.activeTypes = this.getIncomingTypes();
+      this.getIncomingSearch();
     },
   },
   mounted() {
@@ -190,7 +191,7 @@ export default {
 
 <template>
   <div class="SearchBar">
-    <div class="SearchBar-topControl">
+    <div class="SearchBar-topControl"> 
       <tab-menu :link="true" :tabs="[
         { 'id': 'libris', 'text': 'Libris', link: '/search/libris'},
         { 'id': 'remote', 'text': 'Other sources', link: '/search/remote' },
@@ -210,7 +211,7 @@ export default {
             <div class="SearchBar-helpContent" v-html="searchHelpDocs"></div>
           </div>
         </div>
-      </div> 
+      </div>
     </div>
     <form id="searchForm" class="SearchBar-form">
       <div class="SearchBar-formContent">

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -74,14 +74,18 @@ export default {
       this.focusSearchInput();
     },
     getIncomingSearch() {
-      let match = PropertyMappings
-        .filter(prop => Object.keys(prop.mappings)
-          .every(key => this.$route.query.hasOwnProperty(key)));
-
-      if (match.length > 1) { // multiple sets of matching parameters
-        const newMatch = match
-          .filter(prop => prop.mappings['identifiedBy.@type'] === this.$route.query['identifiedBy.@type']);
-        match = newMatch;
+      let match = PropertyMappings.filter((prop) => {
+        const keys = Object.keys(prop.mappings);
+        return keys.every(key => this.$route.query.hasOwnProperty(key));
+      });
+      if (match.length > 1) {
+        // multiple matching parameters...
+        const filteredMatch = match
+          // try separate ISSN from ISBN
+          .filter(prop => prop.mappings['identifiedBy.@type'] === this.$route.query['identifiedBy.@type'])
+          // remove 'q'
+          .filter(prop => !prop.mappings.hasOwnProperty('q'));
+        match = filteredMatch;
       }
       if (match.length > 0) {
         const matchObj = match[0];
@@ -90,6 +94,7 @@ export default {
         });
         return matchObj;
       }
+      // no match -> return default
       return PropertyMappings[0];
     },
     getIncomingTypes() {
@@ -148,7 +153,7 @@ export default {
       return this.searchPerimeter === 'remote' ? 'ISBN eller valfria sökord' : 'Search';
     },
     composedSearchParam() {
-      const composed = this.activeSearchParam.mappings;
+      const composed = Object.assign({}, this.activeSearchParam.mappings);
       composed[this.activeSearchParam.searchProp] = this.searchPhrase.length > 0 ? this.searchPhrase : '*';
       return composed;
     },

--- a/viewer/vue-client/src/components/search/sort.vue
+++ b/viewer/vue-client/src/components/search/sort.vue
@@ -94,7 +94,7 @@ export default {
   }
   &-select {
     text-align-last: start;
-    margin-right: 10px;
+    margin: 0 10px 10px 0;
   }
 }
 </style>

--- a/viewer/vue-client/src/models/user.js
+++ b/viewer/vue-client/src/models/user.js
@@ -17,6 +17,7 @@ export class User {
       language: 'sv',
       defaultDatabases: ['OCLC'],
       forceFullViewPanel: false,
+      searchParam: false,
     };
   }
 

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -315,6 +315,7 @@
     "Gave": "Gav",
     "Hits": "Träffar",
     "Per page": "Per sida",
-    "Search for": "Sökning på"
+    "Search for": "Sökning på",
+    "The search gave more results than can be displayed": "Sökningen gav fler träffar än vad som kan visas"
     }
 }

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -316,6 +316,7 @@
     "Hits": "Träffar",
     "Per page": "Per sida",
     "Search for": "Sökning på",
-    "The search gave more results than can be displayed": "Sökningen gav fler träffar än vad som kan visas"
+    "The search gave more results than can be displayed": "Sökningen gav fler träffar än vad som kan visas",
+    "No hits": "Inga träffar"
     }
 }


### PR DESCRIPTION
Reworked `search-controls` component according to design in [ticket](https://jira.kb.se/browse/LXL-2432) including:

* Display active facets as removable filter badges
* New copy / search info

Also 
* Made type checkboxes + search bar query + searchtype dropdown reactive to route changes to always reflect the actual search (when using the back-button for example) - necessary since we no longer print out the searchphrase in search-controls info.

**U may need to restart Vagrant to include an API fix that fixes facet 'up'-links**

**UPDATE:**
Now also includes [LXL-2453](https://jira.kb.se/browse/LXL-2453) since it's practically an extension of the code above. The current search param (Free text, ISBN, Main title etc) is now stored in user settings and reused on a clean search. 

The 'active' option now falls back like: 
Presence of existing query param --> user setting param --> Fallback/default value

Test: See user story in ticket.