### PR TITLE
LXL-2489 Fix property sort (without rollback)

### DIFF
--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -111,6 +111,15 @@ export function getDisplayProperties(className, displayDefinitions, vocab, setti
       level = 'chips';
     }
   }
+
+  if (level === 'full') {
+    props = getLensPropertiesDeep(cn, displayDefinitions, vocab, settings, context, level, depth);
+    if (props.length === 0 && depth === 0) {
+      // Try fallback to card level
+      level = 'cards';
+    }
+  }
+
   // If level is not tokens 
   if (level !== 'tokens') {
     props = getLensPropertiesDeep(cn, displayDefinitions, vocab, settings, context, level, depth);


### PR DESCRIPTION
**Bug:** 
[LXL-2489](https://jira.kb.se/browse/LXL-2489)

**Probable cause:** 
`getDisplayProperties()` returns nothing for `Work` since it never looks beyond `'full'` level. So the `formObj` is rendered as-is, unsorted.

**Fix:**
Make `'full'` level fall back to `'card'` (like before).
