### PR TITLE
LXL-2351 - Fix breadcrumbs

### DIFF
--- a/viewer/vue-client/src/components/inspector/breadcrumb.vue
+++ b/viewer/vue-client/src/components/inspector/breadcrumb.vue
@@ -1,9 +1,10 @@
 <script>
 /*
- Displays breadcrumbs/between post navigation in inspector
+  Displays breadcrumbs/between post navigation in inspector
 */
 
 import { mapGetters } from 'vuex';
+import { each } from 'lodash-es';
 
 export default {
   name: 'breadcrumb',
@@ -15,16 +16,15 @@ export default {
   },
   data() {
     return {
-      recordTypeChange: false,
+      // recordTypeChange: false,
+      prevPath: '',
+      nextPath: '',
     };
   },
   computed: {
     ...mapGetters([
       'inspector',
-      'resources',
-      'user',
       'settings',
-      'status',
     ]),
     showFromPost() {
       if (!this.fromPostUrl || !this.recordTypeChange) return false;
@@ -34,7 +34,7 @@ export default {
       return false;
     },
     searchResultUrl() {
-      return this.inspector.breadcrumb[0].resultUrl;
+      return this.$route.meta.breadcrumb.resultUrl;
     },
     fromPostUrl() {
       const breadcrumbTrail = this.inspector.breadcrumb;
@@ -51,100 +51,162 @@ export default {
 
       return fromPostId;
     },
-    fromPostType() {
-      const breadcrumbTrail = this.inspector.breadcrumb;
-      let fromPostType;
+    // fromPostType() {
+    //   const breadcrumbTrail = this.inspector.breadcrumb;
+    //   let fromPostType;
 
-      if (breadcrumbTrail.length > 1) {
-        const result = breadcrumbTrail.filter(breadcrumb => breadcrumb.type === 'fromPost');
-        fromPostType = result[0].recordType;
-      } else if (breadcrumbTrail.length > 0) {
-        fromPostType = breadcrumbTrail[0].recordType;
-      } else {
-        fromPostType = '';
-      }
+    //   if (breadcrumbTrail.length > 1) {
+    //     const result = breadcrumbTrail.filter(breadcrumb => breadcrumb.type === 'fromPost');
+    //     fromPostType = result[0].recordType;
+    //   } else if (breadcrumbTrail.length > 0) {
+    //     fromPostType = breadcrumbTrail[0].recordType;
+    //   } else {
+    //     fromPostType = '';
+    //   }
 
-      return fromPostType;
+    //   return fromPostType;
+    // },
+    // currentPost() {
+    //   return this.inspector.data.mainEntity['@id'];
+    // },
+    // currentPostNumber() {
+    //   if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return null;
+    //   const items = this.inspector.breadcrumb[0].result.items;
+
+    //   const item = items.find(itemObj => itemObj['@id'] === this.currentPost);
+    //   const itemIndex = items.indexOf(item);
+
+    //   return itemIndex + 1;
+    // },
+    totalItems() {
+      return this.$route.meta.breadcrumb.totalItems;
     },
-    currentPost() {
-      return this.inspector.data.mainEntity['@id'];
+    currentOffset() {
+      return this.$route.meta.breadcrumb.offset;
     },
-    currentPostNumber() {
-      if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return null;
-      const items = this.inspector.breadcrumb[0].result.items;
+    // prevPostIndex() {
+    //   if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return null;
 
-      const item = items.find(itemObj => itemObj['@id'] === this.currentPost);
-      const itemIndex = items.indexOf(item);
-
-      return itemIndex + 1;
-    },
-    totalPostNumber() {
-      if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return null;
-
-      return this.inspector.breadcrumb[0].result.totalItems;
-    },
-    prevPostIndex() {
-      if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return null;
-
-      const items = this.inspector.breadcrumb[0].result.items;
+    //   const items = this.inspector.breadcrumb[0].result.items;
       
-      const item = items.find(itemObj => itemObj['@id'] === this.currentPost);
-      const itemIndex = items.indexOf(item);
+    //   const item = items.find(itemObj => itemObj['@id'] === this.currentPost);
+    //   const itemIndex = items.indexOf(item);
+    //   return itemIndex - 1;
+    // },
+    // prevPath() {
+    //   return 'www.google.se';
+    //   // if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return '';
+
+    //   // if (this.prevPostIndex < 0) return '';
+
+    //   // const items = this.inspector.breadcrumb[0].result.items;
+
+    //   // const prevItem = items[this.prevPostIndex];
+    //   // if (prevItem.hasOwnProperty('@id')) {
+    //   //   const uriParts = prevItem['@id'].split('/');
+    //   //   const fnurgel = uriParts[uriParts.length - 1];
+    //   //   return `/${fnurgel}`;
+    //   // }
+
+    //   // return '';
+    // },
+    // nextPostIndex() {
+    //   if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) {
+    //     return null;
+    //   }
+
+    //   const items = this.inspector.breadcrumb[0].result.items;
+      
+    //   const item = items.find(itemObj => itemObj['@id'] === this.currentPost);
+    //   const itemIndex = items.indexOf(item);
      
-      return itemIndex - 1;
-    },
-    prevPostPath() {
-      if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return '';
-
-      if (this.prevPostIndex < 0) return '';
-
-      const items = this.inspector.breadcrumb[0].result.items;
-
-      const prevItem = items[this.prevPostIndex];
-      if (prevItem.hasOwnProperty('@id')) {
-        const uriParts = prevItem['@id'].split('/');
-        const fnurgel = uriParts[uriParts.length - 1];
-        return `/${fnurgel}`;
-      }
-
-      return '';
-    },
-    nextPostIndex() {
-      if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) {
-        return null;
-      }
-
-      const items = this.inspector.breadcrumb[0].result.items;
+    //   return itemIndex + 1;
+    // },
+    // nextPath() {
+    //   return 'www.google.se';
+    //   // if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return '';
       
-      const item = items.find(itemObj => itemObj['@id'] === this.currentPost);
-      const itemIndex = items.indexOf(item);
-     
-      return itemIndex + 1;
-    },
-    nextPostPath() {
-      if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return '';
-      
-      if (this.nextPostIndex > this.totalPostNumber) return '';
+    //   // if (this.nextPostIndex > this.totalPostNumber) return '';
 
-      const items = this.inspector.breadcrumb[0].result.items;
+    //   // const items = this.inspector.breadcrumb[0].result.items;
 
-      const nextItem = items[this.nextPostIndex];
+    //   // const nextItem = items[this.nextPostIndex];
 
-      if (nextItem && nextItem.hasOwnProperty('@id')) {
-        const uriParts = nextItem['@id'].split('/');
-        const fnurgel = uriParts[uriParts.length - 1];
-        return `/${fnurgel}`;
-      }
+    //   // if (nextItem && nextItem.hasOwnProperty('@id')) {
+    //   //   const uriParts = nextItem['@id'].split('/');
+    //   //   const fnurgel = uriParts[uriParts.length - 1];
+    //   //   return `/${fnurgel}`;
+    //   // }
 
-      return '';
-    },
+    //   // return '';
+    // },
   },
   methods: {
+    getPrev() {
+      if (this.currentOffset > 0) {
+        const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query);
+        queryObj._offset = this.currentOffset - 1;
+        this.getLink(queryObj)
+          .then((res) => {
+            if (res.items.length === 1) {
+              this.prevPath = res.items[0]['@id'];
+            }
+          }).catch(err => console.log(err));
+      }
+    },
+    getNext() {
+      if (this.currentOffset + 1 < this.totalItems) {
+        const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query);
+        queryObj._offset = this.currentOffset + 1;
+        this.getLink(queryObj)
+          .then((res) => {
+            if (res.items.length === 1) {
+              this.nextPath = res.items[0]['@id'];
+            }
+          }).catch(err => console.log(err));
+      }
+    },
+    getQuery(direction) {
+      const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query, { _limit: 1 });
+      switch (direction) {
+        case 'prev':
+          queryObj._offset = this.currentOffset - 1;
+          break;
+        case 'next': 
+          queryObj._offset = this.currentOffset + 1;
+          break;
+        default:
+          break;
+      }
+      
+      let queryString = `${this.settings.apiPath}/find.json?`;
+      each(queryObj, (v, k) => {
+        queryString += (`${encodeURIComponent(k)}=${encodeURIComponent(v)}&`);
+      });
+      return [queryString, direction];
+    },
+    fetchLink(url, direction) {
+      fetch(url)
+        .then((res) => {
+          if (res.ok) {
+            res.json().then((json) => {
+              if (json.items.length === 1 && direction === 'prev') {
+                this.prevPath = json.items[0]['@id'];
+              } else if (json.items.length === 1 && direction === 'next') {
+                this.nextPath = json.items[0]['@id'];
+              }
+            });
+          }
+        })
+        .catch(err => console.log('Error fetching breadcrumb data', err));
+    },
   },
   watch: {
   },
   mounted() {
     this.$nextTick(() => {
+      this.fetchLink(...this.getQuery('prev'));
+      this.fetchLink(...this.getQuery('next'));
     });
   },
 };
@@ -154,24 +216,22 @@ export default {
   <div class="Breadcrumb">
     <div class="Breadcrumb-back">
       <router-link class="Breadcrumb-backLink"
-        v-if="this.searchResultUrl != ''"
-        :to="this.searchResultUrl">Till träfflistan</router-link>
-      <span v-if="this.showFromPost"> ›
+        :to="searchResultUrl">{{ 'To result list' | translatePhrase }}</router-link>
+      <!-- <span v-if="this.showFromPost"> ›
         <router-link class="Breadcrumb-backLink" 
           :to="this.fromPostUrl">Tillbaka till {{this.fromPostType | labelByLang }}</router-link>
-      </span>
+      </span> -->
     </div>
-    <div class="Breadcrumb-postData" v-if="totalPostNumber > 1 && currentPostNumber !== 0">
-      <span class="Breadcrumb-postNumbers">{{this.currentPostNumber}} av {{this.totalPostNumber}}</span>
-      <div class="Breadcrumb-postLinks"
-        v-if="this.prevPostPath || this.nextPostPath">
-        <router-link class="Breadcrumb-prev"
-          v-if="this.prevPostPath != ''"
-          :to="this.prevPostPath">Föregående post</router-link>
-        <span v-if="this.prevPostPath && this.nextPostPath"> | </span>
+    <div class="Breadcrumb-postData">
+      <span class="Breadcrumb-postNumbers">{{ currentOffset + 1 }} {{ 'of' | translatePhrase }} {{ totalItems }}</span>
+      <div class="Breadcrumb-postLinks" v-if="prevPath || nextPath">
+        <router-link class="Breadcrumb-prev" 
+          v-if="currentOffset > 0 && prevPath"
+          :to="prevPath | asFnurgelLink">{{ ['Previous', 'post'] | translatePhrase }}</router-link>
+        <span v-if="prevPath && nextPath"> | </span>
         <router-link class="Breadcrumb-next"
-          v-if="this.nextPostPath != ''"
-          :to="this.nextPostPath">Nästa post</router-link>
+          v-if="currentOffset + 1 < totalItems && nextPath"
+          :to="nextPath | asFnurgelLink">{{ ['Next', 'post'] | translatePhrase }}</router-link>
       </div>
     </div>
   </div>

--- a/viewer/vue-client/src/components/inspector/breadcrumb.vue
+++ b/viewer/vue-client/src/components/inspector/breadcrumb.vue
@@ -119,7 +119,6 @@ export default {
       
     //   const item = items.find(itemObj => itemObj['@id'] === this.currentPost);
     //   const itemIndex = items.indexOf(item);
-     
     //   return itemIndex + 1;
     // },
     // nextPath() {
@@ -142,30 +141,30 @@ export default {
     // },
   },
   methods: {
-    getPrev() {
-      if (this.currentOffset > 0) {
-        const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query);
-        queryObj._offset = this.currentOffset - 1;
-        this.getLink(queryObj)
-          .then((res) => {
-            if (res.items.length === 1) {
-              this.prevPath = res.items[0]['@id'];
-            }
-          }).catch(err => console.log(err));
-      }
-    },
-    getNext() {
-      if (this.currentOffset + 1 < this.totalItems) {
-        const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query);
-        queryObj._offset = this.currentOffset + 1;
-        this.getLink(queryObj)
-          .then((res) => {
-            if (res.items.length === 1) {
-              this.nextPath = res.items[0]['@id'];
-            }
-          }).catch(err => console.log(err));
-      }
-    },
+    // getPrev() {
+    //   if (this.currentOffset > 0) {
+    //     const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query);
+    //     queryObj._offset = this.currentOffset - 1;
+    //     this.getLink(queryObj)
+    //       .then((res) => {
+    //         if (res.items.length === 1) {
+    //           this.prevPath = res.items[0]['@id'];
+    //         }
+    //       }).catch(err => console.log(err));
+    //   }
+    // },
+    // getNext() {
+    //   if (this.currentOffset + 1 < this.totalItems) {
+    //     const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query);
+    //     queryObj._offset = this.currentOffset + 1;
+    //     this.getLink(queryObj)
+    //       .then((res) => {
+    //         if (res.items.length === 1) {
+    //           this.nextPath = res.items[0]['@id'];
+    //         }
+    //       }).catch(err => console.log(err));
+    //   }
+    // },
     getQuery(direction) {
       const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query, { _limit: 1 });
       switch (direction) {
@@ -178,11 +177,11 @@ export default {
         default:
           break;
       }
-      
       let queryString = `${this.settings.apiPath}/find.json?`;
       each(queryObj, (v, k) => {
         queryString += (`${encodeURIComponent(k)}=${encodeURIComponent(v)}&`);
       });
+
       return [queryString, direction];
     },
     fetchLink(url, direction) {
@@ -199,6 +198,12 @@ export default {
           }
         })
         .catch(err => console.log('Error fetching breadcrumb data', err));
+    },
+    reduceOffset() {
+      this.$route.meta.breadcrumb.offset = this.$route.meta.breadcrumb.offset - 1;
+    },
+    addOffset() {
+      this.$route.meta.breadcrumb.offset = this.$route.meta.breadcrumb.offset + 1;
     },
   },
   watch: {
@@ -227,11 +232,12 @@ export default {
       <div class="Breadcrumb-postLinks" v-if="prevPath || nextPath">
         <router-link class="Breadcrumb-prev" 
           v-if="currentOffset > 0 && prevPath"
-          :to="prevPath | asFnurgelLink">{{ ['Previous', 'post'] | translatePhrase }}</router-link>
+          :to="prevPath | asFnurgelLink"
+          @click.native="reduceOffset"><span @click="reduceOffset">{{ ['Previous', 'post'] | translatePhrase }}</span></router-link>
         <span v-if="prevPath && nextPath"> | </span>
         <router-link class="Breadcrumb-next"
           v-if="currentOffset + 1 < totalItems && nextPath"
-          :to="nextPath | asFnurgelLink">{{ ['Next', 'post'] | translatePhrase }}</router-link>
+          :to="nextPath | asFnurgelLink"><span @click="addOffset">{{ ['Next', 'post'] | translatePhrase }}</span></router-link>
       </div>
     </div>
   </div>

--- a/viewer/vue-client/src/components/inspector/breadcrumb.vue
+++ b/viewer/vue-client/src/components/inspector/breadcrumb.vue
@@ -17,8 +17,6 @@ export default {
   data() {
     return {
       // recordTypeChange: false,
-      prevPath: '',
-      nextPath: '',
     };
   },
   computed: {
@@ -26,31 +24,31 @@ export default {
       'inspector',
       'settings',
     ]),
-    showFromPost() {
-      if (!this.fromPostUrl || !this.recordTypeChange) return false;
-      if ((this.fromPostUrl !== '') && (this.fromPostUrl !== this.currentPost)) {
-        return true;
-      }  
-      return false;
-    },
+    // showFromPost() {
+    //   if (!this.fromPostUrl || !this.recordTypeChange) return false;
+    //   if ((this.fromPostUrl !== '') && (this.fromPostUrl !== this.currentPost)) {
+    //     return true;
+    //   }  
+    //   return false;
+    // },
     searchResultUrl() {
       return this.$route.meta.breadcrumb.resultUrl;
     },
-    fromPostUrl() {
-      const breadcrumbTrail = this.inspector.breadcrumb;
-      let fromPostId;
+    // fromPostUrl() {
+    //   const breadcrumbTrail = this.inspector.breadcrumb;
+    //   let fromPostId;
 
-      if (breadcrumbTrail.length > 1) {
-        const result = breadcrumbTrail.filter(breadcrumb => breadcrumb.type === 'fromPost');
-        fromPostId = result[0].postUrl;
-      } else if (breadcrumbTrail.length > 0) {
-        fromPostId = breadcrumbTrail[0].postUrl;
-      } else {
-        fromPostId = '';
-      }
+    //   if (breadcrumbTrail.length > 1) {
+    //     const result = breadcrumbTrail.filter(breadcrumb => breadcrumb.type === 'fromPost');
+    //     fromPostId = result[0].postUrl;
+    //   } else if (breadcrumbTrail.length > 0) {
+    //     fromPostId = breadcrumbTrail[0].postUrl;
+    //   } else {
+    //     fromPostId = '';
+    //   }
 
-      return fromPostId;
-    },
+    //   return fromPostId;
+    // },
     // fromPostType() {
     //   const breadcrumbTrail = this.inspector.breadcrumb;
     //   let fromPostType;
@@ -81,8 +79,31 @@ export default {
     totalItems() {
       return this.$route.meta.breadcrumb.totalItems;
     },
-    currentOffset() {
-      return this.$route.meta.breadcrumb.offset;
+    absoluteOffset() {
+      return this.$route.meta.breadcrumb.absoluteOffset;
+    },
+    relativeOffset() {
+      return this.$route.meta.breadcrumb.relativeOffset;
+    },
+    prevOutOfBounds() {
+      if (this.absoluteOffset > 0 && this.relativeOffset === 0) {
+        return true;
+      } return false;
+    },
+    prevPath() {
+      if (!this.prevOutOfBounds) {
+        return this.$route.meta.breadcrumb.paths[this.relativeOffset - 1];
+      } return false;
+    },
+    nextOutOfBounds() {
+      if (this.absoluteOffset + 1 < this.totalItems && this.relativeOffset + 1 > this.$route.meta.breadcrumb.paths.length - 1) {
+        return true;
+      } return false;
+    },
+    nextPath() {
+      if (!this.nextOutOfBounds) {
+        return this.$route.meta.breadcrumb.paths[this.relativeOffset + 1];
+      } return false;
     },
     // prevPostIndex() {
     //   if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return null;
@@ -141,38 +162,14 @@ export default {
     // },
   },
   methods: {
-    // getPrev() {
-    //   if (this.currentOffset > 0) {
-    //     const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query);
-    //     queryObj._offset = this.currentOffset - 1;
-    //     this.getLink(queryObj)
-    //       .then((res) => {
-    //         if (res.items.length === 1) {
-    //           this.prevPath = res.items[0]['@id'];
-    //         }
-    //       }).catch(err => console.log(err));
-    //   }
-    // },
-    // getNext() {
-    //   if (this.currentOffset + 1 < this.totalItems) {
-    //     const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query);
-    //     queryObj._offset = this.currentOffset + 1;
-    //     this.getLink(queryObj)
-    //       .then((res) => {
-    //         if (res.items.length === 1) {
-    //           this.nextPath = res.items[0]['@id'];
-    //         }
-    //       }).catch(err => console.log(err));
-    //   }
-    // },
     getQuery(direction) {
-      const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query, { _limit: 1 });
+      const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query);
       switch (direction) {
         case 'prev':
-          queryObj._offset = this.currentOffset - 1;
+          queryObj._offset = this.absoluteOffset - 1;
           break;
         case 'next': 
-          queryObj._offset = this.currentOffset + 1;
+          queryObj._offset = this.$route.meta.breadcrumb.range.end;
           break;
         default:
           break;
@@ -181,37 +178,47 @@ export default {
       each(queryObj, (v, k) => {
         queryString += (`${encodeURIComponent(k)}=${encodeURIComponent(v)}&`);
       });
+    },
 
-      return [queryString, direction];
-    },
-    fetchLink(url, direction) {
-      fetch(url)
-        .then((res) => {
-          if (res.ok) {
-            res.json().then((json) => {
-              if (json.items.length === 1 && direction === 'prev') {
-                this.prevPath = json.items[0]['@id'];
-              } else if (json.items.length === 1 && direction === 'next') {
-                this.nextPath = json.items[0]['@id'];
-              }
-            });
-          }
-        })
-        .catch(err => console.log('Error fetching breadcrumb data', err));
-    },
+    //   return [queryString, direction];
+    // },
+    // fetchLink(url, direction) {
+    //   fetch(url)
+    //     .then((res) => {
+    //       if (res.ok) {
+    //         res.json().then((json) => {
+    //           if (json.items.length === 1 && direction === 'prev') {
+    //             this.prevPath = json.items[0]['@id'];
+    //           } else if (json.items.length === 1 && direction === 'next') {
+    //             this.nextPath = json.items[0]['@id'];
+    //           }
+    //         });
+    //       }
+    //     })
+    //     .catch(err => console.log('Error fetching breadcrumb data', err));
+    // },
     reduceOffset() {
-      this.$route.meta.breadcrumb.offset = this.$route.meta.breadcrumb.offset - 1;
+      const meta = Object.assign({}, this.$route.meta);
+      meta.breadcrumb.relativeOffset--;
+      meta.breadcrumb.absoluteOffset--;
+      this.$route.meta = meta;
     },
     addOffset() {
-      this.$route.meta.breadcrumb.offset = this.$route.meta.breadcrumb.offset + 1;
+      const meta = Object.assign({}, this.$route.meta);
+      meta.breadcrumb.relativeOffset++;
+      meta.breadcrumb.absoluteOffset++;
+      this.$route.meta = meta;
     },
   },
   watch: {
   },
   mounted() {
     this.$nextTick(() => {
-      this.fetchLink(...this.getQuery('prev'));
-      this.fetchLink(...this.getQuery('next'));
+      if (this.nextOutOfBounds) {
+        this.fetchLink(...this.getQuery('next'));
+      } else if (this.prevOutOfBounds) {
+        this.fetchLink(...this.getQuery('prev'));
+      }
     });
   },
 };
@@ -228,17 +235,17 @@ export default {
       </span> -->
     </div>
     <div class="Breadcrumb-postData">
-      <span class="Breadcrumb-postNumbers">{{ currentOffset + 1 }} {{ 'of' | translatePhrase }} {{ totalItems }}</span>
+      <span class="Breadcrumb-postNumbers">{{ absoluteOffset + 1 }} {{ 'of' | translatePhrase }} {{ totalItems }}</span>
       <div class="Breadcrumb-postLinks" v-if="prevPath || nextPath">
         <router-link class="Breadcrumb-prev" 
-          v-if="currentOffset > 0 && prevPath"
-          :to="prevPath | asFnurgelLink"
-          @click.native="reduceOffset"><span @click="reduceOffset">{{ ['Previous', 'post'] | translatePhrase }}</span></router-link>
+          v-if="prevPath"
+          :to="prevPath | asFnurgelLink"><span @click="reduceOffset">{{ ['Previous', 'post'] | translatePhrase }}</span></router-link>
         <span v-if="prevPath && nextPath"> | </span>
         <router-link class="Breadcrumb-next"
-          v-if="currentOffset + 1 < totalItems && nextPath"
+          v-if="nextPath"
           :to="nextPath | asFnurgelLink"><span @click="addOffset">{{ ['Next', 'post'] | translatePhrase }}</span></router-link>
       </div>
+      absolute: {{ absoluteOffset }} relative: {{relativeOffset}} getnext: {{nextOutOfBounds}} getprev: {{prevOutOfBounds}}
     </div>
   </div>
 </template>

--- a/viewer/vue-client/src/components/inspector/breadcrumb.vue
+++ b/viewer/vue-client/src/components/inspector/breadcrumb.vue
@@ -131,7 +131,6 @@ export default {
   },
   mounted() {
     this.$nextTick(() => {
-      console.log(this.$route.meta.breadcrumb);
     });
   },
 };

--- a/viewer/vue-client/src/components/inspector/breadcrumb.vue
+++ b/viewer/vue-client/src/components/inspector/breadcrumb.vue
@@ -1,22 +1,18 @@
 <script>
-/*
-  Displays breadcrumbs/between post navigation in inspector
-*/
-
 import { mapGetters } from 'vuex';
 import { each } from 'lodash-es';
+import VueSimpleSpinner from 'vue-simple-spinner';
 
 export default {
   name: 'breadcrumb',
+  components: {
+    'vue-simple-spinner': VueSimpleSpinner,
+  },
   props: {
-    recordType: {
-      type: String,
-      default: '',
-    },
   },
   data() {
     return {
-      // recordTypeChange: false,
+      loading: false,
     };
   },
   computed: {
@@ -24,58 +20,9 @@ export default {
       'inspector',
       'settings',
     ]),
-    // showFromPost() {
-    //   if (!this.fromPostUrl || !this.recordTypeChange) return false;
-    //   if ((this.fromPostUrl !== '') && (this.fromPostUrl !== this.currentPost)) {
-    //     return true;
-    //   }  
-    //   return false;
-    // },
     searchResultUrl() {
       return this.$route.meta.breadcrumb.resultUrl;
     },
-    // fromPostUrl() {
-    //   const breadcrumbTrail = this.inspector.breadcrumb;
-    //   let fromPostId;
-
-    //   if (breadcrumbTrail.length > 1) {
-    //     const result = breadcrumbTrail.filter(breadcrumb => breadcrumb.type === 'fromPost');
-    //     fromPostId = result[0].postUrl;
-    //   } else if (breadcrumbTrail.length > 0) {
-    //     fromPostId = breadcrumbTrail[0].postUrl;
-    //   } else {
-    //     fromPostId = '';
-    //   }
-
-    //   return fromPostId;
-    // },
-    // fromPostType() {
-    //   const breadcrumbTrail = this.inspector.breadcrumb;
-    //   let fromPostType;
-
-    //   if (breadcrumbTrail.length > 1) {
-    //     const result = breadcrumbTrail.filter(breadcrumb => breadcrumb.type === 'fromPost');
-    //     fromPostType = result[0].recordType;
-    //   } else if (breadcrumbTrail.length > 0) {
-    //     fromPostType = breadcrumbTrail[0].recordType;
-    //   } else {
-    //     fromPostType = '';
-    //   }
-
-    //   return fromPostType;
-    // },
-    // currentPost() {
-    //   return this.inspector.data.mainEntity['@id'];
-    // },
-    // currentPostNumber() {
-    //   if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return null;
-    //   const items = this.inspector.breadcrumb[0].result.items;
-
-    //   const item = items.find(itemObj => itemObj['@id'] === this.currentPost);
-    //   const itemIndex = items.indexOf(item);
-
-    //   return itemIndex + 1;
-    // },
     totalItems() {
       return this.$route.meta.breadcrumb.totalItems;
     },
@@ -85,91 +32,39 @@ export default {
     relativeOffset() {
       return this.$route.meta.breadcrumb.relativeOffset;
     },
+    range() {
+      return this.$route.meta.breadcrumb.range;
+    },
+    paths() {
+      return this.$route.meta.breadcrumb.paths;
+    },
+    prevPath() {
+      return this.paths[this.relativeOffset - 1];
+    },
+    nextPath() {
+      return this.paths[this.relativeOffset + 1];
+    },
     prevOutOfBounds() {
       if (this.absoluteOffset > 0 && this.relativeOffset === 0) {
         return true;
       } return false;
     },
-    prevPath() {
-      if (!this.prevOutOfBounds) {
-        return this.$route.meta.breadcrumb.paths[this.relativeOffset - 1];
-      } return false;
-    },
     nextOutOfBounds() {
-      if (this.absoluteOffset + 1 < this.totalItems && this.relativeOffset + 1 > this.$route.meta.breadcrumb.paths.length - 1) {
+      if (this.absoluteOffset + 1 < this.totalItems && this.relativeOffset + 1 > this.paths.length - 1) {
         return true;
       } return false;
     },
-    nextPath() {
-      if (!this.nextOutOfBounds) {
-        return this.$route.meta.breadcrumb.paths[this.relativeOffset + 1];
-      } return false;
-    },
-    // prevPostIndex() {
-    //   if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return null;
-
-    //   const items = this.inspector.breadcrumb[0].result.items;
-      
-    //   const item = items.find(itemObj => itemObj['@id'] === this.currentPost);
-    //   const itemIndex = items.indexOf(item);
-    //   return itemIndex - 1;
-    // },
-    // prevPath() {
-    //   return 'www.google.se';
-    //   // if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return '';
-
-    //   // if (this.prevPostIndex < 0) return '';
-
-    //   // const items = this.inspector.breadcrumb[0].result.items;
-
-    //   // const prevItem = items[this.prevPostIndex];
-    //   // if (prevItem.hasOwnProperty('@id')) {
-    //   //   const uriParts = prevItem['@id'].split('/');
-    //   //   const fnurgel = uriParts[uriParts.length - 1];
-    //   //   return `/${fnurgel}`;
-    //   // }
-
-    //   // return '';
-    // },
-    // nextPostIndex() {
-    //   if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) {
-    //     return null;
-    //   }
-
-    //   const items = this.inspector.breadcrumb[0].result.items;
-      
-    //   const item = items.find(itemObj => itemObj['@id'] === this.currentPost);
-    //   const itemIndex = items.indexOf(item);
-    //   return itemIndex + 1;
-    // },
-    // nextPath() {
-    //   return 'www.google.se';
-    //   // if (this.inspector.breadcrumb === undefined || this.inspector.breadcrumb.length === 0) return '';
-      
-    //   // if (this.nextPostIndex > this.totalPostNumber) return '';
-
-    //   // const items = this.inspector.breadcrumb[0].result.items;
-
-    //   // const nextItem = items[this.nextPostIndex];
-
-    //   // if (nextItem && nextItem.hasOwnProperty('@id')) {
-    //   //   const uriParts = nextItem['@id'].split('/');
-    //   //   const fnurgel = uriParts[uriParts.length - 1];
-    //   //   return `/${fnurgel}`;
-    //   // }
-
-    //   // return '';
-    // },
   },
   methods: {
     getQuery(direction) {
       const queryObj = Object.assign({}, this.$route.meta.breadcrumb.query);
+      queryObj._limit = this.range.itemsPerPage;
       switch (direction) {
         case 'prev':
-          queryObj._offset = this.absoluteOffset - 1;
+          queryObj._offset = this.range.start - this.range.itemsPerPage;
           break;
         case 'next': 
-          queryObj._offset = this.$route.meta.breadcrumb.range.end;
+          queryObj._offset = this.range.start + this.range.itemsPerPage;
           break;
         default:
           break;
@@ -178,47 +73,61 @@ export default {
       each(queryObj, (v, k) => {
         queryString += (`${encodeURIComponent(k)}=${encodeURIComponent(v)}&`);
       });
+      return [queryString, direction];
     },
-
-    //   return [queryString, direction];
-    // },
-    // fetchLink(url, direction) {
-    //   fetch(url)
-    //     .then((res) => {
-    //       if (res.ok) {
-    //         res.json().then((json) => {
-    //           if (json.items.length === 1 && direction === 'prev') {
-    //             this.prevPath = json.items[0]['@id'];
-    //           } else if (json.items.length === 1 && direction === 'next') {
-    //             this.nextPath = json.items[0]['@id'];
-    //           }
-    //         });
-    //       }
-    //     })
-    //     .catch(err => console.log('Error fetching breadcrumb data', err));
-    // },
+    fetchLink(url, direction) {
+      fetch(url)
+        .then((res) => {
+          if (res.ok) {
+            res.json().then((json) => {
+              this.updatedPaths = json.items.map(item => item['@id']);
+              if (direction === 'prev') {
+                this.prevPath = this.updatedPaths[this.range.itemsPerPage - 1];
+              } else if (direction === 'next') {
+                this.nextPath = this.updatedPaths[0];
+              }
+            });
+          }
+        })
+        .catch(err => console.log('Error fetching breadcrumb data', err));
+    },
     reduceOffset() {
-      const meta = Object.assign({}, this.$route.meta);
-      meta.breadcrumb.relativeOffset--;
-      meta.breadcrumb.absoluteOffset--;
-      this.$route.meta = meta;
+      const crumb = Object.assign({}, this.$route.meta.breadcrumb);
+      crumb.absoluteOffset--;
+      crumb.relativeOffset--;
+      this.$route.meta.breadcrumb = crumb;
     },
     addOffset() {
-      const meta = Object.assign({}, this.$route.meta);
-      meta.breadcrumb.relativeOffset++;
-      meta.breadcrumb.absoluteOffset++;
-      this.$route.meta = meta;
+      const crumb = Object.assign({}, this.$route.meta.breadcrumb);
+      crumb.absoluteOffset++;
+      crumb.relativeOffset++;
+      this.$route.meta.breadcrumb = crumb;
+    },
+    getPrev() {
+      this.loading = true;
+      console.log('will handle prev manually');
+      // this.fetchLink(...this.getQuery('prev'));
+      // const crumb = Object.assign({}, this.$route.meta.breadcrumb);
+      // crumb.absoluteOffset--;
+      // crumb.relativeOffset = this.range.itemsPerPage;
+      // crumb.paths = something;
+      // this.$route.meta.breadcrumb = crumb;
+    },
+    getNext() {
+      this.loading = true;
+      console.log('will handle next manually');
+      // this.fetchLink(...this.getQuery('next'));
+      // const crumb = Object.assign({}, this.$route.meta.breadcrumb);
+      // crumb.absoluteOffset++;
+      // crumb.relativeOffset = 0;
+      // crumb.paths = something;
+      // this.$route.meta.breadcrumb = crumb;
     },
   },
   watch: {
   },
   mounted() {
     this.$nextTick(() => {
-      if (this.nextOutOfBounds) {
-        this.fetchLink(...this.getQuery('next'));
-      } else if (this.prevOutOfBounds) {
-        this.fetchLink(...this.getQuery('prev'));
-      }
     });
   },
 };
@@ -229,21 +138,29 @@ export default {
     <div class="Breadcrumb-back">
       <router-link class="Breadcrumb-backLink"
         :to="searchResultUrl">{{ 'To result list' | translatePhrase }}</router-link>
-      <!-- <span v-if="this.showFromPost"> ›
-        <router-link class="Breadcrumb-backLink" 
-          :to="this.fromPostUrl">Tillbaka till {{this.fromPostType | labelByLang }}</router-link>
-      </span> -->
     </div>
     <div class="Breadcrumb-postData">
       <span class="Breadcrumb-postNumbers">{{ absoluteOffset + 1 }} {{ 'of' | translatePhrase }} {{ totalItems }}</span>
-      <div class="Breadcrumb-postLinks" v-if="prevPath || nextPath">
-        <router-link class="Breadcrumb-prev" 
+      <div class="Breadcrumb-postLinks">
+        <router-link class="Breadcrumb-prev"
           v-if="prevPath"
           :to="prevPath | asFnurgelLink"><span @click="reduceOffset">{{ ['Previous', 'post'] | translatePhrase }}</span></router-link>
-        <span v-if="prevPath && nextPath"> | </span>
+        <a class="Breadcrumb-prev" 
+          v-if="prevOutOfBounds" 
+          @click="getPrev">
+          <span v-if="!loading">{{ ['Previous', 'post'] | translatePhrase }}</span>
+          <vue-simple-spinner v-if="loading" size="small"></vue-simple-spinner>
+        </a>
+        <span v-if="absoluteOffset > 0 && absoluteOffset < this.totalItems"> | </span>
         <router-link class="Breadcrumb-next"
           v-if="nextPath"
           :to="nextPath | asFnurgelLink"><span @click="addOffset">{{ ['Next', 'post'] | translatePhrase }}</span></router-link>
+        <a class="Breadcrumb-next" 
+          v-if="nextOutOfBounds" 
+          @click="getNext">
+          <span v-if="!loading">{{ ['Next', 'post'] | translatePhrase }}</span>
+          <vue-simple-spinner v-if="loading" size="small"></vue-simple-spinner>
+        </a>
       </div>
       absolute: {{ absoluteOffset }} relative: {{relativeOffset}} getnext: {{nextOutOfBounds}} getprev: {{prevOutOfBounds}}
     </div>

--- a/viewer/vue-client/src/components/inspector/breadcrumb.vue
+++ b/viewer/vue-client/src/components/inspector/breadcrumb.vue
@@ -1,6 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import { each } from 'lodash-es';
+import * as RecordUtil from '@/utils/record';
 import VueSimpleSpinner from 'vue-simple-spinner';
 
 export default {
@@ -53,6 +54,12 @@ export default {
       if (this.absoluteOffset + 1 < this.totalItems && this.relativeOffset + 1 > this.paths.length - 1) {
         return true;
       } return false;
+    },
+    thisIsSearchResult() {
+      // check if this id is present in our list of paths. Otherwise user has gone off path (to a holding for example)
+      // and prev/next are no longer valid
+      const match = this.paths.filter(path => `/${RecordUtil.extractFnurgel(path)}` === this.$route.path);
+      return match.length === 1;
     },
   },
   methods: {
@@ -142,7 +149,7 @@ export default {
       <router-link class="Breadcrumb-backLink"
         :to="searchResultUrl">{{ 'To result list' | translatePhrase }}</router-link>
     </div>
-    <div class="Breadcrumb-postData">
+    <div class="Breadcrumb-postData" v-if="thisIsSearchResult">
       <span class="Breadcrumb-postNumbers">{{ absoluteOffset + 1 }} {{ 'of' | translatePhrase }} {{ totalItems }}</span>
       <div class="Breadcrumb-postLinks">
         <span class="Breadcrumb-prev" v-if="absoluteOffset > 0">
@@ -191,6 +198,10 @@ export default {
   &-postLinks {
     display: flex;
     margin: 0 0 0 30px;
+
+    & .vue-simple-spinner {
+      margin-top: 5px !important;
+    }
   }
 
   &-back {
@@ -204,10 +215,12 @@ export default {
 
   &-next {
     margin: 0 0 0 10px;
+    min-width: 50px;
   }
 
   &-prev {
     margin: 0 10px 0 0;
+    min-width: 50px;
   }
 }
 </style>

--- a/viewer/vue-client/src/components/search/search-result.vue
+++ b/viewer/vue-client/src/components/search/search-result.vue
@@ -1,5 +1,4 @@
 <script>
-// import * as StringUtil from '@/utils/string';
 import ResultList from './result-list';
 import ResultControls from './result-controls';
 
@@ -15,44 +14,17 @@ export default {
   },
   data() {
     return {
-      // fullResult: {},
       keyword: '',
       showResult: false,
     };
   },
   methods: {
-    // getFullLocalResult() {
-    //   let currentQuery = this.query;
-    //   currentQuery = currentQuery.replace(/&_offset=.*/, '&_offset=');
-
-    //   const unlimitedQuery = currentQuery.replace(/_limit=.*&/, `_limit=${this.totalItems}&`);
-      
-    //   const fetchUrl = `${this.settings.apiPath}/find.json?${unlimitedQuery}`;
-
-    //   fetch(fetchUrl).then(response => response.json(), (error) => {
-    //     this.$store.dispatch('pushNotification', { type: 'danger', message: `${StringUtil.getUiPhraseByLang('Something went wrong', this.user.settings.language)} ${error}` });
-    //     this.searchInProgress = false;
-    //   }).then((result) => {
-    //     this.fullResult = result;
-    //     this.searchInProgress = false;
-    //   });
-    // },
     doSort(newsort) {
       const newQuery = Object.assign({}, this.$route.query, { _sort: newsort, _offset: 0 });
       this.$router.push({ query: newQuery });
     },
   },
   watch: {
-    // fullResult(newValue) {
-    //   this.$store.dispatch('setBreadcrumbData',
-    //     [
-    //       {
-    //         type: 'searchResult',
-    //         result: newValue,
-    //         resultUrl: this.$route.fullPath,
-    //       },
-    //     ]);
-    // },
   },
   computed: {
     status() {
@@ -85,7 +57,6 @@ export default {
   },
   mounted() {
     this.$nextTick(() => {
-      // this.getFullLocalResult();
       setTimeout(() => {
         this.showResult = true;
       }, 1);

--- a/viewer/vue-client/src/components/search/search-result.vue
+++ b/viewer/vue-client/src/components/search/search-result.vue
@@ -1,5 +1,5 @@
 <script>
-import * as StringUtil from '@/utils/string';
+// import * as StringUtil from '@/utils/string';
 import ResultList from './result-list';
 import ResultControls from './result-controls';
 
@@ -15,44 +15,44 @@ export default {
   },
   data() {
     return {
-      fullResult: {},
+      // fullResult: {},
       keyword: '',
       showResult: false,
     };
   },
   methods: {
-    getFullLocalResult() {
-      let currentQuery = this.query;
-      currentQuery = currentQuery.replace(/&_offset=.*/, '&_offset=');
+    // getFullLocalResult() {
+    //   let currentQuery = this.query;
+    //   currentQuery = currentQuery.replace(/&_offset=.*/, '&_offset=');
 
-      const unlimitedQuery = currentQuery.replace(/_limit=.*&/, `_limit=${this.totalItems}&`);
+    //   const unlimitedQuery = currentQuery.replace(/_limit=.*&/, `_limit=${this.totalItems}&`);
       
-      const fetchUrl = `${this.settings.apiPath}/find.json?${unlimitedQuery}`;
+    //   const fetchUrl = `${this.settings.apiPath}/find.json?${unlimitedQuery}`;
 
-      fetch(fetchUrl).then(response => response.json(), (error) => {
-        this.$store.dispatch('pushNotification', { type: 'danger', message: `${StringUtil.getUiPhraseByLang('Something went wrong', this.user.settings.language)} ${error}` });
-        this.searchInProgress = false;
-      }).then((result) => {
-        this.fullResult = result;
-        this.searchInProgress = false;
-      });
-    },
+    //   fetch(fetchUrl).then(response => response.json(), (error) => {
+    //     this.$store.dispatch('pushNotification', { type: 'danger', message: `${StringUtil.getUiPhraseByLang('Something went wrong', this.user.settings.language)} ${error}` });
+    //     this.searchInProgress = false;
+    //   }).then((result) => {
+    //     this.fullResult = result;
+    //     this.searchInProgress = false;
+    //   });
+    // },
     doSort(newsort) {
       const newQuery = Object.assign({}, this.$route.query, { _sort: newsort, _offset: 0 });
       this.$router.push({ query: newQuery });
     },
   },
   watch: {
-    fullResult(newValue) {
-      this.$store.dispatch('setBreadcrumbData',
-        [
-          {
-            type: 'searchResult',
-            result: newValue,
-            resultUrl: this.$route.fullPath,
-          },
-        ]);
-    },
+    // fullResult(newValue) {
+    //   this.$store.dispatch('setBreadcrumbData',
+    //     [
+    //       {
+    //         type: 'searchResult',
+    //         result: newValue,
+    //         resultUrl: this.$route.fullPath,
+    //       },
+    //     ]);
+    // },
   },
   computed: {
     status() {
@@ -85,7 +85,7 @@ export default {
   },
   mounted() {
     this.$nextTick(() => {
-      this.getFullLocalResult();
+      // this.getFullLocalResult();
       setTimeout(() => {
         this.showResult = true;
       }, 1);

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -319,6 +319,7 @@
     "Search for": "Sökning på",
     "The search gave more results than can be displayed": "Sökningen gav fler träffar än vad som kan visas",
     "No hits": "Inga träffar",
-    "Attention": "OBS"
+    "Attention": "OBS",
+    "To result list": "Till träfflistan"
     }
 }

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -27,7 +27,6 @@ const store = new Vuex.Store({
       holdingsMoved: [],
     },
     inspector: {
-      // breadcrumb: [],
       data: {},
       insertData: {},
       originalData: {},
@@ -318,9 +317,6 @@ const store = new Vuex.Store({
     setInsertData(state, data) {
       state.inspector.insertData = data;
     },
-    // setBreadcrumbData(state, data) {
-    //   state.inspector.breadcrumb = data;
-    // },
     addToQuoted(state, data) {
       const quoted = cloneDeep(state.inspector.data.quoted);
       quoted[data['@id']] = data;
@@ -612,9 +608,6 @@ const store = new Vuex.Store({
     setInsertData({ commit }, data) {
       commit('setInsertData', data);
     },
-    // setBreadcrumbData({ commit }, data) {
-    //   commit('setBreadcrumbData', data);
-    // },
     updateInspectorData({ commit }, payload) {
       commit('updateInspectorData', payload);
     },

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -27,7 +27,7 @@ const store = new Vuex.Store({
       holdingsMoved: [],
     },
     inspector: {
-      breadcrumb: [],
+      // breadcrumb: [],
       data: {},
       insertData: {},
       originalData: {},
@@ -318,9 +318,9 @@ const store = new Vuex.Store({
     setInsertData(state, data) {
       state.inspector.insertData = data;
     },
-    setBreadcrumbData(state, data) {
-      state.inspector.breadcrumb = data;
-    },
+    // setBreadcrumbData(state, data) {
+    //   state.inspector.breadcrumb = data;
+    // },
     addToQuoted(state, data) {
       const quoted = cloneDeep(state.inspector.data.quoted);
       quoted[data['@id']] = data;
@@ -612,9 +612,9 @@ const store = new Vuex.Store({
     setInsertData({ commit }, data) {
       commit('setInsertData', data);
     },
-    setBreadcrumbData({ commit }, data) {
-      commit('setBreadcrumbData', data);
-    },
+    // setBreadcrumbData({ commit }, data) {
+    //   commit('setBreadcrumbData', data);
+    // },
     updateInspectorData({ commit }, payload) {
       commit('updateInspectorData', payload);
     },

--- a/viewer/vue-client/src/views/Find.vue
+++ b/viewer/vue-client/src/views/Find.vue
@@ -147,7 +147,6 @@ export default {
   beforeRouteLeave(to, from, next) {
     if (to.name === 'Inspector') {
       const startOffset = this.result.itemOffset;
-      const endOffset = startOffset + this.result.itemsPerPage - 1;
       const relativeOffset = this.result.items.findIndex(item => RecordUtil.extractFnurgel(item['@id']) === to.params.fnurgel);
       const absoluteOffset = startOffset + relativeOffset;
 
@@ -157,7 +156,7 @@ export default {
         query: Object.assign({}, this.$route.query),
         relativeOffset,
         absoluteOffset,
-        range: { start: startOffset, end: endOffset },
+        range: { start: startOffset, itemsPerPage: this.result.itemsPerPage },
         paths: this.result.items.map(el => el['@id']),
       };
       to.meta.breadcrumb = breadcrumb;

--- a/viewer/vue-client/src/views/Find.vue
+++ b/viewer/vue-client/src/views/Find.vue
@@ -144,6 +144,21 @@ export default {
       this.initialized = true;
     });
   },
+  beforeRouteLeave(to, from, next) {
+    if (to.name === 'Inspector') {
+      const startOffset = parseInt(this.$route.query._offset);
+      const pageOffset = this.result.items.findIndex(item => RecordUtil.extractFnurgel(item['@id']) === to.params.fnurgel);
+      const offset = Number.isNaN(startOffset) ? pageOffset : startOffset + pageOffset;
+      const breadcrumb = {
+        resultUrl: from.fullPath,
+        totalItems: this.result.totalItems,
+        query: Object.assign({}, this.$route.query),
+        offset,
+      };
+      to.meta.breadcrumb = breadcrumb;
+    }
+    next();
+  },
   components: {
     'facet-controls': FacetControls,
     'search-result': SearchResult,

--- a/viewer/vue-client/src/views/Find.vue
+++ b/viewer/vue-client/src/views/Find.vue
@@ -146,14 +146,19 @@ export default {
   },
   beforeRouteLeave(to, from, next) {
     if (to.name === 'Inspector') {
-      const startOffset = parseInt(this.$route.query._offset);
-      const pageOffset = this.result.items.findIndex(item => RecordUtil.extractFnurgel(item['@id']) === to.params.fnurgel);
-      const offset = Number.isNaN(startOffset) ? pageOffset : startOffset + pageOffset;
+      const startOffset = this.result.itemOffset;
+      const endOffset = startOffset + this.result.itemsPerPage - 1;
+      const relativeOffset = this.result.items.findIndex(item => RecordUtil.extractFnurgel(item['@id']) === to.params.fnurgel);
+      const absoluteOffset = startOffset + relativeOffset;
+
       const breadcrumb = {
         resultUrl: from.fullPath,
         totalItems: this.result.totalItems,
         query: Object.assign({}, this.$route.query),
-        offset,
+        relativeOffset,
+        absoluteOffset,
+        range: { start: startOffset, end: endOffset },
+        paths: this.result.items.map(el => el['@id']),
       };
       to.meta.breadcrumb = breadcrumb;
     }

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -9,13 +9,11 @@ import * as DisplayUtil from '@/utils/display';
 import * as RecordUtil from '@/utils/record';
 import * as md5 from 'md5';
 import EntityForm from '@/components/inspector/entity-form';
-import TagSwitch from '@/components/shared/tag-switch';
 import Toolbar from '@/components/inspector/toolbar';
 import EntityChangelog from '@/components/inspector/entity-changelog';
 import EntityHeader from '@/components/inspector/entity-header';
 import Breadcrumb from '@/components/inspector/breadcrumb';
 import ModalComponent from '@/components/shared/modal-component';
-import ReverseRelations from '@/components/inspector/reverse-relations';
 import MarcPreview from '@/components/inspector/marc-preview';
 import TabMenu from '@/components/shared/tab-menu';
 import ValidationSummary from '@/components/inspector/validation-summary';
@@ -37,7 +35,6 @@ export default {
     }
   },
   beforeRouteUpdate(to, from, next) {
-    // this.addBreadcrumb();
     if (this.shouldWarnOnUnload()) {
       const confString = StringUtil.getUiPhraseByLang('You have unsaved changes. Do you want to leave the page?', this.settings.language);
       const answer = window.confirm(confString); // eslint-disable-line no-alert
@@ -78,34 +75,6 @@ export default {
         message: `${StringUtil.getUiPhraseByLang('Formulär uppdaterat, glöm inte att spara posten', this.user.settings.language)}`, 
       });
     },
-    // addBreadcrumb() {
-    //   if (this.inspector.breadcrumb !== '') {
-    //     const currentTrail = this.inspector.breadcrumb;
-    //     const firstTrail = currentTrail.shift();
-
-    //     const newBreadcrumb = {
-    //       type: 'fromPost',
-    //       recordType: this.recordType,
-    //       postUrl: this.$route.fullPath,
-    //     };
-
-    //     const newTrail = [];
-    //     newTrail.push(firstTrail);
-    //     newTrail.push(newBreadcrumb);
-
-    //     this.$store.dispatch('setBreadcrumbData', 
-    //       newTrail);
-    //   } else {
-    //     this.$store.dispatch('setBreadcrumbData', 
-    //       [
-    //         {
-    //           type: 'fromPost',
-    //           recordType: this.recordType,
-    //           postUrl: this.$route.fullPath,
-    //         },
-    //       ]);
-    //   }
-    // },
     shouldWarnOnUnload() {
       return (
         (this.$route.name === 'Inspector' || this.$route.name === 'NewDocument')
@@ -643,11 +612,9 @@ export default {
     'modal-component': ModalComponent,
     toolbar: Toolbar,
     'entity-changelog': EntityChangelog,
-    'reverse-relations': ReverseRelations,
     breadcrumb: Breadcrumb,
     'marc-preview': MarcPreview,
     'tab-menu': TabMenu,
-    TagSwitch,
     'validation-summary': ValidationSummary,
   },
   mounted() {

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -37,7 +37,7 @@ export default {
     }
   },
   beforeRouteUpdate(to, from, next) {
-    this.addBreadcrumb();
+    // this.addBreadcrumb();
     if (this.shouldWarnOnUnload()) {
       const confString = StringUtil.getUiPhraseByLang('You have unsaved changes. Do you want to leave the page?', this.settings.language);
       const answer = window.confirm(confString); // eslint-disable-line no-alert
@@ -78,34 +78,34 @@ export default {
         message: `${StringUtil.getUiPhraseByLang('Formulär uppdaterat, glöm inte att spara posten', this.user.settings.language)}`, 
       });
     },
-    addBreadcrumb() {
-      if (this.inspector.breadcrumb !== '') {
-        const currentTrail = this.inspector.breadcrumb;
-        const firstTrail = currentTrail.shift();
+    // addBreadcrumb() {
+    //   if (this.inspector.breadcrumb !== '') {
+    //     const currentTrail = this.inspector.breadcrumb;
+    //     const firstTrail = currentTrail.shift();
 
-        const newBreadcrumb = {
-          type: 'fromPost',
-          recordType: this.recordType,
-          postUrl: this.$route.fullPath,
-        };
+    //     const newBreadcrumb = {
+    //       type: 'fromPost',
+    //       recordType: this.recordType,
+    //       postUrl: this.$route.fullPath,
+    //     };
 
-        const newTrail = [];
-        newTrail.push(firstTrail);
-        newTrail.push(newBreadcrumb);
+    //     const newTrail = [];
+    //     newTrail.push(firstTrail);
+    //     newTrail.push(newBreadcrumb);
 
-        this.$store.dispatch('setBreadcrumbData', 
-          newTrail);
-      } else {
-        this.$store.dispatch('setBreadcrumbData', 
-          [
-            {
-              type: 'fromPost',
-              recordType: this.recordType,
-              postUrl: this.$route.fullPath,
-            },
-          ]);
-      }
-    },
+    //     this.$store.dispatch('setBreadcrumbData', 
+    //       newTrail);
+    //   } else {
+    //     this.$store.dispatch('setBreadcrumbData', 
+    //       [
+    //         {
+    //           type: 'fromPost',
+    //           recordType: this.recordType,
+    //           postUrl: this.$route.fullPath,
+    //         },
+    //       ]);
+    //   }
+    // },
     shouldWarnOnUnload() {
       return (
         (this.$route.name === 'Inspector' || this.$route.name === 'NewDocument')
@@ -677,9 +677,7 @@ export default {
         </router-link>
       </div>
       <div v-if="postLoaded" class="Inspector-entity">
-        <breadcrumb v-if="$route.meta.breadcrumb" class="Inspector-breadcrumb"
-          :record-type="recordType">
-        </breadcrumb>   
+        <breadcrumb v-if="$route.meta.breadcrumb" class="Inspector-breadcrumb" /> 
         <div class="Inspector-admin">
           <div class="Inspector-header">
             <h1 class="Inspector-title mainTitle" :title="recordType">

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -677,8 +677,7 @@ export default {
         </router-link>
       </div>
       <div v-if="postLoaded" class="Inspector-entity">
-        <breadcrumb class="Inspector-breadcrumb"
-          v-if="postLoaded && this.inspector.breadcrumb.length !== 0"
+        <breadcrumb v-if="$route.meta.breadcrumb" class="Inspector-breadcrumb"
           :record-type="recordType">
         </breadcrumb>   
         <div class="Inspector-admin">


### PR DESCRIPTION
This PR suggests a new approach to breadcrumbs, to fix the following problems:
* Fetching of excessive data in search results
* Breadcrumb links not corresponding with result list (when using custom sort for example), ie [LXL-2351](https://jira.kb.se/browse/LXL-2351)
* Breadcrumb links not showing at all (when searching by mainTitle for example)
* Breadcrumb component throwing errors

**What it does:**

Instead of doing a costly parallell search, fetching and saving _all_ results into vuex, this merely re-uses existing search result data as a starting point. When navigating from the `Find` to the `Inspector` view, we pass it along in the vue router `meta`-field together with the offset and position on current page. When this is not sufficient (on the last post of a page clicking "next", for example), we fetch new data _on demand_.

I.e: No extra data is ever fetched unless the user is actively using the feature and needs it. By using the same search data, we (sort) of make sure result list & breadcrumbs don't diverge.