### PR TITLE
Add help section to page title

### DIFF
--- a/viewer/vue-client/src/main.js
+++ b/viewer/vue-client/src/main.js
@@ -97,6 +97,9 @@ new Vue({
     'inspector.title'() {
       this.updateTitle();
     },
+    'status.helpSectionTitle'() {
+      this.updateTitle();
+    },
     'user.emailHash'() {
       this.syncUserStorage();
     },
@@ -190,6 +193,8 @@ new Vue({
         } else {
           title += StringUtil.getUiPhraseByLang('Loading document', this.user.settings.language);
         }
+      } else if (route.name === 'Help') {
+        title += this.status.helpSectionTitle;
       } else {
         title += StringUtil.getUiPhraseByLang(route.name, this.user.settings.language);
       }

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -59,7 +59,7 @@ const store = new Vuex.Store({
       },
       loadingIndicators: [],
       notifications: [],
-      helpSection: 'none',
+      helpSectionTitle: '',
       remoteDatabases: [],
     },
     user: User.getUserObject(),

--- a/viewer/vue-client/src/views/Help.vue
+++ b/viewer/vue-client/src/views/Help.vue
@@ -15,6 +15,19 @@ export default {
     };
   },
   methods: {
+    setSectionTitle() {
+      const value = this.activeSectionTitle;
+      let titleStr = '';
+      if (value === 'Start') {
+        titleStr = StringUtil.getUiPhraseByLang('Help', this.user.settings.language);
+      } else {
+        titleStr = `${value} - ${StringUtil.getUiPhraseByLang('Help', this.user.settings.language)}`;
+      }
+      this.$store.dispatch('setStatusValue', { 
+        property: 'helpSectionTitle',
+        value: titleStr,
+      });
+    },
     getImagePath(imgName) {
       const pathParts = imgName.split('/');
       const fileName = pathParts[pathParts.length - 1];
@@ -53,8 +66,14 @@ export default {
       this.$router.push({ path: `/help/${value}` });
     },
   },
+  updated() {
+    this.$nextTick(() => {
+      this.setSectionTitle();
+    });
+  },
   mounted() {
     this.$nextTick(() => {
+      this.setSectionTitle();
     });
   },
   components: {
@@ -79,6 +98,9 @@ export default {
       }
       return false;
     },
+    activeSectionTitle() {
+      return this.activeSectionData.title;
+    },
     activeSectionData() {
       for (const section in this.docs) {
         if (this.docs[section].basename === this.activeSection) {
@@ -89,9 +111,6 @@ export default {
     },
     status() {
       return this.$store.getters.status;
-    },
-    helpSection() {
-      return this.status.helpSection;
     },
     helpCategories() {
       const json = this.docs;


### PR DESCRIPTION
Example:
We're on the section "Att använda verktyget" in the help docs.

Before page title was:
`Hjälp | Libris katalogisering`
Now it will be:
`Att använda verktyget - Hjälp | Libris katalogisering`