### PR TITLE
Embellish highlight fix

### DIFF
--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -526,7 +526,9 @@ export default {
           value: [],
         });
       }
-      this.justEmbellished = false;
+      setTimeout(() => {
+        this.justEmbellished = false;
+      }, 300);
     },
   },
   watch: {


### PR DESCRIPTION
Sometimes embellish actions triggers multiple `inspector.data` changes (`change` events on dropdowns for example). The timeout prevents the second event from cancelling the highlight triggered by the first.

Example: 'Datorspel' template.
 