### PR TITLE
LXL-2505 Broken summary fix

### DIFF
--- a/viewer/vue-client/src/components/shared/entity-summary.vue
+++ b/viewer/vue-client/src/components/shared/entity-summary.vue
@@ -89,13 +89,16 @@ export default {
       'user',
     ]),
     idAsFnurgel() {
-      const id = this.focusData['@id'];
-      const fnurgel = RecordUtil.extractFnurgel(id);
-      if (fnurgel && this.isLibrisResource) {
-        return fnurgel;
+      if (this.focusData.hasOwnProperty('@id')) {
+        const id = this.focusData['@id'];
+        const fnurgel = RecordUtil.extractFnurgel(id);
+        if (fnurgel && this.isLibrisResource) {
+          return fnurgel;
+        }
+        const cleaned = id.replace('https://', '').replace('http://', '');
+        return cleaned;
       }
-      const cleaned = id.replace('https://', '').replace('http://', '');
-      return cleaned;
+      return null;
     },
     hiddenDetailsNumber() {
       return this.totalInfo.length - this.keyDisplayLimit;
@@ -237,7 +240,7 @@ export default {
       {{categorization.join(', ')}} {{ isLocal ? '{lokal entitet}' : '' }}
       <span class="EntitySummary-sourceLabel" v-if="database">{{ database }}</span>
     </div>
-    <div v-if="excludeComponents.indexOf('id') < 0" class="EntitySummary-id uppercaseHeading--light" :class="{'recently-copied': recentlyCopiedId }" @mouseover="idHover = true" @mouseout="idHover = false">
+    <div v-if="idAsFnurgel && excludeComponents.indexOf('id') < 0" class="EntitySummary-id uppercaseHeading--light" :class="{'recently-copied': recentlyCopiedId }" @mouseover="idHover = true" @mouseout="idHover = false">
       <i v-tooltip.top="idTooltipText" class="fa fa-copy EntitySummary-idCopyIcon" :class="{'collapsedIcon': !idHover || recentlyCopiedId }" @click.stop="copyFnurgel">
       </i>{{ idAsFnurgel }}
     </div>


### PR DESCRIPTION
[LXL-2505](https://jira.kb.se/browse/LXL-2505) - Entity summary breaks in preview mode (in sidepanel when using the link tool)

**Example:**
Id: n60000q0107s08v
Instans av verk -> text -> har del -> multimedia -> länk-ikon

**Cause:** 
`EntitySummary-id` (where u can copy the ID) tries to extract the `@id` - but there is none since the post doesn't exist (yet, it's a preview) - and breaks.

**Fix:**
Don't render this element if `idAsFnurgel()` doesn't return a proper value.