### PR TITLE
LXL-2540 - Support checking permissions on heldBy in hasComponent

### DIFF
--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -258,13 +258,10 @@ export default {
       this.$store.dispatch('undoInspectorChange');
     },
     edit() {
-      if (!this.inspector.status.editing && this.userIsPermittedToEdit) {
-        this.loadingEdit = true;
-        this.$store.dispatch('setInspectorStatusValue', { 
-          property: 'editing', 
-          value: true, 
-        });
-      }
+      this.$store.dispatch('pushInspectorEvent', { 
+        name: 'post-control', 
+        value: 'start-edit', 
+      });
     },
     navigateFormChanges(direction) {
       this.navigateChangeHistory(this.inspector.status.focus, direction);
@@ -385,16 +382,6 @@ export default {
       } else {
         return true;
       }
-      // if (this.user.hasAnyCollections() === false) {
-      //   return false;
-      // }
-      // const permission = this.user.getPermissions();
-      // if (this.inspector.data.mainEntity['@type'] === 'Item' && permission.registrant === true) {
-      //   return true;
-      // } if (permission.cataloger === true) {
-      //   return true;
-      // }
-      // return false;
     },
     showRecord() {
       return this.status.showRecord;


### PR DESCRIPTION
* In addition to checking `mainEntity.heldBy`, check in hasComponent if the active sigel is found there to calculate permission of editing the holding
* If `mainEntity.heldBy` is missing when starting edit, we will add the active sigel automatically.

Extra:
* Switched out components directly setting `inspector.status.editing` and made them use the post-control event system instead (which calls the `startEditing` and `stopEditing` functions).
* Renamed computed property `libraryUrl` to `activeSigelId`