### PR TITLE
Change embedded youtube video to go through GDPR-compliant domain

### DIFF
--- a/viewer/vue-client/src/resources/json/copy.json
+++ b/viewer/vue-client/src/resources/json/copy.json
@@ -48,7 +48,7 @@
     "linkText": "Supportforum"
   },
   "instructional-videos": {
-    "video": "https://www.youtube.com/embed/?listType=playlist&list=PLZVkEICvA5-GRT2oJQmLgq_2Pksx6zYPy&html5=1&rel=0&showinfo=0",
+    "video": "https://www.youtube-nocookie.com/embed/?listType=playlist&list=PLZVkEICvA5-GRT2oJQmLgq_2Pksx6zYPy&html5=1&rel=0&showinfo=0",
     "header": "Instruktionsfilmer",
     "text": "För att underlätta katalogisering i XL producerar vi kontinuerligt instruktionsfilmer som vi lägger upp på Kungliga bibliotekets kanal på Youtube. Filmerna uppdateras vid förändringar och uppdateringar av de tjänster de visar. Navigera runt och titta på de filmer som stödjer ditt arbete i XL på bästa sätt.",
     "linkUrl": "https://www.youtube.com/watch?v=p2vcgoTfNpw&list=PLZVkEICvA5-GRT2oJQmLgq_2Pksx6zYPy",


### PR DESCRIPTION
Instead of going through
`youtube.com`
we will embed it through 
`youtube-nocookie.com`