### PR TITLE
Sync application language with user language

### DIFF
--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -206,6 +206,7 @@
     "Creating link": "Skapar länk",
     "Item": "Bestånd",
     "Missing label": "Etikett saknas",
+    "missing": "saknas",
     "Make copy": "Kopiera",
     "Create link from local entity": "Skapa länk av lokal entitet",
     "Copy title from": "Kopiera titel från",

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -394,6 +394,9 @@ const store = new Vuex.Store({
     },
     setUser(state, userObj) {
       state.user = userObj;
+      // Sync user language with app language
+      state.settings.language = state.user.settings.language;
+      // Sync user settings with localstorage
       state.user.saveSettings();
     },
     setUserStorage(state, data) {

--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -241,7 +241,7 @@ export function getDisplayObject(item, level, displayDefs, quoted, vocab, settin
             vocab,
             context,
           );
-          result[property] = `{${expectedClassName} saknas}`;
+          result[property] = `{${expectedClassName} ${StringUtil.getUiPhraseByLang('missing', settings.language)}}`;
         }
       }
     }


### PR DESCRIPTION
Some of the translation uses the application settings instead of the user settings for the language parameter.

Syncing these would solve some of the things not being internationalized.

**In particular this concerns the** `...byLang` **properties in display chips/cards**