### PR TITLE
LXL-2770 Sort options for Work and Concept

### DIFF
--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -218,8 +218,14 @@ export default {
     },
     prefSort() {
       if (this.user && this.user.settings.sort) {
-        return { _sort: this.user.settings.sort };
-      } return false;
+        const availableSorts = this.settings.sortOptions[this.user.settings.searchType];
+        for (let i = 0; i < availableSorts.length; i++) {
+          if (availableSorts[i].query === this.user.settings.sort) {
+            return { _sort: this.user.settings.sort };
+          }
+        }
+      }
+      return { _sort: '' };
     },
     mergedParams() {
       return Object.assign(

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -308,6 +308,8 @@
     "Publication year (ascending)": "Utgivningsår (äldst först)",
     "Main title (A-Z)": "Huvudtitel (A-Ö)",
     "Main title (Z-A)": "Huvudtitel (Ö-A)",
+    "Preferred label (A-Z)": "Föredragen benämning (A-Ö)",
+    "Preferred label (Z-A)": "Föredragen benämning (Ö-A)",
     "Sigel (A-Z)": "Sigel (A-Ö)",
     "Sigel (Z-A)": "Sigel (Ö-A)",
     "Free text": "Fritext",

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -246,7 +246,7 @@ const store = new Vuex.Store({
       },
       sortOptions: {
         Instance: [
-          { 
+          {
             query: '',
             label: 'Relevance', 
           },
@@ -267,16 +267,44 @@ const store = new Vuex.Store({
             label: 'Publication year (ascending)',
           },
         ],
-        Item: [
-          { 
+        Work: [
+          {
             query: '',
             label: 'Relevance', 
           },
-          { 
+          {
+            query: 'hasTitle.mainTitle',
+            label: 'Main title (A-Z)',
+          },
+          {
+            query: '-hasTitle.mainTitle',
+            label: 'Main title (Z-A)',
+          },
+        ],
+        Concept: [
+          {
+            query: '',
+            label: 'Relevance', 
+          },
+          {
+            query: 'prefLabel',
+            label: 'Preferred label (A-Z)',
+          },
+          {
+            query: '-prefLabel',
+            label: 'Preferred label (Z-A)',
+          },
+        ],
+        Item: [
+          {
+            query: '',
+            label: 'Relevance', 
+          },
+          {
             query: 'heldBy.@id',
             label: 'Sigel (A-Z)', 
           },
-          { 
+          {
             query: '-heldBy.@id',
             label: 'Sigel (Z-A)', 
           },


### PR DESCRIPTION
* Adds sorting options for Work (hasTitle.mainTitle = same as for instance)
* Adds sorting options for Concept (prefLabel) (note: lots of concepts lack this property, so they will come after the sorted ones).

Bonus:
* Fixed so that the preferred sort order will reset to default if the specific type doesn't allow that sort order, instead of just trying to sort by it and failing (and showing empty input field).