### PR TITLE
Fetch jsonld everywhere instead of json

### DIFF
--- a/viewer/vue-client/src/components/care/holding-list.vue
+++ b/viewer/vue-client/src/components/care/holding-list.vue
@@ -207,7 +207,7 @@ export default {
         'itemOf.@id': bibId,
         '@type': 'Item',
       };
-      let url = `${this.settings.apiPath}/find.json?`;
+      let url = `${this.settings.apiPath}/find.jsonld?`;
       each(queryPairs, (v, k) => {
         url += (`${encodeURIComponent(k)}=${encodeURIComponent(v)}&`);
       });

--- a/viewer/vue-client/src/components/inspector/breadcrumb.vue
+++ b/viewer/vue-client/src/components/inspector/breadcrumb.vue
@@ -76,7 +76,7 @@ export default {
         default:
           break;
       }
-      let queryString = `${this.settings.apiPath}/find.json?`;
+      let queryString = `${this.settings.apiPath}/find.jsonld?`;
       each(queryObj, (v, k) => {
         queryString += (`${encodeURIComponent(k)}=${encodeURIComponent(v)}&`);
       });

--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -522,7 +522,7 @@ export default {
         // Add wildcard if user is not using operators
         q = `${keyword} | ${keyword}*`;
       }
-      let searchUrl = `${this.settings.apiPath}/find.json?q=${q}`;
+      let searchUrl = `${this.settings.apiPath}/find.jsonld?q=${q}`;
       if (typeof typeArray !== 'undefined' && typeArray.length > 0) {
         for (const type of typeArray) {
           searchUrl += `&@type=${type}`;

--- a/viewer/vue-client/src/components/inspector/relations-list.vue
+++ b/viewer/vue-client/src/components/inspector/relations-list.vue
@@ -85,7 +85,7 @@ export default {
       }
       queryPairs._offset = this.currentPage * this.maxResults;
       queryPairs._limit = this.maxResults;
-      let q = `${this.settings.apiPath}/find.json?`;
+      let q = `${this.settings.apiPath}/find.jsonld?`;
       each(queryPairs, (v, k) => {
         q += (`${encodeURIComponent(k)}=${encodeURIComponent(v)}&`);
       });

--- a/viewer/vue-client/src/components/inspector/search-window.vue
+++ b/viewer/vue-client/src/components/inspector/search-window.vue
@@ -317,7 +317,7 @@ export default {
         // Add wildcard if user is not using operators
         q = `${keyword} | ${keyword}*`;
       }
-      let searchUrl = `${this.settings.apiPath}/find.json?q=${q}`;
+      let searchUrl = `${this.settings.apiPath}/find.jsonld?q=${q}`;
       if (typeof typeArray !== 'undefined' && typeArray.length > 0) {
         for (const type of typeArray) {
           searchUrl += `&@type=${type}`;

--- a/viewer/vue-client/src/components/shared/preview-card.vue
+++ b/viewer/vue-client/src/components/shared/preview-card.vue
@@ -40,7 +40,7 @@ export default {
       const self = this;
       self.fetchStatus = 'loading';
       return new Promise((resolve, reject) => {
-        const url = `${id}/data.json?lens=card`;
+        const url = `${id}/data.jsonld?lens=card`;
         fetch(url).then((res) => {
           if (res.status === 200) {
             self.fetchStatus = null;

--- a/viewer/vue-client/src/components/shared/tag-switch.vue
+++ b/viewer/vue-client/src/components/shared/tag-switch.vue
@@ -54,7 +54,7 @@ export default {
       'inspector',
     ]),
     documentId() {
-      return this.document['@id'] || '';
+      return this.document['@id'].split('#')[0] || '';
     },
     documentTitle() {
       return DisplayUtil.getItemLabel(

--- a/viewer/vue-client/src/models/user.js
+++ b/viewer/vue-client/src/models/user.js
@@ -106,7 +106,7 @@ export class User {
   }
 
   async loadUserData(apiPath) {
-    const findUrl = `${apiPath}/find.json?@type=EntityContainer&${
+    const findUrl = `${apiPath}/find.jsonld?@type=EntityContainer&${
       this.collections.map(it => `administeredBy.@id=${getLibraryUri(it.code)}`).join('&')
     }`;
     const uriMinter = await createUriMinter(findUrl);

--- a/viewer/vue-client/src/utils/http.js
+++ b/viewer/vue-client/src/utils/http.js
@@ -85,7 +85,7 @@ function request(opts, data) {
 export function getRelatedPosts(queryPairs, apiPath) {
   // Returns a list of posts that links to <id> with <property>
   return new Promise((resolve, reject) => {
-    let relatedPosts = `${apiPath}/find.json?`;
+    let relatedPosts = `${apiPath}/find.jsonld?`;
     each(queryPairs, (v, k) => {
       relatedPosts += (`${encodeURIComponent(k)}=${encodeURIComponent(v)}&`);
     });

--- a/viewer/vue-client/src/views/DirectoryCare.vue
+++ b/viewer/vue-client/src/views/DirectoryCare.vue
@@ -55,7 +55,7 @@ export default {
     },
     fetchOne(item) {
       return new Promise((resolve, reject) => {
-        HttpUtil.getDocument(item['@id'], 'application/json') // Should be JSON, not JSON-LD
+        HttpUtil.getDocument(`${item['@id'].split('#')[0]}/data.jsonld?lens=card`)
           .then((responseObject) => {
             if (responseObject.status === 200) {
               resolve(responseObject.data);

--- a/viewer/vue-client/src/views/Find.vue
+++ b/viewer/vue-client/src/views/Find.vue
@@ -63,7 +63,7 @@ export default {
       this.importData = [];
     },
     getLocalResult() {
-      const fetchUrl = `${this.settings.apiPath}/find.json?${this.query}`;
+      const fetchUrl = `${this.settings.apiPath}/find.jsonld?${this.query}`;
       fetch(fetchUrl).then(response => response.text(), (error) => {
         this.$store.dispatch('pushNotification', { type: 'danger', message: `${StringUtil.getUiPhraseByLang('Something went wrong', this.user.settings.language)} ${error}` });
         this.searchInProgress = false;


### PR DESCRIPTION
Bonus:
* When tagging for Directory Care we will tag the record id (instead of mainEntity like before).
* When fetching the list for Directory Care, use the lens-param to only fetch cards instead of fetching the record and then extracting the mainEntity.