### PR TITLE
LXL-2771 Add more options for search form

### DIFF
--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -308,6 +308,7 @@
     "Publication year (ascending)": "Utgivningsår (äldst först)",
     "Main title (A-Z)": "Huvudtitel (A-Ö)",
     "Main title (Z-A)": "Huvudtitel (Ö-A)",
+    "Preferred label": "Föredragen benämning",
     "Preferred label (A-Z)": "Föredragen benämning (A-Ö)",
     "Preferred label (Z-A)": "Föredragen benämning (Ö-A)",
     "Sigel (A-Z)": "Sigel (A-Ö)",

--- a/viewer/vue-client/src/resources/json/propertymappings.json
+++ b/viewer/vue-client/src/resources/json/propertymappings.json
@@ -41,7 +41,8 @@
       "hasTitle.mainTitle": ""
     },
     "types": [
-      "Instance"
+      "Instance",
+      "Work"
     ]
   }
 ]

--- a/viewer/vue-client/src/resources/json/propertymappings.json
+++ b/viewer/vue-client/src/resources/json/propertymappings.json
@@ -24,6 +24,16 @@
     ]
   },
   {
+    "key": "Preferred label",
+    "searchProp": "prefLabel",
+    "mappings": {
+      "prefLabel": ""
+    },
+    "types": [
+      "Concept"
+    ]
+  },
+  {
     "key": "ISSN",
     "searchProp": "identifiedBy.value",
     "mappings": {


### PR DESCRIPTION
Added:
* You can use form to search for `hasTitle.mainTitle` for type `Work`.
* You can use form to search for `prefLabel` for type `Concept`.