### PR TITLE
Handle Etag with -gzip

### DIFF
--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -578,7 +578,7 @@ app.context_processor(lambda: RDFNS)
 def vocabview(suffix=None):
     voc = daccess.vocab.get_util()
 
-    if request.headers.get('if-none-match') == daccess.vocab.vocab_etag:
+    if request.headers.get('if-none-match').replace('-gzip', '') == daccess.vocab.vocab_etag:
         return Response(status=304)
 
     def link(obj):

--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -578,7 +578,8 @@ app.context_processor(lambda: RDFNS)
 def vocabview(suffix=None):
     voc = daccess.vocab.get_util()
 
-    if request.headers.get('if-none-match').replace('-gzip', '') == daccess.vocab.vocab_etag:
+    etag = request.headers.get('if-none-match', default = '').replace('-gzip', '')
+    if etag == daccess.vocab.vocab_etag:
         return Response(status=304)
 
     def link(obj):


### PR DESCRIPTION
Handle it the same way as backend.
An alternative would have been to configure apache to strip `-gzip` from the header or to not add it in the first place.