### PR TITLE
Apply derivedFrom when extracting entities

### DIFF
--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -135,30 +135,6 @@ export default {
       }
       return false;
     },
-    extractedItem() {
-      const newRecord = {};
-      newRecord.descriptionCreator = { '@id': this.user.getActiveLibraryUri() };
-      const objAsRecord = RecordUtil.getObjectAsRecord(this.extractedMainEntity, newRecord);
-      return objAsRecord;
-    },
-    extractedMainEntity() {
-      const cleanObj = DataUtil.removeNullValues(this.item);
-
-      if (this.copyTitle) {
-        cleanObj.hasTitle = this.editorData.mainEntity.hasTitle;
-      }
-      return cleanObj;
-    },
-    isExtractable() {
-      if (this.isCompositional === true) {
-        return false;
-      }
-      const classId = StringUtil.getCompactUri(this.item['@type'], this.resources.context);
-      if (VocabUtil.isExtractable(classId, this.resources.vocab, this.settings, this.resources.context)) {
-        return true;
-      }
-      return false;
-    },
     getPath() {
       if (this.inArray) {
         return `${this.parentPath}[${this.index}]`;

--- a/viewer/vue-client/src/components/inspector/item-sibling.vue
+++ b/viewer/vue-client/src/components/inspector/item-sibling.vue
@@ -117,30 +117,6 @@ export default {
       }
       return false;
     },
-    extractedItem() {
-      const newRecord = {};
-      newRecord.descriptionCreator = { '@id': this.user.getActiveLibraryUri() };
-      const objAsRecord = RecordUtil.getObjectAsRecord(this.extractedMainEntity, newRecord);
-      return objAsRecord;
-    },
-    extractedMainEntity() {
-      const cleanObj = DataUtil.removeNullValues(this.item);
-
-      if (this.copyTitle) {
-        cleanObj.hasTitle = this.editorData.mainEntity.hasTitle;
-      }
-      return cleanObj;
-    },
-    isExtractable() {
-      if (this.isCompositional === true) {
-        return false;
-      }
-      const classId = StringUtil.getCompactUri(this.item['@type'], this.resources.context);
-      if (VocabUtil.isExtractable(classId, this.resources.vocab, this.settings, this.resources.context)) {
-        return true;
-      }
-      return false;
-    },
     isLastAdded() {
       if (this.inspector.status.lastAdded === this.getPath) {
         return true;

--- a/viewer/vue-client/src/components/mixins/item-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/item-mixin.vue
@@ -85,6 +85,33 @@ export default {
       }
       return `${this.parentPath}`;
     },
+    extractedMainEntity() {
+      const cleanObj = DataUtil.removeNullValues(this.item);
+      if (this.copyTitle) {
+        cleanObj.hasTitle = this.inspector.data.mainEntity.hasTitle;
+      }
+      return cleanObj;
+    },
+    extractedItem() {
+      if (this.focusData.hasOwnProperty('@type') === false) {
+        return null;
+      }
+      const newRecord = {};
+      newRecord.descriptionCreator = { '@id': this.user.getActiveLibraryUri() };
+      newRecord.derivedFrom = { '@id': this.inspector.data.record['@id'] };
+      const objAsRecord = RecordUtil.getObjectAsRecord(this.extractedMainEntity, newRecord);
+      return objAsRecord;
+    },
+    isExtractable() {
+      if (this.isCompositional === true) {
+        return false;
+      }
+      const classId = StringUtil.getCompactUri(this.item['@type'], this.resources.context);
+      if (VocabUtil.isExtractable(classId, this.resources.vocab, this.settings, this.resources.context)) {
+        return true;
+      }
+      return false;
+    },
     isEmbedded() {
       return VocabUtil.isEmbedded(this.item['@type'], this.resources.vocab, this.settings, this.resources.context);
     },

--- a/viewer/vue-client/src/components/mixins/item-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/item-mixin.vue
@@ -2,6 +2,7 @@
 import * as DataUtil from '@/utils/data';
 import * as VocabUtil from '@/utils/vocab';
 import * as StringUtil from '@/utils/string';
+import * as RecordUtil from '@/utils/record';
 import { cloneDeep, isArray, get, isObject } from 'lodash-es';
 import { mapGetters } from 'vuex';
 

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -144,6 +144,7 @@ const store = new Vuex.Store({
         'modified',
         'descriptionCreator',
         'descriptionLastModifier',
+        'derivedFrom',
       ],
       dataSetFilters: {
         libris: [


### PR DESCRIPTION
Also:
* Move general code into mixin
* Lock derivedFrom property in app-settings (so it can't be deleted/edited in GUI)