### PR TITLE
Speed up getValueByLang

### DIFF
--- a/viewer/vue-client/package.json
+++ b/viewer/vue-client/package.json
@@ -63,6 +63,7 @@
       "@vue/airbnb"
     ],
     "rules": {
+      "no-use-before-define": "off",
       "no-plusplus": "off",
       "no-restricted-syntax": "off",
       "no-console": "off",

--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -36,7 +36,7 @@ function getValueByLang(item, propertyId, displayDefs, langCode, context) {
     throw new Error('getValueByLang was called with an undefined language code.');
   }
   let translatedValue = item[propertyId]; // Set original value
-  let byLangKey = VocabUtil.getMappedPropertyByContainer(propertyId, '@language', context);
+  const byLangKey = VocabUtil.getMappedPropertyByContainer(propertyId, '@language', context);
   if (byLangKey && item[byLangKey] && item[byLangKey][langCode]) {
     translatedValue = item[byLangKey][langCode];
   }

--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -36,13 +36,8 @@ function getValueByLang(item, propertyId, displayDefs, langCode, context) {
     throw new Error('getValueByLang was called with an undefined language code.');
   }
   let translatedValue = item[propertyId]; // Set original value
-  const contextKey = VocabUtil.getContextProperty(propertyId, context);
-  const langPropObject = VocabUtil.getContextWithContainer(contextKey, '@language', context);
-  let byLangKey = '';
-  if (typeof langPropObject !== 'undefined') {
-    byLangKey = langPropObject['@id'];
-  }
-  if (item[byLangKey] && item[byLangKey][langCode]) {
+  let byLangKey = VocabUtil.getMappedPropertyByContainer(propertyId, '@language', context);
+  if (byLangKey && item[byLangKey] && item[byLangKey][langCode]) {
     translatedValue = item[byLangKey][langCode];
   }
   return translatedValue;

--- a/viewer/vue-client/src/utils/vocab.js
+++ b/viewer/vue-client/src/utils/vocab.js
@@ -15,7 +15,7 @@ export function getVocab(apiPath) {
 export function getContext(apiPath) {
   return new Promise((resolve, reject) => {
     httpUtil.getResourceFromCache(`${apiPath}/context.jsonld`).then((result) => {
-      resolve(result);
+      resolve(preprocessContext(result));
     }, (error) => {
       reject(error);
     });
@@ -506,34 +506,13 @@ export function isExtractable(classId, vocab, settings, context) {
   return false;
 }
 
-export function getContextProperty(propertyId, context) {
-  const originalKey = propertyId;
-  const contextProperty = originalKey;
-  const contextList = context[1];
-  let resultProp = originalKey;
-
-  if (contextList.hasOwnProperty(contextProperty)) {
-    if (!isPlainObject(contextList[contextProperty])) {
-      resultProp = originalKey;
-    } else {
-      resultProp = contextList[contextProperty]['@id'];
-    }
+export function getMappedPropertyByContainer(property, container, context) {
+  const computed = context[2];
+  const containerMap = computed['containerMap'];
+  if (containerMap[container]) {
+    return containerMap[container][property];
   }
-  return resultProp;
-}
-
-export function getContextWithContainer(propertyId, container, context) {
-  const contextList = context[1];
-
-  let contextObj;
-  forOwn(contextList, (value, key) => {
-    if (typeof value !== 'undefined' && value !== null) {
-      if (value.hasOwnProperty('@id') && value['@id'] === propertyId && value.hasOwnProperty('@container') && value['@container'] === container) {
-        contextObj = { '@id': key, '@container': value['@container'] };
-      }
-    }
-  });
-  return contextObj;
+  return false;
 }
 
 export function getBaseUriFromPrefix(prefix, context) {
@@ -627,4 +606,41 @@ export function printTree(term, vocab, context) {
     }
   }
   printNode(getTree(term, vocab, context), '', true);
+}
+
+export function preprocessContext(context) {
+  const computed = {'containerMap': computeContainerMap(context['@context'][1])};
+  context['@context'].push(computed);
+  return context;
+}
+
+export function computeContainerMap(contextList) {
+  function forContextList(closure) {
+    forOwn(contextList, (value, key) => {
+      if (typeof value !== 'undefined' && value !== null && value['@id']) {
+        closure(key, value['@id'], value)
+      }
+    });
+  }
+
+  let containerMap = {};
+  let containers = ['@language'];
+  each(containers, container => {
+    let idToProperty = {};
+    forContextList( (property, id, value) => {
+      if (value['@container'] && value['@container'] === container) {
+        idToProperty[id] = property
+      }
+    });
+
+    let propertyToProperty = {};
+    forContextList( (property, id) => {
+      if (idToProperty[id]) {
+        propertyToProperty[property] = idToProperty[id];
+      }
+    });
+    containerMap[container] = propertyToProperty;
+  })
+  
+  return containerMap;
 }

--- a/viewer/vue-client/src/utils/vocab.js
+++ b/viewer/vue-client/src/utils/vocab.js
@@ -508,11 +508,11 @@ export function isExtractable(classId, vocab, settings, context) {
 
 export function getMappedPropertyByContainer(property, container, context) {
   const computed = context[2];
-  const containerMap = computed['containerMap'];
+  const containerMap = computed.containerMap;
   if (containerMap[container]) {
     return containerMap[container][property];
   }
-  return false;
+  return null;
 }
 
 export function getBaseUriFromPrefix(prefix, context) {
@@ -609,7 +609,7 @@ export function printTree(term, vocab, context) {
 }
 
 export function preprocessContext(context) {
-  const computed = {'containerMap': computeContainerMap(context['@context'][1])};
+  const computed = { containerMap: computeContainerMap(context['@context'][1]) };
   context['@context'].push(computed);
   return context;
 }
@@ -618,29 +618,29 @@ export function computeContainerMap(contextList) {
   function forContextList(closure) {
     forOwn(contextList, (value, key) => {
       if (typeof value !== 'undefined' && value !== null && value['@id']) {
-        closure(key, value['@id'], value)
+        closure(key, value['@id'], value);
       }
     });
   }
 
-  let containerMap = {};
-  let containers = ['@language'];
-  each(containers, container => {
-    let idToProperty = {};
-    forContextList( (property, id, value) => {
+  const containerMap = {};
+  const containers = ['@language'];
+  each(containers, (container) => {
+    const idToProperty = {};
+    forContextList((property, id, value) => {
       if (value['@container'] && value['@container'] === container) {
-        idToProperty[id] = property
+        idToProperty[id] = property;
       }
     });
 
-    let propertyToProperty = {};
-    forContextList( (property, id) => {
+    const propertyToProperty = {};
+    forContextList((property, id) => {
       if (idToProperty[id]) {
         propertyToProperty[property] = idToProperty[id];
       }
     });
     containerMap[container] = propertyToProperty;
-  })
+  });
   
   return containerMap;
 }


### PR DESCRIPTION
It used in many places. 
Fix: Precompute all "byLang" keys (e.g. 'prefLabel' -> 'prefLabelByLang') when loading context.

Speeds up search results list a lot.
Cuts loading time of "Kalle Anka & C:o" (https://libris-stg.kb.se/katalogisering/l3wsrw5x0wwzqlh) with 25% on my machine.

