### PR TITLE
Only translate if language in settings is present in item

### DIFF
--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -42,16 +42,9 @@ function tryGetValueByLang(item, propertyId, langCode, context) {
   }
   const byLangKey = VocabUtil.getMappedPropertyByContainer(propertyId, '@language', context);
   
-  let result = null;
-  if (byLangKey && item[byLangKey]) {
-    if (item[byLangKey][langCode]) {
-      result = item[byLangKey][langCode];
-    } else {
-      const langKeys = Object.keys(item[byLangKey]);
-      result = item[byLangKey][langKeys[0]];
-    }
-  }
-  return result;
+  return byLangKey && item[byLangKey] && item[byLangKey][langCode]
+    ? item[byLangKey][langCode]
+    : null;
 }
 
 export function getLensById(id, displayDefs) {


### PR DESCRIPTION
Original behavior.
i.e. https://libris-qa.kb.se/katalogisering/1rznbwb534c3znk5 should not display altLabel in card if user language setting is "sv."