### PR TITLE
Labels: Replace "{property} missing" with "{type} without {property}"

### DIFF
--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -215,6 +215,7 @@
     "Item": "Bestånd",
     "Missing label": "Etikett saknas",
     "missing": "saknas",
+    "without": "utan",
     "Make copy": "Kopiera",
     "Create link from local entity": "Skapa länk av lokal entitet",
     "Copy title from": "Kopiera titel från",

--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -250,7 +250,7 @@ export function getDisplayObject(item, level, displayDefs, quoted, vocab, settin
             vocab,
             context,
           );
-          result[property] = `{${expectedClassName} ${StringUtil.getUiPhraseByLang('missing', settings.language)}}`;
+          result[property] = `{${StringUtil.getLabelByLang(trueItem['@type'], settings.language, vocab, context)} ${StringUtil.getUiPhraseByLang('without', settings.language)} ${expectedClassName.toLowerCase()}}`;
         }
       }
     }


### PR DESCRIPTION
Example:

A language is missing "code". Instead of returning:
`{Missing code}` (or `{Kod saknas}`)
it will return:
`{Language without code}` (or `{Språk utan kod}`)

Should make it clearer what object is missing the property in question.