### PR TITLE
Add lock to generationDate and generationProcess in record

### DIFF
--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -145,6 +145,8 @@ const store = new Vuex.Store({
         'descriptionCreator',
         'descriptionLastModifier',
         'derivedFrom',
+        'generationDate',
+        'generationProcess',
       ],
       dataSetFilters: {
         libris: [


### PR DESCRIPTION
## Checklist:
- [ ] I have ran the unit tests. `yarn test:unit`
- [ ] I have ran the e2e test. `yarn test:e2e_ci` or `yarn test:e2e` (if you don't have a frontend, ask someone who does)
- [ ] I have ran the linter. `yarn lint`

## Description

### Tickets involved
No ticket

### Solves

Lock generationDate and generationProcess properties in adminmetadata.
