### PR TITLE
Add record type to string translations in delete dialog

### DIFF
--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -294,7 +294,10 @@ export default {
       this.closeRemoveModal();
       const url = `${this.settings.apiPath}/${this.documentId}`;
       HttpUtil._delete({ url, activeSigel: this.user.settings.activeSigel, token: this.user.token }).then(() => {
-        this.$store.dispatch('pushNotification', { type: 'success', message: `${StringUtil.getUiPhraseByLang('The post was deleted', this.user.settings.language)}!` });
+        this.$store.dispatch('pushNotification', { 
+          type: 'success', 
+          message: `${StringUtil.getUiPhraseByLang(this.recordType, this.user.settings.language)} ${StringUtil.getUiPhraseByLang('has been removed', this.user.settings.language)}!`, 
+        });
         // Force reload
         this.$router.go(-1);
       }, (error) => {
@@ -777,7 +780,7 @@ export default {
           {{ 'This operation can\'t be reverted' | translatePhrase }}
         </p>
         <div class="RemovePostModal-buttonContainer">
-          <button class="btn btn-danger btn--md" @click="doRemovePost()">{{ 'Remove the record' | translatePhrase }}</button>
+          <button class="btn btn-danger btn--md" @click="doRemovePost()">{{ 'Remove' | translatePhrase }} {{ this.recordType | labelByLang | lowercase }}</button>
           <button class="btn btn-gray btn--md" @click="closeRemoveModal()">{{ 'Cancel' | translatePhrase }}</button>
         </div>
       </div>


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the e2e test. `yarn test:e2e_ci` or `yarn test:e2e` (if you don't have a frontend, ask someone who does)
- [x] I have run the linter. `yarn lint`

## Description
Change text for button and confirm message to reflect the record type being deleted

### Tickets involved
[LXL-2781](https://jira.kb.se/browse/LXL-2781)

### Solves
Confusion whether item or post was being removed.
