### PR TITLE
Fix that some preview-cards are not fetching data correctly

### DIFF
--- a/viewer/vue-client/src/components/shared/preview-card.vue
+++ b/viewer/vue-client/src/components/shared/preview-card.vue
@@ -59,7 +59,7 @@ export default {
       'settings',
     ]),
     shouldFetch() {
-      if (this.focusData['@id'].startsWith(this.settings.dataPath) || (this.focusData.hasOwnProperty('meta') && this.focusData.meta['@id'].startsWith(this.settings.dataPath))) {
+      if (this.focusData['@id'].startsWith(this.settings.dataPath) || this.recordId.startsWith(this.settings.dataPath) || (this.focusData.hasOwnProperty('meta') && this.focusData.meta['@id'].startsWith(this.settings.dataPath))) {
         return this.fetchedData === null;
       }
       return false;

--- a/viewer/vue-client/src/utils/record.js
+++ b/viewer/vue-client/src/utils/record.js
@@ -67,10 +67,14 @@ export function getRecordId(data, quoted) {
       recordObj = data;
     }
   }
+  let recordId;
   if (recordObj.hasOwnProperty('@id')) {
-    return recordObj['@id'];
+    recordId = recordObj['@id'];
+  } else {
+    recordId = recordObj['@graph'][0]['@id'];
   }
-  return recordObj['@graph'][0]['@id'];
+  recordId = recordId.split('#')[0];
+  return recordId;
 }
 
 export function recordObjectFromGraph(id, quoted) {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [ ] I have run the e2e test. `yarn test:e2e_ci` or `yarn test:e2e` (if you don't have a frontend, ask someone who does)
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-2864](https://jira.kb.se/browse/LXL-2864)

### Solves

Translates id.kb.se links correctly for the items still not being translated correctly. Also fixed some cards not fetching card data due to the #it being kept in recordId.

### Summary of changes

* shouldFetch flag does now checks `this.recordId` in addition to `this.focusData['@id']`.
* `getRecordId` now strips `#id` from the id.

