### PR TITLE
bump combokeys version

### DIFF
--- a/viewer/vue-client/package.json
+++ b/viewer/vue-client/package.json
@@ -24,7 +24,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
     "bootstrap": "https://github.com/twbs/bootstrap/archive/v3.3.7.tar.gz",
-    "combokeys": "^3.0.0",
+    "combokeys": "https://github.com/avocode/combokeys/archive/v3.1.0.tar.gz",
     "eslint": "^5.8.0",
     "eslint-plugin-vue": "^5.0.0-0",
     "font-awesome": "4.7.0",

--- a/viewer/vue-client/yarn.lock
+++ b/viewer/vue-client/yarn.lock
@@ -2759,10 +2759,9 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-combokeys@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/combokeys/-/combokeys-3.0.0.tgz#955c59a3959af40d26846ab6fc3c682448e7572e"
-  integrity sha1-lVxZo5Wa9A0mhGq2/DxoJEjnVy4=
+"combokeys@https://github.com/avocode/combokeys/archive/v3.1.0.tar.gz":
+  version "3.1.0"
+  resolved "https://github.com/avocode/combokeys/archive/v3.1.0.tar.gz#270196ed420522581d74e08d92cac901edec1fea"
 
 commander@2.15.1:
   version "2.15.1"


### PR DESCRIPTION
#383  Description

Bump Combokeys to newest version which includes our pull request.

### Tickets involved
[LXL-1893](https://jira.kb.se/browse/LXL-1893)

### Solves

Firefox key-shortcut for alt+plus not working on Windows

### Summary of changes

Points to a tar.gz in combokeys Github-repo.
