### PR TITLE
Don't expect 'Accept' header to always be present

### DIFF
--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -489,7 +489,7 @@ def _proxy_request(request, session, json_data=None, query_params=[],
     url_path = url_path or request.path
 
     headers = dict(request.headers)
-    accept_header = accept_header or headers['Accept']
+    accept_header = accept_header or headers.get('Accept')
     adjusted_accept_header = _adjust_accept_header(accept_header)
     if adjusted_accept_header:
         headers['Accept'] = adjusted_accept_header


### PR DESCRIPTION
This broke downloading raw data by saving from Chrome, which apparently
doesn't send any Accept header on save request.

(Also using `curl -H'Accept:' -v https://libris-dev.kb.se/zg858p49460nsps/data.jsonld` triggers this.)