### PR TITLE
Change item-error to be a table of key/values instead of just json string

### DIFF
--- a/viewer/vue-client/src/components/inspector/item-error.vue
+++ b/viewer/vue-client/src/components/inspector/item-error.vue
@@ -7,6 +7,10 @@ export default {
   mixins: [ItemMixin],
   props: {
     item: {},
+    isLocked: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {
@@ -21,7 +25,7 @@ export default {
       if (cleanItem.hasOwnProperty('_uid')) {
         delete cleanItem._uid;
       }
-      return JSON.stringify(cleanItem);
+      return cleanItem;
     },
     failedValidations() {
       const failedValidations = [];
@@ -55,7 +59,12 @@ export default {
 
 <template>
   <div class="ItemError" :id="`formPath-${path}`" :class="{ 'has-failed-validations': failedValidations.length > 0 }">
-    <code>{{itemAsJson}}</code>
+    <i v-if="!isLocked" class="fa fa-question-circle" />
+    <table>
+      <tr v-for="(value, key) in itemAsJson" :key="key">
+        <td class="ItemError-key">{{ key }}</td><td class="ItemError-value">{{ value }}</td>
+      </tr>
+    </table>
   </div>
 </template>
 
@@ -65,11 +74,14 @@ export default {
   line-height: 1.6;
   width: 100%;
   display: inline-block;
+  font-family: monospace;
+  &-key {
+    padding-right: 1em;
+  }
   code {
     color: @black;
     background-color: transparent;
   }
-
   &.has-failed-validations {
     outline: 1px dotted red;
   }

--- a/viewer/vue-client/src/components/inspector/item-error.vue
+++ b/viewer/vue-client/src/components/inspector/item-error.vue
@@ -59,7 +59,6 @@ export default {
 
 <template>
   <div class="ItemError" :id="`formPath-${path}`" :class="{ 'has-failed-validations': failedValidations.length > 0 }">
-    <i v-if="!isLocked" class="fa fa-question-circle" />
     <table>
       <tr v-for="(value, key) in itemAsJson" :key="key">
         <td class="ItemError-key">{{ key }}</td><td class="ItemError-value">{{ value }}</td>


### PR DESCRIPTION


## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [ ] I have run the e2e test. `yarn test:e2e_ci` or `yarn test:e2e` (if you don't have a frontend, ask someone who does)
- [x] I have run the linter. `yarn lint`

## Description
Changes the items where we can't render a proper component on an object. Instead of just showing a JSON-string we will now show it as a table.
See http://localhost:8080/katalogisering/7k64qptb958dhb8s for an example of a post where this type is shown.

### Tickets involved
None

### Summary of changes

* Added some css for the table and font
* Switched out the json string in template to a loop over the item into a table.
