### PR TITLE
Feature/lxl 2754 lock external search

### DIFF
--- a/viewer/vue-client/src/components/shared/tab-menu.vue
+++ b/viewer/vue-client/src/components/shared/tab-menu.vue
@@ -13,14 +13,18 @@
 
   Tab-Objects:
     A tab object needs two things.
-      * id   -  Just an identifier, it is used when emitting the go-event and to match against the "active" prop.
-      * text -  A fancy text for your tab, which should be in english. The component will automatically try to
-                translate this text to the users language, based on the i18n file.
-      * html -  (Optional) Raw html for the item, will replace 'text'
+      * id          -  Just an identifier, it is used when emitting the go-event and to match against the "active" prop.
+      * text        -  A fancy text for your tab, which should be in english. The component will automatically try to
+                        translate this text to the users language, based on the i18n file.
+      * icon        -  (Optional) The tab icon                        
+      * html        -  (Optional) Raw html for the item, will replace 'text'
+      * disabled    -  (Optional) Boolean - disables the tab
+      * tooltipText -  (Optional) Display given text on tab hover or focus
 
     Example tab-object:
       {'id': 'MyTab1', 'text': 'My tab text' }
       {'id': 'MyTab1', 'html': 'My <strong>tab</strong> text' }
+      {'id': 'MyTab1', 'text': 'My tab text', 'disabled': true, 'tooltipText': 'Access denied' }
 
   The go-event:
     If a tab is clicked, it will emit an event with the id on the tab.
@@ -129,9 +133,13 @@ export default {
         v-for="item in tabs" 
         tabindex="0"
         :key="item.id" 
-        @click="go(item.id)" 
-        @keyup.enter="go(item.id)"
-        :class="{'is-active': active === item.id }"
+        @click="item.disabled ? null : go(item.id)" 
+        @keyup.enter="item.disabled ? null : go(item.id)"
+        v-tooltip="{
+          trigger: 'hover focus',
+          content: item.tooltipText
+        }"
+        :class="{'is-active': active === item.id, 'is-disabled': item.disabled }"
         role="tab">
           <i v-if="item.icon" class="TabMenu-tabIcon visible-xs-block" :class="`fa fa-fw fa-${item.icon}`"></i>
           <span class="TabMenu-tabText" :class="{'hidden-xs': item.icon }" v-if="item.html" v-html="item.html"></span>
@@ -143,8 +151,13 @@ export default {
       <router-link tag="a" class="TabMenu-tab" 
         v-for="item in tabs" :key="item.id"
         tabindex="0"
-        :class="{'is-active': active === item.id }" 
-        :to="item.link">
+        :event="item.disabled ? null : 'click'"
+        :class="{'is-active': active === item.id, 'is-disabled': item.disabled }" 
+        :to="item.link"
+        v-tooltip="{
+          trigger: 'hover focus',
+          content: item.tooltipText
+        }">        
         <i v-if="item.icon" class="TabMenu-tabIcon visible-xs-block" :class="`fa fa-fw fa-${item.icon}`"></i>
         <span class="TabMenu-tabText" :class="{'hidden-xs': item.icon }" v-if="item.html" v-html="item.html"></span>
         <span class="TabMenu-tabText" :class="{'hidden-xs': item.icon }" v-else>{{item.text | translatePhrase}}</span>
@@ -190,13 +203,21 @@ export default {
       margin: 0;
       color: @white;
       transition: background-color 0.25s ease;
-      &:hover {
-        background-color: darken(@brand-primary, 15%);
-        text-decoration: none;
-      }
+      text-decoration: none;
+
       &.is-active {
-        background-color: @brand-primary;
-        text-decoration: none;
+        background-color: @brand-primary;        
+      }
+
+      &:not(.is-disabled) {
+        &:hover {
+          background-color: darken(@brand-primary, 15%);
+        }
+      }
+
+      &.is-disabled {
+        color: @grey;
+        cursor: not-allowed;
       }
     }
     .style-underline & {
@@ -205,14 +226,22 @@ export default {
       font-size: 18px;
       font-size: 1.6rem;
   
-      &:hover,
-      &:focus {
-        color: @brand-primary;
-        text-decoration: none;
-      }
       &.is-active {
         color: @black;
         text-decoration: none;
+      }
+
+      &:not(.is-disabled) {
+        &:hover,
+        &:focus {
+          color: @brand-primary;
+          text-decoration: none;
+        }
+      }
+
+      &.is-disabled {
+        color: @grey-light;
+        cursor: not-allowed;
       }
     }
   }

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -267,6 +267,7 @@
     "Unauthorized": "Obehörig",
     "Authenticating": "Loggar in",
     "You need to be logged in to perform this action": "Du måste vara inloggad för att utföra den här åtgärden",
+    "Sign in to search other sources": "Logga in för att söka i andra källor",
     "You were logged in": "Du loggades in",
     "You were logged out": "Du loggades ut",
     "Login failed": "Inloggning misslyckades",

--- a/viewer/vue-client/src/views/Find.vue
+++ b/viewer/vue-client/src/views/Find.vue
@@ -159,7 +159,7 @@ export default {
           id: 'remote', 
           text: StringUtil.getUiPhraseByLang('Other sources', this.user.settings.language),
           disabled: !this.user.isLoggedIn,
-          tooltipText: !this.user.isLoggedIn ? StringUtil.getUiPhraseByLang('You need to be logged in to perform this action', this.user.settings.language) : null,
+          tooltipText: !this.user.isLoggedIn ? StringUtil.getUiPhraseByLang('Sign in to search other sources', this.user.settings.language) : null,
         },
       ];
       return tabs;

--- a/viewer/vue-client/src/views/Find.vue
+++ b/viewer/vue-client/src/views/Find.vue
@@ -45,7 +45,7 @@ export default {
   },
   methods: {
     setSearchPerimeter(id) {
-      this.$router.push({ path: `/search/${id}` }).catch(err => {});
+      this.$router.push({ path: `/search/${id}` }).catch(() => {});
     },
     getResult() {
       this.emptyResults();
@@ -153,7 +153,7 @@ export default {
       const tabs = [
         { id: 'libris', text: StringUtil.getUiPhraseByLang('Libris', this.user.settings.language) },
       ];
-      if(this.user.isLoggedIn) {
+      if (this.user.isLoggedIn) {
         tabs.push({ id: 'remote', text: StringUtil.getUiPhraseByLang('Other sources', this.user.settings.language) });
       }
       return tabs;

--- a/viewer/vue-client/src/views/Find.vue
+++ b/viewer/vue-client/src/views/Find.vue
@@ -45,7 +45,7 @@ export default {
   },
   methods: {
     setSearchPerimeter(id) {
-      this.$router.push({ path: `/search/${id}` });
+      this.$router.push({ path: `/search/${id}` }).catch(err => {});
     },
     getResult() {
       this.emptyResults();

--- a/viewer/vue-client/src/views/Find.vue
+++ b/viewer/vue-client/src/views/Find.vue
@@ -150,10 +150,13 @@ export default {
       'status',
     ]),
     findTabs() {
-      return [
+      const tabs = [
         { id: 'libris', text: StringUtil.getUiPhraseByLang('Libris', this.user.settings.language) },
-        { id: 'remote', text: StringUtil.getUiPhraseByLang('Other sources', this.user.settings.language) },
       ];
+      if(this.user.isLoggedIn) {
+        tabs.push({ id: 'remote', text: StringUtil.getUiPhraseByLang('Other sources', this.user.settings.language) });
+      }
+      return tabs;
     },
     copy() {
       return Copy;

--- a/viewer/vue-client/src/views/Find.vue
+++ b/viewer/vue-client/src/views/Find.vue
@@ -169,6 +169,9 @@ export default {
       if (this.$route.params.perimeter !== 'libris' && this.$route.params.perimeter !== 'remote') {
         this.$router.push({ path: '/search/' });
       }
+      if (!this.user.isLoggedIn && this.$route.params.perimeter === 'remote') {
+        this.$router.push({ path: '/search/' });
+      }
       this.query = this.$route.fullPath.split('?')[1];
       this.getResult();
       this.initialized = true;

--- a/viewer/vue-client/src/views/Find.vue
+++ b/viewer/vue-client/src/views/Find.vue
@@ -151,11 +151,17 @@ export default {
     ]),
     findTabs() {
       const tabs = [
-        { id: 'libris', text: StringUtil.getUiPhraseByLang('Libris', this.user.settings.language) },
+        { 
+          id: 'libris', 
+          text: StringUtil.getUiPhraseByLang('Libris', this.user.settings.language),
+        },
+        { 
+          id: 'remote', 
+          text: StringUtil.getUiPhraseByLang('Other sources', this.user.settings.language),
+          disabled: !this.user.isLoggedIn,
+          tooltipText: !this.user.isLoggedIn ? StringUtil.getUiPhraseByLang('You need to be logged in to perform this action', this.user.settings.language) : null,
+        },
       ];
-      if (this.user.isLoggedIn) {
-        tabs.push({ id: 'remote', text: StringUtil.getUiPhraseByLang('Other sources', this.user.settings.language) });
-      }
       return tabs;
     },
     copy() {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [ ] I have run the e2e test. `yarn test:e2e_ci` or `yarn test:e2e` (if you don't have a frontend, ask someone who does)
- [x] I have run the linter. `yarn lint`

## Description

Remote search should only be accessible for logged in users.

### Tickets involved
[LXL-2754](https://jira.kb.se/browse/LXL-2754)

### Summary of changes

When not logged in:
- prevent direct access to /search/remote
- hide remote search tab

### ToDo:

Desired behaviour is to disable the remote tab, showing an explainable tooltip on hover
Requires some work on TabMenu component

