### PR TITLE
terminology: replace "record" with "resource" in error page statuses

### DIFF
--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -203,6 +203,7 @@
     "This entity has active links": "Den här entiteten har aktiva länkningar",
     "The entity was removed": "Entiteten blev raderad",
     "The record": "Posten",
+    "The resource": "Resursen",
     "has been removed": "har blivit borttagen",
     "could not be found": "kunde inte hittas",
     "You have unsaved changes. Do you want to leave the page?": "Du har osparade ändringar. Vill du lämna sidan?",

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -730,10 +730,10 @@ export default {
       <div v-if="!postLoaded && loadFailure">
         <h2>{{loadFailure.status}}</h2>
         <p v-if="loadFailure.status === 404">
-          {{ 'The record' | translatePhrase }} <code>{{documentId}}</code> {{ 'could not be found' | translatePhrase}}.
+          {{ 'The resource' | translatePhrase }} <code>{{documentId}}</code> {{ 'could not be found' | translatePhrase}}.
         </p>
         <p v-if="loadFailure.status === 410">
-          {{ 'The record' | translatePhrase }} <code>{{documentId}}</code> {{ 'has been removed' | translatePhrase}}.
+          {{ 'The resource' | translatePhrase }} <code>{{documentId}}</code> {{ 'has been removed' | translatePhrase}}.
         </p>
         <router-link to="/">
           {{ 'Back to home page' | translatePhrase }}


### PR DESCRIPTION

Replaced "record"/"post" with a more general term "resource"/"resurs"  