### PR TITLE
Feature/lxl 2899 hover states

### DIFF
--- a/viewer/vue-client/src/components/inspector/entity-form.vue
+++ b/viewer/vue-client/src/components/inspector/entity-form.vue
@@ -194,31 +194,6 @@ export default {
     list-style: none;
     width: 100%;
     box-shadow: none;
-
-    &:hover {
-      & .icon:not(.is-disabled) {
-        color: @gray-dark-transparent;
-      }
-
-      &:not(.locked) >.actions {
-        opacity: 1;
-      }
-    }
-
-    .user-is-tabbing &:focus-within { // icon 'hover-effect' when tabbing 
-      & .icon:not(.is-disabled) {
-        color: @gray-dark-transparent;
-      }
-    }
-
-    & .icon {
-      color: @gray-light-transparent;
-
-      &:hover:not(.is-disabled),
-      &:focus {
-        color: @gray-very-dark-transparent;
-      }
-    }
   }
 
   &-item.is-distinguished {    

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -1023,7 +1023,7 @@ export default {
         color: @field-path-alt;
         position: absolute;
         left: 0px;
-        top: -1px;
+        top: 0px;
       }
     } 
 

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -539,6 +539,7 @@ export default {
       'Field--inner': !asColumns,
       'is-lastAdded': isLastAdded, 
       'is-removed': removed,
+      'is-locked': locked,
       'is-highlighted': embellished,
       'has-failed-validations': failedValidations.length > 0,
       'is-distinguished': isDistinguished,
@@ -883,6 +884,19 @@ export default {
     overflow: visible;
     display: block;
 
+    .icon-hover();
+        
+    &:hover {
+      background: @bg-site;
+      box-shadow: inset 0 0 0 1px @gray-lighter;
+    }
+
+    &.is-locked,
+    .Field--inner & {
+      background: none;
+      box-shadow: none;
+    }
+
     &.is-marked {
       background-color: @add;
     }
@@ -941,6 +955,8 @@ export default {
     &.is-hovered * {
       z-index: 1;
     }
+
+    .icon-hover();
 
     pre {
       margin-top: 5px;

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -389,26 +389,14 @@ export default {
       userStorage.copyClipboard = null;
       this.$store.dispatch('setUserStorage', userStorage);
     },
-    actionHighlight(active, event) {
+    highlight(active, event, cssClass) {
+      let item = event.target;
       if (active) {
-        let item = event.target;
         while ((item = item.parentElement) && !item.classList.contains('js-field'));
-        item.classList.add('is-marked');
+        item.classList.add(cssClass);
       } else {
-        let item = event.target;
         while ((item = item.parentElement) && !item.classList.contains('js-field'));
-        item.classList.remove('is-marked');
-      }
-    },
-    removeHighlight(active, event) {
-      if (active) {
-        let item = event.target;
-        while ((item = item.parentElement) && !item.classList.contains('js-field'));
-        item.classList.add('is-removeable');
-      } else {
-        let item = event.target;
-        while ((item = item.parentElement) && !item.classList.contains('js-field'));
-        item.classList.remove('is-removeable');
+        item.classList.remove(cssClass);
       }
     },
     removeThis() {
@@ -573,10 +561,10 @@ export default {
               tabindex="0"
               v-on:click="removeThis(true)"
               @keyup.enter="removeThis(true)"
-              @focus="removeHover = true, removeHighlight(true, $event)" 
-              @blur="removeHover = false, removeHighlight(false, $event)"
-              @mouseover="removeHover = true, removeHighlight(true, $event)" 
-              @mouseout="removeHover = false, removeHighlight(false, $event)">
+              @focus="removeHover = true, highlight(true, $event, 'is-removeable')" 
+              @blur="removeHover = false, highlight(false, $event, 'is-removeable')"
+              @mouseover="removeHover = true, highlight(true, $event, 'is-removeable')" 
+              @mouseout="removeHover = false, highlight(false, $event, 'is-removeable')">
               <tooltip-component 
                 :show-tooltip="removeHover" 
                 tooltip-text="Remove"></tooltip-component>
@@ -617,10 +605,10 @@ export default {
               :aria-label="'Paste entity' | translatePhrase"
               @click="pasteClipboardItem"
               @keyup.enter="pasteClipboardItem"
-              @focus="pasteHover = true, actionHighlight(true, $event)" 
-              @blur="pasteHover = false, actionHighlight(false, $event)"
-              @mouseover="pasteHover = true, actionHighlight(true, $event)" 
-              @mouseout="pasteHover = false, actionHighlight(false, $event)">
+              @focus="pasteHover = true, highlight(true, $event, 'is-marked')" 
+              @blur="pasteHover = false, highlight(false, $event, 'is-marked')"
+              @mouseover="pasteHover = true, highlight(true, $event, 'is-marked')" 
+              @mouseout="pasteHover = false, highlight(false, $event, 'is-marked')">
               <tooltip-component 
                 :show-tooltip="pasteHover" 
                 tooltip-text="Paste entity"></tooltip-component>
@@ -677,10 +665,10 @@ export default {
             :aria-label="'Remove' | translatePhrase"
             v-on:click="removeThis(true)"
             @keyup.enter="removeThis(true)"
-            @focus="removeHover = true, removeHighlight(true, $event)" 
-            @blur="removeHover = false, removeHighlight(false, $event)" 
-            @mouseover="removeHover = true, removeHighlight(true, $event)" 
-            @mouseout="removeHover = false, removeHighlight(false, $event)"  >
+            @focus="removeHover = true, highlight(true, $event, 'is-removeable')" 
+            @blur="removeHover = false, highlight(false, $event, 'is-removeable')" 
+            @mouseover="removeHover = true, highlight(true, $event, 'is-removeable')" 
+            @mouseout="removeHover = false, highlight(false, $event, 'is-removeable')">
             <tooltip-component
               :show-tooltip="removeHover" 
               tooltip-text="Remove"></tooltip-component>
@@ -695,10 +683,10 @@ export default {
             :aria-label="'Paste entity' | translatePhrase"
             @click="pasteClipboardItem"
             @keyup.enter="pasteClipboardItem"
-            @focus="pasteHover = true, actionHighlight(true, $event)" 
-            @blur="pasteHover = false, actionHighlight(false, $event)"
-            @mouseover="pasteHover = true, actionHighlight(true, $event)" 
-            @mouseout="pasteHover = false, actionHighlight(false, $event)">
+            @focus="pasteHover = true, highlight(true, $event, 'is-marked')" 
+            @blur="pasteHover = false, highlight(false, $event, 'is-marked')"
+            @mouseover="pasteHover = true, highlight(true, $event, 'is-marked')" 
+            @mouseout="pasteHover = false, highlight(false, $event, 'is-marked')">
             <tooltip-component 
               :show-tooltip="pasteHover" 
               tooltip-text="Paste entity"></tooltip-component>
@@ -934,8 +922,8 @@ export default {
       }
     }
   }
-
-    &-labelContainer {
+    
+  &-labelContainer {
     display: flex;
     flex: 0 0 225px;
     flex-direction: column;
@@ -1147,16 +1135,13 @@ export default {
     display: inline-block;
     margin-right: 5px;
   
-  &.placeholder {
-    width: 20px;
-    display: none;
+    &.placeholder {
+      width: 20px;
+      display: none;
 
-    @media (min-width: @screen-sm) {
-      display: block;
-    }
-  }
-
-    &:hover {
+      @media (min-width: @screen-sm) {
+        display: block;
+      }
     }
   }
 

--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -569,7 +569,7 @@ export default {
   position: relative;
   flex: 1 100%;
   transition: background-color .5s ease;
-  border-radius: 4px;
+  border-radius: 4px;  
 
   &.has-failed-validations {
     outline: 1px dotted red;
@@ -579,7 +579,9 @@ export default {
     display: block;
     flex: 1 100%;
     font-weight: normal;
-    position: relative;
+    position: relative;    
+
+    .icon-hover();
   }
 
   &-label {

--- a/viewer/vue-client/src/components/inspector/item-sibling.vue
+++ b/viewer/vue-client/src/components/inspector/item-sibling.vue
@@ -494,6 +494,8 @@ export default {
     flex: 1 100%;
     font-weight: normal;
     position: relative;
+
+    .icon-hover();
   }
 
   &-label {

--- a/viewer/vue-client/src/components/inspector/item-type.vue
+++ b/viewer/vue-client/src/components/inspector/item-type.vue
@@ -190,6 +190,8 @@ export default {
     margin-top: 0.2em;
     margin-right: 0.5em;
     display: inline-block;
+    border: 1px solid @gray-light;
+    background-color: @white;
     &:disabled {
       opacity: 0.7;
     }

--- a/viewer/vue-client/src/styles/_mixins.less
+++ b/viewer/vue-client/src/styles/_mixins.less
@@ -8,3 +8,30 @@
 .panel {
   .panel-mixin(@neutral-color);
 }
+
+.icon-hover {
+  &:hover {
+    & .icon:not(.is-disabled) {
+      color: @gray-dark-transparent;
+    }
+
+    &:not(.locked) >.actions {
+      opacity: 1;
+    }
+  }
+
+  .user-is-tabbing &:focus-within { // icon 'hover-effect' when tabbing 
+    & .icon:not(.is-disabled) {
+      color: @gray-dark-transparent;
+    }
+  }
+
+  & .icon {
+    color: @gray-light-transparent;
+
+    &:hover:not(.is-disabled),
+    &:focus {
+      color: @gray-very-dark-transparent;
+    }
+  }
+}


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [ ] I have run the e2e test. `yarn test:e2e_ci` or `yarn test:e2e` (if you don't have a frontend, ask someone who does)
- [x] I have run the linter. `yarn lint`

## Description

The UI needs more distinct hover states in order to emphasise the actions that apply to a certain part of the entity form.

### Tickets involved
[LXL-2875](https://jira.kb.se/browse/LXL-2875)

### Solves

Solves only the need for a different hover state behaviour (not the entire Jira ticket).

### Summary of changes

Added separate icon hover states for field, item-local and item-sibling
Inner field hover styling
item-type select has now more contrasting colors
