### PR TITLE
Feature/lxl 2899 hover states

### DIFF
--- a/viewer/vue-client/src/components/inspector/item-entity.vue
+++ b/viewer/vue-client/src/components/inspector/item-entity.vue
@@ -136,7 +136,7 @@ export default {
             <span v-if="(!isDistinguished || !expanded) && !isLibrisResource"><a :href="item['@id'] | convertResourceLink">{{getItemLabel}}</a></span>
             <span class="placeholder"></span></span>
           <div class="ItemEntity-removeButton chip-removeButton" v-if="!isLocked">
-            <i class="fa fa-times-circle icon icon--sm" 
+            <i class="fa fa-times-circle icon icon--sm chip-icon" 
               v-if="!isLocked"
               role="button"
               tabindex="0"

--- a/viewer/vue-client/src/components/inspector/item-vocab.vue
+++ b/viewer/vue-client/src/components/inspector/item-vocab.vue
@@ -185,6 +185,8 @@ export default {
   &-select {
     width: 100%;
     margin-top: 0.2em;
+    border: 1px solid @gray-light;
+    background-color: @white;
   }
 }
 

--- a/viewer/vue-client/src/styles/_mixins.less
+++ b/viewer/vue-client/src/styles/_mixins.less
@@ -11,7 +11,7 @@
 
 .icon-hover {
   &:hover {
-    & .icon:not(.is-disabled) {
+    & .icon:not(.chip-icon):not(.is-disabled) {
       color: @gray-dark-transparent;
     }
 
@@ -21,7 +21,7 @@
   }
 
   .user-is-tabbing &:focus-within { // icon 'hover-effect' when tabbing 
-    & .icon:not(.is-disabled) {
+    & .icon:not(.chip-icon):not(.is-disabled) {
       color: @gray-dark-transparent;
     }
   }

--- a/viewer/vue-client/src/styles/_variables.less
+++ b/viewer/vue-client/src/styles/_variables.less
@@ -124,7 +124,8 @@
 // CHIPS
 @chip-color: @link-color;
 @chip-color-hover: @link-hover-color;
-@chip-background: transparent;
+// @chip-background: transparent;
+@chip-background: @white;
 
 // SHADOWS
 @shadow-base: none;


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

Adjustments according to @mattiasbolin feedback.

### Tickets involved
[LXL-2899](https://jira.kb.se/browse/LXL-2899)

### Solves

Hover on field should highlight all of the icons in that field, except for chip close icon
Chip should have white background even when hovering a field it is contained in.

### Summary of changes

Exclude chip icon from hover rule.
Set white background on chip, instead of transparent.
