### PR TITLE
Add confirmation to play video from youtube

### DIFF
--- a/viewer/vue-client/src/components/search/link-card.vue
+++ b/viewer/vue-client/src/components/search/link-card.vue
@@ -1,5 +1,4 @@
 <script>
-import Button from '@/components/shared/button.vue';
 
 export default {
   name: 'link-card',
@@ -21,7 +20,7 @@ export default {
           show: false,
           styling: 'green',
           text: 'button',
-        }
+        },
       },
     };
   },
@@ -33,7 +32,6 @@ export default {
     },
   },
   components: {
-    'button-component': Button,
   },
   watch: {
   },

--- a/viewer/vue-client/src/components/search/link-card.vue
+++ b/viewer/vue-client/src/components/search/link-card.vue
@@ -59,7 +59,7 @@ export default {
         </div>
       </div>
       <div class="LinkCard-video Video" v-if="videoUrl.indexOf('youtube') ==! -1 || youtube.accepted">
-        <iframe :src="videoUrl" frameborder="0" allowfullscreen :title="header"></iframe>
+        <iframe :src="videoUrl" frameborder="0" allow="autoplay" allowfullscreen :title="header"></iframe>
       </div>
     </div> 
     <div class="LinkCard-content card-content">

--- a/viewer/vue-client/src/components/search/link-card.vue
+++ b/viewer/vue-client/src/components/search/link-card.vue
@@ -1,4 +1,6 @@
 <script>
+import Button from '@/components/shared/button.vue';
+
 export default {
   name: 'link-card',
   props: [
@@ -13,6 +15,14 @@ export default {
   data() {
     return {
       keyword: '',
+      youtube: {
+        accepted: false,
+        styling: {
+          show: false,
+          styling: 'green',
+          text: 'button',
+        }
+      },
     };
   },
   methods: {
@@ -23,6 +33,7 @@ export default {
     },
   },
   components: {
+    'button-component': Button,
   },
   watch: {
   },
@@ -39,7 +50,17 @@ export default {
     <img v-if="image" :src="resolvedImage" class="LinkCard-img" :alt="header"/>
 
     <div v-else-if="videoUrl" class="LinkCard-videoWrap">
-      <div class="LinkCard-video Video">
+      <div class="LinkCard-youtubeDialog" v-if="videoUrl.indexOf('youtube') > -1 && !youtube.accepted"
+                    @click="youtube.accepted = true"
+            @keyup.enter="youtube.accepted = true" tabindex="0">
+        <div>
+          <p>
+            Genom att spela våra instruktionsfilmer godkänner du cookies från YouTube
+          </p>
+          <i class="fa fa-3x fa-play"></i>
+        </div>
+      </div>
+      <div class="LinkCard-video Video" v-if="videoUrl.indexOf('youtube') ==! -1 || youtube.accepted">
         <iframe :src="videoUrl" frameborder="0" allowfullscreen :title="header"></iframe>
       </div>
     </div> 
@@ -76,6 +97,30 @@ export default {
     flex-shrink: 0; // Prevent weird image sizing behaviour in IE11
     border: solid #f1f1f1;
     border-width: 0px 0px 1px 0px;
+  }
+
+  &-youtubeDialog {
+    display: flex;
+    cursor: pointer;
+    background-color: rgb(36, 36, 36);
+    color: #ddd;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    height: 100%;
+    margin-bottom: -1px;
+    p {
+      font-size: 0.8em;
+    }
+    i {
+      &:hover {
+        color: rgb(170, 170, 170);
+      }
+    }
+    div {
+      flex-grow: 1;
+      text-align: center;
+    }
   }
 
   &-videoWrap {

--- a/viewer/vue-client/src/resources/json/copy.json
+++ b/viewer/vue-client/src/resources/json/copy.json
@@ -48,7 +48,7 @@
     "linkText": "Supportforum"
   },
   "instructional-videos": {
-    "video": "https://www.youtube-nocookie.com/embed/?listType=playlist&list=PLZVkEICvA5-GRT2oJQmLgq_2Pksx6zYPy&html5=1&rel=0&showinfo=0",
+    "video": "https://www.youtube-nocookie.com/embed/?listType=playlist&list=PLZVkEICvA5-GRT2oJQmLgq_2Pksx6zYPy&html5=1&rel=0&showinfo=0&autoplay=1",
     "header": "Instruktionsfilmer",
     "text": "För att underlätta katalogisering i XL producerar vi kontinuerligt instruktionsfilmer som vi lägger upp på Kungliga bibliotekets kanal på Youtube. Filmerna uppdateras vid förändringar och uppdateringar av de tjänster de visar. Navigera runt och titta på de filmer som stödjer ditt arbete i XL på bästa sätt.",
     "linkUrl": "https://www.youtube.com/watch?v=p2vcgoTfNpw&list=PLZVkEICvA5-GRT2oJQmLgq_2Pksx6zYPy",


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-2887](https://jira.kb.se/browse/LXL-2887)

### Solves

Even though we use the youtube-nocookie variant, youtube still saves some small cookies.

### Summary of changes

Add a confirmation box before autoplaying the video if the video has a youtube-url.
