### PR TITLE
Feature/lxl 2775 sort by reverse links

### DIFF
--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -9,6 +9,7 @@ import * as DisplayUtil from '@/utils/display';
 import * as StringUtil from '@/utils/string';
 import ToolTipComponent from '../shared/tooltip-component.vue';
 import PanelSearchList from '../search/panel-search-list.vue';
+import Sort from '@/components/search/sort';
 import PanelComponent from '@/components/shared/panel-component.vue';
 import ModalPagination from '@/components/inspector/modal-pagination.vue';
 import FilterSelect from '@/components/shared/filter-select.vue';
@@ -31,6 +32,7 @@ export default {
       active: false,
       currentPage: 0,
       maxResults: 20,
+      sort: '',
       isCompact: false,
     };
   },
@@ -110,6 +112,7 @@ export default {
     'filter-select': FilterSelect,
     'type-select': TypeSelect,
     'vue-simple-spinner': VueSimpleSpinner,
+    sort: Sort,
   },
   watch: {
     'inspector.event'(val) {
@@ -521,6 +524,7 @@ export default {
       }
       const offset = this.currentPage * this.maxResults;
       searchUrl += `&_limit=${this.maxResults}&_offset=${offset}`;
+      searchUrl += `&_sort=${this.sort}`;
       searchUrl = encodeURI(searchUrl);
       return new Promise((resolve, reject) => {
         fetch(searchUrl).then((response) => {
@@ -529,6 +533,11 @@ export default {
           reject('Error searching...', error);
         });
       });
+    },
+    setSort($event, keyword) {
+      this.sort = $event;
+
+      this.handleChange(keyword);
     },
   },
 };
@@ -634,15 +643,26 @@ export default {
                     autofocus />
                 </div>
                 <div class="EntityAdder-filterSearchContainer">
-                  <span class="EntityAdder-filterSearchLabel">{{ 'Show' | translatePhrase }}</span>
-                  <filter-select class="EntityAdder-filterSearchInput FilterSelect--openDown"
-                    :class-name="'js-filterSelect'"
-                    :custom-placeholder="filterPlaceHolder"
-                    :options="{ tree: selectOptions, priority: priorityOptions }"
-                    :options-all="allSearchTypes"
-                    :options-all-suggested="someValuesFrom"
-                    :is-filter="true"
-                    v-on:filter-selected="setFilter($event, keyword)"></filter-select>
+                  <div class="EntityAdder-filterSearchContainerItem">
+                    <filter-select class="EntityAdder-filterSearchInput FilterSelect--openDown"
+                      :class-name="'js-filterSelect'"
+                      :label="'Show' | translatePhrase"
+                      :custom-placeholder="filterPlaceHolder"
+                      :options="{ tree: selectOptions, priority: priorityOptions }"
+                      :options-all="allSearchTypes"
+                      :options-all-suggested="someValuesFrom"                    
+                      :is-filter="true"
+                      :styleVariant="'material'"
+                      v-on:filter-selected="setFilter($event, keyword)"></filter-select>
+                  </div>
+                  <div class="EntityAdder-filterSearchContainerItem">
+                    <sort
+                      :recordTypes="currentSearchTypes"
+                      :commonSort="true"
+                      :currentSort="''"
+                      :styleVariant="'material'"
+                      @change="setSort($event, keyword)" />
+                  </div>
                 </div>
               </div>
             </div>
@@ -764,9 +784,9 @@ export default {
 
 
   &-controls {
-    line-height: 1.2;
+    // line-height: 1.2;
     width: 100%;
-    margin: 0 0 0.7em 0;
+    margin: 0 0 0.5em 0;
   }
 
   &-controlForm {
@@ -792,8 +812,25 @@ export default {
 
   &-filterSearchContainer {
     width: 100%;
-    margin-top: 0.5em;
-    text-align: right;
+    display: flex;
+    flex-direction: column;
+
+    @media (min-width: @screen-xs) {
+      flex-direction: row;
+    }
+  }
+
+  &-filterSearchContainerItem {
+    width: 100%;
+    margin: 0.5em 1em 0 0;
+
+    @media (min-width: @screen-xs) {
+      width: 50%;
+    }
+
+    &:last-child {
+      margin-right: 0;
+    }
   }
 
   &-filterSearchLabel {
@@ -802,11 +839,12 @@ export default {
 
   &-filterSearchInput {
     position: relative;
-    width: 50%;
   }
 
   &-searchInput {
     color: @black;
+    background-color: @white;
+    border: 1px solid @gray-lighter;
   }
 
   &-searchSelect {

--- a/viewer/vue-client/src/components/inspector/search-window.vue
+++ b/viewer/vue-client/src/components/inspector/search-window.vue
@@ -535,16 +535,6 @@ export default {
     }
   }
 
-  &-input {
-    // color: @black;
-    // background-color: #fff;
-    // border: 1px solid @grey-lighter;
-    // &:focus {
-    //   border-color: @brand-primary;
-    // }
-  }
-
-
   &-filterSearchContainer {
     width: 100%;
     display: flex;

--- a/viewer/vue-client/src/components/inspector/search-window.vue
+++ b/viewer/vue-client/src/components/inspector/search-window.vue
@@ -7,6 +7,7 @@ import * as DisplayUtil from '@/utils/display';
 import * as VocabUtil from '@/utils/vocab';
 import PanelComponent from '@/components/shared/panel-component';
 import PanelSearchList from '@/components/search/panel-search-list';
+import Sort from '@/components/search/sort';
 import ModalPagination from '@/components/inspector/modal-pagination';
 import FilterSelect from '@/components/shared/filter-select.vue';
 import SummaryAction from './summary-action';
@@ -42,6 +43,7 @@ export default {
       active: false,
       currentPage: 0,
       maxResults: 20,
+      sort: '',
       isCompact: false,
     };
   },
@@ -107,6 +109,7 @@ export default {
     'modal-pagination': ModalPagination,
     'filter-select': FilterSelect,
     'vue-simple-spinner': VueSimpleSpinner,
+    sort: Sort,
   },
   watch: {
     keyword(value) {
@@ -226,6 +229,11 @@ export default {
       this.currentSearchTypes = valuesArray;
       this.handleChange(keyword);
     },
+    setSort($event, keyword) {
+      this.sort = $event;
+
+      this.handleChange(keyword);
+    },
     handleChange(value) {
       this.searchMade = false;
       if (value) {
@@ -323,6 +331,7 @@ export default {
       }
       const offset = this.currentPage * this.maxResults;
       searchUrl += `&_limit=${this.maxResults}&_offset=${offset}`;
+      searchUrl += `&_sort=${this.sort}`;
       searchUrl = encodeURI(searchUrl);
       return new Promise((resolve, reject) => {
         fetch(searchUrl).then((response) => {
@@ -395,15 +404,26 @@ export default {
                   :aria-label="'Search' | translatePhrase">
               </div>
               <div class="SearchWindow-filterSearchContainer">
-                <span class="SearchWindow-filterSearchLabel">{{ 'Show' | translatePhrase }}</span>
-                <filter-select class="SearchWindow-filterSearchInput FilterSelect--openDown"
-                  :class-name="'js-filterSelect'"
-                  :custom-placeholder="filterPlaceHolder"
-                  :options="{ tree: selectOptions, priority: priorityOptions }"
-                  :options-all="allSearchTypes"
-                  :options-all-suggested="someValuesFrom"
-                  :is-filter="true"
-                  v-on:filter-selected="setFilter($event, keyword)"></filter-select>
+                <div class="SearchWindow-filterSearchContainerItem">                
+                  <filter-select class="SearchWindow-filterSearchInput FilterSelect--openDown"
+                    :class-name="'js-filterSelect'"
+                    :label="'Show' | translatePhrase"
+                    :custom-placeholder="filterPlaceHolder"
+                    :options="{ tree: selectOptions, priority: priorityOptions }"
+                    :options-all="allSearchTypes"
+                    :options-all-suggested="someValuesFrom"
+                    :is-filter="true"
+                    :styleVariant="'material'"
+                    v-on:filter-selected="setFilter($event, keyword)"></filter-select>
+                </div>
+                <div class="SearchWindow-filterSearchContainerItem">
+                  <sort
+                    :recordTypes="currentSearchTypes"
+                    :currentSort="''"
+                    :commonSort="true"
+                    :styleVariant="'material'"
+                    @change="setSort($event, keyword)" />
+                </div>                
               </div>
             </div>
           </div>
@@ -460,22 +480,22 @@ export default {
             >
             </modal-pagination>
             <div class="SearchWindow-listTypes">
-              <i class="fa fa-th-list icon icon--sm"
+              <i class="fa fa-th-list icon icon--md"
                 role="button"
                 @click="isCompact = false"
                 @keyup.enter="isCompact = false"
                 :class="{'icon--primary' : !isCompact}"
                 :title="'Detailed view' | translatePhrase"
                 tabindex="0"></i>
-              <i class="fa fa-list icon icon--sm"
+              <i class="fa fa-list icon icon--md"
                 role="button"
                 @click="isCompact = true"
                 @keyup.enter="isCompact = true"
                 :class="{'icon--primary' : isCompact}"
                 :title="'Compact view' | translatePhrase"
                 tabindex="0"></i>
-              </div>
             </div>
+          </div>
           <div class="SearchWindow-footerContainer" v-if="itemInfo && extractable">
             <p class="preview-entity-text uppercaseHeading">{{ "Create link from local entity" | translatePhrase }}:</p>
             <div class="SearchWindow-summaryContainer">
@@ -516,28 +536,45 @@ export default {
   }
 
   &-input {
-    color: @black;
+    // color: @black;
+    // background-color: #fff;
+    // border: 1px solid @grey-lighter;
+    // &:focus {
+    //   border-color: @brand-primary;
+    // }
   }
 
 
   &-filterSearchContainer {
     width: 100%;
-    margin-top: 0.5em;
-    text-align: right;
+    display: flex;
+    flex-direction: column;
+
+    @media (min-width: @screen-xs) {
+      flex-direction: row;
+    }
   }
 
-  &-filterSearchLabel {
+  &-filterSearchContainerItem {
+    width: 100%;
+    margin: 0.5em 1em 0 0;
 
+    @media (min-width: @screen-xs) {
+      width: 50%;
+    }
+
+    &:last-child {
+      margin-right: 0;
+    }
   }
 
   &-filterSearchInput {
     position: relative;
-    width: 50%;
   }
 
   &-header {
     width: 100%;
-    margin: 0 0 0.7em 0;
+    margin: 0 0 0.5em 0;
   }
 
   &-inputContainer {
@@ -570,9 +607,9 @@ export default {
   &-listTypes {
     display: flex;
     justify-content: space-between;
-    height: 20px;
-    height: fit-content;
-    width: 45px;
+    align-items: center;
+    height: 54px;
+    width: 54px;
   }
 
   &-footerContainer {

--- a/viewer/vue-client/src/components/search/panel-search-item.vue
+++ b/viewer/vue-client/src/components/search/panel-search-item.vue
@@ -120,7 +120,7 @@ export default {
         @action="useItem()">
       </summary-action>
       <div 
-        class="PanelSearch-link-count"
+        class="PanelSearch-linkCount"
         :class="{'has-links' : reverseLinksAmount !== 0}"
         v-tooltip="{
           placement: 'right',
@@ -206,7 +206,7 @@ export default {
     flex-direction: column;
   }
 
-  &-link-count {
+  &-linkCount {
     border: 2px solid #29A1A2;
     width: 100%;
     text-align: center;
@@ -221,7 +221,8 @@ export default {
       color: @brand-primary;
     }
 
-    .is-added & {
+    .PanelComponent-listItem.is-added &,
+    .PanelComponent-listItem.is-replaced & {
       border-color: @gray-lighter;
     }
   }

--- a/viewer/vue-client/src/components/search/sort.vue
+++ b/viewer/vue-client/src/components/search/sort.vue
@@ -12,6 +12,14 @@ export default {
     currentSort: { // sortparam-value to set initial select option
       type: String,
     },
+    commonSort: {
+      type: Boolean,
+      default: false,
+    },
+    styleVariant: {
+      type: String,
+      default: '',
+    },
   },
   data() {
     return {
@@ -33,17 +41,17 @@ export default {
       const sortOptions = this.$store.getters.settings.sortOptions[this.commonBaseType];
       if (sortOptions) {
         return sortOptions;
-      }
+      }      
       return false;
     },
-    commonBaseType() {
+    commonBaseType() {      
       if (typeof this.recordTypes === 'string') {
         return VocabUtil.getRecordType(
           this.recordTypes,
           this.resources.vocab, 
           this.resources.context,
         );
-      }
+      }      
       if (Array.isArray(this.recordTypes)) {
         const baseTypes = this.recordTypes.reduce((accumulator, currType) => {
           const baseType = VocabUtil.getRecordType(currType, this.resources.vocab, this.resources.context);
@@ -55,7 +63,11 @@ export default {
         }, []);
         if (baseTypes.length === 1) { // same base class -> check sort options
           return baseTypes.join();
-        } return false; // different base classes -> disallow sort
+        } 
+        if (this.commonSort) {
+          return 'Common'; // different base classes -> fall back to a common sort definition
+        }
+        return false; // different base classes -> disallow sort
       }
       return false;
     },
@@ -74,8 +86,11 @@ export default {
 </script>
 
 <template>
-  <div class="Sort" v-if="options">
-    <label class="Sort-label" for="sort-select">{{ 'Sorting' | translatePhrase }}:</label>
+  <div 
+    class="Sort" 
+    :class="{ 'variantMaterial' : styleVariant === 'material' }"
+    v-if="options">
+    <label class="Sort-label" for="sort-select">{{ 'Sorting' | translatePhrase }}{{ styleVariant === 'material' ? '' : ':' }}</label>
     <select id="sort-select"
       class="Sort-select customSelect" 
       v-model="boundVal" 
@@ -96,13 +111,35 @@ export default {
   flex-wrap: nowrap;
   align-items: center;
 
+  &.variantMaterial {
+    flex-direction: column;
+    align-items: start;
+    position: relative;
+  }
+
   &-label {
     margin: 0 10px 10px 0;
     font-weight: 600;
+
+    .Sort.variantMaterial & {
+      position: absolute;
+      font-size: 1.2rem;
+      left: 1rem;
+      top: 0.4rem;
+      color: @brand-darker;
+    }
   }
   &-select {
     text-align: start;
     margin: 0 10px 10px 0;
+
+    .Sort.variantMaterial & {
+      margin: 0;
+      padding: 1.8rem 3.5rem 0 1rem;
+      background-color: @white;
+      border: 1px solid @gray-lighter;
+      line-height: 2.8rem;
+    }
   }
 }
 </style>

--- a/viewer/vue-client/src/components/shared/filter-select.vue
+++ b/viewer/vue-client/src/components/shared/filter-select.vue
@@ -38,6 +38,14 @@ export default {
       type: Boolean,
       default: true,
     },
+    styleVariant: {
+      type: String,
+      default: '',
+    },
+    label: {
+      type: String,
+      default: '',
+    },
   },
   data() {
     return {
@@ -208,81 +216,107 @@ export default {
 
 <template>
   <div class="FilterSelect" 
-    :class="className" 
+    :class="[{'variantMaterial' : styleVariant === 'material'}, className]" 
     v-on-clickaway="close"
     :tabindex="0"
     @keydown.space="preventBodyScroll"
     @keyup.space="focusOnInput">
-    <input class="FilterSelect-input js-filterSelectInput" 
-      type="text" 
-      v-bind:placeholder="translatedPlaceholder"
-      :aria-label="translatedPlaceholder"
-      @keyup.exact="filter()"
-      @keyup.space="checkInput($event)"
-      @click="filterVisible = !filterVisible"
-      ref="filterselectInput"
-      :tabindex="-1">
-    <ul class="FilterSelect-dropdown js-filterSelectDropdown"
-      :class="{'is-visible': filterVisible}" v-show="filterVisible">
-      <li class="FilterSelect-dropdownHeader" v-show="options.priority.length > 0">
-        {{ 'Suggested' | translatePhrase }}:
-      </li>
-      <li class="FilterSelect-dropdownItem js-filterSelectItem"
-        :class="{ 'is-abstract': option.abstract, 'is-concrete': !option.abstract }"
-        @click="selectOption"
-        @keyup.enter="selectOption"
-        v-for="option in options.priority"
-        :key="option">
-        <span class="FilterSelect-dropdownText js-filterSelectText" 
-          tabindex="-1"
-          :data-filter="option"
-          :data-abstract="option.abstract"
-          :data-key="option">{{ option | labelByLang }}</span >
-      </li>
-      <hr class="FilterSelect-dropdownDivider" v-show="options.priority.length > 0">
-      <li class="FilterSelect-dropdownHeader" v-show="options.tree.length > 0 && options.priority.length > 0">
-        {{ 'All' | translatePhrase }}:
-      </li>
-      <li class="FilterSelect-dropdownItem js-filterSelectItem"
-        :class="{ 'is-abstract': option.abstract && !isFilter, 'is-concrete': !option.abstract || isFilter }"
-        @click="selectOption"
-        @keyup.enter="selectOption"
-        v-for="option in options.tree"
-        :key="option.key">
-        <span class="FilterSelect-dropdownText js-filterSelectText" 
-          tabindex="-1"
-          :data-filter="option.value"
-          :data-abstract="option.abstract"
-          :data-key="option.key">{{ option.label }}</span>
-      </li>
-    </ul>
-    <i
-      class="fa icon icon--sm FilterSelect-open"
-      :class="{'fa-angle-up': filterVisible, 'fa-angle-down': !filterVisible}"
-      role="button"
-      :title="!filterVisible ? 'Expand' : 'Minimize' | translatePhrase"
-      @click="filterVisible = !filterVisible"
-      @keyup.enter="filterVisible = !filterVisible"></i>
-    <i v-if="isFilter"
-      class="fa fa-close icon icon--sm FilterSelect-clear"
-      :title="'Close' | translatePhrase"
-      role="button"
-      @click="clear()"
-      @keyup.enter="clear()"></i>
+    <label
+      class="FilterSelect-label" 
+      for="filterselectInput">{{ label }}{{ styleVariant !== 'material' && label ? ':' : '' }}</label>
+    <div class="FilterSelect-inputContainer">
+      <input class="FilterSelect-input js-filterSelectInput" 
+        type="text" 
+        v-bind:placeholder="translatedPlaceholder"
+        :aria-label="translatedPlaceholder"
+        @keyup.exact="filter()"
+        @keyup.space="checkInput($event)"
+        @click="filterVisible = !filterVisible"
+        ref="filterselectInput"
+        :tabindex="-1">
+      <ul class="FilterSelect-dropdown js-filterSelectDropdown"
+        :class="{'is-visible': filterVisible}" v-show="filterVisible">
+        <li class="FilterSelect-dropdownHeader" v-show="options.priority.length > 0">
+          {{ 'Suggested' | translatePhrase }}:
+        </li>
+        <li class="FilterSelect-dropdownItem js-filterSelectItem"
+          :class="{ 'is-abstract': option.abstract, 'is-concrete': !option.abstract }"
+          @click="selectOption"
+          @keyup.enter="selectOption"
+          v-for="option in options.priority"
+          :key="option">
+          <span class="FilterSelect-dropdownText js-filterSelectText" 
+            tabindex="-1"
+            :data-filter="option"
+            :data-abstract="option.abstract"
+            :data-key="option">{{ option | labelByLang }}</span >
+        </li>
+        <hr class="FilterSelect-dropdownDivider" v-show="options.priority.length > 0">
+        <li class="FilterSelect-dropdownHeader" v-show="options.tree.length > 0 && options.priority.length > 0">
+          {{ 'All' | translatePhrase }}:
+        </li>
+        <li class="FilterSelect-dropdownItem js-filterSelectItem"
+          :class="{ 'is-abstract': option.abstract && !isFilter, 'is-concrete': !option.abstract || isFilter }"
+          @click="selectOption"
+          @keyup.enter="selectOption"
+          v-for="option in options.tree"
+          :key="option.key">
+          <span class="FilterSelect-dropdownText js-filterSelectText" 
+            tabindex="-1"
+            :data-filter="option.value"
+            :data-abstract="option.abstract"
+            :data-key="option.key">{{ option.label }}</span>
+        </li>
+      </ul>
+      <i
+        class="FilterSelect-open"
+        :class="{'is-opened': filterVisible}"
+        role="button"
+        :title="!filterVisible ? 'Expand' : 'Minimize' | translatePhrase"
+        @click="filterVisible = !filterVisible"
+        @keyup.enter="filterVisible = !filterVisible"></i>
+
+      <i v-if="isFilter"
+        class="fa fa-close icon icon--sm FilterSelect-clear"
+        :title="'Close' | translatePhrase"
+        role="button"
+        @click="clear()"
+        @keyup.enter="clear()"></i>
+    </div>
   </div>
 </template>
 
 <style lang="less">
-.FilterSelect {
-  position: relative;
-  display: inline-block;
+.FilterSelect {  
+  display: flex;
   font-weight: normal;
   width: 100%;
   border-radius: 10px;
-  box-shadow: @shadow-panel;
   text-align: left;
 
+  &-inputContainer {
+    position: relative;
+    flex: 1;
+  }
+
+  &-label {
+    font-weight: normal;
+    margin: 3px 10px 0 0;
+
+    .FilterSelect.variantMaterial & {
+      position: absolute;
+      font-size: 1.2rem;
+      font-weight: 600;
+      left: 1rem;
+      top: 0.4rem;
+      color: @brand-darker;
+      z-index: 10;
+      margin: 0;
+    }
+  }
+
   &-input {
+    flex: 1;
     padding: 5px 40px 5px 10px;
     border: none;
     border-bottom: 1px solid #ddd;
@@ -291,12 +325,22 @@ export default {
     font-size: 1.6rem;
     width: 100%;
     height: 30px;
-    background-color: @white;
-    border: 1px solid @gray-light;
-    border-radius: 5px;
+    background-color: @white;    
     z-index: 2;
     position: relative;
     text-overflow: ellipsis;
+    border: 1px solid @gray-light;    
+    border-radius: 5px;
+    box-shadow: @shadow-panel;  
+
+    .FilterSelect.variantMaterial & {
+      box-shadow: none;
+      border-radius: 0.2em;
+      border: 1px solid @gray-lighter;
+      background-color: @white;
+      height: 4.8rem;
+      padding: 1.8rem 6rem 0 1rem;
+    }
 
     &::placeholder {
       color: @black;
@@ -319,7 +363,7 @@ export default {
     position: absolute;
     top: auto;
     min-width: 100%;
-    right: 0px;
+    left: 0px;
     bottom: 28px;
     background-color: @panel-header-bg;
     border: 1px solid @gray-light;
@@ -347,6 +391,11 @@ export default {
       border-radius: 10px;
       border-top-left-radius: 0;
       border-top-right-radius: 0;
+    }
+
+    .FilterSelect--openDown.variantMaterial & {
+      top: 5rem;
+      border-radius: 2px;
     }
   }
 
@@ -389,20 +438,43 @@ export default {
 
   &-clear,
   &-open {
-    position: absolute;
-    top: 7px;
-    right: 24px;
+    position: absolute;    
     cursor: pointer;
     z-index: 3;
     font-weight: 300;
+  }
+
+  &-clear {
+    top: 7px;
+    right: 24px;
+
+    .FilterSelect.variantMaterial & {
+      right: 34px;
+      top: 16px;
+    }
   }
 
   &-open {
     font-size: 18px;
     font-size: 1.8rem;
     font-weight: 700;
-    right: 8px;
-    top: 6px;
+    right: 6px;
+    top: 5px;
+    width: 20px;
+    height: 20px;
+    background-position: 5px center;
+    background-repeat: no-repeat;
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' height='10px' width='15px'%3E%3Ctext x='0' y='10' fill='gray'%3E%E2%96%BE%3C/text%3E%3C/svg%3E");
+
+    &.is-opened {
+      transform:rotate(180deg);
+      transform-origin: center;
+    }
+
+    .FilterSelect.variantMaterial & {
+      right: 10px;
+      top: 14px;
+    }
   }
 }
 </style>

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -312,6 +312,8 @@
     "Publication year (ascending)": "Utgivningsår (äldst först)",
     "Main title (A-Z)": "Huvudtitel (A-Ö)",
     "Main title (Z-A)": "Huvudtitel (Ö-A)",
+    "Most linked": "Mest länkad",
+    "Last updated": "Senast uppdaterad",
     "Preferred label": "Föredragen benämning",
     "Preferred label (A-Z)": "Föredragen benämning (A-Ö)",
     "Preferred label (Z-A)": "Föredragen benämning (Ö-A)",

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -311,6 +311,14 @@ const store = new Vuex.Store({
             query: '-hasTitle.mainTitle',
             label: 'Main title (Z-A)',
           },
+          {
+            query: '-meta.modified',
+            label: 'Last updated',
+          },
+          {
+            query: '-reverseLinks.totalItems',
+            label: 'Most linked',
+          },
         ],
         Concept: [
           {
@@ -338,6 +346,34 @@ const store = new Vuex.Store({
           {
             query: '-heldBy.@id',
             label: 'Sigel (Z-A)',
+          },
+        ],
+        Other: [
+          {
+            query: '',
+            label: 'Relevance',
+          },
+          {
+            query: '-meta.modified',
+            label: 'Last updated',
+          },
+          {
+            query: '-reverseLinks.totalItems',
+            label: 'Most linked',
+          },
+        ],
+        Common: [
+          {
+            query: '',
+            label: 'Relevance',
+          },
+          {
+            query: '-meta.modified',
+            label: 'Last updated',
+          },
+          {
+            query: '-reverseLinks.totalItems',
+            label: 'Most linked',
           },
         ],
       },


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

Add sort select to side panel search results.
Styling adjustments, new style of select / filter in side panel.

### Tickets involved
[LXL-2775](https://jira.kb.se/browse/LXL-2775)

### Solves

The need of sorting side panel search results by relevance/most linked/last updated

### Summary of changes

Added new styling to the Sort and Filter Select component, both have two different styles now, the default one and material design-ish one.

Side panel search is now using the Sort component from main search to sort results.
In the Sort component, added a boolean commonSort param to override which returns common search params even if search result items have different base classes.
