### PR TITLE
Feature/personalname template

### DIFF
--- a/viewer/vue-client/src/resources/json/combinedTemplates.json
+++ b/viewer/vue-client/src/resources/json/combinedTemplates.json
@@ -2300,11 +2300,7 @@
             "@id": "https://id.kb.se/language/swe"
           },
           "cataloguersNote": [""],
-          "sourceConsulted": [],
-          "marc:personalName": {
-            "@id": "https://id.kb.se/marc/DifferentiatedPersonalName"
-          }
-
+          "sourceConsulted": []
         },
         "mainEntity": {
           "@id": "https://id.kb.se/TEMPID#it",

--- a/viewer/vue-client/src/resources/json/combinedTemplates.json
+++ b/viewer/vue-client/src/resources/json/combinedTemplates.json
@@ -2326,8 +2326,7 @@
             "value": ""
           }],
           "nationality": [{
-            "@id": "https://id.kb.se/nationality/e-sw---",
-            "code": "e-sw---"
+            "@id": "https://id.kb.se/nationality/e-sw---"
           }]
         }
       }


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`
- [x] Locally linted.

## Description

### Tickets involved
[LXL-2813](https://jira.kb.se/browse/LXL-2813)

### Solves

Remove property marc:personalName on Person entities which is set automatically by conversion as per https://github.com/libris/librisxl/pull/536

(code property was only redundant and not really part of the solution of the ticket)

### Summary of changes

Remove properties from templates. 
