### PR TITLE
corrected translation string

### DIFF
--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -74,7 +74,7 @@ export default {
       this.$store.dispatch('setInspectorData', data);
       this.$store.dispatch('pushNotification', {
         type: 'success',
-        message: `${StringUtil.getUiPhraseByLang('Formulär uppdaterat, glöm inte att spara posten', this.user.settings.language)}`,
+        message: `${StringUtil.getUiPhraseByLang('Form updated, don\'t forget to save', this.user.settings.language)}`,
       });
     },
     shouldWarnOnUnload() {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

Stumbled upon this translation string, that should be in English.