### PR TITLE
Feature/lxl 3030 tab order

### DIFF
--- a/viewer/vue-client/src/App.vue
+++ b/viewer/vue-client/src/App.vue
@@ -18,7 +18,7 @@
             <p>Om felet kvarstår, kontakta <a href="mailto:libris@kb.se">libris@kb.se</a>.</p>
           </div>
         </div>
-        <router-view v-if="resourcesLoaded" />
+        <router-view ref="routerView" v-if="resourcesLoaded"></router-view>
     </main>
     <portal-target name="sidebar" multiple />
     <footer-component></footer-component>
@@ -53,7 +53,32 @@ export default {
       'status',
     ]),
   },
-  watch: {
+  watch: {    
+    '$route'(to, from) {
+      this.$nextTick(() => {
+        if (from.name !== null && to.name !== 'Search') {
+          setTimeout(() => {
+            // get component's "routeFocusTarget" ref
+            // if not existent, use router view container
+            const focusTarget = (this.$refs.routerView.$refs.componentFocusTarget !== undefined) 
+              ? this.$refs.routerView.$refs.componentFocusTarget
+              : this.$refs.routerView.$el;
+
+            // make focustarget programmatically focussable
+            focusTarget.setAttribute('tabindex', '-1');
+
+            // focus element
+            focusTarget.focus({
+              preventScroll: true,
+            });
+
+            // remove tabindex from focustarget. 
+            // reason: https://axesslab.com/skip-links/#update-3-a-comment-from-gov-uk
+            focusTarget.removeAttribute('tabindex');
+          }, 0);
+        }
+      });
+    },
   },
   methods: {
     disableDebugMode() {

--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -435,8 +435,8 @@ export default {
 
 <template>
   <div class="Toolbar" id="editor-container">
-    <input type="file" class="TemplatePicker" ref="TemplatePicker" accept=".jsonld,application/ld+json,text/*" aria-hidden="true"/>
-    <input type="file" class="OverridePicker" ref="OverridePicker" accept=".jsonld,application/ld+json,text/*" aria-hidden="true"/>
+    <input type="file" class="TemplatePicker" ref="TemplatePicker" accept=".jsonld,application/ld+json,text/*" tabindex="-1" aria-hidden="true"/>
+    <input type="file" class="OverridePicker" ref="OverridePicker" accept=".jsonld,application/ld+json,text/*" tabindex="-1" aria-hidden="true"/>
     <div class="dropdown Toolbar-menu OtherFormatMenu"
       v-if="!inspector.status.editing" 
       v-on-clickaway="hideOtherFormatMenu">

--- a/viewer/vue-client/src/views/DirectoryCare.vue
+++ b/viewer/vue-client/src/views/DirectoryCare.vue
@@ -126,33 +126,35 @@ export default {
 </script>
 
 <template>
-  <div class="DirectoryCare" v-if="fetchComplete">
-    <tab-menu @go="switchTool" :tabs="tabs" :active="$route.params.tool"></tab-menu>
-    <holding-mover 
-      v-if="$route.params.tool === 'holdings'"
-      :flaggedInstances="flaggedInstances"/>
-    <div class="" v-if="$route.params.tool === 'merge'">
-      <h1>merge posts</h1>
-      <!-- replace this whole div with the component -->
-    </div>
-    <modal-component 
-      v-if="showModal"
-      title="Directory care list adjusted" 
-      modal-type="info" 
-      @close="closeModal">
-      <div slot="modal-body" class="DirectoryCare-modalBody">
-        <p>{{ ['The following resources could not be retrieved', 
-          'because they no longer exist. They have been removed from the directory care list'] | translatePhrase }}:</p>
-        <ul>
-          <li v-for="error in errors.removed" :key="error['@id']">
-            {{error.label}}
-          </li>
-        </ul>
-        <div class="DirectoryCare-modalBtnContainer">
-          <button class="btn btn-primary btn--md" @click="closeModal">OK</button>
-        </div>
+  <div class="DirectoryCare">
+    <div v-if="fetchComplete">
+      <tab-menu @go="switchTool" :tabs="tabs" :active="$route.params.tool"></tab-menu>
+      <holding-mover 
+        v-if="$route.params.tool === 'holdings'"
+        :flaggedInstances="flaggedInstances"/>
+      <div class="" v-if="$route.params.tool === 'merge'">
+        <h1>merge posts</h1>
+        <!-- replace this whole div with the component -->
       </div>
-    </modal-component>
+      <modal-component 
+        v-if="showModal"
+        title="Directory care list adjusted" 
+        modal-type="info" 
+        @close="closeModal">
+        <div slot="modal-body" class="DirectoryCare-modalBody">
+          <p>{{ ['The following resources could not be retrieved', 
+            'because they no longer exist. They have been removed from the directory care list'] | translatePhrase }}:</p>
+          <ul>
+            <li v-for="error in errors.removed" :key="error['@id']">
+              {{error.label}}
+            </li>
+          </ul>
+          <div class="DirectoryCare-modalBtnContainer">
+            <button class="btn btn-primary btn--md" @click="closeModal">OK</button>
+          </div>
+        </div>
+      </modal-component>
+    </div>
   </div>
 </template>
 

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -750,6 +750,12 @@ export default {
 </script>
 <template>
   <div class="row">
+    <div v-if="postLoaded" class="col-12 col-sm-12" :class="{'col-md-1 col-md-offset-11': !status.panelOpen, 'col-md-5 col-md-offset-7': status.panelOpen }">
+      <div class="Toolbar-placeholder" ref="ToolbarPlaceholder"></div>
+      <div class="Toolbar-container" ref="ToolbarTest">
+        <toolbar></toolbar>
+      </div>
+    </div>
     <div class="Inspector col-sm-12" :class="{'col-md-11': !status.panelOpen, 'col-md-7': status.panelOpen, 'hideOnPrint': marcPreview.active}" ref="Inspector">
       <div v-if="!postLoaded && loadFailure">
         <h2>{{loadFailure.status}}</h2>
@@ -787,12 +793,6 @@ export default {
           :is-main-entity-form="tab.id === 'mainEntity'"
           :locked="!inspector.status.editing">
         </entity-form>
-      </div>
-    </div>
-    <div v-if="postLoaded" class="col-12 col-sm-12" :class="{'col-md-1': !status.panelOpen, 'col-md-5': status.panelOpen }">
-      <div class="Toolbar-placeholder" ref="ToolbarPlaceholder"></div>
-      <div class="Toolbar-container" ref="ToolbarTest">
-        <toolbar></toolbar>
       </div>
     </div>
     <portal to="sidebar" v-if="marcPreview.active">


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Tab focus ending up in footer when navigating between routes.
Example: Navigate from search results to a post.

### Tickets involved
[LXL-3030](https://jira.kb.se/browse/LXL-3030)

### Solves

Tab navigation issues, specifically when navigating from search results to a single post.

### Summary of changes

Added negative tabindex to file input in Toolbar 

Placed Toolbar before Inspector in HTML, in order to get the tab order right

Added Bootstrap classes to "offset" Toolbar in order to keep it in the same position in the layout

in App.js, added a watch on $route, setting tabindex and focus to router-view when route changes

added a wrapper div in DirectoreCare to prevent the focus thing from throwing an error because of content not yet rendered

