### PR TITLE
show reverse links amount on instance

### DIFF
--- a/viewer/vue-client/src/components/inspector/reverse-relations.vue
+++ b/viewer/vue-client/src/components/inspector/reverse-relations.vue
@@ -82,14 +82,20 @@ export default {
           // Sort panel query by alphabetical order of sigel id
           this.panelQuery._sort = 'heldBy.@id';
         }
-        HttpUtil.getRelatedPosts(query, this.settings.apiPath)
-          .then((response) => {
-            this.relationInfo = response.items;
-            this.numberOfRelations = response.totalItems;
-            this.checkingRelations = false;
-          }, (error) => {
-            console.log('Error checking for relations', error);
-          });
+
+        if (this.mainEntity.reverseLinks && this.recordType === 'Instance') {
+          this.numberOfRelations = this.mainEntity.reverseLinks.totalItems;
+          this.checkingRelations = false;
+        } else {
+          HttpUtil.getRelatedPosts(query, this.settings.apiPath)
+            .then((response) => {
+              this.relationInfo = response.items;
+              this.numberOfRelations = response.totalItems;
+              this.checkingRelations = false;
+            }, (error) => {
+              console.log('Error checking for relations', error);
+            });
+        }
       }, timeoutLength);
     },
     gotoHolding() {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

For now, show reverseLinks for type Instance

### Tickets involved
[LXL-2929](https://jira.kb.se/browse/LXL-2929)

### Solves

Performance improvement (less calls to server)

### Summary of changes

Checking if mainEntity has reverseLinks and recordType is Instance, then show the amount
If false, do the o-query as usual
