### PR TITLE
Convert to array if not array on target obj property

### DIFF
--- a/viewer/vue-client/src/components/care/detailed-enrichment.vue
+++ b/viewer/vue-client/src/components/care/detailed-enrichment.vue
@@ -75,7 +75,10 @@ export default {
         if (isArray(this.source[this.existingKeys[i]])) {
           // Case for arrays
           const nodeSourceArray = this.source[this.existingKeys[i]];
-          const nodeTargetArray = this.target[this.existingKeys[i]];
+          let nodeTargetArray = this.target[this.existingKeys[i]];
+          if (isArray(nodeTargetArray) === false) {
+            nodeTargetArray = [nodeTargetArray];
+          }
           for (let x = 0; x < nodeSourceArray.length; x++) {
             // Loop over a value that is an array
             const nodeValue = nodeSourceArray[x];


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

### Tickets involved
[LXL-3041](https://jira.kb.se/browse/LXL-3041)

### Solves

When comparing for diffs, the detailed enrichment function will crash altogether when values are different data types (in this case array vs object).
Example:
Target: cvnkvtsp5mw6z7h
Source: vc534w6631h7tdf

### Summary of changes

Before comparing arrays, make sure both are arrays.