### PR TITLE
Feature/update edition statement templates

### DIFF
--- a/viewer/vue-client/src/resources/json/combinedTemplates.json
+++ b/viewer/vue-client/src/resources/json/combinedTemplates.json
@@ -243,7 +243,7 @@
             "value": "",
             "qualifier": ""
           }],
-          "editionStatement": "",
+          "editionStatement": [""],
           "publication": [
             {
               "@type": "PrimaryPublication",
@@ -658,7 +658,7 @@
             }
           ],
           "marc:otherPhysicalDetails": "",
-          "editionStatement": "",
+          "editionStatement": [""],
           "accompaniedBy": [
             {
               "@type": "Instance",
@@ -806,7 +806,7 @@
             }
           ],
           "responsibilityStatement": "",
-          "editionStatement": "",
+          "editionStatement": [""],
           "publication": [
             {
               "@type": "PrimaryPublication",
@@ -983,7 +983,7 @@
             "value": "",
             "qualifier": ""
           }],
-          "editionStatement": "",
+          "editionStatement": [""],
           "publication": [],
           "marc:primaryProvisionActivity": {
             "@type": "PrimaryPublication",
@@ -1183,7 +1183,7 @@
             "value": "",
             "qualifier": ""
           }],
-          "editionStatement": "",
+          "editionStatement": [""],
           "publication": [
             {
               "@type": "PrimaryPublication",
@@ -1498,8 +1498,8 @@
               }
             }
           ],
-          "editionStatement": "",
-          "editionStatementRemainder": "",
+          "editionStatement": [""],
+          "editionStatementRemainder": [""],
           "marc:otherPhysicalDetails": "",
           "publication": [
             {

--- a/viewer/vue-client/src/resources/json/combinedTemplates.json
+++ b/viewer/vue-client/src/resources/json/combinedTemplates.json
@@ -2401,7 +2401,6 @@
         "mainEntity": {
           "@id": "https://id.kb.se/TEMPID#it",
           "@type": "Geographic",
-          "@id": "https://id.kb.se/TEMPID#it",
           "inScheme": {
             "@id": "https://id.kb.se/term/sao"
           },


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

- Due to changes of mapping of bib 250 we now need to make editionStatement and editionStatementRemainer repeatable.

- Also removes duplicate @id in Geographic template.

### Tickets involved
[LXL-3040](https://jira.kb.se/browse/LXL-3040)

### Other PR involved
https://github.com/libris/definitions/pull/186

### Summary of changes
Updates occurrences of editionStatement and editionStatementRemainer in templates.
