### PR TITLE
[LXL-2821] Sort in user language

### DIFF
--- a/viewer/vue-client/src/components/create/creation-card.vue
+++ b/viewer/vue-client/src/components/create/creation-card.vue
@@ -23,8 +23,8 @@ export default {
     setIndex() {
       this.$emit('set-active-index', this.index);
     },
-    getFormattedSelectOption(term, settings, vocab, context) {
-      return DisplayUtil.getFormattedSelectOption(term, settings, vocab, context);
+    getLabelWithTreeDepth(term, settings, vocab, context) {
+      return DisplayUtil.getLabelWithTreeDepth(term, settings, vocab, context);
     },
   },
   computed: {
@@ -64,7 +64,7 @@ export default {
             :value="term.id" 
             :key="index" 
             :disabled="term.abstract"
-            v-html="getFormattedSelectOption(term, settings, resources.vocab, resources.context)">
+            v-html="getLabelWithTreeDepth(term, settings, resources.vocab, resources.context)">
           </option>
         </select>
       </div>

--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -170,7 +170,7 @@ export default {
         const term = {};
         term.depth = classTree[i].depth;
         term.abstract = classTree[i].abstract;
-        term.label = this.getFormattedSelectOption(classTree[i]);
+        term.label = this.getLabelWithTreeDepth(classTree[i]);
         term.value = classTree[i].id;
         term.key = `${classTree[i].id}-${i}`;
         options.push(term);
@@ -285,8 +285,8 @@ export default {
         item.classList.remove('is-marked');
       }
     },
-    getFormattedSelectOption(term) {
-      return DisplayUtil.getFormattedSelectOption(
+    getLabelWithTreeDepth(term) {
+      return DisplayUtil.getLabelWithTreeDepth(
         term, 
         this.settings, 
         this.resources.vocab, 

--- a/viewer/vue-client/src/components/inspector/item-type.vue
+++ b/viewer/vue-client/src/components/inspector/item-type.vue
@@ -49,8 +49,8 @@ export default {
     },
   },
   methods: {
-    getFormattedSelectOption(term) {
-      return DisplayUtil.getFormattedSelectOption(term, this.settings, this.resources.vocab, this.resources.context);
+    getLabelWithTreeDepth(term) {
+      return DisplayUtil.getLabelWithTreeDepth(term, this.settings, this.resources.vocab, this.resources.context);
     },
     unlockEdit() {
       this.unlockedByUser = true;
@@ -118,7 +118,7 @@ export default {
           :value="term.id"
           :key="index"
           :disabled="term.abstract"
-          v-html="getFormattedSelectOption(term, settings, resources.vocab, resources.context)"
+          v-html="getLabelWithTreeDepth(term, settings, resources.vocab, resources.context)"
           ></option>
       </select>
       <div class="ItemType-actions">

--- a/viewer/vue-client/src/components/inspector/search-window.vue
+++ b/viewer/vue-client/src/components/inspector/search-window.vue
@@ -161,7 +161,7 @@ export default {
         const term = {};
         term.depth = classTree[i].depth;
         term.abstract = classTree[i].abstract;
-        term.label = this.getFormattedSelectOption(classTree[i]);
+        term.label = this.getLabelWithTreeDepth(classTree[i]);
         term.value = classTree[i].id;
         term.key = `${classTree[i].id}-${i}`;
         options.push(term);
@@ -203,8 +203,8 @@ export default {
     extract() {
       this.$emit('extract');
     },
-    getFormattedSelectOption(term) {
-      return DisplayUtil.getFormattedSelectOption(
+    getLabelWithTreeDepth(term) {
+      return DisplayUtil.getLabelWithTreeDepth(
         term, 
         this.settings, 
         this.resources.vocab, 

--- a/viewer/vue-client/src/components/shared/filter-select.vue
+++ b/viewer/vue-client/src/components/shared/filter-select.vue
@@ -74,6 +74,9 @@ export default {
     },
   },
   methods: {
+    getLabelWithTreeDepth(term) {
+      return DisplayUtil.getLabelWithTreeDepth(term, this.settings, this.resources.vocab, this.resources.context);
+    },
     preventBodyScroll(e) {
       const keys = this.keyEnums;
       if ([
@@ -257,6 +260,8 @@ export default {
             :data-filter="option"
             :data-abstract="option.abstract"
             :data-key="option">{{ option | labelByLang }}</span >
+            v-html="getLabelWithTreeDepth(option, settings, resources.vocab, resources.context)"
+            ></span>
         </li>
         <hr class="FilterSelect-dropdownDivider" v-show="options.priority.length > 0">
         <li class="FilterSelect-dropdownHeader" v-show="options.tree.length > 0 && options.priority.length > 0">
@@ -273,6 +278,8 @@ export default {
             :data-filter="option.value"
             :data-abstract="option.abstract"
             :data-key="option.key">{{ option.label }}</span>
+            v-html="getLabelWithTreeDepth(option, settings, resources.vocab, resources.context)"
+            ></span>
         </li>
       </ul>
       <i

--- a/viewer/vue-client/src/components/shared/filter-select.vue
+++ b/viewer/vue-client/src/components/shared/filter-select.vue
@@ -74,9 +74,6 @@ export default {
     },
   },
   methods: {
-    getLabelWithTreeDepth(term) {
-      return DisplayUtil.getLabelWithTreeDepth(term, this.settings, this.resources.vocab, this.resources.context);
-    },
     preventBodyScroll(e) {
       const keys = this.keyEnums;
       if ([

--- a/viewer/vue-client/src/components/shared/filter-select.vue
+++ b/viewer/vue-client/src/components/shared/filter-select.vue
@@ -259,9 +259,7 @@ export default {
             tabindex="-1"
             :data-filter="option"
             :data-abstract="option.abstract"
-            :data-key="option">{{ option | labelByLang }}</span >
-            v-html="getLabelWithTreeDepth(option, settings, resources.vocab, resources.context)"
-            ></span>
+            :data-key="option">{{ option | labelByLang }}</span>
         </li>
         <hr class="FilterSelect-dropdownDivider" v-show="options.priority.length > 0">
         <li class="FilterSelect-dropdownHeader" v-show="options.tree.length > 0 && options.priority.length > 0">
@@ -278,8 +276,6 @@ export default {
             :data-filter="option.value"
             :data-abstract="option.abstract"
             :data-key="option.key">{{ option.label }}</span>
-            v-html="getLabelWithTreeDepth(option, settings, resources.vocab, resources.context)"
-            ></span>
         </li>
       </ul>
       <i

--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -324,7 +324,7 @@ export function getItemSummary(item, displayDefs, quoted, vocab, settings, conte
   return summary;
 }
 
-export function getFormattedSelectOption(term, settings, vocab, context) {
+export function getLabelWithTreeDepth(term, settings, vocab, context) {
   const maxLength = 43;
   let labelByLang = StringUtil.getLabelByLang(term.id, settings.language, vocab, context);
   if (labelByLang.length > maxLength) {

--- a/viewer/vue-client/src/utils/vocab.js
+++ b/viewer/vue-client/src/utils/vocab.js
@@ -1,4 +1,4 @@
-import { isObject, uniq, isArray, find, each, isPlainObject, cloneDeep, uniqBy, forOwn } from 'lodash-es';
+import { isObject, uniq, isArray, find, sortBy, each, isPlainObject, cloneDeep, uniqBy, forOwn } from 'lodash-es';
 import * as httpUtil from '@/utils/http';
 import * as StringUtil from '@/utils/string';
 
@@ -573,6 +573,7 @@ export function getTree(term, vocab, context, counter = 0, parentChainString = '
   const termObj = getTermObject(term, vocab, context);
   const treeNode = {
     id: term,
+    labels: termObj.labelByLang,
     sub: [],
     abstract: isAbstract(termObj, vocab, context),
     depth: counter,
@@ -588,10 +589,16 @@ export function getTree(term, vocab, context, counter = 0, parentChainString = '
 }
 
 export function flattenTree(termArray, vocab, context, language) {
-  return termArray.reduce((acc, current) => acc.concat(
-    [current],
-    flattenTree(current.sub, vocab, context, language),
-  ), []);
+  const flat = termArray.reduce((acc, current) => {
+    const sortedSub = sortBy(current.sub, (o) => {
+      return o.labels[language];
+    })
+    return acc.concat(
+      [current],
+      flattenTree(sortedSub, vocab, context, language),
+    )
+  }, []);
+  return flat;
 }
 
 export function printTree(term, vocab, context) {

--- a/viewer/vue-client/src/utils/vocab.js
+++ b/viewer/vue-client/src/utils/vocab.js
@@ -590,13 +590,11 @@ export function getTree(term, vocab, context, counter = 0, parentChainString = '
 
 export function flattenTree(termArray, vocab, context, language) {
   const flat = termArray.reduce((acc, current) => {
-    const sortedSub = sortBy(current.sub, (o) => {
-      return o.labels[language];
-    })
+    const sortedSub = sortBy(current.sub, o => o.labels[language]);
     return acc.concat(
       [current],
       flattenTree(sortedSub, vocab, context, language),
-    )
+    );
   }, []);
   return flat;
 }


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-2821](https://jira.kb.se/browse/LXL-2821)

### Solves

Sorts the type-select in the users language instead of just english.

### Summary of changes

* When accumulating sub-classes of a term, sort the list of subclasses before returning them.
* Renamed utility function `getFormattedSelectOption` to `getLabelWithTreeDepth`
