### PR TITLE
Show tags/hashes in version indicator

### DIFF
--- a/viewer/vue-client/package.json
+++ b/viewer/vue-client/package.json
@@ -28,6 +28,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-vue": "^6.1.2",
     "font-awesome": "4.7.0",
+    "git-describe": "^4.0.4",
     "kungbib-styles": "^1.3.3",
     "less": "^3.10.3",
     "less-loader": "^4.1.0",

--- a/viewer/vue-client/src/components/layout/search-bar.vue
+++ b/viewer/vue-client/src/components/layout/search-bar.vue
@@ -20,6 +20,12 @@ export default {
       'settings',
       'user',
     ]),
+    version() {
+      return this.settings.gitInfo.tag !== 'null' ? this.settings.gitInfo.tag : this.settings.gitInfo.hash;
+    },
+    versionInfo() {
+      return `${this.environmentLabel.toUpperCase()} ${this.version}`;
+    },
     environmentLabel() {
       if (this.settings.environment !== 'prod') {
         return this.settings.environment;
@@ -40,10 +46,10 @@ export default {
           <router-link to="/" class="SearchBar-brandLink">
             <img class="SearchBar-brandLogo" src="~kungbib-styles/dist/assets/kb_logo_black.svg" alt="Kungliga Bibliotekets logotyp">
           </router-link>
-          <router-link to="/" class="SearchBar-brandTitle" :title="`Version ${settings.version}`">
+          <router-link to="/" class="SearchBar-brandTitle" :title="`Version ${version}`">
             <span id="service-name">{{ settings.title }}</span>
             <span class="SearchBar-envLabel">
-            {{ environmentLabel }} {{ settings.version }}
+            {{ versionInfo }}
             </span>
           </router-link>
         </div>
@@ -149,7 +155,6 @@ export default {
     font-weight: bold;
     float: right;
     margin: -1em 0px 0px 0em;
-    text-transform: uppercase;
   }
 }
 

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -86,6 +86,10 @@ const store = new Vuex.Store({
       language: 'sv',
       environment: process.env.VUE_APP_ENV_LABEL || 'local',
       version: process.env.VUE_APP_VERSION,
+      gitInfo: {
+        tag: process.env.VUE_APP_GIT_TAG,
+        hash: process.env.VUE_APP_GIT_HASH,
+      },
       dataPath: process.env.VUE_APP_DATA_PATH || process.env.VUE_APP_API_PATH,
       apiPath: process.env.VUE_APP_API_PATH,
       authPath: process.env.VUE_APP_AUTH_PATH,

--- a/viewer/vue-client/vue.config.js
+++ b/viewer/vue-client/vue.config.js
@@ -1,7 +1,8 @@
 const path = require('path');
 const webpack = require('webpack');
-const {gitDescribe, gitDescribeSync} = require('git-describe');
+const { gitDescribeSync } = require('git-describe');
 process.env.VUE_APP_VERSION = require('./package.json').version;
+
 process.env.VUE_APP_GIT_TAG = gitDescribeSync().tag;
 process.env.VUE_APP_GIT_HASH = gitDescribeSync().hash;
 

--- a/viewer/vue-client/vue.config.js
+++ b/viewer/vue-client/vue.config.js
@@ -1,6 +1,9 @@
 const path = require('path');
 const webpack = require('webpack');
+const {gitDescribe, gitDescribeSync} = require('git-describe');
 process.env.VUE_APP_VERSION = require('./package.json').version;
+process.env.VUE_APP_GIT_TAG = gitDescribeSync().tag;
+process.env.VUE_APP_GIT_HASH = gitDescribeSync().hash;
 
 module.exports = {
   publicPath: '/katalogisering/',

--- a/viewer/vue-client/yarn.lock
+++ b/viewer/vue-client/yarn.lock
@@ -4681,6 +4681,15 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-describe@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/git-describe/-/git-describe-4.0.4.tgz#f3d55bce309becf6dc27fed535d380a621967e8c"
+  integrity sha512-L1X9OO1e4MusB4PzG9LXeXCQifRvyuoHTpuuZ521Qyxn/B0kWHWEOtsT4LsSfSNacZz0h4ZdYDsDG7f+SrA3hg==
+  dependencies:
+    lodash "^4.17.11"
+  optionalDependencies:
+    semver "^5.6.0"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
To clarify what version is run on different environments, this change will make the version-indicator in the header show the tag if on a tag, and the (short) commit hash if not on a tag.

### Tickets involved
None

### Summary of changes

* Added package git-describe
* Changed the info shown in the header
