### PR TITLE
Fix sorting issue with terms without labels

### DIFF
--- a/viewer/vue-client/src/utils/vocab.js
+++ b/viewer/vue-client/src/utils/vocab.js
@@ -590,9 +590,7 @@ export function getTree(term, vocab, context, counter = 0, parentChainString = '
 
 export function flattenTree(termArray, vocab, context, language) {
   const flat = termArray.reduce((acc, current) => {
-    const sortedSub = sortBy(current.sub, (o) => {
-      return o.labels && o.labels[language]
-    });
+    const sortedSub = sortBy(current.sub, o => o.labels && o.labels[language]);
     return acc.concat(
       [current],
       flattenTree(sortedSub, vocab, context, language),

--- a/viewer/vue-client/src/utils/vocab.js
+++ b/viewer/vue-client/src/utils/vocab.js
@@ -573,7 +573,7 @@ export function getTree(term, vocab, context, counter = 0, parentChainString = '
   const termObj = getTermObject(term, vocab, context);
   const treeNode = {
     id: term,
-    labels: termObj.labelByLang,
+    labels: termObj.labelByLang || termObj.prefLabelByLang,
     sub: [],
     abstract: isAbstract(termObj, vocab, context),
     depth: counter,
@@ -590,7 +590,9 @@ export function getTree(term, vocab, context, counter = 0, parentChainString = '
 
 export function flattenTree(termArray, vocab, context, language) {
   const flat = termArray.reduce((acc, current) => {
-    const sortedSub = sortBy(current.sub, o => o.labels[language]);
+    const sortedSub = sortBy(current.sub, (o) => {
+      return o.labels && o.labels[language]
+    });
     return acc.concat(
       [current],
       flattenTree(sortedSub, vocab, context, language),


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

### Tickets involved
None

### Solves
Fixes the sorting crashing when there is no label on the term being sorted.

### Summary of changes
* Allow it to check prefLabel as well as label (was only label before)
* Check for existance of label in sort, otherwise sort at end
