### PR TITLE
LXL-3071 - Fix type changer not appearing where expected

### DIFF
--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -465,12 +465,7 @@ export default {
           '@id': this.user.getActiveLibraryUri(),
         };
       }
-
-      if (this.path === 'mainEntity.instanceOf') {
-        this.addSibling(obj);
-      } else {
-        this.addItem(obj);
-      }
+      this.addItem(obj);
     },
     addType(typeId) {
       const shortenedType = StringUtil.convertToPrefix(typeId, this.resources.context);

--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -1,5 +1,5 @@
 <script>
-import { each, cloneDeep, get } from 'lodash-es';
+import { cloneDeep, get } from 'lodash-es';
 import { mixin as clickaway } from 'vue-clickaway';
 import { mapGetters } from 'vuex';
 import * as httpUtil from '@/utils/http';
@@ -147,7 +147,8 @@ export default {
       const itemKeys = Object.keys(this.item);
       if (itemKeys.length > 1) {
         return false;
-      } else if (itemKeys.length === 1 && this.showTypeChanger) {
+      }
+      if (itemKeys.length === 1 && this.showTypeChanger) {
         return false;
       }
       return true;

--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -144,16 +144,13 @@ export default {
       return this.item;
     },
     isEmpty() {
-      let bEmpty = true;
-      // Check if item has any keys besides @type and _uid. If not, we'll consider it empty.
-      each(this.item, (value, key) => {
-        if (key !== '@type' && key !== '_uid') {
-          if (typeof value !== 'undefined') {
-            bEmpty = false;
-          }
-        }
-      });
-      return bEmpty;
+      const itemKeys = Object.keys(this.item);
+      if (itemKeys.length > 1) {
+        return false;
+      } else if (itemKeys.length === 1 && this.showTypeChanger) {
+        return false;
+      }
+      return true;
     },
     isLastAdded() {
       if (this.inspector.status.lastAdded === this.getPath) {

--- a/viewer/vue-client/src/components/mixins/form-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/form-mixin.vue
@@ -34,13 +34,10 @@ export default {
       return VocabUtil.getRecordType(this.formType, this.resources.vocab, this.resources.context);
     },
     showTypeChanger() {
-      if (typeof this.item !== 'undefined' && this.inspector.data.work && this.item['@id'] === this.inspector.data.work['@id']) {
+      if (this.recordType === 'Work' || this.recordType === 'Instance' || this.isMainEntityForm) {
         return true;
       }
-      if (this.isMainEntityForm === false || this.isHolding || this.recordType === 'Concept' || this.recordType === 'Other') {
-        return false;
-      }
-      return true;
+      return false;
     },
     filteredItem() {
       const fItem = cloneDeep(this.sortedFormData);


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3071](https://jira.kb.se/browse/LXL-3071)

### Solves

Fixes a problem where the type changer component wouldn't be shown in local entities.

### Summary of changes

- Changed the condition for when to show the type changer (`item-type`)
- Changed the condition for when a local entity is considered "empty", allowed it to take the above condition in consideration (ie if the type changer is shown, count @type as a field, if not then don't).
- Fixed so that siblings are never added in the gui, only tolerated.