### PR TITLE
Handle null mappings in marcframe view

### DIFF
--- a/viewer/templates/marcframeview.html
+++ b/viewer/templates/marcframeview.html
@@ -200,7 +200,7 @@
       <tr>
         <th><div id="${cat}-${tag}-${key}">${key}</div></th>
         <td>
-          % for k, v in sorted((subdfn or {'': 'ignored'}).items())
+          % for k, v in sorted((subdfn or {'ignored': True}).items())
             % if not k.startswith('TODO') and v
               <i>${k}</i>: ${show_value(cat, key, k, v)}
               <br />

--- a/viewer/templates/marcframeview.html
+++ b/viewer/templates/marcframeview.html
@@ -154,7 +154,8 @@
 % endblock
 
 % macro show_value(cat, tag_or_code, key, value)
-  % if (not isinstance(value, unicode) or not value.startswith(('@', '_'))
+  % if (key.startswith('TODO'))
+  % elif (not isinstance(value, unicode) or not value.startswith(('@', '_'))
       ) and not isinstance(value, bool) and key in (
         'aboutType', 'link', 'addLink', 'property', 'addProperty', 'resourceType')
     <a href="/vocab/#${value}" class="${key}">${value}</a>
@@ -169,21 +170,23 @@
   % elif isinstance(value, dict)
     <table class="table table-condensed table-striped">
         % for key, val in sorted(value.items())
-        <tr>
-            <th>${key}</th>
-            <td>
-              % if isinstance(val, dict)
-                % for k, v in sorted(val.items())
-                  % if not k.startswith('TODO:')
-                  <i>${k}</i>: ${show_value(cat, key, k, v)}
-                  <br />
-                  % endif
-                % endfor
-              % else
-                ${show_value(None, None, key, val)}
-              % endif
-            </td>
-        </tr>
+          % if not key.startswith('TODO')
+          <tr>
+              <th>${key}</th>
+              <td>
+                % if isinstance(val, dict)
+                  % for k, v in sorted(val.items())
+                    % if not k.startswith('TODO')
+                    <i>${k}</i>: ${show_value(cat, key, k, v)}
+                    <br />
+                    % endif
+                  % endfor
+                % else
+                  ${show_value(None, None, key, val)}
+                % endif
+              </td>
+          </tr>
+          % endif
         % endfor
     </table>
   % else
@@ -197,8 +200,8 @@
       <tr>
         <th><div id="${cat}-${tag}-${key}">${key}</div></th>
         <td>
-          %for k, v in sorted((subdfn or {'': 'ignored'}).items())
-            % if not k.startswith('TODO:') and v
+          % for k, v in sorted((subdfn or {'': 'ignored'}).items())
+            % if not k.startswith('TODO') and v
               <i>${k}</i>: ${show_value(cat, key, k, v)}
               <br />
             % endif

--- a/viewer/templates/marcframeview.html
+++ b/viewer/templates/marcframeview.html
@@ -197,7 +197,7 @@
       <tr>
         <th><div id="${cat}-${tag}-${key}">${key}</div></th>
         <td>
-          % for k, v in sorted(subdfn.items())
+          %for k, v in sorted((subdfn or {'': 'ignored'}).items())
             % if not k.startswith('TODO:') and v
               <i>${k}</i>: ${show_value(cat, key, k, v)}
               <br />


### PR DESCRIPTION
### Solves
https://jira.kb.se/browse/LXL-3084

Handles fields mapped to null in marcframe view template. Template would throw on these resulting in HTTP 500.

example marcframe.json
```
"Multimedia": {
        "[18] [19] [20] [21]": null,
``` 

Also hides some more instances of "TODO" in the marcframe view.