### PR TITLE
encode additional characters in order to sync with backend encoded uris

### DIFF
--- a/viewer/vue-client/src/utils/uriminter.js
+++ b/viewer/vue-client/src/utils/uriminter.js
@@ -7,6 +7,12 @@ function asArray(value) {
   return value != null ? [value] : [];
 }
 
+// Additional encoding for following special chars: []()!'*
+// in order to sync with backend encoded uris
+function fixedEncodeURIComponent(str) {
+  return encodeURIComponent(str).replace(/[!'()*]/g, c => `%${c.charCodeAt(0).toString(16)}`);
+}
+
 export default class URIMinter {
   constructor(containers) {
     this.containerMap = {};
@@ -71,7 +77,7 @@ export default class URIMinter {
       throw new Error(`Missing slugProperty ${container.slugProperty} for ${mainEntity[ID]}`);
     }
 
-    const uri = container[ID] + encodeURIComponent(slugValue);
+    const uri = container[ID] + fixedEncodeURIComponent(slugValue);
 
     let sameAs = mainEntity.sameAs ? asArray(mainEntity.sameAs) : [];
     if (!sameAs.find(it => it[ID] === mainEntity[ID])) {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Frontend encoded uris does not match backend encoded uris, ie. parantheses () not being encoded to %28 %29 with the standard javascript method encodeURIComponent.
This fixes this problem.

### Tickets involved
[LXL-3066](https://jira.kb.se/browse/LXL-3066)

### Solves

Encode following special chars: [!'()*] 

### Summary of changes

Added a wrapper function that encodes additional special characters.
