### PR TITLE
[LXL-3113] Filter templates with "draft" status, move template storage into store

### DIFF
--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -316,6 +316,7 @@ export default {
     ...mapGetters([
       'inspector',
       'resources',
+      'templates',
       'user',
       'settings',
       'status',
@@ -350,9 +351,8 @@ export default {
     },
     validTemplates() {
       const type = this.inspector.data.mainEntity['@type'];
-      const CombinedTemplates = require('@/resources/json/combinedTemplates');
       const baseType = VocabUtil.getRecordType(type, this.resources.vocab, this.resources.context);
-      const templates = VocabUtil.getValidTemplates(type, CombinedTemplates[baseType.toLowerCase()], this.resources.vocabClasses, this.resources.context);
+      const templates = VocabUtil.getValidTemplates(type, this.templates[baseType.toLowerCase()], this.resources.vocabClasses, this.resources.context);
       return templates;
     },
     formObj() {

--- a/viewer/vue-client/src/main.js
+++ b/viewer/vue-client/src/main.js
@@ -172,6 +172,7 @@ new Vue({
   mounted() {
     this.$nextTick(() => {
       this.verifyConfig();
+      this.loadTemplates();
       window.addEventListener('focus', () => {
         this.syncUserStorage();
       });
@@ -286,6 +287,13 @@ new Vue({
       }, (error) => {
         console.log(error);
       });
+    },
+    loadTemplates() {
+      const templates = {
+        base: require('@/resources/json/baseTemplates'),
+        combined: require('@/resources/json/combinedTemplates'),
+      };
+      store.dispatch('setTemplates', templates);
     },
     getLdDependencies() {
       const promiseArray = [];

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import { cloneDeep, each, set, get, assign } from 'lodash-es';
+import { cloneDeep, each, set, get, assign, filter } from 'lodash-es';
 import * as VocabUtil from '@/utils/vocab';
 import * as StringUtil from '@/utils/string';
 import * as User from '@/models/user';
@@ -16,6 +16,7 @@ const store = new Vuex.Store({
       vocab: {},
       display: {},
       context: {},
+      templates: {},
       helpDocs: null,
     },
     directoryCare: {
@@ -602,6 +603,9 @@ const store = new Vuex.Store({
     setVocabClasses(state, data) {
       state.resources.vocabClasses = data;
     },
+    setTemplates(state, data) {
+      state.resources.templates = data;
+    },
     setContext(state, data) {
       state.resources.context = data;
     },
@@ -620,6 +624,7 @@ const store = new Vuex.Store({
     resources: state => state.resources,
     resourcesLoaded: state => state.resources.resourcesLoaded,
     resourcesLoadingError: state => state.resources.loadingError,
+    templates: state => state.resources.templates,
     settings: state => state.settings,
     user: state => state.user,
     userStorage: state => state.userStorage,
@@ -854,6 +859,22 @@ const store = new Vuex.Store({
     },
     setDirectoryCare({ commit }, obj) {
       commit('setDirectoryCare', obj);
+    },
+    setTemplates({ commit }, data) {
+      const templates = {
+        base: data.base,
+        combined: {},
+      };
+      const combinedBaseTypes = Object.keys(data.combined);
+      for (let i = 0; i < combinedBaseTypes.length; i++) {
+        templates.combined[combinedBaseTypes[i]] = filter(data.combined[combinedBaseTypes[i]], (o) => {
+          if (o.hasOwnProperty('status') && o.status === 'draft') {
+            return false;
+          }
+          return true;
+        });
+      }
+      commit('setTemplates', templates);
     },
     setHelpDocs({ commit }, helpDocsJson) {
       commit('setHelpDocs', helpDocsJson);

--- a/viewer/vue-client/src/views/Create.vue
+++ b/viewer/vue-client/src/views/Create.vue
@@ -1,6 +1,7 @@
 <script>
 import { sortBy } from 'lodash-es';
 import { mixin as clickaway } from 'vue-clickaway';
+import { mapGetters } from 'vuex';
 import * as RecordUtil from '@/utils/record';
 import * as VocabUtil from '@/utils/vocab';
 import CreationCard from '@/components/create/creation-card';
@@ -34,7 +35,7 @@ export default {
     },
     useBase(type) {
       this.chosenType = type;
-      const BaseTemplates = require('@/resources/json/baseTemplates');
+      const BaseTemplates = this.templates.base;
       const baseRecord = Object.assign(this.baseRecord, BaseTemplates[this.selectedCreation.toLowerCase()].record);
       const baseMainEntity = Object.assign(this.baseMainEntity, BaseTemplates[this.selectedCreation.toLowerCase()].mainEntity);
       const templateValue = {
@@ -91,6 +92,11 @@ export default {
   events: {
   },
   computed: {
+    ...mapGetters([
+      'settings',
+      'user',
+      'templates',
+    ]),
     creationList() {
       const list = [
         { id: 'Instance', text: 'Instance' },
@@ -131,8 +137,8 @@ export default {
       return baseRecord;
     },
     combinedTemplates() {
-      const CombinedTemplates = require('@/resources/json/combinedTemplates');
-      return sortBy(CombinedTemplates[this.selectedCreation.toLowerCase()], template => template.label);
+      const sorted = sortBy(this.templates.combined[this.selectedCreation.toLowerCase()], template => template.label);
+      return sorted;
     },
     hasChosen() {
       return this.activeIndex > 0 || (this.activeIndex === 0 && this.chosenType);


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Allow authors of templates to set `status: draft` on templates which will hide them from use in UI.

### Tickets involved
[LXL-3113](https://jira.kb.se/browse/LXL-3113)

### Summary of changes
- Added filtering of `status`  property on templates.
- Moved the import of template json to store.