### PR TITLE
Feature/lxl 3083 header remake

### DIFF
--- a/viewer/vue-client/src/components/layout/navbar.vue
+++ b/viewer/vue-client/src/components/layout/navbar.vue
@@ -106,6 +106,7 @@ export default {
         <tab-menu
           :tabs="tabs"
           :active="$route.name"
+          :class="'extra-spacing'"
           @go="navigate"
           :link="true"
           lookStyle="dark"
@@ -278,11 +279,8 @@ export default {
   }
 
   & .TabMenu {
-
-    &-tabList {
-      margin-bottom: 0;
-      margin-top: 0;
-    }
+    margin-bottom: 0;
+    margin-top: 0;
   }
 }
 

--- a/viewer/vue-client/src/components/layout/navbar.vue
+++ b/viewer/vue-client/src/components/layout/navbar.vue
@@ -96,57 +96,56 @@ export default {
 <template>
   <nav class="NavBar" id="NavBar" aria-labelledby="service-name">
     <div class="NavBar-container container">
-      <div class="row">
-        <div class="NavBar-brand col-xs-2 col-sm-1 hidden-md hidden-lg">
-          <router-link to="/" class="NavBar-brandLink">
-            <img class="NavBar-brandLogo" src="~kungbib-styles/dist/assets/kb_logo_white.svg" alt="Kungliga Bibliotekets logotyp">
-          </router-link>
-        </div>
-        <div class="MainNav col-xs-8 col-sm-7 col-md-6">
-          <tab-menu
-            :tabs="tabs"
-            :active="$route.name"
-            @go="navigate"
-            :link="true"
-            lookStyle="dark"
-            />
-        </div>
-        <ul class="MainNav-userWrapper col-xs-2 col-xs-push-0 col-sm-push-0 col-sm-4 col-md-4 col-md-push-2">
-          <li 
-            class="MainNav-item" 
-            :class="{ 'active': showUserMenu && !isUserPage, 'highlight': highlightNavItem && !isUserPage }" 
-            @mouseover="highlightNavItem = true"
-            @mouseleave="highlightNavItem = false"
-            @focus="highlightNavItem = true"
-            @blur="highlightNavItem = false"
-            v-if="user.isLoggedIn"
-            v-tooltip="tooltipOptions" >
-            <div tabindex="0" @click="toggleUserMenu" @keyup.enter="toggleUserMenu">
-              <user-avatar 
-                class="hidden-xs" 
-                :highlight="highlightNavItem && !isUserPage"
-                :size="30" />
-              <user-avatar 
-                class="visible-xs-block" 
-                :highlight="highlightNavItem && !isUserPage"
-                :size="32" />
-              <span class="MainNav-linkText userName hidden-sm">
-              {{ user.fullName }} <span v-cloak class="sigelLabel">({{ user.settings.activeSigel }})</span>
-              </span>
-              <i class="fa fa-fw hidden-xs" :class="{ 'fa-caret-down': !isUserPage, 'active': showUserMenu }"></i>
-            </div>
-            <user-settings 
-              v-if="showUserMenu && !isUserPage" 
-              compact 
-              v-on-clickaway="hideUserMenu" />
-          </li>
-          <li class="MainNav-item" v-if="!user.isLoggedIn">
-            <a :href="`${settings.apiPath}/login/authorize`" class="MainNav-link">
-              <span class="MainNav-linkText">{{"Log in" | translatePhrase}}</span>
-            </a>
-          </li>
-        </ul>
+      
+      <div class="NavBar-brand">
+        <router-link to="/" class="NavBar-brandLink">
+          <img class="NavBar-brandLogo" src="~kungbib-styles/dist/assets/kb_logo_white.svg" alt="Kungliga Bibliotekets logotyp">
+        </router-link>
       </div>
+      <div class="MainNav">
+        <tab-menu
+          :tabs="tabs"
+          :active="$route.name"
+          @go="navigate"
+          :link="true"
+          lookStyle="dark"
+          />
+      </div>
+      <ul class="MainNav-userWrapper">
+        <li 
+          class="MainNav-item" 
+          :class="{ 'active': showUserMenu && !isUserPage, 'highlight': highlightNavItem && !isUserPage }" 
+          @mouseover="highlightNavItem = true"
+          @mouseleave="highlightNavItem = false"
+          @focus="highlightNavItem = true"
+          @blur="highlightNavItem = false"
+          v-if="user.isLoggedIn"
+          v-tooltip="tooltipOptions" >
+          <div tabindex="0" @click="toggleUserMenu" @keyup.enter="toggleUserMenu">
+            <user-avatar 
+              class="hidden-xs" 
+              :highlight="highlightNavItem && !isUserPage"
+              :size="30" />
+            <user-avatar 
+              class="visible-xs-block" 
+              :highlight="highlightNavItem && !isUserPage"
+              :size="32" />
+            <span class="MainNav-linkText userName hidden-sm">
+            {{ user.fullName }} <span v-cloak class="sigelLabel">({{ user.settings.activeSigel }})</span>
+            </span>
+            <i class="fa fa-fw hidden-xs" :class="{ 'fa-caret-down': !isUserPage, 'active': showUserMenu }"></i>
+          </div>
+          <user-settings 
+            v-if="showUserMenu && !isUserPage" 
+            compact 
+            v-on-clickaway="hideUserMenu" />
+        </li>
+        <li class="MainNav-item" v-if="!user.isLoggedIn">
+          <a :href="`${settings.apiPath}/login/authorize`" class="MainNav-link">
+            <span class="MainNav-linkText">{{"Log in" | translatePhrase}}</span>
+          </a>
+        </li>
+      </ul>
     </div>
   </nav>
 </template>
@@ -165,8 +164,11 @@ export default {
     line-height: unset;
   }
 
-  &-brand {
-    height: 100%;
+  &-brand {    
+    margin-right: 2rem;
+    @media screen and (min-width: @screen-sm) {
+      display: none;
+    }
   }
   &-brandLink {
     height: 100%;
@@ -185,6 +187,7 @@ export default {
     }
   }
   &-container {
+    display: flex;
     padding: 0 25px;
     height: 100%;
     @media screen and (max-width: @screen-lg){

--- a/viewer/vue-client/src/components/shared/tab-menu.vue
+++ b/viewer/vue-client/src/components/shared/tab-menu.vue
@@ -82,9 +82,10 @@ export default {
           for (let i = 0; i < listElements.length; i++) {
             listWidth += listElements[i].clientWidth;
           }
+          
           const paddingLeft = parseInt(window.getComputedStyle($activeTab).paddingLeft.replace('px', ''));
           const paddingRight = parseInt(window.getComputedStyle($activeTab).paddingRight.replace('px', ''));
-          const left = `${parseInt((listWidth * -1) + $activeTab.offsetLeft + paddingLeft + 5)}px`;
+          const left = `${$activeTab.offsetLeft + paddingLeft}px`;
           const width = `${parseInt($activeTab.clientWidth - (paddingLeft + paddingRight))}px`;
           $underline.style.width = width;
           $underline.style.left = left;
@@ -151,8 +152,7 @@ export default {
           <i v-if="item.icon" class="TabMenu-tabIcon visible-xs-block" :class="`fa fa-fw fa-${item.icon}`"></i>
           <span class="TabMenu-tabText" :class="{'hidden-xs': item.icon }" v-if="item.html" v-html="item.html"></span>
           <span class="TabMenu-tabText" :class="{'hidden-xs': item.icon }" v-else>{{item.text | translatePhrase}}</span>
-      </li>
-      <hr v-show="hasActive" class="TabMenu-underline" ref="underline">
+      </li>      
     </ul>
     <ul v-else class="TabMenu-tabList" ref="tablist">
       <li class="TabMenu-tab" 
@@ -173,8 +173,8 @@ export default {
           </router-link>
           <span v-if="item.badge" class="badge UserCare-badge" :class="'badge-' + item.badge.type">{{ item.badge.value }}</span>
       </li>
-      <hr v-show="hasActive" class="TabMenu-underline hidden-xs" ref="underline">
     </ul>
+    <hr v-show="hasActive" class="TabMenu-underline" :class="{'hidden-xs' : hasIcons}" ref="underline">
   </div>
 </template>
 
@@ -185,6 +185,7 @@ export default {
   opacity: 1;
   transition: opacity 0.25s ease;
   position: relative;
+  margin: 10px 0;
 
   &-link,
   &-tabText {
@@ -269,6 +270,9 @@ export default {
       &.has-badge {
         padding-right: 30px;
       }
+      .TabMenu.extra-spacing & {
+        padding: 0 20px;
+      }
     }
 
     .badge {
@@ -292,10 +296,14 @@ export default {
   }
 
   &-tabList {
-    margin: 10px 0 10px -10px;    
+    margin: 0 0 0 -10px;    
     height: 100%;
     padding: 0;
     white-space: nowrap;
+
+    .TabMenu.extra-spacing & {
+      margin-left: -20px;
+    }
 
     @media screen and (max-width: @screen-sm) {
       .has-icons & {
@@ -305,11 +313,12 @@ export default {
   }
 
   &-underline {
+    position: absolute;
     display: inline-block;
-    transition: all 0.25s ease .025s;
-    position: relative;
+    transition: all 0.25s ease .025s;    
     height: 3px;
-    top: 0.5em;
+    left: 0;
+    bottom: 8px;
     margin: 0px;
     min-width: 5px;
     border: none;

--- a/viewer/vue-client/src/components/shared/tab-menu.vue
+++ b/viewer/vue-client/src/components/shared/tab-menu.vue
@@ -76,13 +76,7 @@ export default {
         const $activeTab = this.$el.querySelector('.is-active');
         const $tabList = this.$refs.tablist;
         if ($activeTab && $tabList) {
-          const $underline = this.$refs.underline;
-          const listElements = $tabList.getElementsByTagName('li');
-          let listWidth = 0;
-          for (let i = 0; i < listElements.length; i++) {
-            listWidth += listElements[i].clientWidth;
-          }
-          
+          const $underline = this.$refs.underline;          
           const paddingLeft = parseInt(window.getComputedStyle($activeTab).paddingLeft.replace('px', ''));
           const paddingRight = parseInt(window.getComputedStyle($activeTab).paddingRight.replace('px', ''));
           const left = `${$activeTab.offsetLeft + paddingLeft}px`;


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Bugfix and minor refactoring of tabMenu component

### Tickets involved
[LXL-3083](https://jira.kb.se/browse/LXL-3083)

### Solves
Bug caused by Bootstrap classes resulting in navbar items overlapping on a smaller screen
A need for extra spacing between items in tabMenu
Adjusting how underline calculation works with and without extra spacing

### Summary of changes
removed Bootstrap grid classes from navbar, in order 
added extra-spacing class which can be passed to tabMenu to increase spacing between items
moved underline outside of ul as it was non-valid html
changed how underline position is calculated
