### PR TITLE
3126 Digital Reproduction flow

### DIFF
--- a/viewer/vue-client/src/App.vue
+++ b/viewer/vue-client/src/App.vue
@@ -18,7 +18,7 @@
             <p>Om felet kvarstår, kontakta <a href="mailto:libris@kb.se">libris@kb.se</a>.</p>
           </div>
         </div>
-        <router-view ref="routerView" v-if="resourcesLoaded"></router-view>
+        <router-view ref="routerView" v-if="resourcesLoaded" v-show="status.loadingIndicators.length === 0"></router-view>
     </main>
     <portal-target name="sidebar" multiple />
     <footer-component></footer-component>

--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -516,7 +516,7 @@ export default {
         </li>
         <li class="Toolbar-menuItem" v-if="user.isLoggedIn && !inspector.status.editing && isSubClassOf('Instance') && !isSubClassOf('Electronic')">
           <a class="Toolbar-menuLink"  @click="postControl('create-digital-reproduction'), hideToolsMenu()">
-          <i class="fa fa-fw fa-files-o"></i>
+          <i class="fa fa-fw fa-wpforms"></i>
           {{ "Create digital reproduction" | translatePhrase }}{{ getKeybindText('create-digital-reproduction') ? ` (${getKeybindText('create-digital-reproduction')})` : ''}}
           </a>
         </li>

--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -514,7 +514,7 @@ export default {
           {{ "Make copy" | translatePhrase }}{{ getKeybindText('duplicate-item') ? ` (${getKeybindText('duplicate-item')})` : ''}}
           </a>
         </li>
-        <li class="Toolbar-menuItem" v-if="user.isLoggedIn && !inspector.status.editing && !isSubClassOf('Item')">
+        <li class="Toolbar-menuItem" v-if="user.isLoggedIn && !inspector.status.editing && isSubClassOf('Instance')">
           <a class="Toolbar-menuLink"  @click="postControl('create-digital-reproduction'), hideToolsMenu()">
           <i class="fa fa-fw fa-files-o"></i>
           {{ "Create digital reproduction" | translatePhrase }}{{ getKeybindText('create-digital-reproduction') ? ` (${getKeybindText('create-digital-reproduction')})` : ''}}

--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -514,6 +514,12 @@ export default {
           {{ "Make copy" | translatePhrase }}{{ getKeybindText('duplicate-item') ? ` (${getKeybindText('duplicate-item')})` : ''}}
           </a>
         </li>
+        <li class="Toolbar-menuItem" v-if="user.isLoggedIn && !inspector.status.editing && !isSubClassOf('Item')">
+          <a class="Toolbar-menuLink"  @click="postControl('create-digital-reproduction'), hideToolsMenu()">
+          <i class="fa fa-fw fa-files-o"></i>
+          {{ "Create digital reproduction" | translatePhrase }}{{ getKeybindText('create-digital-reproduction') ? ` (${getKeybindText('create-digital-reproduction')})` : ''}}
+          </a>
+        </li>
         <li class="Toolbar-menuItem" :class="{'is-active': showEmbellishTemplateSubMenu}" v-if="user.isLoggedIn && inspector.status.editing">
           <a class="Toolbar-menuLink" @click="showEmbellishTemplateSubMenu = !showEmbellishTemplateSubMenu">
             <i class="fa fa-fw fa-clipboard"></i>

--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -514,7 +514,7 @@ export default {
           {{ "Make copy" | translatePhrase }}{{ getKeybindText('duplicate-item') ? ` (${getKeybindText('duplicate-item')})` : ''}}
           </a>
         </li>
-        <li class="Toolbar-menuItem" v-if="user.isLoggedIn && !inspector.status.editing && isSubClassOf('Instance')">
+        <li class="Toolbar-menuItem" v-if="user.isLoggedIn && !inspector.status.editing && isSubClassOf('Instance') && !isSubClassOf('Electronic')">
           <a class="Toolbar-menuLink"  @click="postControl('create-digital-reproduction'), hideToolsMenu()">
           <i class="fa fa-fw fa-files-o"></i>
           {{ "Create digital reproduction" | translatePhrase }}{{ getKeybindText('create-digital-reproduction') ? ` (${getKeybindText('create-digital-reproduction')})` : ''}}

--- a/viewer/vue-client/src/resources/json/combinedTemplates.json
+++ b/viewer/vue-client/src/resources/json/combinedTemplates.json
@@ -196,6 +196,7 @@
     "digitizedMonographText": {
       "label": "Digitaliserad bok",
       "description": "Elektroniskt reproducerad monografi - RDA",
+      "key": "digitizedMonographText",
       "value": {
         "record": {
           "@id": "https://id.kb.se/TEMPID",

--- a/viewer/vue-client/src/resources/json/display.json
+++ b/viewer/vue-client/src/resources/json/display.json
@@ -3,18 +3,14 @@
   "@context": "/context.jsonld",
   "@graph": [
     {
-      "@id": "https://libris.kb.se/00nj5pg324f356g2",
-      "created": "2019-03-01T21:47:09.064+01:00",
+      "@id": "https://libris.kb.se/00nj5pg320rmk5gx",
+      "@type": "Record",
+      "created": "2020-04-29T16:15:28.88+02:00",
       "mainEntity": {
         "@id": "https://id.kb.se/vocab/display"
       },
-      "modified": "2019-03-01T21:47:09.064+01:00",
-      "recordStatus": "marc:New",
-      "sameAs": [
-        {
-          "@id": "https://id.kb.se/vocab/display.jsonld"
-        }
-      ]
+      "modified": "2020-04-29T16:15:28.88+02:00",
+      "recordStatus": "marc:New"
     },
     {
       "@id": "https://id.kb.se/vocab/display"
@@ -26,26 +22,42 @@
       "@type": "fresnel:Group",
       "lenses": {
         "CarrierType": {
+          "@id": "CarrierType-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "CarrierType",
+          "fresnel:extends": {
+            "@id": "CarrierType-chips"
+          },
           "showProperties": [
-            "prefLabel",
-            "label",
+            "fresnel:super",
             "code",
-            "termGroup"
+            "inScheme",
+            "termGroup",
+            "definition"
           ]
         },
         "Cartographic": {
+          "@id": "Cartographic-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Cartographic",
           "showProperties": [
+            "prefLabel",
             "marc:westernmostLongitudeCoordinates",
             "marc:easternmostLongitudeCoordinates",
             "marc:northernmostLatitudeCoordinates",
             "marc:southernmostLatitudeCoordinates"
           ]
         },
+        "Classification": {
+          "fresnel:extends": {
+            "@id": "Classification-chips"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
         "Concept": {
+          "@id": "Concept-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Concept",
           "showProperties": [
@@ -65,21 +77,27 @@
             "scopeNote",
             "label",
             "code",
-            "note",
-            "keyword"
+            "keyword",
+            "termComponentList"
           ]
         },
         "ContentType": {
+          "@id": "ContentType-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "ContentType",
+          "fresnel:extends": {
+            "@id": "ContentType-chips"
+          },
           "showProperties": [
-            "prefLabel",
-            "label",
+            "fresnel:super",
             "code",
-            "termGroup"
+            "inScheme",
+            "termGroup",
+            "definition"
           ]
         },
         "Contribution": {
+          "@id": "Contribution-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Contribution",
           "showProperties": [
@@ -88,6 +106,7 @@
           ]
         },
         "Country": {
+          "@id": "Country-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Country",
           "showProperties": [
@@ -97,12 +116,25 @@
           ]
         },
         "DescriptionConventions": {
+          "@id": "DescriptionConventions-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "DescriptionConventions",
+          "fresnel:extends": {
+            "@id": "DescriptionConventions-chips"
+          },
           "showProperties": [
-            "prefLabel",
-            "label",
+            "fresnel:super",
             "code"
+          ]
+        },
+        "EntityContainer": {
+          "@id": "EntityContainer-cards",
+          "showProperties": [
+            "administeredBy",
+            "membershipResource",
+            "isMemberOfRelation",
+            "memberClass",
+            "slugProperty"
           ]
         },
         "Family": {
@@ -110,21 +142,42 @@
           "@type": "fresnel:Lens",
           "classLensDomain": "Family",
           "showProperties": [
+            "hasTypeOfFamily",
             "name",
             "marc:titlesAndOtherWordsAssociatedWithAName",
             "lifeSpan",
-            "hasTypeOfFamily",
-            "note",
+            "place",
+            "hasVariant",
+            "seeAlso",
+            "description",
+            "disambiguatingDescription",
             "identifiedBy",
-            "hasVariant"
+            "nationality"
           ]
         },
         "ISBN": {
+          "@id": "ISBN-cards",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ISBN",
+          "fresnel:extends": {
+            "@id": "ISBN-chips"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Identifier": {
+          "@id": "Identifier-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Identifier",
+          "fresnel:extends": {
+            "@id": "Identifier-chips"
+          },
           "showProperties": [
-            "value",
-            "qualifier"
+            "fresnel:super",
+            "qualifier",
+            "agent",
+            "source"
           ]
         },
         "Instance": {
@@ -132,6 +185,8 @@
           "@type": "fresnel:Lens",
           "classLensDomain": "Instance",
           "showProperties": [
+            "reproductionOf",
+            "identifiedBy",
             "issuanceType",
             "mediaType",
             "carrierType",
@@ -147,19 +202,23 @@
             "distribution",
             "copyright",
             "copyrightDate",
-            "identifiedBy",
             "indirectlyIdentifiedBy",
             "extent",
             "hasDimensions",
+            "hasDuration",
             "marc:otherPhysicalDetails",
+            "genreForm",
             "accompaniedBy",
             "seriesMembership",
+            "intendedAudience",
+            "associatedMedia",
             {
               "inverseOf": "itemOf"
             }
           ]
         },
         "Item": {
+          "@id": "Item-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Item",
           "showProperties": [
@@ -167,60 +226,95 @@
             "heldBy",
             "hasComponent",
             "physicalLocation",
-            "shelfMark"
+            "shelfMark",
+            "language",
+            "genreForm",
+            "classification",
+            "subject"
           ]
         },
         "Jurisdiction": {
+          "@id": "Jurisdiction-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Jurisdiction",
           "showProperties": [
             "name",
             "isPartOf",
             "marc:subordinateUnit",
-            "note",
+            "hasVariant",
+            "seeAlso",
+            "description",
+            "disambiguatingDescription",
+            "activityStartDate",
+            "activityEndDate",
             "identifiedBy",
-            "hasVariant"
+            "nationality"
           ]
         },
         "Language": {
+          "@id": "Language-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Language",
+          "fresnel:extends": {
+            "@id": "Language-chips"
+          },
           "showProperties": [
-            "prefLabel",
-            "label",
-            "code"
+            "fresnel:super",
+            "altLabel",
+            "code",
+            "isReplacedBy"
           ]
         },
         "Library": {
+          "@id": "Library-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Library",
           "showProperties": [
             "sigel"
           ]
         },
+        "MediaObject": {
+          "fresnel:extends": {
+            "@id": "MediaObject-chips"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
         "MediaType": {
+          "@id": "MediaType-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "MediaType",
+          "fresnel:extends": {
+            "@id": "MediaType-chips"
+          },
           "showProperties": [
-            "prefLabel",
-            "label",
+            "fresnel:super",
             "code",
-            "termGroup"
+            "inScheme",
+            "termGroup",
+            "definition"
           ]
         },
         "Meeting": {
+          "@id": "Meeting-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Meeting",
           "showProperties": [
             "name",
-            "marc:subordinateUnit",
+            "marc:numeration",
             "date",
-            "note",
+            "place",
+            "hasVariant",
+            "seeAlso",
+            "description",
+            "disambiguatingDescription",
             "identifiedBy",
-            "hasVariant"
+            "nationality"
           ]
         },
         "NotatedMusic": {
+          "@id": "NotatedMusic-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "NotatedMusic",
           "showProperties": [
@@ -234,10 +328,13 @@
             "genreForm",
             "classification",
             "subject",
+            "intendedAudience",
+            "contentType",
             "isPartOf"
           ]
         },
         "Ontology": {
+          "@id": "Ontology-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Ontology",
           "showProperties": [
@@ -255,9 +352,14 @@
             "name",
             "isPartOf",
             "marc:subordinateUnit",
-            "note",
+            "hasVariant",
+            "seeAlso",
+            "description",
+            "disambiguatingDescription",
+            "activityStartDate",
+            "activityEndDate",
             "identifiedBy",
-            "hasVariant"
+            "nationality"
           ]
         },
         "Person": {
@@ -272,14 +374,31 @@
             "marc:titlesAndOtherWordsAssociatedWithAName",
             "marc:fullerFormName",
             "lifeSpan",
-            "marc:attributionQualifier",
-            "personTitle",
-            "note",
+            "hasVariant",
+            "seeAlso",
+            "hasOccupation",
+            "fieldOfActivity",
+            "description",
+            "disambiguatingDescription",
             "identifiedBy",
-            "hasVariant"
+            "nationality"
+          ]
+        },
+        "Publication": {
+          "@id": "Publication-cards",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "Publication",
+          "fresnel:extends": {
+            "@id": "Publication-chips"
+          },
+          "showProperties": [
+            "fresnel:super",
+            "marc:sequenceStatus",
+            "hasPart"
           ]
         },
         "Record": {
+          "@id": "Record-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Record",
           "showProperties": [
@@ -287,19 +406,23 @@
             "inDataset",
             "created",
             "modified",
+            "identifiedBy",
             "bibliography",
             "encodingLevel",
+            "technicalNote",
             "recordStatus",
             "descriptionCreator",
             "descriptionUpgrader",
             "descriptionLastModifier",
             "descriptionConventions",
-            "identifiedBy",
+            "cataloguersNote",
             "generationDate",
-            "generationProcess"
+            "generationProcess",
+            "sourceConsulted"
           ]
         },
         "Resource": {
+          "@id": "Resource-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Resource",
           "showProperties": [
@@ -308,7 +431,6 @@
             "label",
             "name",
             "code",
-            "sameAs",
             "exactMatch",
             "closeMatch",
             "broadMatch",
@@ -317,6 +439,7 @@
           ]
         },
         "SeriesMembership": {
+          "@id": "SeriesMembership-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "SeriesMembership",
           "showProperties": [
@@ -325,24 +448,58 @@
             "seriesEnumeration"
           ]
         },
+        "SourceData": {
+          "@id": "SourceData-cards",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "SourceData",
+          "showProperties": [
+            "label",
+            "citationNote",
+            "uri"
+          ]
+        },
         "StructuredValue": {
+          "@id": "StructuredValue-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "StructuredValue",
           "showProperties": [
             "label"
           ]
         },
+        "ToCEntry": {
+          "@id": "ToCEntry-cards",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ToCEntry",
+          "showProperties": [
+            "label",
+            "responsibilityStatement",
+            "comment"
+          ]
+        },
         "Work": {
+          "@id": "Work-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Work",
           "showProperties": [
             "hasTitle",
             "contribution",
             "language",
+            "hasVariant",
             "genreForm",
             "classification",
             "subject",
+            "intendedAudience",
+            "contentType",
+            "illustrativeContent",
             "isPartOf"
+          ]
+        },
+        "marc:EnumeratedTerm": {
+          "@id": "EnumeratedTerm-cards",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "marc:EnumeratedTerm",
+          "showProperties": [
+            "prefLabel"
           ]
         }
       }
@@ -351,7 +508,25 @@
       "@id": "chips",
       "@type": "fresnel:Group",
       "lenses": {
+        "CarrierType": {
+          "@id": "CarrierType-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "CarrierType",
+          "showProperties": [
+            "prefLabel",
+            "label"
+          ]
+        },
+        "Cartographic": {
+          "@id": "Cartographic-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "Cartographic",
+          "showProperties": [
+            "prefLabel"
+          ]
+        },
         "Classification": {
+          "@id": "Classification-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Classification",
           "showProperties": [
@@ -361,17 +536,27 @@
           ]
         },
         "Concept": {
+          "@id": "Concept-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Concept",
           "showProperties": [
             "prefLabel",
             "label",
             "code",
-            "inScheme",
-            "inCollection"
+            "inScheme"
+          ]
+        },
+        "ContentType": {
+          "@id": "ContentType-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ContentType",
+          "showProperties": [
+            "prefLabel",
+            "label"
           ]
         },
         "Contribution": {
+          "@id": "Contribution-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Contribution",
           "showProperties": [
@@ -380,22 +565,53 @@
           ]
         },
         "Country": {
+          "@id": "Country-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Country",
           "showProperties": [
             "prefLabel"
           ]
         },
+        "DescriptionConventions": {
+          "@id": "DescriptionConventions-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "DescriptionConventions",
+          "showProperties": [
+            "prefLabel",
+            "label"
+          ]
+        },
+        "Duration": {
+          "@id": "Duration-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "Duration",
+          "showProperties": [
+            "value",
+            "hasPart"
+          ]
+        },
         "Family": {
+          "@id": "Family-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Family",
           "showProperties": [
             "name",
             "marc:titlesAndOtherWordsAssociatedWithAName",
-            "lifeSpan"
+            "lifeSpan",
+            "place"
+          ]
+        },
+        "ISBN": {
+          "@id": "ISBN-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ISBN",
+          "showProperties": [
+            "value",
+            "qualifier"
           ]
         },
         "Identifier": {
+          "@id": "Identifier-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Identifier",
           "showProperties": [
@@ -405,6 +621,7 @@
           ]
         },
         "Instance": {
+          "@id": "Instance-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Instance",
           "showProperties": [
@@ -413,14 +630,17 @@
           ]
         },
         "Item": {
+          "@id": "Item-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Item",
           "showProperties": [
             "itemOf",
-            "heldBy"
+            "heldBy",
+            "shelfMark"
           ]
         },
         "Jurisdiction": {
+          "@id": "Jurisdiction-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Jurisdiction",
           "showProperties": [
@@ -429,30 +649,70 @@
             "marc:subordinateUnit"
           ]
         },
+        "KeyTitle": {
+          "@id": "KeyTitle-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "KeyTitle",
+          "showProperties": [
+            "mainTitle",
+            "qualifier"
+          ]
+        },
         "Language": {
+          "@id": "Language-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Language",
           "showProperties": [
-            "prefLabel"
+            "prefLabel",
+            "label"
           ]
         },
         "Library": {
+          "@id": "Library-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Library",
           "showProperties": [
             "sigel"
           ]
         },
+        "MediaObject": {
+          "@id": "MediaObject-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "MediaObject",
+          "showProperties": [
+            "uri"
+          ]
+        },
+        "MediaType": {
+          "@id": "MediaType-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "MediaType",
+          "showProperties": [
+            "prefLabel",
+            "label"
+          ]
+        },
         "Meeting": {
+          "@id": "Meeting-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Meeting",
           "showProperties": [
             "name",
-            "marc:subordinateUnit",
-            "date"
+            "marc:numeration",
+            "date",
+            "place"
+          ]
+        },
+        "Nationality": {
+          "@id": "Nationality-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "Nationality",
+          "showProperties": [
+            "prefLabel"
           ]
         },
         "Organization": {
+          "@id": "Organization-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Organization",
           "showProperties": [
@@ -462,6 +722,7 @@
           ]
         },
         "Person": {
+          "@id": "Person-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Person",
           "showProperties": [
@@ -475,6 +736,7 @@
           ]
         },
         "ProvisionActivity": {
+          "@id": "ProvisionActivity-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "ProvisionActivity",
           "showProperties": [
@@ -489,24 +751,31 @@
           ]
         },
         "Publication": {
+          "@id": "Publication-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Publication",
           "showProperties": [
             "place",
             "agent",
             "year",
-            "date"
+            "startYear",
+            "endYear",
+            "date",
+            "marc:publicationStatus"
           ]
         },
         "Record": {
+          "@id": "Record-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Record",
           "showProperties": [
             "controlNumber",
+            "encodingLevel",
             "inDataset"
           ]
         },
         "Relationship": {
+          "@id": "Relationship-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Relationship",
           "showProperties": [
@@ -515,6 +784,7 @@
           ]
         },
         "Resource": {
+          "@id": "Resource-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Resource",
           "showProperties": [
@@ -529,6 +799,7 @@
           ]
         },
         "Serial": {
+          "@id": "Serial-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Serial",
           "showProperties": [
@@ -537,6 +808,7 @@
           ]
         },
         "SeriesMembership": {
+          "@id": "SeriesMembership-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "SeriesMembership",
           "showProperties": [
@@ -546,13 +818,32 @@
           ]
         },
         "ShelfMark": {
+          "@id": "ShelfMark-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "ShelfMark",
           "showProperties": [
             "label"
           ]
         },
+        "SourceData": {
+          "@id": "SourceData-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "SourceData",
+          "showProperties": [
+            "label",
+            "citationNote"
+          ]
+        },
+        "TableOfContents": {
+          "@id": "TableOfContents-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "TableOfContents",
+          "showProperties": [
+            "label"
+          ]
+        },
         "Title": {
+          "@id": "Title-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Title",
           "showProperties": [
@@ -562,10 +853,12 @@
             "titleRemainder",
             "partNumber",
             "partName",
-            "hasPart"
+            "hasPart",
+            "marc:mediaTerm"
           ]
         },
         "TitlePart": {
+          "@id": "TitlePart-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Title",
           "showProperties": [
@@ -573,25 +866,54 @@
             "partName"
           ]
         },
+        "ToCEntry": {
+          "@id": "ToCEntry-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ToCEntry",
+          "showProperties": [
+            "label"
+          ]
+        },
         "Work": {
+          "@id": "Work-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Work",
           "showProperties": [
             "hasTitle",
             "language"
           ]
-        }
-      }
-    },
-    "tokens": {
-      "@id": "tokens",
-      "@type": "fresnel:Group",
-      "lenses": {
-        "Role": {
+        },
+        "marc:AddedEntryHierarchicalPlaceName": {
+          "@id": "AddedEntryHierarchicalPlaceName-chips",
           "@type": "fresnel:Lens",
-          "classLensDomain": "Role",
+          "classLensDomain": "marc:AddedEntryHierarchicalPlaceName",
+          "showProperties": [
+            "marc:countryOrLargerEntity",
+            "marc:city"
+          ]
+        },
+        "marc:EnumeratedTerm": {
+          "@id": "EnumeratedTerm-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "marc:EnumeratedTerm",
           "showProperties": [
             "prefLabel"
+          ]
+        },
+        "marc:LanguageNote": {
+          "@id": "LanguageNote-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "marc:LanguageNote",
+          "showProperties": [
+            "label"
+          ]
+        },
+        "marc:SystemDetailsNote": {
+          "@id": "SystemDetailsNote-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "marc:SystemDetailsNote",
+          "showProperties": [
+            "marc:systemDetailsNote"
           ]
         }
       }
@@ -600,17 +922,96 @@
       "@id": "full",
       "@type": "fresnel:Group",
       "lenses": {
+        "CarrierType": {
+          "fresnel:extends": {
+            "@id": "CarrierType-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Cartographic": {
+          "fresnel:extends": {
+            "@id": "Cartographic-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Classification": {
+          "fresnel:extends": {
+            "@id": "Classification-chips"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Concept": {
+          "fresnel:extends": {
+            "@id": "Concept-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "ContentType": {
+          "fresnel:extends": {
+            "@id": "ContentType-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Contribution": {
+          "fresnel:extends": {
+            "@id": "Contribution-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Country": {
+          "fresnel:extends": {
+            "@id": "Country-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "DescriptionConventions": {
+          "fresnel:extends": {
+            "@id": "DescriptionConventions-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
         "Family": {
           "fresnel:extends": {
             "@id": "Family-cards"
           },
           "showProperties": [
             "fresnel:super",
-            "hasTypeOfFamily",
             "establishDate",
             "terminateDate",
             "activityStartDate",
             "activityEndDate"
+          ]
+        },
+        "ISBN": {
+          "fresnel:extends": {
+            "@id": "ISBN-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Identifier": {
+          "fresnel:extends": {
+            "@id": "Identifier-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
           ]
         },
         "Instance": {
@@ -620,6 +1021,7 @@
           "showProperties": [
             "instanceOf",
             "fresnel:super",
+            "tableOfContents",
             {
               "inverseOf": "itemOf"
             }
@@ -633,6 +1035,62 @@
             "fresnel:super",
             "shelfLabel",
             "shelfControlNumber"
+          ]
+        },
+        "Jurisdiction": {
+          "fresnel:extends": {
+            "@id": "Jurisdiction-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Language": {
+          "fresnel:extends": {
+            "@id": "Language-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Library": {
+          "fresnel:extends": {
+            "@id": "Library-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "MediaType": {
+          "fresnel:extends": {
+            "@id": "MediaType-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Meeting": {
+          "fresnel:extends": {
+            "@id": "Meeting-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "NotatedMusic": {
+          "fresnel:extends": {
+            "@id": "NotatedMusic-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Ontology": {
+          "fresnel:extends": {
+            "@id": "Ontology-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
           ]
         },
         "Organization": {
@@ -655,6 +1113,128 @@
             "fresnel:super",
             "birthDate",
             "deathDate"
+          ]
+        },
+        "ProvisionActivity": {
+          "fresnel:extends": {
+            "@id": "ProvisionActivity-chips"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Record": {
+          "fresnel:extends": {
+            "@id": "Record-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Relationship": {
+          "fresnel:extends": {
+            "@id": "Relationship-chips"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "SeriesMembership": {
+          "fresnel:extends": {
+            "@id": "SeriesMembership-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "ShelfMark": {
+          "fresnel:extends": {
+            "@id": "ShelfMark-chips"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "StructuredValue": {
+          "fresnel:extends": {
+            "@id": "StructuredValue-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "TableOfContents": {
+          "fresnel:extends": {
+            "@id": "TableOfContents-chips"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Title": {
+          "fresnel:extends": {
+            "@id": "Title-chips"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "TitlePart": {
+          "fresnel:extends": {
+            "@id": "TitlePart-chips"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "ToCEntry": {
+          "fresnel:extends": {
+            "@id": "ToCEntry-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        },
+        "Work": {
+          "fresnel:extends": {
+            "@id": "Work-cards"
+          },
+          "showProperties": [
+            "fresnel:super"
+          ]
+        }
+      }
+    },
+    "tokens": {
+      "@id": "tokens",
+      "@type": "fresnel:Group",
+      "lenses": {
+        "ConceptScheme": {
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ConceptScheme",
+          "showProperties": [
+            "code"
+          ]
+        },
+        "Language": {
+          "@type": "fresnel:Lens",
+          "classLensDomain": "Language",
+          "showProperties": [
+            "prefLabel"
+          ]
+        },
+        "Role": {
+          "@type": "fresnel:Lens",
+          "classLensDomain": "Role",
+          "showProperties": [
+            "prefLabel"
+          ]
+        },
+        "TermCollection": {
+          "@type": "fresnel:Lens",
+          "classLensDomain": "TermCollection",
+          "showProperties": [
+            "code"
           ]
         }
       }

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -126,6 +126,7 @@
     "All types": "Alla typer",
     "Suggested types": "Föreslagna typer",
     "Duplicate entity" : "Duplicera entitet",
+    "Create digital reproduction": "Skapa digital reproduktion",
     "Copy to clipboard": "Kopiera till urklipp",
     "Copied entity to clipboard": "Kopierade entitet till urklipp",
     "Paste entity": "Klistra in entitet",

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -126,6 +126,8 @@
     "All types": "Alla typer",
     "Suggested types": "Föreslagna typer",
     "Duplicate entity" : "Duplicera entitet",
+    "Preparing copy": "Förbereder kopia",
+    "Preparing reproduction": "Förbereder reproduktion",
     "Create digital reproduction": "Skapa digital reproduktion",
     "Copy to clipboard": "Kopiera till urklipp",
     "Copied entity to clipboard": "Kopierade entitet till urklipp",

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -107,6 +107,13 @@ const store = new Vuex.Store({
         // 'Concept', - Blocking this per request of MSS
         'Work',
       ],
+      digitalReproduction: {
+        keysToCopy: [
+          //'mainEntity.instanceOf', HANDLED EXPLICITLY in routine
+          'mainEntity.hasTitle',
+          'mainEntity.responsibilityStatement',
+        ],
+      },
       keysToClear: {
         duplication: [
           'record.controlNumber',

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -107,13 +107,6 @@ const store = new Vuex.Store({
         // 'Concept', - Blocking this per request of MSS
         'Work',
       ],
-      digitalReproduction: {
-        keysToCopy: [
-          //'mainEntity.instanceOf', HANDLED EXPLICITLY in routine
-          'mainEntity.hasTitle',
-          'mainEntity.responsibilityStatement',
-        ],
-      },
       keysToClear: {
         duplication: [
           'record.controlNumber',

--- a/viewer/vue-client/src/utils/record.js
+++ b/viewer/vue-client/src/utils/record.js
@@ -127,8 +127,7 @@ export function getMainEntity(graph) {
   return mainEntity;
 }
 
-export function getDigitalReproductionObject(original, resources, settings) {
-
+export function getDigitalReproductionObject(original, resources) {
   // Get the template
   const instanceTemplates = resources.templates.combined.instance;
   let digitalReproTemplate;
@@ -144,7 +143,7 @@ export function getDigitalReproductionObject(original, resources, settings) {
       // Work was local
       digitalReproTemplate.work = Object.assign({}, original.work);
       digitalReproTemplate.work['@id'] = 'https://id.kb.se/TEMPID#work';
-      digitalReproTemplate.mainEntity.instanceOf = 'https://id.kb.se/TEMPID#work'
+      digitalReproTemplate.mainEntity.instanceOf = 'https://id.kb.se/TEMPID#work';
     } else {
       // Work was linked
       digitalReproTemplate.mainEntity.instanceOf = original.mainEntity.instanceOf;

--- a/viewer/vue-client/src/utils/record.js
+++ b/viewer/vue-client/src/utils/record.js
@@ -163,6 +163,11 @@ export function getDigitalReproductionObject(original, resources, settings) {
     }
   }
 
+  // Copy identifier
+  if (original.mainEntity.hasOwnProperty('identifiedBy')) {
+    digitalReproTemplate.mainEntity.indirectlyIdentifiedBy = original.mainEntity.identifiedBy;
+  }
+
   digitalReproTemplate.mainEntity.reproductionOf = { '@id': original.mainEntity['@id'] };
 
   // Toss in the quoted list

--- a/viewer/vue-client/src/utils/record.js
+++ b/viewer/vue-client/src/utils/record.js
@@ -127,6 +127,29 @@ export function getMainEntity(graph) {
   return mainEntity;
 }
 
+export function getDigitalReproductionObject(original, resources) {
+  const instanceTemplates = resources.templates.combined.instance;
+  let digitalReproTemplate;
+  for (let i = 0; i < instanceTemplates.length; i++) {
+    if (instanceTemplates[i].key === 'digitizedMonographText') {
+      digitalReproTemplate = instanceTemplates[i].value;
+    }
+  }
+  if (original.mainEntity.hasOwnProperty('instanceOf')) {
+    if (original.mainEntity.instanceOf['@id'].indexOf('#work') > -1) {
+      // Work was local
+      digitalReproTemplate.work = Object.assign({}, original.work);
+      digitalReproTemplate.work['@id'] = 'https://id.kb.se/TEMPID#work';
+      digitalReproTemplate.mainEntity.instanceOf = 'https://id.kb.se/TEMPID#work'
+    } else {
+      // Work was linked
+      digitalReproTemplate.mainEntity.instanceOf = original.mainEntity.instanceOf;
+    }
+  }
+  digitalReproTemplate.quoted = original.quoted;
+  return digitalReproTemplate;
+}
+
 export function getItemObject(itemOf, heldBy, instance) {
   const itemObj = {
     record: {

--- a/viewer/vue-client/src/utils/record.js
+++ b/viewer/vue-client/src/utils/record.js
@@ -152,7 +152,10 @@ export function getDigitalReproductionObject(original, resources, settings) {
   }
 
   // Copy the other keys we want to copy
-  const keysToCopy = settings.digitalReproduction.keysToCopy;
+  const keysToCopy = [
+    'mainEntity.hasTitle',
+    'mainEntity.responsibilityStatement',
+  ];
   for (let i = 0; i < keysToCopy.length; i++) {
     const originalValue = get(original, keysToCopy[i]);
     if (typeof originalValue !== 'undefined') {

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -567,16 +567,24 @@ export default {
     },
     duplicateItem() {
       if (!this.status.inEdit && !this.isItem) {
+        this.$store.dispatch('pushLoadingIndicator', 'Preparing copy');
         const duplicate = RecordUtil.prepareDuplicateFor(this.inspector.data, this.user, this.settings.keysToClear.duplication);
         this.$store.dispatch('setInsertData', duplicate);
-        this.$router.push({ path: '/new' });
+        setTimeout(() => {
+          this.$store.dispatch('removeLoadingIndicator', 'Preparing copy');
+          this.$router.push({ path: '/new' });
+        }, 0);
       }
     },
     createDigitalReproduction() {
+      this.$store.dispatch('pushLoadingIndicator', 'Preparing reproduction');
       const repro = RecordUtil.getDigitalReproductionObject(this.inspector.data, this.resources, this.settings);
       const cleanedRepro = RecordUtil.prepareDuplicateFor(repro, this.user, this.settings.keysToClear.duplication);
       this.$store.dispatch('setInsertData', cleanedRepro);
-      this.$router.push({ path: '/new' });
+      setTimeout(() => {
+        this.$store.dispatch('removeLoadingIndicator', 'Preparing reproduction');
+        this.$router.push({ path: '/new' });
+      }, 0);
     },
     saveItem(done = false) {
       this.$store.dispatch('setInspectorStatusValue', { property: 'saving', value: true });

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -573,7 +573,7 @@ export default {
       }
     },
     createDigitalReproduction() {
-      const repro = RecordUtil.getDigitalReproductionObject(this.inspector.data, this.resources);
+      const repro = RecordUtil.getDigitalReproductionObject(this.inspector.data, this.resources, this.settings);
       const cleanedRepro = RecordUtil.prepareDuplicateFor(repro, this.user, this.settings.keysToClear.duplication);
       this.$store.dispatch('setInsertData', cleanedRepro);
       this.$router.push({ path: '/new' });

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -572,6 +572,12 @@ export default {
         this.$router.push({ path: '/new' });
       }
     },
+    createDigitalReproduction() {
+      const repro = RecordUtil.getDigitalReproductionObject(this.inspector.data, this.resources);
+      const cleanedRepro = RecordUtil.prepareDuplicateFor(repro, this.user, this.settings.keysToClear.duplication);
+      this.$store.dispatch('setInsertData', cleanedRepro);
+      this.$router.push({ path: '/new' });
+    },
     saveItem(done = false) {
       this.$store.dispatch('setInspectorStatusValue', { property: 'saving', value: true });
 
@@ -709,6 +715,9 @@ export default {
             break;
           case 'start-edit':
             this.startEditing();
+            break;
+          case 'create-digital-reproduction':
+            this.createDigitalReproduction();
             break;
           case 'download-json':
             this.downloadJson();


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Adds a meny item on instances (which are not already Electronic) to create a "Digital Reproduction" version of the same instance.

### Tickets involved
[LXL-3126](https://jira.kb.se/browse/LXL-3126)


### Summary of changes
* Added menu item to toolbar
* Added translations
* Added utility `getDigitalReproductionObject` in `RecordUtil`
* Added loading indicators for toolbar operations `duplicateItem` and `createDigitalReproduction`.
* Added `v-show` conditional for `router-view`.
