### PR TITLE
LXL-3147 Change youtube playlist link to actually go to the playlist

### DIFF
--- a/viewer/vue-client/src/resources/json/copy.json
+++ b/viewer/vue-client/src/resources/json/copy.json
@@ -55,7 +55,7 @@
     "video": "https://www.youtube-nocookie.com/embed/?listType=playlist&list=PLZVkEICvA5-GRT2oJQmLgq_2Pksx6zYPy&html5=1&rel=0&showinfo=0&autoplay=1",
     "header": "Instruktionsfilmer",
     "text": "För att underlätta katalogisering i XL producerar vi kontinuerligt instruktionsfilmer som vi lägger upp på Kungliga bibliotekets kanal på Youtube. Filmerna uppdateras vid förändringar och uppdateringar av de tjänster de visar. Navigera runt och titta på de filmer som stödjer ditt arbete i XL på bästa sätt.",
-    "linkUrl": "https://www.youtube.com/watch?v=p2vcgoTfNpw&list=PLZVkEICvA5-GRT2oJQmLgq_2Pksx6zYPy",
+    "linkUrl": "https://www.youtube.com/playlist?list=PLZVkEICvA5-GRT2oJQmLgq_2Pksx6zYPy",
     "linkText": "Till spellistan"
   },
   "studies": {


### PR DESCRIPTION

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3147](https://jira.kb.se/browse/LXL-3147)

### Summary of changes

* Changes the link (not the video) to go to the playlist instead of the first video.
* Embedded video is unchanged.
