### PR TITLE
2960 Fix PreviewCard not showing correct card

### DIFF
--- a/viewer/vue-client/src/components/shared/preview-card.vue
+++ b/viewer/vue-client/src/components/shared/preview-card.vue
@@ -76,7 +76,7 @@ export default {
       if (oldValue !== newValue) {
         this.fetchedData = null;
       }
-    }
+    },
   },
   mounted() { // Ready method is deprecated in 2.0, switch to "mounted"
     this.$nextTick(() => {

--- a/viewer/vue-client/src/components/shared/preview-card.vue
+++ b/viewer/vue-client/src/components/shared/preview-card.vue
@@ -72,6 +72,11 @@ export default {
     },
   },
   watch: {
+    focusData(oldValue, newValue) {
+      if (oldValue !== newValue) {
+        this.fetchedData = null;
+      }
+    }
   },
   mounted() { // Ready method is deprecated in 2.0, switch to "mounted"
     this.$nextTick(() => {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

### Tickets involved
[LXL-2960](https://jira.kb.se/browse/LXL-2960)

### Solves
PreviewCard showing wrong card. This can happen when focusData is changed after the full data had already been fetched. If the array of entities is changed, vue sometimes confused which entity is which. This ensures that when the focusData is changed, it is reflected in the fetchedData and fullData.

### Summary of changes

Added a watcher on focusData which resets the fetchedData to null, triggering a new fetch if it is needed.
