### PR TITLE
Feature/lxl 3005 additional tweaks

### DIFF
--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -142,6 +142,11 @@ export default {
     keyword(value) {
       this.handleChange(value);
     },
+    active(value) {
+      if (!value) {
+        this.$refs.adderFocusElement.focus();
+      }
+    },
   },
   computed: {
     settings() {

--- a/viewer/vue-client/src/components/inspector/field-adder.vue
+++ b/viewer/vue-client/src/components/inspector/field-adder.vue
@@ -257,6 +257,11 @@ export default {
         }
       }
     }, 
+    active(val) {
+      if (!val) {
+        this.$refs.adderButton.focus();
+      }
+    },
   },
   mounted() {
     this.$nextTick(() => { // TODO: Fix proper scroll tracking. This is just an ugly solution using document.onscroll here and window.scroll in editorcontrols.vue

--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -347,6 +347,11 @@ export default {
         this.expandChildren = true;
       }
     },
+    extractDialogActive(val) {
+      if (!val) {
+        this.$refs.linkAction.focus();
+      }
+    },
   },
   beforeDestroy() {
     this.$store.dispatch('setValidation', { path: this.path, validates: true });
@@ -427,6 +432,7 @@ export default {
             v-if="!isLocked && !isEmbedded && !isCompositional"
             role="button"
             tabindex="0"
+            ref="linkAction"
             :aria-label="'Link entity' | translatePhrase"
             @click="openExtractDialog(), expand()" 
             v-tooltip.top="translate('Link entity')"

--- a/viewer/vue-client/src/components/inspector/item-sibling.vue
+++ b/viewer/vue-client/src/components/inspector/item-sibling.vue
@@ -308,6 +308,11 @@ export default {
         this.expandChildren = true;
       }
     },
+    extractDialogActive(val) {
+      if (!val) {
+        this.$refs.linkAction.focus();
+      }
+    },
   },
   created() {
     this.$on('collapse-item', () => {
@@ -385,6 +390,7 @@ export default {
             role="button"
             :aria-label="'Link entity' | translatePhrase"
             tabindex="0"
+            ref="linkAction"
             v-if="inspector.status.editing && !isEmbedded && !isLocked"
             v-tooltip.top="translate('Link entity')"
             @click="openExtractDialog(), expand()"

--- a/viewer/vue-client/src/components/shared/modal-component.vue
+++ b/viewer/vue-client/src/components/shared/modal-component.vue
@@ -124,7 +124,12 @@ export default {
             {{ translatedTitle }}
           </header>
           <span class="ModalComponent-windowControl" v-if="closeable">
-            <i @click="close" class="fa fa-close icon--md"></i>
+            <i 
+              @click="close" 
+              role="button"
+              tabindex="0"
+              class="fa fa-close icon--md">
+            </i>
           </span>
         </slot>
       </div>

--- a/viewer/vue-client/src/components/shared/panel-component.vue
+++ b/viewer/vue-client/src/components/shared/panel-component.vue
@@ -128,15 +128,18 @@ export default {
               <i class="fullview-toggle-button fa fa-compress icon icon--md"
                 v-show="user.settings.forceFullViewPanel"
                 role="button"
+                tabindex="0"
                 @click="toggleFullView" 
                 :title="'Minimize' | translatePhrase"></i>
               <i class="fullview-toggle-button fa fa-expand icon icon--md"
                 v-show="!user.settings.forceFullViewPanel"
                 role="button"
+                tabindex="0"
                 @click="toggleFullView" 
                 :title="'Expand' | translatePhrase"></i>
               <i class="fa fa-close icon icon--md"
                 role="button"
+                tabindex="0"
                 @click="close"
                 :title="'Close' | translatePhrase"></i>
             </span>


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

Prevent focus ending up in footer when navigating with a keyboard 

### Tickets involved
[LXL-3005](https://jira.kb.se/browse/LXL-3005)

### Summary of changes

added tabindex on some buttons making those accessible by a keyboard 
added logic to focus back on linkAction and fieldAdder after side panel has been closed
