### PR TITLE
Delete @reverse nodes in prepareDuplicateFor method

### DIFF
--- a/viewer/vue-client/src/utils/record.js
+++ b/viewer/vue-client/src/utils/record.js
@@ -348,6 +348,7 @@ export function prepareDuplicateFor(inspectorData, user, keysToClear) {
 
   // Remove the @reverse part, this is only to prevent visual bugs since it will be generated automatically anyway
   delete newData.mainEntity['@reverse'];
+  delete newData.record['@reverse'];
 
   // Replace @id and internal @id references
   if (newData.mainEntity) {

--- a/viewer/vue-client/src/utils/record.js
+++ b/viewer/vue-client/src/utils/record.js
@@ -346,6 +346,9 @@ export function prepareDuplicateFor(inspectorData, user, keysToClear) {
     unset(newData, property);
   });
 
+  // Remove the @reverse part, this is only to prevent visual bugs since it will be generated automatically anyway
+  delete newData.mainEntity['@reverse'];
+
   // Replace @id and internal @id references
   if (newData.mainEntity) {
     newData.mainEntity['@id'] = newData.mainEntity['@id'].replace(oldBaseId, newBaseId);


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3208](https://jira.kb.se/browse/LXL-3208)

### Solves

Solves visual bug where @reverse nodes are being included in copies of a post (ie copy, enrichment etc).

### Summary of changes

Remove @reverse nodes in prepareDuplicateFor method.
