### PR TITLE
Make "Create digital reproduction" not crash when instanceOf is missing @id

### DIFF
--- a/viewer/vue-client/src/utils/record.js
+++ b/viewer/vue-client/src/utils/record.js
@@ -138,7 +138,7 @@ export function getDigitalReproductionObject(original, resources) {
   }
   // Copying instanceOf explicitly cause of how #work works
   if (original.mainEntity.hasOwnProperty('instanceOf')) {
-    if (original.mainEntity.instanceOf['@id'].indexOf('#work') > -1) {
+    if (original.mainEntity.instanceOf.hasOwnProperty('@id') && original.mainEntity.instanceOf['@id'].indexOf('#work') > -1) {
       // Work was local
       digitalReproObject.work = Object.assign({}, original.work);
       digitalReproObject.work['@id'] = 'https://id.kb.se/TEMPID#work';


### PR DESCRIPTION
# NOTE: Verify merging branch (base) before merging
Should merge into a hotfix branch if hotfix, else develop

### Tickets involved
[LXL-3231](https://jira.kb.se/browse/LXL-3231)

### Summary of changes

- Add undefined check before accessing @id on instanceOf value
