### PR TITLE
Fix HTTP 500 on missing Accept header

### DIFF
--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -244,9 +244,9 @@ def thingview(path, suffix=None):
 # FIXME make this less sketcy
 def _get_view_data_accept_header(request, suffix):
     mimetype, _ = negotiator.negotiate(request, suffix)
-    if mimetype in ('application/json'):
+    if mimetype and mimetype in ('application/json'):
         return 'application/json'
-    elif mimetype in ('text/html', 'application/xhtml+xml'):
+    elif mimetype and mimetype in ('text/html', 'application/xhtml+xml'):
         return 'application/json'
     else:
         return None


### PR DESCRIPTION
### Solves
Requests to `/<id>` without `Accept:` header would return HTTP 500.

`curl 'http://kblocalhost.kb.se:5000/n0xpcvb8l93wbdhq' -H 'Accept:'`

before:
`< HTTP/1.0 500 INTERNAL SERVER ERROR`

after:
`< HTTP/1.0 406 NOT ACCEPTABLE`