### PR TITLE
[WIP] LXL-3211 - Support for putting some reverse-properties in the regular form

### DIFF
--- a/viewer/vue-client/src/components/inspector/entity-form.vue
+++ b/viewer/vue-client/src/components/inspector/entity-form.vue
@@ -4,7 +4,6 @@
   It recieves modification events from other components through $dispatch calls
   and makes changes to the bound 'focus' object accordingly.
 */
-import { cloneDeep, groupBy, each } from 'lodash-es';
 import { mapGetters } from 'vuex';
 import * as VocabUtil from '@/utils/vocab';
 import LensMixin from '@/components/mixins/lens-mixin';

--- a/viewer/vue-client/src/components/inspector/entity-form.vue
+++ b/viewer/vue-client/src/components/inspector/entity-form.vue
@@ -166,7 +166,7 @@ export default {
       </div>
     </ul>
 
-    <!-- <div 
+    <div 
       v-if="reverseItem && editingObject === 'mainEntity'"
       class="EntityForm-reverse">
       <h6 class="uppercaseHeading">Resurser som länkar hit</h6>
@@ -183,7 +183,7 @@ export default {
           :field-value="v" 
           :parent-path="editingObject" />
       </ul>
-    </div> -->
+    </div>
   </div>
 </template>
 

--- a/viewer/vue-client/src/components/inspector/entity-form.vue
+++ b/viewer/vue-client/src/components/inspector/entity-form.vue
@@ -91,40 +91,11 @@ export default {
       }
       return false;
     },
+    showIncomingLinksSection() {
+      return Object.keys(this.reverseItemSorted).length > 0;
+    },
     formObj() {
       return this.formData;
-    },
-    reverseItemSorted() {
-      const reverseItem = cloneDeep(this.reverseItem);
-      const reverseItemSorted = {};
-
-      each(reverseItem, (item, key) => {
-        let groupedReverseItems = {};
-
-        // get label and add it to the object for sorting        
-        item.map((obj) => {
-          obj.label = this.getLabel(obj);
-          return obj;
-        });         
-
-        // sort aplphabetically
-        item.sort((a, b) => a.label.localeCompare(b.label, 'sv'));
-
-        // group by first letter
-        groupedReverseItems = groupBy(item, i => i.label.substring(0, 1));
-
-        // delete label
-        Object.keys(groupedReverseItems).forEach((k) => {
-          groupedReverseItems[k].forEach(v => delete v.label);
-        });        
-
-        reverseItemSorted[key] = {};
-        reverseItemSorted[key].items = groupedReverseItems;
-        reverseItemSorted[key].isGrouped = true;
-        reverseItemSorted[key].totalItems = item.length;
-      });
-
-      return reverseItemSorted;
     },
   },
   watch: {
@@ -167,9 +138,9 @@ export default {
     </ul>
 
     <div 
-      v-if="reverseItem && editingObject === 'mainEntity'"
+      v-if="reverseItem && editingObject === 'mainEntity' && showIncomingLinksSection"
       class="EntityForm-reverse">
-      <h6 class="uppercaseHeading">Resurser som länkar hit</h6>
+      <h6 class="uppercaseHeading">{{ 'A selection of resources linking to this resource' | translatePhrase }}</h6>
       <ul class="FieldList">
         <field class="FieldList-item"        
           v-for="(v,k) in reverseItemSorted"

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -132,6 +132,9 @@ export default {
   watch: {
   },
   computed: {
+    isReverseProperty() {
+      return this.fieldKey.indexOf('@reverse') > -1;
+    },
     isFieldDiff() {
       return this.isDiff && this.newDiffValues.length === 0;
     },
@@ -283,6 +286,9 @@ export default {
     },
     locked() {
       if (this.settings.lockedProperties.indexOf(this.fieldKey) !== -1) {
+        return true;
+      }
+      if (this.isReverseProperty) {
         return true;
       }
       return this.isLocked;
@@ -613,6 +619,12 @@ export default {
       v-if="showKey && !isInner" >
       <div class="Field-labelWrapper">
         <div v-if="!isLocked" class="Field-actions">
+          <div class="Field-reverse" v-if="isReverseProperty">
+            <i class="fa fa-exchange fa-fw icon icon--sm"
+              v-tooltip.top="translate('Incoming link')"
+            ></i>
+          </div>
+
           <div class="Field-action Field-remove" 
             v-show="!locked && isRemovable" 
             :class="{'disabled': activeModal}">

--- a/viewer/vue-client/src/components/mixins/form-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/form-mixin.vue
@@ -1,5 +1,5 @@
 <script>
-import { cloneDeep, isArray, sortBy } from 'lodash-es';
+import { cloneDeep, isArray, sortBy, each, groupBy } from 'lodash-es';
 import { mapGetters } from 'vuex';
 import * as DisplayUtil from '@/utils/display';
 import * as VocabUtil from '@/utils/vocab';
@@ -50,10 +50,61 @@ export default {
 
       return fItem;
     },
-    reverseItem() {      
-      return this.sortedFormData['@reverse'];
+    reverseItem() {
+      return this.formObj['@reverse'];
+    },
+    reverseItemInForm() {
+      const reverseItem = cloneDeep(this.reverseItem);
+      const propsInMainForm = require('@/resources/json/displayGroups.json').reverse.mainForm;
+      const objToMainForm = {};
+      each(reverseItem, (item, key) => {
+        if (propsInMainForm.indexOf(`@reverse/${key}`) > -1) {
+          objToMainForm[`@reverse/${key}`] = item;
+        }
+      });
+      return objToMainForm;
+    },
+    reverseItemSorted() {
+      const reverseItem = cloneDeep(this.reverseItem);
+      const propsInMainForm = require('@/resources/json/displayGroups.json').reverse.mainForm;
+      for (let i = 0; i < propsInMainForm.length; i++) {
+        const key = propsInMainForm[i].replace('@reverse/', '');
+        if (reverseItem.hasOwnProperty(key)) {
+          delete reverseItem[key];
+        }
+      }
+      const reverseItemSorted = {};
+
+      each(reverseItem, (item, key) => {
+        let groupedReverseItems = {};
+
+        // get label and add it to the object for sorting        
+        item.map((obj) => {
+          obj.label = this.getLabel(obj);
+          return obj;
+        });
+
+        // sort aplphabetically
+        item.sort((a, b) => a.label.localeCompare(b.label, 'sv'));
+
+        // group by first letter
+        groupedReverseItems = groupBy(item, i => i.label.substring(0, 1));
+
+        // delete label
+        Object.keys(groupedReverseItems).forEach((k) => {
+          groupedReverseItems[k].forEach(v => delete v.label);
+        });        
+
+        reverseItemSorted[key] = {};
+        reverseItemSorted[key].items = groupedReverseItems;
+        reverseItemSorted[key].isGrouped = true;
+        reverseItemSorted[key].totalItems = item.length;
+      });
+
+      return reverseItemSorted;
     },
     sortedFormData() {
+      const formObjConcatenated = Object.assign(this.formObj, this.reverseItemInForm);
       const sortedForm = {};
       for (const property of this.sortedProperties) {
         const k = property;

--- a/viewer/vue-client/src/components/mixins/form-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/form-mixin.vue
@@ -104,12 +104,13 @@ export default {
       return reverseItemSorted;
     },
     sortedFormData() {
-      const formObjConcatenated = Object.assign(this.formObj, this.reverseItemInForm);
+      const formObj = cloneDeep(this.formObj);
+      const formObjWithReverse = Object.assign(formObj, this.reverseItemInForm);
       const sortedForm = {};
       for (const property of this.sortedProperties) {
         const k = property;
-        if (typeof this.formObj[k] !== 'undefined' || this.formObj[k] === '') {
-          sortedForm[k] = this.formObj[k];
+        if (typeof formObjWithReverse[k] !== 'undefined' || formObjWithReverse[k] === '') {
+          sortedForm[k] = formObjWithReverse[k];
         }
       }
       return sortedForm;

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -200,7 +200,7 @@ export default {
       return this.searchPerimeter === 'remote' ? 'ISBN eller valfria sökord' : 'Search';
     },
     composedSearchParam() { // pair current search param with searchphrase
-      const composed = Object.assign({}, this.activeSearchParam.mappings);
+      const composed = Object.assign({}, this.activeSearchParam.mappings || {});
       composed[this.activeSearchParam.searchProp] = this.searchPhrase.length > 0 ? this.searchPhrase : '*';
       return composed;
     },

--- a/viewer/vue-client/src/main.js
+++ b/viewer/vue-client/src/main.js
@@ -276,7 +276,8 @@ new Vue({
           return console.log('%c LXL ', 'background: #009788; color: #fff;', ...strings);
         }
         return false;
-      };      window.lxlWarnStack = [];
+      };
+      window.lxlWarnStack = [];
       window.lxlWarning = (...strings) => {
         if (window.lxlWarnStack.indexOf(JSON.stringify(strings.join())) === -1) {
           window.lxlWarnStack.push(JSON.stringify(strings.join()));

--- a/viewer/vue-client/src/resources/json/displayGroups.json
+++ b/viewer/vue-client/src/resources/json/displayGroups.json
@@ -1,28 +1,36 @@
 {
-  "categorization": [
-    "@type",
-    "issuanceType",
-    "inCollection",
-    "inScheme",
-    "mediaType",
-    "carrierType"
-  ],
-  "header": [
-    "hasTitle",
-    "title",
-    "prefLabel",
-    "label",
-    "heldBy",
-    "familyName",
-    "givenName",
-    "name",
-    "marc:numeration",
-    "marc:titlesAndOtherWordsAssociatedWithAName",
-    "qualifyingNote",
-    "fullerFormOfName",
-    "lifeSpan",
-    "marc:attributionQualifier",
-    "isPartOf",
-    "marc:subordinateUnit"
-  ]
+  "card": {
+    "categorization": [
+      "@type",
+      "issuanceType",
+      "inCollection",
+      "inScheme",
+      "mediaType",
+      "carrierType"
+    ],
+    "header": [
+      "hasTitle",
+      "title",
+      "prefLabel",
+      "label",
+      "heldBy",
+      "familyName",
+      "givenName",
+      "name",
+      "marc:numeration",
+      "marc:titlesAndOtherWordsAssociatedWithAName",
+      "qualifyingNote",
+      "fullerFormOfName",
+      "lifeSpan",
+      "marc:attributionQualifier",
+      "isPartOf",
+      "marc:subordinateUnit"
+    ]
+  },
+  "reverse": {
+    "mainForm": [
+      "@reverse/broader"
+    ]
+  }
 }
+

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -79,6 +79,8 @@
     "Add entity" : "Lägg till entitet",
     "Add field" : "Lägg till egenskaper",
     "Add field in" : "Lägg till egenskaper under",
+    "Incoming link": "Inkommande länk",
+    "A selection of resources linking to this resource": "Urval av resurser som länkar hit",
     "The property is not repeatable": "Egenskapen är ej repeterbar",
     "The property is not recognized": "Egenskapen känns inte igen",
     "The entity is missing crucial data": "Entiteten saknar nödvändig data",

--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -1,4 +1,4 @@
-import { cloneDeep, each, isObject, uniq, includes, remove, isArray, isEmpty } from 'lodash-es';
+import { cloneDeep, each, isObject, uniq, includes, remove, isArray, filter, isEmpty } from 'lodash-es';
 import moment from 'moment';
 import * as httpUtil from './http';
 import * as DataUtil from './data';
@@ -141,8 +141,25 @@ export function getDisplayProperties(className, displayDefinitions, vocab, setti
     props = ['@type'].concat(props);
   }
   props = uniq(props);
-  remove(props, x => isObject(x));
-  return props;
+  const propsWithTranslatedObjects = [];
+  for (let i = 0; i < props.length; i++) {
+    if (isObject(props[i])) {
+      const translated = translateObjectProp(props[i], context);
+      if (translated !== null) {
+        propsWithTranslatedObjects[i] = translated;
+      }
+    } else {
+      propsWithTranslatedObjects[i] = props[i];
+    }
+  }
+  return propsWithTranslatedObjects;
+}
+
+export function translateObjectProp(object) {
+  if (object.hasOwnProperty('inverseOf')) {
+    return `@reverse/${object['inverseOf']}`;
+  }
+  return null;
 }
 
 /* eslint-disable no-use-before-define */

--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -311,7 +311,7 @@ export function getItemSummary(item, displayDefs, quoted, vocab, settings, conte
       delete card[excludeProperties[i]];
     }
   }
-  const displayGroups = require('@/resources/json/displayGroups.json');
+  const cardDisplayGroups = require('@/resources/json/displayGroups.json').card;
   const summary = {
     categorization: [],
     header: [],
@@ -320,9 +320,9 @@ export function getItemSummary(item, displayDefs, quoted, vocab, settings, conte
   each(card, (value, key) => {
     if (value !== null) {
       const v = isArray(value) ? value : [value];
-      if (displayGroups.header.indexOf(key) !== -1) {
+      if (cardDisplayGroups.header.indexOf(key) !== -1) {
         summary.header.push({ property: key, value: v });
-      } else if (displayGroups.categorization.indexOf(key) !== -1) {
+      } else if (cardDisplayGroups.categorization.indexOf(key) !== -1) {
         summary.categorization.push({ property: key, value: v });
       } else {
         const translated = tryGetValueByLang(item, key, settings.language, context);

--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -1,4 +1,4 @@
-import { cloneDeep, each, isObject, uniq, includes, remove, isArray, filter, isEmpty } from 'lodash-es';
+import { cloneDeep, each, isObject, uniq, includes, remove, isArray, isEmpty } from 'lodash-es';
 import moment from 'moment';
 import * as httpUtil from './http';
 import * as DataUtil from './data';
@@ -12,8 +12,8 @@ export function getDisplayDefinitions(settings) {
   const baseUri = settings.idPath;
   return new Promise((resolve, reject) => {
     if (settings.mockDisplay === true) {
-      window.lxlInfo(`🎭 MOCKING DISPLAY FILE - Using local file instead of live version`);
-      resolve(require('@/resources/json/mockDisplay.json'))
+      window.lxlInfo('🎭 MOCKING DISPLAY FILE - Using local file instead of live version');
+      resolve(require('@/resources/json/mockDisplay.json'));
     } else {
       httpUtil.getResourceFromCache(`${baseUri}/vocab/display/data.jsonld`).then((result) => {
         const clonedResult = cloneDeep(result);
@@ -121,7 +121,6 @@ export function getDisplayProperties(className, displayDefinitions, vocab, setti
   const cn = StringUtil.getCompactUri(className, context);
   let level = inputLevel;
   let props = [];
-  const lensGroups = displayDefinitions.lensGroups;
 
   // If we want tokens, we traverse them first, since they can "fail"
   if (level === 'tokens') {
@@ -157,7 +156,7 @@ export function getDisplayProperties(className, displayDefinitions, vocab, setti
 
 export function translateObjectProp(object) {
   if (object.hasOwnProperty('inverseOf')) {
-    return `@reverse/${object['inverseOf']}`;
+    return `@reverse/${object.inverseOf}`;
   }
   return null;
 }


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3211](https://jira.kb.se/browse/LXL-3211)

### Solves

Makes it possible to alter `displayGroups.json` to tell reverse properties if they should be placed into the regular form instead of the section with "resources that link to this resource".

### Summary of changes

* Split up reverse-list depending on the `displayGroups.json`
* Hide "resources that link here" if the list is empty.
* Added icon and lock state for the reverse properties that are placed in the form.

