### PR TITLE
Fix side panel entity search for words containing hyphen

### DIFF
--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -505,7 +505,7 @@ export default {
       let q = '';
       if (keyword === '') {
         q = '*';
-      } else if (keyword.match(/[|~*+\-"]/)) {
+      } else if (keyword.match(/[|~*+"]/) || keyword.match(/^-| -/)) {
         // User is using operators, accept their keyword as-is
         q = keyword;
       } else {


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description


### Solves
Fix search containing hyphen in side panel
example: Lill-arm should find Lill-armenien

### Summary of changes
Make the condition matching "operator" handle hyphen correctly, i.e do not match inside words.
e.g. match "-armenien" but not "lill-armenien"
