### PR TITLE
adjust toolbar menu height  to viewport height, add scroll

### DIFF
--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -739,10 +739,14 @@ export default {
 
   &-menuList {
     display: block;
-    top: -250%;
+    top: auto;
     left: 50px;
     bottom: 0;
     padding: 10px 0;
+    min-height: 250px;
+    max-height: 300px;
+    overflow: hidden;
+    overflow-y: auto;
 
     & .Toolbar-menuItem {
       &.is-active {
@@ -775,7 +779,19 @@ export default {
       bottom: auto;
       right: 0;
     }
-  }
+
+    @media (min-height: 650px) {
+      max-height: 400px;
+    }
+
+    @media (min-height: 850px) {
+      max-height: 550px;
+    }
+
+    @media (min-height: 1000px) {
+      max-height: none;
+    }
+  } 
   .TemplatePicker, .OverridePicker {
     width: 1px;
     height: 1px;


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
A Part of toolbar menu is not accessible with a submenu expanded.

### Tickets involved
[LXL-3282](https://jira.kb.se/browse/LXL-3282)

### Solves
Fixes the bug by making the menu scrollable.

### Summary of changes
Added scroll and various max-height values depending on viewport height.
