### PR TITLE
Feature/lxl 3104 tweaks

### DIFF
--- a/viewer/vue-client/src/components/inspector/entity-form.vue
+++ b/viewer/vue-client/src/components/inspector/entity-form.vue
@@ -91,7 +91,7 @@ export default {
       return false;
     },
     showIncomingLinksSection() {
-      return Object.keys(this.reverseItemSorted).length > 0;
+      return Object.keys(this.reverseItemStandalone).length > 0;
     },
     formObj() {
       return this.formData;
@@ -128,7 +128,7 @@ export default {
         :key="k" 
         :field-key="k" 
         :field-value="v" 
-        :parent-path="editingObject" />      
+        :parent-path="editingObject" />
       <div id="result" v-if="user.settings.appTech && !isLocked">
         <pre class="col-md-12">
           {{ formObj }}
@@ -142,16 +142,16 @@ export default {
       <h6 class="uppercaseHeading">{{ 'Incoming links' | translatePhrase }}</h6>
       <ul class="FieldList">
         <field class="FieldList-item"
-          v-for="(v,k) in reverseItemSorted"
+          v-for="(v,k) in reverseItemStandalone"
           v-bind:class="{ 'locked': isLocked }" 
           :entity-type="formObj['@type']" 
           :is-inner="false" 
           :is-removable="false" 
           :is-locked="true" 
           :key="k" 
-          :field-key="'@reverse/' + k" 
+          :field-key="k" 
           :field-value="v" 
-          :parent-path="editingObject" />
+          :parent-path="'reverseItems'" />
       </ul>
     </div>
   </div>

--- a/viewer/vue-client/src/components/inspector/entity-form.vue
+++ b/viewer/vue-client/src/components/inspector/entity-form.vue
@@ -139,7 +139,7 @@ export default {
     <div 
       v-if="reverseItem && editingObject === 'mainEntity' && showIncomingLinksSection"
       class="EntityForm-reverse">
-      <h6 class="uppercaseHeading">{{ 'A selection of resources linking to this resource' | translatePhrase }}</h6>
+      <h6 class="uppercaseHeading">{{ 'Incoming links' | translatePhrase }}</h6>
       <ul class="FieldList">
         <field class="FieldList-item"
           v-for="(v,k) in reverseItemSorted"

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -619,12 +619,6 @@ export default {
       v-if="showKey && !isInner" >
       <div class="Field-labelWrapper">
         <div v-if="!isLocked" class="Field-actions">
-          <div class="Field-reverse" v-if="isReverseProperty">
-            <i class="fa fa-exchange fa-fw icon icon--sm"
-              v-tooltip.top="translate('Incoming link')"
-            ></i>
-          </div>
-
           <div class="Field-action Field-remove" 
             v-show="!locked && isRemovable" 
             :class="{'disabled': activeModal}">

--- a/viewer/vue-client/src/components/inspector/item-grouped.vue
+++ b/viewer/vue-client/src/components/inspector/item-grouped.vue
@@ -23,6 +23,10 @@ export default {
       type: String,
       default: '',
     },
+    parentPath: {
+      type: String,
+      default: '',
+    }
   },
   data() {
     return {
@@ -45,9 +49,18 @@ export default {
         return true;
       }
       return false;
-    }
+    },
+    isInForm() {
+      if (this.parentPath.indexOf('mainEntity') === 0) {
+        return true;
+      }
+      return false;
+    },
   },
   mounted() {
+    if (this.isInForm) {
+      this.expand();
+    }
   },
   watch: {
   },
@@ -79,7 +92,7 @@ export default {
     @focus="addFocus()"
     @blur="removeFocus()">
 
-    <strong class="ItemGrouped-heading">
+    <strong class="ItemGrouped-heading" v-if="!isInForm">
       <div class="ItemGrouped-label"
         :class="{'is-locked': isLocked }"
         @click="toggleExpanded()">
@@ -88,7 +101,8 @@ export default {
       </div>
     </strong>
 
-    <ul class="ItemGrouped-list">
+    <ul class="ItemGrouped-list"
+      :class="{'has-hidden-keys' : !showKeys}">
       <field
       v-for="(value, key) in groupedItems"
       :key="key"
@@ -163,6 +177,10 @@ export default {
 
     .is-expanded & {
       display: block;
+    }
+
+    &.has-hidden-keys {
+      margin-left: -1em;
     }
   }
 }

--- a/viewer/vue-client/src/components/inspector/item-grouped.vue
+++ b/viewer/vue-client/src/components/inspector/item-grouped.vue
@@ -26,7 +26,7 @@ export default {
     parentPath: {
       type: String,
       default: '',
-    }
+    },
   },
   data() {
     return {
@@ -45,7 +45,7 @@ export default {
       return this.item.items;
     },
     showKeys() {
-      if (Object.keys(this.groupedItems).length > 1){
+      if (Object.keys(this.groupedItems).length > 1) {
         return true;
       }
       return false;

--- a/viewer/vue-client/src/components/inspector/item-grouped.vue
+++ b/viewer/vue-client/src/components/inspector/item-grouped.vue
@@ -37,6 +37,15 @@ export default {
       'settings',
       'status',
     ]),
+    groupedItems() {
+      return this.item.items;
+    },
+    showKeys() {
+      if (Object.keys(this.groupedItems).length > 1){
+        return true;
+      }
+      return false;
+    }
   },
   mounted() {
   },
@@ -81,13 +90,14 @@ export default {
 
     <ul class="ItemGrouped-list">
       <field
-      v-for="(value, key) in item.items"
+      v-for="(value, key) in groupedItems"
       :key="key"
       :entity-type="entityType" 
       :is-inner="false" 
       :is-locked="true" 
       :is-removable="false" 
       :is-grouped="true"
+      :show-key="showKeys"
       :field-key="key"
       :field-value="value"></field>
     </ul>  

--- a/viewer/vue-client/src/resources/json/displayGroups.json
+++ b/viewer/vue-client/src/resources/json/displayGroups.json
@@ -30,6 +30,9 @@
   "reverse": {
     "mainForm": [
       "@reverse/broader"
+    ],
+    "hidden": [
+      "@reverse/itemOf"
     ]
   }
 }

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -80,6 +80,7 @@
     "Add field" : "Lägg till egenskaper",
     "Add field in" : "Lägg till egenskaper under",
     "Incoming link": "Inkommande länk",
+    "Incoming links": "Inkommande länkar",
     "A selection of resources linking to this resource": "Urval av resurser som länkar hit",
     "The property is not repeatable": "Egenskapen är ej repeterbar",
     "The property is not recognized": "Egenskapen känns inte igen",


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

Presentational tweaks of @reverse items.

### Tickets involved
[LXL-3104](https://jira.kb.se/browse/LXL-3104)

### Solves

- @reverse.itemOf should be hidden
- @reverse.broader should be expanded, sorted and grouped when in mainForm
- minor design and text tweaks

### Summary of changes

- removed "incoming links"-icon
- inverse in form is now sorted and grouped alphabetically 
- hidden label when there is only one group
- inverse in form is always expanded
- added "reverse.hidden" list to displayGroups.json, use to hide items in form



