### PR TITLE
Feature/lxl 2971 add alt text to img

### DIFF
--- a/viewer/vue-client/src/resources/json/copy.json
+++ b/viewer/vue-client/src/resources/json/copy.json
@@ -1,7 +1,7 @@
 {
   "about-xl-full": {
     "image": "omxllarge_new.png",
-    "image_alt_text": "Två kvinnor framför en datorskärm",
+    "image_alt_text": "Ett nav av tekniska produkter som är kopplade till ett moln",
     "header": "Om nya Libris och XL",
     "text": {
       "abstract": "Libris katalogisering är den nya katalogiseringstjänsten. I verktyget är gränssnittet anpassat för att ta tillvara de möjligheter som nytt format och ny systemarkitektur erbjuder. För att göra katalogiseringen så smidig som möjligt finns hjälp och stöd inbyggt i systemet.",

--- a/viewer/vue-client/src/views/About.vue
+++ b/viewer/vue-client/src/views/About.vue
@@ -13,6 +13,9 @@ export default {
     image() {
       return require(`@/assets/img/${this.copy.image}`);
     },
+    imageAltText() {
+      return this.copy.image_alt_text;
+    },
     text() {
       return this.copy.text;
     },
@@ -22,7 +25,7 @@ export default {
 
 <template>
   <article class="panel panel-default Article">
-    <img :src="image" class="Article-featuredImg" title="Abstract XL Graphics"/>
+    <img :src="image" class="Article-featuredImg" :alt="imageAltText" title="Abstract XL Graphics"/>
     <div class="Article-content">
       <header class="Article-header">
         <h1 class="Article-title">{{ header }}</h1>


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-2971](https://jira.kb.se/browse/LXL-2971)

### Solves

Missing alt text on image

### Summary of changes

Added alt text 
Changed text in copy.json to one that correctly describes the image
