### PR TITLE
LXL-3035 - use reverseLinks

### DIFF
--- a/viewer/vue-client/src/components/inspector/reverse-relations.vue
+++ b/viewer/vue-client/src/components/inspector/reverse-relations.vue
@@ -70,7 +70,8 @@ export default {
               console.log(error);
             });
         } else if (this.recordType === 'Work') {
-          query['instanceOf.@id'] = this.mainEntity['@id'];
+          // query['instanceOf.@id'] = this.mainEntity['@id'];
+          query.o = this.mainEntity['@id'];
           query['@type'] = 'Instance';
         } else if (this.recordType === 'Agent') {
           query['instanceOf.contribution.agent.@id'] = this.mainEntity['@id'];
@@ -83,7 +84,7 @@ export default {
           this.panelQuery._sort = 'heldBy.@id';
         }
 
-        if (this.mainEntity.reverseLinks && this.recordType === 'Instance') {
+        if (this.mainEntity.reverseLinks && this.recordType !== 'Agent') {
           this.numberOfRelations = this.mainEntity.reverseLinks.totalItems;
           this.checkingRelations = false;
         } else {

--- a/viewer/vue-client/src/components/inspector/reverse-relations.vue
+++ b/viewer/vue-client/src/components/inspector/reverse-relations.vue
@@ -84,7 +84,7 @@ export default {
           this.panelQuery._sort = 'heldBy.@id';
         }
 
-        if (this.mainEntity.reverseLinks && this.recordType !== 'Agent') {
+        if (this.mainEntity.reverseLinks && (this.recordType === 'Work' || this.recordType === 'Concept')) {
           this.numberOfRelations = this.mainEntity.reverseLinks.totalItems;
           this.checkingRelations = false;
         } else {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
enable reverseLinks.totalItems  for Work and Concept
Agent still uses o-query.

### Tickets involved
[LXL-3025](https://jira.kb.se/browse/LXL-3035)

### Summary of changes
use reverseLinks number in search results instead of o-query
use o-query for Work to reflect reverseLinks.totalItems

