### PR TITLE
LXL-3306 - Check for existance of a linked work before writing from the template

### DIFF
--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -315,8 +315,16 @@ export default {
       }
 
       const basePostData = cloneDeep(this.inspector.data);
-      const changeList = [];
 
+      // This part checks if the template should include the work or not (to not overwrite a link)
+      if (basePostData.mainEntity.hasOwnProperty('instanceOf')) {
+        const basePostWork = basePostData.mainEntity.instanceOf;
+        if (Object.keys(basePostWork).length === 1 && basePostWork.hasOwnProperty('@id')) {
+          delete template.mainEntity.instanceOf;
+        }
+      }
+
+      const changeList = [];
       function applyChangeList(templatePath, targetPath = null) {
         if (targetPath === null) {
           // targetPath is used when the target path differs from the templatePath


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3306](https://jira.kb.se/browse/LXL-3306)

### Solves

Fixes linked works being overwritten by local works from the template.

### Summary of changes

Check for existance of link before applying local work from template.
