### PR TITLE
Feature/lxl 3320 reverse field ux improvements

### DIFF
--- a/viewer/vue-client/src/App.vue
+++ b/viewer/vue-client/src/App.vue
@@ -662,6 +662,9 @@ h1 {
       &:extend(.uppercaseHeading);
       font-size: 1.8rem;
     }
+    &--secondary {
+      color: @grey;
+    }
 }
 
 // -------- FORM -------------

--- a/viewer/vue-client/src/components/inspector/entity-action.vue
+++ b/viewer/vue-client/src/components/inspector/entity-action.vue
@@ -110,7 +110,7 @@ export default {
   &.action-larger {
     background-color: @white;
     border: 1px solid;
-    border-radius: 2rem;
+    border-radius: 0.25rem;
     padding: 0rem 1rem 0rem 0.5rem;
     margin: 0 0.2rem;
     .action-label {

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -682,7 +682,18 @@ export default {
           <span v-show="fieldKey === '@id'">{{ 'ID' | translatePhrase | capitalize }}</span>
           <span v-show="fieldKey === '@type'">{{ entityTypeArchLabel | translatePhrase | capitalize }}</span>
           <span v-show="fieldKey !== '@id' && fieldKey !== '@type'" 
-            :title="fieldKey">{{ fieldKey | labelByLang | capitalize }}</span>    
+            :title="fieldKey">{{ fieldKey | labelByLang | capitalize }}</span>          
+          <div class="Field-reverse uppercaseHeading--secondary" v-if="isReverseProperty">
+            <span :title="fieldKey">{{ 'Incoming links' | translatePhrase | capitalize }}</span>          
+            <div class="Field-comment">
+              <i class="fa fa-question-circle-o icon icon--sm"></i>
+              <span class="Field-commentText">{{ 'Non editable incoming link' | translatePhrase }}.
+                <br />
+                <!-- Uncomment link below when the url has been updated with info about inoming links -->
+                <!-- <a href="https://libris.kb.se/katalogisering/help/entity-search" target="_blank">{{ 'Read more about incoming links' | translatePhrase }}.</a> -->
+              </span>
+            </div>
+          </div>
         </div>
       </div>
       <code class="path-code" v-show="user.settings.appTech && !isInner">{{path}}</code>
@@ -1282,6 +1293,15 @@ export default {
       @media (min-width: @screen-sm) {
         display: block;
       }
+    }
+  }
+
+  &-reverse {    
+    .Field-comment {
+      display: inline-block;
+      min-height: 30px;
+      width: auto;
+      margin-right: 0;
     }
   }
 

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -689,8 +689,7 @@ export default {
               <i class="fa fa-question-circle-o icon icon--sm"></i>
               <span class="Field-commentText">{{ 'Non editable incoming link' | translatePhrase }}.
                 <br />
-                <!-- Uncomment link below when the url has been updated with info about inoming links -->
-                <!-- <a href="https://libris.kb.se/katalogisering/help/entity-search" target="_blank">{{ 'Read more about incoming links' | translatePhrase }}.</a> -->
+                <a href="https://libris.kb.se/katalogisering/help/entity-search" target="_blank">{{ 'Read more about incoming links' | translatePhrase }}.</a>
               </span>
             </div>
           </div>

--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -686,9 +686,7 @@ export default {
       margin-left: 0.4rem;
     }
     display: flex;
-    @media (max-width: @screen-sm) {
-      align-items: baseline;
-    }
+    align-items: baseline;
   }
 
   .ManagerMenu {

--- a/viewer/vue-client/src/components/inspector/item-sibling.vue
+++ b/viewer/vue-client/src/components/inspector/item-sibling.vue
@@ -617,9 +617,7 @@ export default {
       margin-left: 0.4rem;
     }
     display: flex;
-    @media (max-width: @screen-sm) {
-      align-items: baseline;
-    }
+    align-items: baseline;
   }
 
   .ManagerMenu {

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -82,6 +82,8 @@
     "Add field in" : "Lägg till egenskaper under",
     "Incoming link": "Inkommande länk",
     "Incoming links": "Inkommande länkar",
+    "Non editable incoming link": "Inkommande och ej redigerbar länk",
+    "Read more about incoming links": "Läs mer om inkommande länkar",
     "A selection of resources linking to this resource": "Urval av resurser som länkar hit",
     "The property is not repeatable": "Egenskapen är ej repeterbar",
     "The property is not recognized": "Egenskapen känns inte igen",


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

Field showing reverse links need a more distinct description

### Tickets involved
[LXL-3320](https://jira.kb.se/browse/LXL-3320)
### Summary of changes

Added extra subheading and help tooltip
