### PR TITLE
Make reverse properties visible on id.kb.se

### DIFF
--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -230,8 +230,11 @@ def thingview(path, suffix=None):
 
     whelk_accept_header = _get_view_data_accept_header(request, suffix)
     query_params = _filter_query_params(request.args)
-
     resource_id = _get_served_uri(request.url_root, path)
+
+    if g.site.get('applyInverseOf', False):
+        query_params['_applyInverseOf'] = 'true'
+    
     resp = _proxy_request(request, session, accept_header=whelk_accept_header,
             url_path=resource_id, query_params=query_params)
 

--- a/viewer/dataaccess.py
+++ b/viewer/dataaccess.py
@@ -54,6 +54,7 @@ sites = {
         "statsindex": '{"inScheme.@id":{"inCollection.@id":["@type"], "@type":[]}}',
         "statsfind": '{"inScheme.@id":{"inCollection.@id":["@type"], "@type":[]}}',
         "filter_param": "inScheme.@id",
+        "applyInverseOf": True,
         "itemList": [
             {ID: "/", "title": "Sök"},
             {ID: "/marcframe/", "title": "MARC-mappningar"},


### PR DESCRIPTION
## Description
Make `@reverse` properties visible on id.kb.se
They will be shown as the acual relation, e.g. `@reverse/broader` will be displayed as narrower. 
Both in the html and data views. (Is this good or bad?)

### Tickets involved
[LXL-3291](https://jira.kb.se/browse/LXL-3291)

### Summary of changes
Make the python packend use `_applyInverseOf` when fetching data from backend. (https://github.com/libris/librisxl/pull/722)
