### PR TITLE
LXL-3356-Newly added linked resource does not render as chip until post is saved.

### DIFF
--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -377,8 +377,12 @@ export default {
       let currentValue = cloneDeep(get(this.inspector.data, this.path));
       if (!isArray(currentValue)) {
         // Converting value to array if it isn't already
-        currentValue = [currentValue];
-      }
+        if (currentValue !== null) {
+          currentValue = [currentValue];
+        } else {
+          currentValue = [];
+        }
+      }      
       const linkObj = { '@id': obj['@id'] };
       currentValue.push(linkObj);
       this.$store.dispatch('addToQuoted', obj);


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

New resource does not render as chip until post is saved.
Caused by a ``null`` value being added to the ``currentValue`` array in ``addLinkedItem``.

### Tickets involved
[LXL-3356](https://jira.kb.se/browse/LXL-3356)

### Summary of changes

Added a null check to prevent a null value being added to the ``currentValue`` array.
