### PR TITLE
LXL-3249 - Distinguish Work cards

### DIFF
--- a/viewer/vue-client/src/components/search/facet-group.vue
+++ b/viewer/vue-client/src/components/search/facet-group.vue
@@ -1,6 +1,7 @@
 <script>
 import Facet from './facet.vue';
 import EncodingLevelIcon from '@/components/shared/encoding-level-icon';
+import TypeIcon from '@/components/shared/type-icon';
 
 export default {
   name: 'facet-group',
@@ -60,6 +61,7 @@ export default {
   components: {
     Facet,
     EncodingLevelIcon,
+    TypeIcon,
   },
 };
 </script>
@@ -84,7 +86,12 @@ export default {
         <encoding-level-icon
           slot="icon"
           v-if="group.dimension === 'meta.encodingLevel'"
-          :encodingLevel="observation.object['@id']"></encoding-level-icon>
+          :encodingLevel="observation.object['@id']" />
+        <type-icon
+          slot="icon"
+          :show-iconless="false"
+          v-if="group.dimension === 'instanceOf.@type' || group.dimension === '@type'"
+          :type="observation.object['@id']" />
       </facet>
     </ul>
     <span 

--- a/viewer/vue-client/src/components/shared/entity-summary.vue
+++ b/viewer/vue-client/src/components/shared/entity-summary.vue
@@ -213,7 +213,7 @@ export default {
         this.resources.context,
       );
       if (type === this.recordType) {
-        return `Ospecifierad, ${translatedBaseType}`;
+        return `${this.$options.filters.translatePhrase('Unspecified')}, ${translatedBaseType}`;
       }
       let translatedType = '';
       if (isArray(type)) {
@@ -305,7 +305,7 @@ export default {
       :encodingLevel="encodingLevel"
       :tooltipText="encodingLevel | labelByLang"/>
     <div :title="categorization.join(', ')" v-if="excludeComponents.indexOf('categorization') < 0" class="EntitySummary-type uppercaseHeading--light">
-      {{typeLabel}}{{ categorization.length > 0 ? ' • ' : '' }}{{categorization.join(', ')}} {{ isLocal ? '{lokal entitet}' : '' }}
+      {{ typeLabel }}{{ categorization.length > 0 ? ' • ' : '' }}{{categorization.join(', ')}} {{ isLocal ? '{lokal entitet}' : '' }}
       <span class="EntitySummary-sourceLabel" v-if="database">{{ database }}</span>
     </div>
     <div v-if="idAsFnurgel && excludeComponents.indexOf('id') < 0" class="EntitySummary-id uppercaseHeading--light" :class="{'recently-copied': recentlyCopiedId }" @mouseover="idHover = true" @mouseout="idHover = false">

--- a/viewer/vue-client/src/components/shared/entity-summary.vue
+++ b/viewer/vue-client/src/components/shared/entity-summary.vue
@@ -3,8 +3,10 @@ import { each, isArray, cloneDeep } from 'lodash-es';
 import { mapGetters } from 'vuex';
 import LensMixin from '../mixins/lens-mixin';
 import EncodingLevelIcon from '@/components/shared/encoding-level-icon';
+import TypeIcon from '@/components/shared/type-icon';
 import SummaryNode from '@/components/shared/summary-node';
 import * as StringUtil from '@/utils/string';
+import * as VocabUtil from '@/utils/vocab';
 import * as RecordUtil from '@/utils/record';
 
 export default {
@@ -13,6 +15,7 @@ export default {
   components: {
     EncodingLevelIcon,
     SummaryNode,
+    TypeIcon,
   },
   props: {
     focusData: {
@@ -198,6 +201,33 @@ export default {
       }
       return limited;
     },
+    recordType() {
+      return VocabUtil.getRecordType(this.focusData['@type'], this.resources.vocab, this.resources.context);
+    },
+    typeLabel() {
+      const type = this.focusData['@type'];
+      const translatedBaseType = StringUtil.getLabelByLang(
+        this.recordType,
+        this.user.settings.language, 
+        this.resources.vocab, 
+        this.resources.context,
+      );
+      if (type === this.recordType) {
+        return `Ospecifierad, ${translatedBaseType}`;
+      }
+      let translatedType = '';
+      if (isArray(type)) {
+        translatedType = type.join(', ');
+      } else {
+        translatedType = StringUtil.getLabelByLang(
+          type,
+          this.user.settings.language, 
+          this.resources.vocab, 
+          this.resources.context,
+        );
+      }
+      return `${translatedType}, ${translatedBaseType}`;
+    },
     categorization() {
       return StringUtil.getFormattedEntries(
         this.getSummary.categorization, 
@@ -266,12 +296,16 @@ export default {
   class="EntitySummary"
   v-bind:class="{'is-embedded-in-field': embeddedInField}">
   <div class="EntitySummary-meta">
+    <type-icon
+      v-if="recordType === 'Work'"
+      :type="focusData['@type']"
+    />
     <encoding-level-icon
-      v-if="encodingLevel && !isItem"
+      v-if="encodingLevel && recordType === 'Instance'"
       :encodingLevel="encodingLevel"
       :tooltipText="encodingLevel | labelByLang"/>
     <div :title="categorization.join(', ')" v-if="excludeComponents.indexOf('categorization') < 0" class="EntitySummary-type uppercaseHeading--light">
-      {{categorization.join(', ')}} {{ isLocal ? '{lokal entitet}' : '' }}
+      {{typeLabel}}{{ categorization.length > 0 ? ' • ' : '' }}{{categorization.join(', ')}} {{ isLocal ? '{lokal entitet}' : '' }}
       <span class="EntitySummary-sourceLabel" v-if="database">{{ database }}</span>
     </div>
     <div v-if="idAsFnurgel && excludeComponents.indexOf('id') < 0" class="EntitySummary-id uppercaseHeading--light" :class="{'recently-copied': recentlyCopiedId }" @mouseover="idHover = true" @mouseout="idHover = false">

--- a/viewer/vue-client/src/components/shared/entity-summary.vue
+++ b/viewer/vue-client/src/components/shared/entity-summary.vue
@@ -228,6 +228,9 @@ export default {
       }
       return `${translatedType}, ${translatedBaseType}`;
     },
+    topBarInformation() {
+      return `${ this.typeLabel }${ this.categorization.length > 0 ? ' • ' : '' }${ this.categorization.join(', ') }`
+    },
     categorization() {
       return StringUtil.getFormattedEntries(
         this.getSummary.categorization, 
@@ -304,8 +307,8 @@ export default {
       v-if="encodingLevel && recordType === 'Instance'"
       :encodingLevel="encodingLevel"
       :tooltipText="encodingLevel | labelByLang"/>
-    <div :title="categorization.join(', ')" v-if="excludeComponents.indexOf('categorization') < 0" class="EntitySummary-type uppercaseHeading--light">
-      {{ typeLabel }}{{ categorization.length > 0 ? ' • ' : '' }}{{categorization.join(', ')}} {{ isLocal ? '{lokal entitet}' : '' }}
+    <div :title="topBarInformation" v-if="excludeComponents.indexOf('categorization') < 0" class="EntitySummary-type uppercaseHeading--light">
+      {{ topBarInformation }} {{ isLocal ? '{lokal entitet}' : '' }}
       <span class="EntitySummary-sourceLabel" v-if="database">{{ database }}</span>
     </div>
     <div v-if="idAsFnurgel && excludeComponents.indexOf('id') < 0" class="EntitySummary-id uppercaseHeading--light" :class="{'recently-copied': recentlyCopiedId }" @mouseover="idHover = true" @mouseout="idHover = false">

--- a/viewer/vue-client/src/components/shared/type-icon.vue
+++ b/viewer/vue-client/src/components/shared/type-icon.vue
@@ -22,7 +22,7 @@ export default {
     return {
       iconMap: {
         'Text': 'file-text',
-        'Text': 'file-text',
+        'ManuscriptText': 'file-text',
         'Audio': 'volume-up',
         'Music': 'volume-up',
         'Kit': 'archive',

--- a/viewer/vue-client/src/components/shared/type-icon.vue
+++ b/viewer/vue-client/src/components/shared/type-icon.vue
@@ -36,7 +36,10 @@ export default {
         'Multimedia': 'laptop',
         'NotatedMusic': 'music',
         'ManuscriptNotatedMusic': 'music',
-      }
+      },
+      forcedUnspecified: [
+        'Work',
+      ],
     };
   },
   methods: {
@@ -47,6 +50,9 @@ export default {
     ]),
     convertedType() {
       return this.type.replace('https://id.kb.se/vocab/', '');
+    },
+    isForcedUnspecified() {
+      return this.forcedUnspecified.indexOf(this.convertedType) > -1;
     },
     iconClass() {
       let iconName = '';
@@ -67,8 +73,8 @@ export default {
 </script>
 
 <template>
-  <div class="TypeIcon" v-if="showIconless === true || iconClass !== ''">
-    <span class="TypeIcon-label" v-if="iconClass === ''">/</span>
+  <div class="TypeIcon" v-if="showIconless === true || iconClass !== '' || isForcedUnspecified">
+    <span class="TypeIcon-label" v-if="iconClass === '' || isForcedUnspecified">/</span>
     <i :class="iconClass" v-if="iconClass !== ''"></i>
   </div>
 </template>

--- a/viewer/vue-client/src/components/shared/type-icon.vue
+++ b/viewer/vue-client/src/components/shared/type-icon.vue
@@ -1,6 +1,5 @@
 <script>
 import { mapGetters } from 'vuex';
-import * as VocabUtil from '@/utils/vocab';
 
 export default {
   name: 'type-icon',
@@ -21,21 +20,21 @@ export default {
   data() {
     return {
       iconMap: {
-        'Text': 'file-text',
-        'ManuscriptText': 'file-text',
-        'Audio': 'volume-up',
-        'Music': 'volume-up',
-        'Kit': 'archive',
-        'StillImage': 'picture-o',
-        'MixedMaterial': 'cubes',
-        'Object': 'cube',
-        'MovingImage': 'film',
-        'Cartography': 'map',
-        'ManuscriptCartography': 'map',
-        'Dataset': 'database',
-        'Multimedia': 'laptop',
-        'NotatedMusic': 'music',
-        'ManuscriptNotatedMusic': 'music',
+        Text: 'file-text',
+        ManuscriptText: 'file-text',
+        Audio: 'volume-up',
+        Music: 'volume-up',
+        Kit: 'archive',
+        StillImage: 'picture-o',
+        MixedMaterial: 'cubes',
+        Object: 'cube',
+        MovingImage: 'film',
+        Cartography: 'map',
+        ManuscriptCartography: 'map',
+        Dataset: 'database',
+        Multimedia: 'laptop',
+        NotatedMusic: 'music',
+        ManuscriptNotatedMusic: 'music',
       },
       forcedUnspecified: [
         'Work',

--- a/viewer/vue-client/src/components/shared/type-icon.vue
+++ b/viewer/vue-client/src/components/shared/type-icon.vue
@@ -1,0 +1,87 @@
+<script>
+import { mapGetters } from 'vuex';
+import * as VocabUtil from '@/utils/vocab';
+
+export default {
+  name: 'type-icon',
+  props: {
+    type: {
+      type: String,
+      required: true,
+    },
+    tooltipText: {
+      type: String,
+      default: '',
+    },
+  },
+  data() {
+    return {
+      iconMap: {
+        'Text': 'file-text',
+        'Text': 'file-text',
+        'Audio': 'volume-up',
+        'Music': 'volume-up',
+        'Kit': 'archive',
+        'StillImage': 'picture-o',
+        'MixedMaterial': 'cubes',
+        'Object': 'cube',
+        'MovingImage': 'film',
+        'Cartography': 'map',
+        'ManuscriptCartography': 'map',
+        'Dataset': 'database',
+        'Multimedia': 'laptop',
+        'NotatedMusic': 'music',
+        'ManuscriptNotatedMusic': 'music',
+      }
+    };
+  },
+  methods: {
+  },
+  computed: {
+    ...mapGetters([
+      'resources',
+    ]),
+    iconClass() {
+      let iconName = '';
+      if (this.iconMap.hasOwnProperty(this.type)) {
+        iconName = this.iconMap[this.type];
+      } else {
+        return '';
+      }
+      return `fa fa-fw fa-${iconName}`;
+    },
+  },
+  components: {
+  },
+  mounted() {
+    this.$nextTick(() => {});
+  },
+};
+</script>
+
+<template>
+  <div class="TypeIcon">
+    <span class="TypeIcon-label" v-if="iconClass === ''">/</span>
+    <i :class="iconClass" v-else></i>
+  </div>
+</template>
+
+<style lang="less">
+.TypeIcon {
+  background-color: @grey-lightest;
+  color: @brand-primary;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 20px;
+  height: 20px;
+  border-radius: 0.25rem;
+  margin-right: 5px;
+  font-size: 12px;
+
+  &-label {
+    font-weight: 800;
+  }
+}
+
+</style>

--- a/viewer/vue-client/src/components/shared/type-icon.vue
+++ b/viewer/vue-client/src/components/shared/type-icon.vue
@@ -13,6 +13,10 @@ export default {
       type: String,
       default: '',
     },
+    showIconless: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {
@@ -41,10 +45,13 @@ export default {
     ...mapGetters([
       'resources',
     ]),
+    convertedType() {
+      return this.type.replace('https://id.kb.se/vocab/', '');
+    },
     iconClass() {
       let iconName = '';
-      if (this.iconMap.hasOwnProperty(this.type)) {
-        iconName = this.iconMap[this.type];
+      if (this.iconMap.hasOwnProperty(this.convertedType)) {
+        iconName = this.iconMap[this.convertedType];
       } else {
         return '';
       }
@@ -60,9 +67,9 @@ export default {
 </script>
 
 <template>
-  <div class="TypeIcon">
+  <div class="TypeIcon" v-if="showIconless === true || iconClass !== ''">
     <span class="TypeIcon-label" v-if="iconClass === ''">/</span>
-    <i :class="iconClass" v-else></i>
+    <i :class="iconClass" v-if="iconClass !== ''"></i>
   </div>
 </template>
 

--- a/viewer/vue-client/src/resources/json/displayGroups.json
+++ b/viewer/vue-client/src/resources/json/displayGroups.json
@@ -1,7 +1,6 @@
 {
   "card": {
     "categorization": [
-      "@type",
       "issuanceType",
       "inCollection",
       "inScheme",

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -236,6 +236,7 @@
     "Create": "Skapa",
     "Creating link": "Skapar länk",
     "Item": "Bestånd",
+    "Unspecified": "Ospecificerad",
     "Missing label": "Etikett saknas",
     "missing": "saknas",
     "without": "utan",

--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -135,10 +135,6 @@ export function getDisplayProperties(className, displayDefinitions, vocab, setti
   if (level !== 'tokens') {
     props = getLensPropertiesDeep(cn, displayDefinitions, vocab, settings, context, level, depth);
   }
-  // Add @type
-  if (level === 'cards') {
-    props = ['@type'].concat(props);
-  }
   props = uniq(props);
   const propsWithTranslatedObjects = [];
   for (let i = 0; i < props.length; i++) {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3249](https://jira.kb.se/browse/LXL-3249)

### Solves

Adds icons to Work-types. Also adds a basetype label (ie Work, Instance, Agent etc) in addition to their specific types (Electronic, Text, Person etc).

### Summary of changes

* Added `type-icon` component. Derived from the `encoding-level-icon`-component.
* Disabled getting type labels from display-utility and getting them in a specific way for the `entity-summary`-component instead. Getting them from display was always kind of a hack anyway.
