### PR TITLE
Search both contribution and instanceOf.contribution for agents

### DIFF
--- a/viewer/vue-client/src/components/inspector/reverse-relations.vue
+++ b/viewer/vue-client/src/components/inspector/reverse-relations.vue
@@ -74,7 +74,8 @@ export default {
           query.o = this.mainEntity['@id'];
           query['@type'] = 'Instance';
         } else if (this.recordType === 'Agent') {
-          query['instanceOf.contribution.agent.@id'] = this.mainEntity['@id'];
+          query['or-instanceOf.contribution.agent.@id'] = this.mainEntity['@id'];
+          query['or-contribution.agent.@id'] = this.mainEntity['@id'];
         } else {
           query.o = this.mainEntity['@id'];
         }


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [X] I have run the linter. `yarn lint`

## Description
When showing contributions for an agent, both instance and work documents should be displayed.
In the bottom-right corner of the card and in the corresponding right-panel search.

### Tickets involved
[LXL-3305](https://jira.kb.se/browse/LXL-3305)
