### PR TITLE
Filter out warnings from rdfxml 'Assertions on rdflib.term.BNode...'

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -2,6 +2,7 @@
 import sys
 import logging
 import argparse
+import warnings
 from viewer import app
 
 log = logging.getLogger()
@@ -11,5 +12,8 @@ log.setLevel(logging.DEBUG if app.debug else logging.INFO)
 argp = argparse.ArgumentParser()
 argp.add_argument('--port', '-p', type=int)
 args = argp.parse_args()
+
+# Warning from rdfxml that should be ignored
+warnings.filterwarnings('ignore', message = 'Assertions on rdflib.term.BNode')
 
 app.run(port=args.port,host='0.0.0.0')


### PR DESCRIPTION
I tested this by generating the same warning in `serve.py` and it was filtered correctly.