### PR TITLE
LXL-3226 - get labels for contribution facets

### DIFF
--- a/viewer/vue-client/src/components/search/facet.vue
+++ b/viewer/vue-client/src/components/search/facet.vue
@@ -1,8 +1,12 @@
 <script>
+import { mapGetters } from 'vuex';
 import * as MathUtil from '@/utils/math';
+import * as VocabUtil from '@/utils/vocab';
+import LensMixin from '@/components/mixins/lens-mixin';
 
 export default {
   name: 'facet',
+  mixins: [LensMixin],
   props: {
     active: {
       type: Boolean,
@@ -22,8 +26,18 @@ export default {
       }
       return object[property];
     },
+    getRecordType(object) {
+      return VocabUtil.getRecordType(
+        object['@type'], 
+        this.resources.vocab, 
+        this.resources.context,
+      );
+    },
   },
   computed: {
+    ...mapGetters([
+      'resources',
+    ]),
     user() {
       return this.$store.getters.user;
     },
@@ -41,10 +55,15 @@ export default {
       const label = this.getByLang(object, 'prefLabel', lang)
         || this.getByLang(object, 'label', lang)
         || this.getByLang(object, 'title', lang);
+      
       if (label) {
         return label;
+      }  
+
+      if (this.getRecordType(object) === 'Agent') {
+        return this.getLabel(object);
       }
-      
+
       const idArray = object['@id'].split('/');
       return `${idArray[idArray.length - 1]} [has no label]`;
     },

--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -3,9 +3,11 @@ import { mapGetters } from 'vuex';
 import * as StringUtil from '@/utils/string';
 import * as httpUtil from '@/utils/http';
 import Sort from '@/components/search/sort';
+import LensMixin from '@/components/mixins/lens-mixin';
 
 export default {
   name: 'result-controls',
+  mixins: [LensMixin],
   props: {
     pageData: {},
     showDetails: {
@@ -41,6 +43,7 @@ export default {
         filters = this.pageData.search.mapping.filter(item => this.excludeFilters.every(el => el !== item.variable))
           .map((item) => {
             let label = '';
+
             if (item.hasOwnProperty('value')) { // Try to use item value to get label
               label = item.value;
             } else if (item.hasOwnProperty('object') && this.pageData.hasOwnProperty('stats')) { // else look for preflabel in stats (if there are results)
@@ -60,6 +63,9 @@ export default {
                       label = matchObj[tryProps[prop]];
                     }
                   }
+                }
+                if (label === '') {
+                  label = this.getLabel(matchObj);
                 }
               } else {
                 label = item.object['@id'];

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -256,21 +256,21 @@ const store = new Vuex.Store({
           sv: 'Språk',
           en: 'Language',
           facet: {
-            order: 8,
+            order: 6,
           },
         },
         genreForm: {
           sv: 'Genre/form',
           en: 'Genre/form',
           facet: {
-            order: 9,
+            order: 7,
           },
         },
         'contribution.agent': {
           sv: 'Medverkan',
           en: 'Contribution',
           facet: {
-            order: 9,
+            order: 7,
           },
         },
         contentType: {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

Need to display proper labels for the newly added contribution facet

### Tickets involved
[LXL-3226](https://jira.kb.se/browse/LXL-3226)

### Solves

Display correct labels for contribution facet

### Summary of changes

Added functionality to fetch label if object in a facet is Agent
Reordered facets
