### PR TITLE
Don't copy ID into derivedFrom if ID is TEMPID

### DIFF
--- a/viewer/vue-client/src/components/mixins/item-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/item-mixin.vue
@@ -99,7 +99,9 @@ export default {
       }
       const newRecord = {};
       newRecord.descriptionCreator = { '@id': this.user.getActiveLibraryUri() };
-      newRecord.derivedFrom = { '@id': this.inspector.data.record['@id'] };
+      if (this.inspector.data.record['@id'] !== 'https://id.kb.se/TEMPID') {
+        newRecord.derivedFrom = { '@id': this.inspector.data.record['@id'] };
+      }
       const objAsRecord = RecordUtil.getObjectAsRecord(this.extractedMainEntity, newRecord);
       return objAsRecord;
     },


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
?

### Solves

Copying a TEMPID into `derivedFrom` could potentially cause a lot of problems.

### Summary of changes

Check if the ID is TEMPID before copying it into `derivedFrom`
