### PR TITLE
Handle HTTP 400 in Find, i.e. invalid queries.

### DIFF
--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -195,6 +195,7 @@
     "Something went wrong": "Något gick snett",
     "Verify structure in template": "Kontrollera strukturen i mallen",
     "Could not process server response": "Kunde inte hantera svaret från servern",
+    "Invalid query": "Felaktig sökfråga",
     "Data is missing a reference, please verify file": "Datan saknar en referens, var god verifiera filen",
     "Detailed enrichment": "Detaljerad berikning",
     "Enrich from": "Berika från",


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Queries with leading wildcards need special handling in backend/ES. These queries might fail, e.g. `*foo "` fails because of unbalanced quotation marks. This change shows a specific error message in this case.

Side panel search is not changed. It shows "No results" on invalid queries.

### Tickets involved
[LXL-3364](https://jira.kb.se/browse/LXL-3364)
