### PR TITLE
Include error message in CRUD api response

### DIFF
--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -549,7 +549,7 @@ def _map_response(response):
                     mimetype=response.headers.get('content-type'),
                     headers=_map_headers(response.headers))
 
-    return resp if resp.status_code < 400 else abort(resp.status_code)
+    return resp if resp.status_code < 500 else abort(resp.status_code)
 
 
 def _write_data(request, query_params=[]):


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [X] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3435](https://jira.kb.se/browse/LXL-3435)

### Solves

Error messages are no longer dropped when jetty response is mapped to flask response. 

### Summary of changes

See commit.
