### PR TITLE
Add field dropdown to right panel search. Add search option 'Label'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,5 @@ npm-debug.log
 *.pyc
 selenium-debug.log
 *venv/
-
+.idea
 viewer/helpdocs/helpdocs\.json

--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -841,6 +841,7 @@ export default {
     flex-direction: row;
     position: relative;
     margin-top: 0.5em;
+    background-color: @white;
     border: 1px solid @grey-lighter;
     border-radius: 0.2em;
   }
@@ -849,12 +850,17 @@ export default {
     color: @black;
     background-color: @white;
     border: none;
+    margin-right: 2px; // make tab-focus border look ok
+    border-radius: 0;
+  }
+
+  &-searchInputContainer select {
     border-radius: 0;
   }
 
   &-paramSelect {
     border-left: 1px solid @grey-lighter;
-    flex-basis: 30%;
+    flex-basis: 33%;
   }
 
   &-filterSearchContainer {

--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -30,7 +30,7 @@ export default {
       searchMade: false,
       currentSearchTypes: [],
       currentSearchParam: null,
-      reset: 0,
+      resetParamSelect: 0,
       active: false,
       currentPage: 0,
       maxResults: 20,
@@ -387,7 +387,7 @@ export default {
       this.currentSearchTypes = this.allSearchTypes;
       this.searchResult = [];
       // TODO: other way force param-select to set select value?
-      this.reset += 1;
+      this.resetParamSelect += 1;
     },
     addLinkedItem(obj) {
       let currentValue = cloneDeep(get(this.inspector.data, this.path));
@@ -691,8 +691,8 @@ export default {
                          autofocus />
                   <param-select class="EntityAdder-paramSelect"
                                 :types="currentSearchTypes"
-                                :reset="reset"
-                                :contextName="'EntityAdder'"
+                                :reset="resetParamSelect"
+                                :userPrefKey="'EntityAdder'"
                                 v-on:param-selected="setParam($event)"></param-select>
                 </div>
               </div>

--- a/viewer/vue-client/src/components/inspector/param-select.vue
+++ b/viewer/vue-client/src/components/inspector/param-select.vue
@@ -13,7 +13,7 @@ export default {
     reset: {
       type: Number,
     },
-    contextName: {
+    userPrefKey: {
       type: String,
       default: '',
     },
@@ -29,21 +29,31 @@ export default {
       this.setUserPref(this.selectedParam);
     },
     resetSelectValue() {
+      console.log('RESET', this.availableSearchParams, this.selectedParam);
       if (!this.availableSearchParams.includes(this.selectedParam)) {
         const pref = this.getUserPref();
         if (this.availableSearchParams.includes(pref)) {
           this.selectedParam = pref;
-        } else {
+        } else if (this.availableSearchParams.length > 0) {
           this.selectedParam = this.availableSearchParams[0];
         }
       }
     },
     setUserPref(param) {
-      this.user.settings[`searchParam-${this.contextName}`] = param;
-      this.$store.dispatch('setUser', this.user);
+      if (this.isUserPrefEnabled()) {
+        this.user.settings[`searchParam-${this.userPrefKey}`] = param;
+        this.$store.dispatch('setUser', this.user);
+      }
     },
     getUserPref() {
-      return this.user.settings[`searchParam-${this.contextName}`];
+      return this.isUserPrefEnabled()
+        ? this.user.settings[`searchParam-${this.userPrefKey}`]
+        : undefined;
+    },
+    isUserPrefEnabled() {
+      return this.userPrefKey !== undefined
+        && this.userPrefKey !== null
+        && this.userPrefKey.length > 0;
     },
   },
   computed: {
@@ -52,7 +62,7 @@ export default {
       'user',
     ]),
     baseClasses() {
-      if (this.types === undefined || this.types.includes(undefined)) {
+      if (this.types === undefined || this.types.includes(undefined) || this.types.length === 0) {
         return [];
       }
 

--- a/viewer/vue-client/src/components/inspector/param-select.vue
+++ b/viewer/vue-client/src/components/inspector/param-select.vue
@@ -1,0 +1,115 @@
+<script>
+import { mapGetters } from 'vuex';
+import * as LayoutUtil from '@/utils/layout';
+import * as VocabUtil from '@/utils/vocab';
+import PropertyMappings from '@/resources/json/propertymappings.json';
+
+export default {
+  name: 'param-select',
+  props: {
+    types: {
+      type: Array,
+    },
+    reset: {
+      type: Number,
+    },
+    contextName: {
+      type: String,
+      default: '',
+    },
+  },
+  data() {
+    return {
+      selectedParam: '',
+    };
+  },
+  methods: {
+    handleChange() {
+      this.$emit('param-selected', this.selectedParam);
+      this.setUserPref(this.selectedParam);
+    },
+    resetSelectValue() {
+      if (!this.availableSearchParams.includes(this.selectedParam)) {
+        const pref = this.getUserPref();
+        if (this.availableSearchParams.includes(pref)) {
+          this.selectedParam = pref;
+        } else {
+          this.selectedParam = this.availableSearchParams[0];
+        }
+      }
+    },
+    setUserPref(param) {
+      this.user.settings[`searchParam-${this.contextName}`] = param;
+      this.$store.dispatch('setUser', this.user);
+    },
+    getUserPref() {
+      return this.user.settings[`searchParam-${this.contextName}`];
+    },
+  },
+  computed: {
+    ...mapGetters([
+      'resources',
+      'user',
+    ]),
+    baseClasses() {
+      if (this.types === undefined || this.types.includes(undefined)) {
+        return [];
+      }
+
+      return VocabUtil.getBaseClassesFromArray(
+        this.types,
+        this.resources.vocab,
+        this.resources.context,
+      );
+    },
+    availableSearchParams() {
+      const intersects = ((a1, a2) => a1.find(value => a2.includes(value)) !== undefined);
+
+      if (this.types === [] || this.types === undefined) {
+        return PropertyMappings;
+      }
+
+      const types = this.types.concat(this.baseClasses);
+      return PropertyMappings.filter(m => intersects(m.types, types));
+    },
+  },
+  components: {
+  },
+  watch: {
+    types() {
+      this.resetSelectValue();
+    },
+    reset() {
+      this.resetSelectValue();
+    },
+  },
+  mounted() {
+    this.$nextTick(() => {
+      LayoutUtil.enableTabbing();
+    });
+  },
+};
+</script>
+
+<template>
+  <div class="ParamSelect">
+    <select
+      class="SearchForm-paramSelect SearchForm-select customSelect"
+      v-model="selectedParam"
+      @change="handleChange()"
+      :aria-label="'Choose type' | translatePhrase">
+      <option
+        v-for="prop in availableSearchParams"
+        :key="prop.key"
+        :value="prop">
+        {{prop.key | translatePhrase}}
+      </option>
+    </select>
+  </div>
+</template>
+
+<style lang="less">
+.ParamSelect {
+  display: flex;
+}
+</style>

--- a/viewer/vue-client/src/components/inspector/param-select.vue
+++ b/viewer/vue-client/src/components/inspector/param-select.vue
@@ -29,7 +29,6 @@ export default {
       this.setUserPref(this.selectedParam);
     },
     resetSelectValue() {
-      console.log('RESET', this.availableSearchParams, this.selectedParam);
       if (!this.availableSearchParams.includes(this.selectedParam)) {
         const pref = this.getUserPref();
         if (this.availableSearchParams.includes(pref)) {

--- a/viewer/vue-client/src/components/inspector/search-window.vue
+++ b/viewer/vue-client/src/components/inspector/search-window.vue
@@ -44,6 +44,7 @@ export default {
       maxResults: 20,
       sort: '',
       isCompact: false,
+      setSearchType: '',
     };
   },
   props: {
@@ -269,6 +270,7 @@ export default {
         .then(() => {
           this.$nextTick(() => {
             this.active = true;
+            this.setSearchType = '';
             this.$nextTick(() => {
               this.resetSearch();
               if (this.itemInfo !== null) {
@@ -295,6 +297,9 @@ export default {
         this.currentSearchTypes = this.someValuesFrom;
       } else {
         this.currentSearchTypes = this.allSearchTypes;
+      }
+      if (this.itemInfo !== undefined && this.itemInfo['@type'] !== undefined) {
+        this.setSearchType = this.itemInfo['@type'];
       }
       this.searchResult = [];
       this.resetParamSelect += 1;
@@ -433,6 +438,7 @@ export default {
                     :options-all-suggested="someValuesFrom"
                     :is-filter="true"
                     :styleVariant="'material'"
+                    :setValue="setSearchType"
                     v-on:filter-selected="setFilter($event)"></filter-select>
                 </div>
                 <div class="SearchWindow-filterSearchContainerItem">

--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -4,6 +4,7 @@ import * as StringUtil from '@/utils/string';
 import * as httpUtil from '@/utils/http';
 import Sort from '@/components/search/sort';
 import LensMixin from '@/components/mixins/lens-mixin';
+import PropertyMappings from '@/resources/json/propertymappings.json';
 
 export default {
   name: 'result-controls',
@@ -26,7 +27,7 @@ export default {
   data() {
     return {
       keyword: '',
-      excludeFilters: ['q', 'identifiedBy.value', 'identifiedBy.@type', 'hasTitle.mainTitle'],
+      excludeFilters: PropertyMappings.flatMap(prop => Object.keys(prop.mappings)),
     };
   },
   computed: {

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -181,7 +181,7 @@ export default {
       if (this.resources.helpDocs != null) {
         const json = this.resources.helpDocs;
         return json;
-      } 
+      }
       return null;
     },
     ...mapGetters([
@@ -216,7 +216,7 @@ export default {
     prefSort() {
       if (this.user && this.user.settings.sort) {
         const availableSorts = this.settings.sortOptions[this.user.settings.searchType];
-        
+
         if (availableSorts) {
           for (let i = 0; i < availableSorts.length; i++) {
             if (availableSorts[i].query === this.user.settings.sort) {
@@ -300,8 +300,8 @@ export default {
             class="SearchForm-typeSelect SearchForm-select customSelect"
             v-model="activeSearchType"
             @change="setPrefSearchType">
-            <option 
-              v-for="filter in dataSetFilters" 
+            <option
+              v-for="filter in dataSetFilters"
               :key="filter.value"
               :value="filter.value">
               {{filter.label | translatePhrase}}
@@ -313,7 +313,7 @@ export default {
             class="SearchForm-paramSelect SearchForm-select customSelect"
             v-model="activeSearchParam"
             @change="setPrefSearchParam">
-            <option 
+            <option
               v-for="prop in availableSearchParams"
               :key="prop.key"
               :value="prop">
@@ -330,8 +330,8 @@ export default {
             @focus="searchGroupFocus.typeSelect = true"
             @blur="searchGroupFocus.typeSelect = false"
             @change="setPrefSearchType">
-            <option 
-              v-for="filter in dataSetFilters" 
+            <option
+              v-for="filter in dataSetFilters"
               :key="filter.value"
               :value="filter.value">
               {{filter.label | translatePhrase}}
@@ -360,7 +360,7 @@ export default {
             @focus="searchGroupFocus.paramSelect = true"
             @blur="searchGroupFocus.paramSelect = false"
             @change="setPrefSearchParam">
-            <option 
+            <option
               v-for="prop in availableSearchParams"
               :key="prop.key"
               :value="prop">
@@ -368,8 +368,8 @@ export default {
             </option>
           </select>
         </div>
-        <button 
-          class="SearchForm-submit btn btn-primary icon--white icon--md" 
+        <button
+          class="SearchForm-submit btn btn-primary icon--white icon--md"
           :aria-label="'Search' | translatePhrase"
           @click.prevent="doSearch"
           @focus="searchGroupFocus.submit = true"
@@ -379,8 +379,8 @@ export default {
           <i class="fa fa-search"></i>
         </button>
       </div>
-      <remote-databases 
-        v-if="searchPerimeter === 'remote'" 
+      <remote-databases
+        v-if="searchPerimeter === 'remote'"
         :remoteSearch="searchPhrase"
         @panelClosed="focusSearchInput"
         ref="dbComponent"></remote-databases>
@@ -395,7 +395,7 @@ export default {
             @click="toggleHelp"
             @keyup.enter="toggleHelp"></i>
         </span>
-        <div class="SearchForm-helpContainer" :style="helpContainerBoundaryStyles" v-if="helpToggled"> 
+        <div class="SearchForm-helpContainer" :style="helpContainerBoundaryStyles" v-if="helpToggled">
           <strong class="SearchForm-helpTitle">Operatorer för frågespråk</strong><i v-if="helpToggled" class="fa fa-times SearchForm-closeHelp" @click="toggleHelp"></i>
           <div class="SearchForm-helpContent" v-html="searchHelpDocs"></div>
         </div>
@@ -581,7 +581,7 @@ export default {
   }
 
   &-select {
-    
+
   }
 
   &-inputLabel {

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -5,6 +5,7 @@ import { mapGetters } from 'vuex';
 import PropertyMappings from '@/resources/json/propertymappings.json';
 import * as StringUtil from '@/utils/string';
 import RemoteDatabases from '@/components/search/remote-databases';
+import { buildQueryString } from '@/utils/http';
 
 export default {
   name: 'search-form',
@@ -50,27 +51,9 @@ export default {
       this.helpToggled = !this.helpToggled;
     },
     composeQuery() {
-      const enc = encodeURIComponent;
-      let query = '';
-      if (this.searchPerimeter === 'libris') {
-        const queryArr = [];
-        Object.keys(this.mergedParams).forEach((param) => {
-          if (Array.isArray(this.mergedParams[param])) {
-            this.mergedParams[param].forEach((el) => {
-              if (el !== null) {
-                queryArr.push(`${enc(param)}=${enc(el)}`);
-              }
-            });
-          } else if (this.mergedParams[param] !== null) {
-            queryArr.push(`${enc(param)}=${enc(this.mergedParams[param])}`);
-          }
-        });
-        query = queryArr.join('&');
-      } else {
-        const databases = this.status.remoteDatabases.join();
-        query = `q=${enc(this.searchPhrase)}&databases=${enc(databases)}`;
-      }
-      return query;
+      return buildQueryString(this.searchPerimeter === 'libris'
+        ? this.mergedParams
+        : { q: this.searchPhrase, databases: this.status.remoteDatabases.join() });
     },
     doSearch() {
       this.helpToggled = false;

--- a/viewer/vue-client/src/components/search/search-form.vue
+++ b/viewer/vue-client/src/components/search/search-form.vue
@@ -82,7 +82,7 @@ export default {
       this.focusSearchInput();
     },
     resetSearchParam() {
-      this.activeSearchParam = PropertyMappings.find(mapping => mapping.searchProp === 'q');
+      this.activeSearchParam = PropertyMappings.find(mapping => mapping.searchProps.includes('q'));
     },
     setSearch() {
       let match = PropertyMappings.filter((prop) => {
@@ -101,7 +101,7 @@ export default {
       if (match.length > 0) {
         const matchObj = match[0];
         this.$nextTick(() => {
-          this.searchPhrase = this.$route.query[matchObj.searchProp];
+          this.searchPhrase = this.$route.query[matchObj.searchProps[0]];
         });
         return matchObj;
       }
@@ -203,7 +203,10 @@ export default {
       let composed = {};
       if (this.activeSearchParam !== null) {
         composed = Object.assign({}, this.activeSearchParam.mappings || {});
-        composed[this.activeSearchParam.searchProp] = this.searchPhrase.length > 0 ? this.searchPhrase : '*';
+        const phrase = this.searchPhrase.length > 0 ? this.searchPhrase : '*';
+        this.activeSearchParam.searchProps.forEach((param) => {
+          composed[param] = phrase;
+        });
       }
       return composed;
     },

--- a/viewer/vue-client/src/components/shared/filter-select.vue
+++ b/viewer/vue-client/src/components/shared/filter-select.vue
@@ -50,6 +50,10 @@ export default {
       type: String,
       default: 'filterselectInput',
     },
+    setValue: {
+      type: String,
+      default: '',
+    },
   },
   data() {
     return {
@@ -84,7 +88,7 @@ export default {
         keys.down,
       ].indexOf(e.keyCode) > -1) {
         e.preventDefault();
-      } 
+      }
     },
     checkInput(event) {
       if (event.keyCode === 32) {
@@ -161,7 +165,7 @@ export default {
       inputEl.value = label;
     },
     focusOnInput(event) {
-      if (event.target.classList.contains('js-filterSelect') 
+      if (event.target.classList.contains('js-filterSelect')
       || event.target.classList.contains('js-createSelect')) {
         const input = this.$refs.filterselectInput;
         this.filterVisible = !this.filterVisible;
@@ -175,7 +179,7 @@ export default {
       const inputContSel = document.getElementsByClassName(this.className);
       const inputContEl = inputContSel[0];
       const texts = inputContEl.getElementsByClassName('js-filterSelectText');
-      
+
       // Make all options visible again
       forEach(texts, (text) => {
         text.removeAttribute('style');
@@ -202,6 +206,17 @@ export default {
         LayoutUtil.scrollLock(val);
       }
     },
+    setValue(value) {
+      this.clear();
+      const option = this.options.tree.find(o => o.value === value);
+      if (option !== undefined) {
+        this.selectedObject = {
+          value: option.value,
+          key: option.key,
+          label: option.label,
+        };
+      }
+    },
   },
   beforeDestroy() {
     if (this.filterVisible === true) { // Make sure we unlock the scroll lock
@@ -212,27 +227,27 @@ export default {
     this.$el.addEventListener('keyup', this.nextItem);
     this.$el.addEventListener('keyup', this.handleKeys);
 
-    this.$nextTick(() => { 
+    this.$nextTick(() => {
     });
   },
 };
 </script>
 
 <template>
-  <div class="FilterSelect" 
-    :class="[{'variantMaterial' : styleVariant === 'material'}, className]" 
+  <div class="FilterSelect"
+    :class="[{'variantMaterial' : styleVariant === 'material'}, className]"
     v-on-clickaway="close"
     :tabindex="0"
     @keydown.space="preventBodyScroll"
     @keyup.space="focusOnInput">
     <label
-      class="FilterSelect-label" 
+      class="FilterSelect-label"
       :for="inputId">
       {{ label }}{{ styleVariant !== 'material' && label ? ':' : '' }}
     </label>
     <div class="FilterSelect-inputContainer">
-      <input class="FilterSelect-input js-filterSelectInput" 
-        type="text" 
+      <input class="FilterSelect-input js-filterSelectInput"
+        type="text"
         :id="inputId"
         v-bind:placeholder="translatedPlaceholder"
         :aria-label="translatedPlaceholder"
@@ -252,7 +267,7 @@ export default {
           @keyup.enter="selectOption"
           v-for="option in options.priority"
           :key="option">
-          <span class="FilterSelect-dropdownText js-filterSelectText" 
+          <span class="FilterSelect-dropdownText js-filterSelectText"
             tabindex="-1"
             :data-filter="option"
             :data-abstract="option.abstract"
@@ -268,7 +283,7 @@ export default {
           @keyup.enter="selectOption"
           v-for="option in options.tree"
           :key="option.key">
-          <span class="FilterSelect-dropdownText js-filterSelectText" 
+          <span class="FilterSelect-dropdownText js-filterSelectText"
             tabindex="-1"
             :data-filter="option.value"
             :data-abstract="option.abstract"
@@ -294,7 +309,7 @@ export default {
 </template>
 
 <style lang="less">
-.FilterSelect {  
+.FilterSelect {
   display: flex;
   font-weight: normal;
   width: 100%;
@@ -332,13 +347,13 @@ export default {
     font-size: 1.6rem;
     width: 100%;
     height: 30px;
-    background-color: @white;    
+    background-color: @white;
     z-index: 2;
     position: relative;
     text-overflow: ellipsis;
-    border: 1px solid @grey-light;    
+    border: 1px solid @grey-light;
     border-radius: 5px;
-    box-shadow: @shadow-panel;  
+    box-shadow: @shadow-panel;
 
     .FilterSelect.variantMaterial & {
       box-shadow: none;
@@ -445,7 +460,7 @@ export default {
 
   &-clear,
   &-open {
-    position: absolute;    
+    position: absolute;
     cursor: pointer;
     z-index: 3;
     font-weight: 300;

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -344,6 +344,7 @@
     "Preferred label": "Föredragen benämning",
     "Preferred label (A-Z)": "Föredragen benämning (A-Ö)",
     "Preferred label (Z-A)": "Föredragen benämning (Ö-A)",
+    "Label": "Benämning",
     "Sigel (A-Z)": "Sigel (A-Ö)",
     "Sigel (Z-A)": "Sigel (Ö-A)",
     "Free text": "Fritext",

--- a/viewer/vue-client/src/resources/json/propertymappings.json
+++ b/viewer/vue-client/src/resources/json/propertymappings.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "Free text",
-    "searchProp": "q",
+    "searchProps": ["q"],
     "mappings": {
       "q": ""
     },
@@ -14,7 +14,7 @@
   },
   {
     "key": "ISBN",
-    "searchProp": "identifiedBy.value",
+    "searchProps": ["identifiedBy.value"],
     "mappings": {
       "identifiedBy.value": "",
       "identifiedBy.@type": "ISBN"
@@ -25,7 +25,7 @@
   },
   {
     "key": "Preferred label",
-    "searchProp": "prefLabel",
+    "searchProps": ["prefLabel"],
     "mappings": {
       "prefLabel": ""
     },
@@ -34,8 +34,20 @@
     ]
   },
   {
+    "key": "Label",
+    "searchProps": ["or-prefLabel", "or-altLabel", "or-hasVariant.prefLabel"],
+    "mappings": {
+      "or-prefLabel": "",
+      "or-altLabel": "",
+      "or-hasVariant.prefLabel": ""
+    },
+    "types": [
+      "Concept"
+    ]
+  },
+  {
     "key": "ISSN",
-    "searchProp": "identifiedBy.value",
+    "searchProps": ["identifiedBy.value"],
     "mappings": {
       "identifiedBy.value": "",
       "identifiedBy.@type": "ISSN"
@@ -46,7 +58,7 @@
   },
   {
     "key": "Main title",
-    "searchProp": "hasTitle.mainTitle",
+    "searchProps": ["hasTitle.mainTitle"],
     "mappings": {
       "hasTitle.mainTitle": ""
     },

--- a/viewer/vue-client/src/resources/json/propertymappings.json
+++ b/viewer/vue-client/src/resources/json/propertymappings.json
@@ -9,7 +9,8 @@
       "Instance",
       "Agent",
       "Concept",
-      "Work"
+      "Work",
+      "Resource"
     ]
   },
   {

--- a/viewer/vue-client/src/utils/http.js
+++ b/viewer/vue-client/src/utils/http.js
@@ -1,5 +1,22 @@
 import { each } from 'lodash-es';
 
+export function buildQueryString(params) {
+  const enc = encodeURIComponent;
+  const queryArr = [];
+  Object.keys(params).forEach((key) => {
+    if (Array.isArray(params[key])) {
+      params[key].forEach((el) => {
+        if (el !== null) {
+          queryArr.push(`${enc(key)}=${enc(el)}`);
+        }
+      });
+    } else if (params[key] !== null) {
+      queryArr.push(`${enc(key)}=${enc(params[key])}`);
+    }
+  });
+  return queryArr.join('&');
+}
+
 function request(opts, data) {
   // method, url, token, accept
   const options = opts;


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Add a "field selection dropdown" to the right panel search. (Free text, Preferred label, ...)

Add a new option "Label" in the search "field selection dropdown" for Concept
The new option searches `prefLabel`, `altLabel`, `hasvariant.prefLabel`.

### Tickets involved
[LXL-3364](https://jira.kb.se/browse/LXL-3364)
[LXL-2586](https://jira.kb.se/browse/LXL-2586)

### Summary of changes
* Make it possible for a "property mapping" to specify multiple fields to be searched.
* Never display "up-link" for fields from the original query (only facets)
* Add option "Label" for Concept
* When clicking "Create/link" on a local entity, the type filter in the search panel has the same type as the local entity selected
* Right panel: Add a "field selection dropdown".
* Right panel: Don't wait 500ms to search after dropdown change (only wait after search phrase change).
* Move function for escaping query string to `HttpUtil` and use it in right panel search also (fixes [LXL-2586](https://jira.kb.se/browse/LXL-2586))

There seems to be a bug in IntelliJ (vue plugin?) that makes it impossible to disable "Strip trailing space on Save" so I finally gave up and commited the changes.
