### PR TITLE
Fix: Don't mint main entity URIs with trailing spaces

### DIFF
--- a/viewer/vue-client/src/utils/uriminter.js
+++ b/viewer/vue-client/src/utils/uriminter.js
@@ -80,7 +80,7 @@ export default class URIMinter {
       throw new Error(`Missing slugProperty ${container.slugProperty} for ${mainEntity[ID]}`);
     }
 
-    const uri = container[ID] + fixedEncodeURIComponent(slugValue);
+    const uri = container[ID] + fixedEncodeURIComponent(slugValue.trim());
 
     let sameAs = mainEntity.sameAs ? asArray(mainEntity.sameAs) : [];
     if (!sameAs.find(it => it[ID] === mainEntity[ID])) {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
All string properties are now trimmed by backend on save but it is frontend that mints id.kb.se URIs from e.g. prefLabel.
Make sure to not create URIs with leading or trailing `%20` in the last path component by trimming the user-supplied string.

### Tickets involved
[LXL-2551](https://jira.kb.se/browse/LXL-2551)