### PR TITLE
Fix type selected and input focus when linking empty item

### DIFF
--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -563,7 +563,7 @@ export default {
       :all-values-from="allValuesFrom"
       :some-values-from="someValuesFrom"
       :all-search-types="allSearchTypes"
-      :entity-type="entityType" 
+      :entity-type="item['@type']"
       :field-key="fieldKey" 
       :extractable="isExtractable"
       :extracting="extracting" 

--- a/viewer/vue-client/src/components/inspector/item-sibling.vue
+++ b/viewer/vue-client/src/components/inspector/item-sibling.vue
@@ -491,7 +491,7 @@ export default {
       :all-values-from="allValuesFrom"
       :some-values-from="someValuesFrom"
       :all-search-types="allSearchTypes"
-      :entity-type="entityType" 
+      :entity-type="item['@type']"
       :field-key="fieldKey" 
       :extracting="extracting" 
       :extractable="isExtractable"

--- a/viewer/vue-client/src/components/inspector/search-window.vue
+++ b/viewer/vue-client/src/components/inspector/search-window.vue
@@ -298,9 +298,7 @@ export default {
       } else {
         this.currentSearchTypes = this.allSearchTypes;
       }
-      if (this.itemInfo !== undefined && this.itemInfo != null && this.itemInfo['@type'] !== undefined) {
-        this.setSearchType = this.itemInfo['@type'];
-      }
+      this.setSearchType = this.entityType;
       this.searchResult = [];
       this.resetParamSelect += 1;
     },

--- a/viewer/vue-client/src/components/inspector/search-window.vue
+++ b/viewer/vue-client/src/components/inspector/search-window.vue
@@ -298,7 +298,7 @@ export default {
       } else {
         this.currentSearchTypes = this.allSearchTypes;
       }
-      if (this.itemInfo !== undefined && this.itemInfo['@type'] !== undefined) {
+      if (this.itemInfo !== undefined && this.itemInfo != null && this.itemInfo['@type'] !== undefined) {
         this.setSearchType = this.itemInfo['@type'];
       }
       this.searchResult = [];


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Clicking "link" on an empty entity would result in an error which leads to
* the search input is not focused
* the correct type is not selected in the search pane

```
TypeError: this.itemInfo is null
--
resetSearch search-window.vue:301
show search-window.vue:274
```


[this is because item-info is set to null if item only contains `@type`](https://github.com/libris/lxlviewer/blob/b74fab2a55f0d5260240d2e2880212f9f9a6200d/viewer/vue-client/src/utils/data.js#L59)

### Tickets involved
[LXL-3447](https://jira.kb.se/browse/LXL-3447)
