### PR TITLE
Fix error when document contains link to itself

### DIFF
--- a/viewer/vue-client/.editorconfig
+++ b/viewer/vue-client/.editorconfig
@@ -1,7 +1,9 @@
 [*.{js,jsx,ts,tsx,vue}]
+root = true
 indent_style = space
 indent_size = 2
 end_of_line = lf
-trim_trailing_whitespace = true
+# removed because of lots of trailing whitespace in source files ATM
+#trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 100

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -498,11 +498,11 @@ export default {
       if (this.fieldKey === '@type' || VocabUtil.getContextValue(this.fieldKey, '@type', this.resources.context) === '@vocab') {
         return 'vocab';
       }
-      if (this.isPlainObject(o) && o.hasOwnProperty('@id') && this.isInGraph(o)) {
-        return 'sibling';
-      }
       if (this.isPlainObject(o) && this.isLinked(o)) {
         return 'entity';
+      }
+      if (this.isPlainObject(o) && o.hasOwnProperty('@id') && this.isInGraph(o)) {
+        return 'sibling';
       }
       if (this.isPlainObject(o) && !this.isLinked(o)) {
         return 'local';

--- a/viewer/vue-client/src/components/mixins/item-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/item-mixin.vue
@@ -129,12 +129,20 @@ export default {
       if (Object.keys(this.item).length > 1) {
         return this.item;
       }
+      // Is link to self
+      if (this.item['@id'] === this.inspector.data.mainEntity['@id']) {
+        return this.inspector.data.mainEntity;
+      }
+      // Is link to other
       return DataUtil.getEmbellished(
         this.item['@id'],
         this.inspector.data.quoted,
       );
     },
     recordId() {
+      if (this.inspector.data.mainEntity['@id'] === this.focusData['@id']) {
+        return this.inspector.data.record['@id'];
+      }
       return RecordUtil.getRecordId(this.focusData, this.inspector.data.quoted);
     },
     isLibrisResource() {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Fixes "the document is missing a reference" error when a document is linking to itself.
* Fix error (datatype should be `entity` not `sibling`)
* Fix chip and link when link points to self (`item-mixin.vue`)

Example (record.inDataset): 
https://libris-dev.kb.se/katalogisering/nrb9xjzsq0rkbtnb