### PR TITLE
Fix dev/qa/stg indicator blocking tool menu

### DIFF
--- a/viewer/vue-client/src/components/layout/global-msg.vue
+++ b/viewer/vue-client/src/components/layout/global-msg.vue
@@ -46,7 +46,7 @@ export default {
   &-corner {
     position: fixed;
     bottom: 0;
-    left: 0.3em;
+    right: 0.3em;
     font-size: 5rem;
     text-shadow: 0.05em 0 #ffffff, 0 0.05em #ffffff, -0.05em 0 #ffffff, 0 -0.05em #ffffff;
     z-index: 9999;


### PR DESCRIPTION
### Solves
dev/qa/stg indicator ("global-msg-corner") overlaps and blocks tool menu on narrow screens.

### Summary of changes
Move it to lower right corner instead of lower left.
