### PR TITLE
Add cataloguersNote to template, and automatically when editing a new Work

### DIFF
--- a/viewer/vue-client/src/resources/json/combinedTemplates.json
+++ b/viewer/vue-client/src/resources/json/combinedTemplates.json
@@ -3043,7 +3043,8 @@
           "recordStatus": "",
           "marc:catalogingSource": {
             "@id": "https://id.kb.se/marc/CooperativeCatalogingProgram"
-          }
+          },
+          "cataloguersNote": [""]
         },
         "mainEntity": {
           "@id": "https://id.kb.se/TEMPID#it",

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -436,6 +436,10 @@ export default {
       if (this.inspector.data.mainEntity['@type'] === 'Item') {
         this.checkForMissingHeldBy();
       }
+      // If this is a *new* work, add an empty cataloguersNote property to the record
+      if (this.recordType === 'Work' && this.inspector.data.record.recordStatus === 'marc:New') {
+        this.addCataloguersNote();
+      }
     },
     checkForMissingHeldBy() {
       const mainEntity = this.inspector.data.mainEntity;
@@ -454,6 +458,22 @@ export default {
           changeList: [{
             path: 'mainEntity.heldBy',
             value: mainEntity.hasComponent[0].heldBy,
+          }],
+          addToHistory: false,
+        });
+      }
+    },
+    addCataloguersNote() {
+      const record = this.inspector.data.record;
+      if (record.hasOwnProperty('cataloguersNote') === false) {
+        this.$store.dispatch('setInspectorStatusValue', {
+          property: 'lastAdded',
+          value: 'record.cataloguersNote',
+        });
+        this.$store.dispatch('updateInspectorData', {
+          changeList: [{
+            path: 'record.cataloguersNote',
+            value: [''],
           }],
           addToHistory: false,
         });


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3398](https://jira.kb.se/browse/LXL-3398)

### Solves

Slightly faster workflow when breaking out works

### Summary of changes

- Add cataloguersNote to record in Work template
- If editing a Work with recordStatus marc:New, add an empty cataloguersNote property if one doesn't already exist (similar to the already existing `checkForMissingHeldBy()`)
