### PR TITLE
Always show all reverse links in card. Add filters for side panel reverse links view.

### DIFF
--- a/viewer/vue-client/src/components/inspector/item-type.vue
+++ b/viewer/vue-client/src/components/inspector/item-type.vue
@@ -71,7 +71,7 @@ export default {
         _limit: 0,
         o: this.inspector.data.mainEntity['@id'],
       };
-      HttpUtil.getRelatedPosts(query, this.settings.apiPath)
+      HttpUtil.getRelatedRecords(query, this.settings.apiPath)
         .then((response) => {
           this.numberOfRelations = response.totalItems;
           this.checkingRelations = false;

--- a/viewer/vue-client/src/components/inspector/relations-list.vue
+++ b/viewer/vue-client/src/components/inspector/relations-list.vue
@@ -83,7 +83,6 @@ export default {
             })).sort((a, b) => a.label.localeCompare(b.label)),
           }));
       }
-      
       return {};
     },
     buildAllOption() {

--- a/viewer/vue-client/src/components/inspector/relations-list.vue
+++ b/viewer/vue-client/src/components/inspector/relations-list.vue
@@ -1,5 +1,4 @@
 <script>
-import { each } from 'lodash-es';
 import { mapGetters } from 'vuex';
 import VueSimpleSpinner from 'vue-simple-spinner';
 import PanelComponent from '@/components/shared/panel-component';
@@ -7,6 +6,9 @@ import PanelSearchList from '@/components/search/panel-search-list';
 import ModalPagination from '@/components/inspector/modal-pagination';
 import * as StringUtil from '@/utils/string';
 import * as DisplayUtil from '@/utils/display';
+import * as MathUtil from '@/utils/math';
+import * as VocabUtil from '@/utils/vocab';
+import * as httpUtil from '@/utils/http';
 
 export default {
   name: 'relations-list',
@@ -30,6 +32,11 @@ export default {
       embellishedList: [],
       showInstances: false,
       hideByContext: {},
+      displayFacets: ['@reverse', '@type'],
+      facets: {},
+      allOption: {},
+      selectedFacet: null,
+      selectedQuery: this.query,
     };
   },
   methods: {
@@ -44,6 +51,11 @@ export default {
             response.json().then((result) => {
               this.searchResult = result;
               this.totalItems = result.totalItems;
+              if (this.selectedQuery === this.query) {
+                this.allOption = this.buildAllOption();
+                this.selectedFacet = this.allOption;
+                this.facets = this.buildFacets(result);
+              }
               this.loading = false;
             });
           }
@@ -56,6 +68,92 @@ export default {
     hide() {
       this.$emit('close');
     },
+    buildFacets(searchResult) {
+      if (searchResult) {
+        const dimensions = searchResult.stats.sliceByDimension;
+        return this.displayFacets
+          .filter(key => dimensions.hasOwnProperty(key))
+          .map(key => dimensions[key])
+          .map(d => ({
+            name: d.dimension,
+            facets: d.observation.map(o => ({
+              query: httpUtil.decomposeQueryString(o.view['@id']),
+              label: this.determinedLabel(o.object),
+            })).sort((a, b) => a.label.localeCompare(b.label)),
+          }));
+      }
+      
+      return {};
+    },
+    buildAllOption() {
+      const all = {};
+      if (this.searchResult) {
+        all.totalItems = this.searchResult.totalItems;
+        all.query = this.query;
+      }
+      return all;
+    },
+    facetGroupLabelByLang(facetType) {
+      const key = facetType.endsWith('@id') ? facetType.slice(0, -4) : facetType;
+      if (this.settings.propertyChains.hasOwnProperty(key)) {
+        return this.settings.propertyChains[key][this.user.settings.language];
+      }
+      
+      return key;
+    },
+    getByLang(object, property, lang) {
+      const langDict = object[`${property}ByLang`];
+      if (typeof langDict === 'object' && typeof langDict[lang] === 'string') {
+        return langDict[lang];
+      }
+      return object[property];
+    },
+    getRecordType(object) {
+      return VocabUtil.getRecordType(
+        object['@type'],
+        this.resources.vocab,
+        this.resources.context,
+      );
+    },
+    determinedLabel(object) {
+      if (object.hasOwnProperty('mainEntity')) {
+        object = object.mainEntity;
+      }
+      const lang = this.user.settings.language;
+
+      if (object.hasOwnProperty('@id')) {
+        const chains = this.settings.propertyChains;
+        const id = object['@id'];
+        if (chains.hasOwnProperty(id)) {
+          return chains[id][this.user.settings.language];
+        }
+      }
+      
+      // TODO: Add chip functionality instead?
+      const label = this.getByLang(object, 'prefLabel', lang)
+        || this.getByLang(object, 'label', lang)
+        || this.getByLang(object, 'title', lang);
+
+      if (label) {
+        return label;
+      }
+
+      if (this.getRecordType(object) === 'Agent') {
+        return this.getLabel(object);
+      }
+
+      const idArray = object['@id'].split('/');
+      return `${idArray[idArray.length - 1]} [has no label]`;
+    },
+    getCompactNumber(observation) {
+      return MathUtil.getCompactNumber(observation.totalItems);
+    },
+    handleFacetSelected() {
+      if (this.selectedFacet) {
+        this.currentPage = 0;
+        this.selectedQuery = this.selectedFacet.query;
+      }
+    },
   },
   computed: {
     ...mapGetters([
@@ -65,6 +163,9 @@ export default {
       'settings',
       'status',
     ]),
+    settings() {
+      return this.$store.getters.settings;
+    },
     resultItems() {
       if (this.searchResult) {
         return this.searchResult.items;
@@ -79,17 +180,14 @@ export default {
       return [];
     },
     builtQuery() {
-      const queryPairs = this.query;
+      const queryPairs = this.selectedQuery;
       if (queryPairs === null) {
         return '';
       }
       queryPairs._offset = this.currentPage * this.maxResults;
       queryPairs._limit = this.maxResults;
-      let q = `${this.settings.apiPath}/find.jsonld?`;
-      each(queryPairs, (v, k) => {
-        q += (`${encodeURIComponent(k)}=${encodeURIComponent(v)}&`);
-      });
-      return q;
+      const q = `${this.settings.apiPath}/find.jsonld?`;
+      return q + httpUtil.buildQueryString(queryPairs);
     },
     windowTitle() {
       if (this.listContextType === 'Item') {
@@ -98,8 +196,6 @@ export default {
         let windowTitle = StringUtil.getUiPhraseByLang('Holdings of', this.user.settings.language);
         windowTitle += ` ${this.itemOfTitle}`;
         return windowTitle;
-      } if (this.listContextType === 'Agent') {
-        return StringUtil.getUiPhraseByLang('Contribution', this.user.settings.language);
       }
       const typeLabel = StringUtil.getLabelByLang(this.listContextType, this.user.settings.language, this.resources.vocab, this.resources.context);
       return `${typeLabel} ${StringUtil.getUiPhraseByLang('Used in', this.user.settings.language)}`;
@@ -133,6 +229,28 @@ export default {
   <div class="RelationsList">
     <panel-component :title="windowTitle" @close="hide()">
       <template slot="panel-header-extra">
+        <div class="RelationsList-searchHeader">
+          <div
+            class="Filter"
+          >
+            <label class="Filter-label" for="filter-select">{{ 'Filter' | translatePhrase }}</label>
+            <select id="filter-select"
+                    class="Filter-select customSelect"
+                    v-model="selectedFacet"
+                    @change="handleFacetSelected"
+                    :aria-label="'Filter' | translatePhrase">
+              >
+              <option :value="allOption">
+                {{ "All" | translatePhrase }} ({{ getCompactNumber(allOption) }})
+              </option>
+              <optgroup v-for="group in facets" :key="group" :label="facetGroupLabelByLang(group.name)">
+                <option v-for="option in group.facets" :key="option" :value="option">
+                  {{ option.label | capitalize }} ({{ getCompactNumber(option) }})
+                </option>
+              </optgroup>
+            </select>
+          </div>
+        </div>
       </template>
       <template slot="panel-body">
         <div class="PanelComponent-searchStatus" v-show="loading">
@@ -170,7 +288,10 @@ export default {
 <style lang="less">
 
 .RelationsList {
-
+  &-searchHeader {
+    margin: 0 0 0.5em 0;
+  }
+  
   &-resultControls {
     display: flex;
     justify-content: space-between;
@@ -195,6 +316,33 @@ export default {
         }
       }
     }
+  }
+}
+
+.Filter {
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: column;
+  align-items: flex-start;
+  position: relative;
+
+  &-label {
+    margin: 0 10px 10px 0;
+    font-weight: 600;
+    position: absolute;
+    font-size: 1.2rem;
+    left: 1rem;
+    top: 0.4rem;
+    color: @brand-primary;
+  }
+  &-select {
+    text-align: start;
+    margin: 0 10px 10px 0;
+    padding: 1.8rem 3.5rem 0 1rem;
+    background-color: @white;
+    border: 1px solid @grey-lighter;
+    line-height: 2.8rem;
+    height: 4.8rem;
   }
 }
 </style>

--- a/viewer/vue-client/src/components/inspector/reverse-relations.vue
+++ b/viewer/vue-client/src/components/inspector/reverse-relations.vue
@@ -47,12 +47,12 @@ export default {
         _limit: 0,
       };
       
-      if (this.recordType !==  'Item' && this.recordType !== 'Instance' && this.mainEntity.reverseLinks) {
+      if (this.recordType !== 'Item' && this.recordType !== 'Instance' && this.mainEntity.reverseLinks) {
         this.numberOfRelations = this.mainEntity.reverseLinks.totalItems;
         this.checkingRelations = false;
         query.o = this.mainEntity['@id'];
         this.panelQuery = Object.assign({}, query);
-        return
+        return;
       }
       
       this.checkingRelations = true;
@@ -69,7 +69,7 @@ export default {
           const myHoldingQuery = Object.assign({}, query);
           myHoldingQuery._limit = 1;
           myHoldingQuery['heldBy.@id'] = this.user.getActiveLibraryUri();
-          HttpUtil.getRelatedPosts(myHoldingQuery, this.settings.apiPath)
+          HttpUtil.getRelatedRecords(myHoldingQuery, this.settings.apiPath)
             .then((response) => {
               if (response.totalItems > 0) {
                 this.myHolding = response.items[0]['@id'];
@@ -86,17 +86,15 @@ export default {
           // Sort panel query by alphabetical order of sigel id
           this.panelQuery._sort = 'heldBy.@id';
         }
-
-        {
-          HttpUtil.getRelatedPosts(query, this.settings.apiPath)
-            .then((response) => {
-              this.relationInfo = response.items;
-              this.numberOfRelations = response.totalItems;
-              this.checkingRelations = false;
-            }, (error) => {
-              console.log('Error checking for relations', error);
-            });
-        }
+        
+        HttpUtil.getRelatedRecords(query, this.settings.apiPath)
+          .then((response) => {
+            this.relationInfo = response.items;
+            this.numberOfRelations = response.totalItems;
+            this.checkingRelations = false;
+          }, (error) => {
+            console.log('Error checking for relations', error);
+          });
       }, timeoutLength);
     },
     gotoHolding() {
@@ -118,9 +116,6 @@ export default {
     },
     hasRelation() {
       return this.myHolding !== null;
-    },
-    libraryUrl() {
-      return this.user.getActiveLibraryUri();
     },
     recordType() {
       return VocabUtil.getRecordType(

--- a/viewer/vue-client/src/components/mixins/facet-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/facet-mixin.vue
@@ -32,15 +32,23 @@ export default {
         object = object.mainEntity;
       }
       const lang = this.user.settings.language;
-
-      if (object.hasOwnProperty('@id')) {
-        const chains = this.settings.propertyChains;
-        const id = object['@id'];
-        if (chains.hasOwnProperty(id)) {
-          return chains[id][this.user.settings.language];
+      
+      for (const prop of ['@id', '_key']) {
+        if (object.hasOwnProperty(prop)) {
+          const chains = this.settings.propertyChains;
+          const id = object[prop];
+          if (chains.hasOwnProperty(id)) {
+            return chains[id][this.user.settings.language];
+          }
         }
       }
 
+      if (object.hasOwnProperty('propertyChainAxiom')) {
+        return object.propertyChainAxiom
+          .map(o => this.$options.filters.capitalize(this.determineLabel(o)))
+          .join('/');
+      } 
+      
       // TODO: Add chip functionality instead?
       const label = this.getByLang(object, 'prefLabel', lang)
         || this.getByLang(object, 'label', lang)

--- a/viewer/vue-client/src/components/mixins/facet-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/facet-mixin.vue
@@ -53,12 +53,9 @@ export default {
       if (this.getRecordType(object) === 'Agent') {
         return this.getLabel(object);
       }
-
-      if (object.hasOwnProperty('@id')) {
-        const idArray = object['@id'].split('/');
-        return `${idArray[idArray.length - 1]} [has no label]`;
-      }
-      return object;
+      
+      const idArray = object['@id'].split('/');
+      return `${idArray[idArray.length - 1]} [has no label]`;
     },
     getCompactNumber(observation) {
       return MathUtil.getCompactNumber(observation.totalItems);

--- a/viewer/vue-client/src/components/mixins/facet-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/facet-mixin.vue
@@ -1,0 +1,80 @@
+<script>
+import { mapGetters } from 'vuex';
+import * as MathUtil from '@/utils/math';
+import * as VocabUtil from '@/utils/vocab';
+import LensMixin from '@/components/mixins/lens-mixin';
+
+export default {
+  mixins: [LensMixin],
+  props: {
+  },
+  data() {
+    return {
+    };
+  },
+  methods: {
+    getByLang(object, property, lang) {
+      const langDict = object[`${property}ByLang`];
+      if (typeof langDict === 'object' && typeof langDict[lang] === 'string') {
+        return langDict[lang];
+      }
+      return object[property];
+    },
+    getRecordType(object) {
+      return VocabUtil.getRecordType(
+        object['@type'],
+        this.resources.vocab,
+        this.resources.context,
+      );
+    },
+    determineLabel(object) {
+      if (object.hasOwnProperty('mainEntity')) {
+        object = object.mainEntity;
+      }
+      const lang = this.user.settings.language;
+
+      if (object.hasOwnProperty('@id')) {
+        const chains = this.settings.propertyChains;
+        const id = object['@id'];
+        if (chains.hasOwnProperty(id)) {
+          return chains[id][this.user.settings.language];
+        }
+      }
+
+      // TODO: Add chip functionality instead?
+      const label = this.getByLang(object, 'prefLabel', lang)
+        || this.getByLang(object, 'label', lang)
+        || this.getByLang(object, 'title', lang);
+
+      if (label) {
+        return label;
+      }
+
+      if (this.getRecordType(object) === 'Agent') {
+        return this.getLabel(object);
+      }
+
+      if (object.hasOwnProperty('@id')) {
+        const idArray = object['@id'].split('/');
+        return `${idArray[idArray.length - 1]} [has no label]`;
+      }
+      return object;
+    },
+    getCompactNumber(observation) {
+      return MathUtil.getCompactNumber(observation.totalItems);
+    },
+  },
+  computed: {
+    ...mapGetters([
+      'resources',
+    ]),
+    user() {
+      return this.$store.getters.user;
+    },
+    settings() {
+      return this.$store.getters.settings;
+    },
+  },
+
+};
+</script>

--- a/viewer/vue-client/src/components/search/facet.vue
+++ b/viewer/vue-client/src/components/search/facet.vue
@@ -1,12 +1,9 @@
 <script>
-import { mapGetters } from 'vuex';
-import * as MathUtil from '@/utils/math';
-import * as VocabUtil from '@/utils/vocab';
-import LensMixin from '@/components/mixins/lens-mixin';
+import FacetMixin from '@/components/mixins/facet-mixin';
 
 export default {
   name: 'facet',
-  mixins: [LensMixin],
+  mixins: [FacetMixin],
   props: {
     active: {
       type: Boolean,
@@ -19,56 +16,13 @@ export default {
     };
   },
   methods: {
-    getByLang(object, property, lang) {
-      const langDict = object[`${property}ByLang`];
-      if (typeof langDict === 'object' && typeof langDict[lang] === 'string') {
-        return langDict[lang];
-      }
-      return object[property];
-    },
-    getRecordType(object) {
-      return VocabUtil.getRecordType(
-        object['@type'], 
-        this.resources.vocab, 
-        this.resources.context,
-      );
-    },
   },
   computed: {
-    ...mapGetters([
-      'resources',
-    ]),
-    user() {
-      return this.$store.getters.user;
+    label() {
+      return this.determineLabel(this.observation.object);
     },
-    settings() {
-      return this.$store.getters.settings;
-    },
-    determinedLabel() {
-      let object = this.observation.object;
-      if (object.hasOwnProperty('mainEntity')) {
-        object = object.mainEntity;
-      }
-      const lang = this.user.settings.language;
-
-      // TODO: Add chip functionality instead?
-      const label = this.getByLang(object, 'prefLabel', lang)
-        || this.getByLang(object, 'label', lang)
-        || this.getByLang(object, 'title', lang);
-      
-      if (label) {
-        return label;
-      }  
-
-      if (this.getRecordType(object) === 'Agent') {
-        return this.getLabel(object);
-      }
-
-      const idArray = object['@id'].split('/');
-      return `${idArray[idArray.length - 1]} [has no label]`;
-    },
-    getCompactNumber() {
-      return MathUtil.getCompactNumber(this.observation.totalItems);
+    compactNumber() {
+      return this.getCompactNumber(this.observation);
     },
   },
   components: {
@@ -86,11 +40,11 @@ export default {
     <slot name="icon"></slot>
     <router-link class="Facet-link"
       :to="observation.view['@id'] | asAppPath" 
-      :title="determinedLabel | capitalize">
+      :title="label | capitalize">
       <span class="Facet-label"
-        :title="determinedLabel | capitalize">
-        {{determinedLabel | capitalize}}</span>
-      <span class="Facet-badge badge">{{getCompactNumber}}</span>
+        :title="label | capitalize">
+        {{label | capitalize}}</span>
+      <span class="Facet-badge badge">{{compactNumber}}</span>
     </router-link>
   </li>
 </template>

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -286,6 +286,13 @@ const store = new Vuex.Store({
             order: 10,
           },
         },
+        '@reverse': {
+          sv: 'Relation',
+          en: 'Relation',
+          facet: {
+            order: 0,
+          },
+        },
       },
       sortOptions: {
         Instance: [

--- a/viewer/vue-client/src/utils/http.js
+++ b/viewer/vue-client/src/utils/http.js
@@ -17,6 +17,25 @@ export function buildQueryString(params) {
   return queryArr.join('&');
 }
 
+export function decomposeQueryString(q) {
+  if (q.includes('?')) {
+    q = q.split('?')[1];
+  }
+
+  const params = {};
+
+  q.split('&').forEach((param) => {
+    const keyVal = param.split('=');
+    const key = decodeURIComponent(keyVal[0]);
+    const val = decodeURIComponent(keyVal[1]);
+    if (!param.hasOwnProperty(key)) {
+      params[key] = [];
+    }
+    params[key].push(val);
+  });
+  return params;
+}
+
 function request(opts, data) {
   // method, url, token, accept
   const options = opts;

--- a/viewer/vue-client/src/utils/http.js
+++ b/viewer/vue-client/src/utils/http.js
@@ -109,14 +109,14 @@ function request(opts, data) {
   });
 }
 
-export function getRelatedPosts(queryPairs, apiPath) {
-  // Returns a list of posts that links to <id> with <property>
+export function getRelatedRecords(queryPairs, apiPath) {
+  // Returns a list of records that links to <id> with <property>
   return new Promise((resolve, reject) => {
-    let relatedPosts = `${apiPath}/find.jsonld?`;
+    let relatedRecords = `${apiPath}/find.jsonld?`;
     each(queryPairs, (v, k) => {
-      relatedPosts += (`${encodeURIComponent(k)}=${encodeURIComponent(v)}&`);
+      relatedRecords += (`${encodeURIComponent(k)}=${encodeURIComponent(v)}&`);
     });
-    fetch(relatedPosts)
+    fetch(relatedRecords)
       .then((response) => {
         if (response.status === 200) {
           resolve(response.json());


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
* Show all reverse links ("Used in"/"Används i") for all types. (except Item and Instance, still only holdings).
* Add a dropdown for filtering reverse links list by relation or type (using facets generated by backend).

Depends on: https://github.com/libris/librisxl/pull/854
### Tickets involved
[LXL-3105](https://jira.kb.se/browse/LXL-3105), [LXL-2355](https://jira.kb.se/browse/LXL-2355)

### Solves
All relations were not visible before, e.g. only "contribution.agent" but not "subject" for Agents.
Make the reverse relations result list a little more navigable. It would be nice to be able to sort it but that requires a generic alphabetical sort that we don't have at the moment. (Sorting now requires knowledge of which type(s) the list contains.)

### Summary of changes
* Other changes
    * Remove 1 second delay when we already have the reverse count.
    * Extract facet-mixin
