### PR TITLE
Group "interesting" facets in reverse relations filter

### DIFF
--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -294,6 +294,12 @@ const store = new Vuex.Store({
           },
         },
       },
+      interestingFacets: {
+        '@reverse': [
+          'contribution.agent',
+          'https://id.kb.se/vocab/subject',
+        ],
+      },
       sortOptions: {
         Instance: [
           {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
In the reverse relations panel, group "intereresting" facets and put them first in the dropdown

e.g.
```
<optgroup label="Relation">
  <option>Medverkan eller primär medverkan (5k)</option>
  <option>Ämne (2k)</option>
  <option disabled="disabled">────────────────────</option>
  <option>Supplement till/Medverkan och funktion/Agent (1)</option>
</optgroup>
```

instead of 

```
<optgroup label="Relation">
  <option>Medverkan eller primär medverkan (5k)</option>
  <option>Supplement till/Medverkan och funktion/Agent (1)</option>
  <option>Ämne (2k)</option>
</optgroup>
```

### Tickets involved
[LXL-3105](https://jira.kb.se/browse/LXL-3105)

### Solves

For entities with many incoming links: solves the issue where the most commonly used relations drown in the list of rare relations.