### PR TITLE
Linked shelfMark and automatic shelfControlNumber

### DIFF
--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -552,6 +552,11 @@ export default {
       if (typeof this.typeArray !== 'undefined' && this.typeArray.length > 0) {
         params['@type'] = this.typeArray;
       }
+      
+      if (this.fieldKey === 'shelfMark') {
+        params['meta.descriptionCreator.@id'] = this.user.getActiveLibraryUri();
+        params['shelfMarkStatus'] = 'ActiveShelfMark';
+      }
 
       const searchUrl = `${this.settings.apiPath}/find.jsonld?${buildQueryString(params)}`;
       return new Promise((resolve, reject) => {

--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -555,7 +555,7 @@ export default {
       
       if (this.fieldKey === 'shelfMark') {
         params['meta.descriptionCreator.@id'] = this.user.getActiveLibraryUri();
-        params['shelfMarkStatus'] = 'ActiveShelfMark';
+        params.shelfMarkStatus = 'ActiveShelfMark';
       }
 
       const searchUrl = `${this.settings.apiPath}/find.jsonld?${buildQueryString(params)}`;

--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -262,7 +262,7 @@ export default {
       }
       return false;
     },
-    canRecieveObjects() {
+    canReceiveObjects() {
       return (this.propertyTypes.indexOf('DatatypeProperty') === -1);
     },
     isLiteral() {
@@ -346,7 +346,7 @@ export default {
         this.addItem({ '@id': '' });
       } else if (this.isVocabField) {
         this.addItem('');
-      } else if (this.canRecieveObjects) {
+      } else if (this.canReceiveObjects) {
         const range = this.rangeFull;
         if (range.length === 1 && this.onlyEmbedded) {
           this.addEmpty(range[0]);

--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -224,6 +224,17 @@ export default {
     hasSingleRange() {
       return this.rangeFull.length === 1;
     },
+    rangeCreatable() {
+      return this.rangeFull.filter(type => !VocabUtil.isDistinct(
+        type, 
+        this.resources.vocab,
+        this.settings,
+        this.resources.context,
+      ));
+    },
+    hasSingleCreatable() {
+      return this.rangeCreatable.length === 1;
+    },
     isVocabField() {
       return VocabUtil.getContextValue(this.fieldKey, '@type', this.resources.context) === '@vocab';
     },
@@ -757,16 +768,16 @@ export default {
           </div>
           <div class="EntityAdder-create">
             <button class="EntityAdder-createBtn btn btn-primary btn--sm"
-              v-if="hasSingleRange"
-              v-on:click="addEmpty(rangeFull[0])">{{ "Create local entity" | translatePhrase }}
+              v-if="hasSingleCreatable"
+              v-on:click="addEmpty(rangeCreatable[0])">{{ "Create local entity" | translatePhrase }}
             </button>
             <filter-select
-              v-if="!hasSingleRange"
+              v-if="!hasSingleCreatable"
               :input-id="'createselectInput'"
               :class-name="'js-createSelect'"
               :options="{ tree: selectOptions, priority: priorityOptions }"
-              :options-all="allSearchTypes"
-              :options-all-suggested="someValuesFrom"
+              :options-all="rangeCreatable"
+              :options-all-suggested="rangeCreatable"
               :is-filter="false"
               :custom-placeholder="'Create local entity:'"
               v-on:filter-selected="addType($event.value)"></filter-select>

--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -394,6 +394,9 @@ export default {
     },
     resetSearch() {
       this.keyword = '';
+      if (this.fieldKey === 'shelfMark') {
+        this.keyword = this.user ? this.user.settings.shelfMarkSearch : '';
+      }
       this.searchMade = false;
       this.currentSearchTypes = this.allSearchTypes;
       this.searchResult = [];
@@ -523,6 +526,10 @@ export default {
       });
     },
     search() {
+      if (this.fieldKey === 'shelfMark' && this.user) {
+        this.user.settings.shelfMarkSearch = this.keyword;
+        this.$store.dispatch('setUser', this.user);
+      }
       const self = this;
       this.loading = true;
       this.typeArray = [].concat(this.currentSearchTypes);

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -16,6 +16,7 @@ import ItemType from './item-type';
 import ItemSibling from './item-sibling';
 import ItemBoolean from './item-boolean';
 import ItemGrouped from './item-grouped';
+import ItemShelfControlNumber from './item-shelf-control-number';
 import * as VocabUtil from '@/utils/vocab';
 import * as LayoutUtil from '@/utils/layout';
 import * as StringUtil from '@/utils/string';
@@ -127,6 +128,7 @@ export default {
     'item-vocab': ItemVocab,
     'item-boolean': ItemBoolean,
     'item-grouped': ItemGrouped,
+    'item-shelf-control-number': ItemShelfControlNumber,
     'entity-adder': EntityAdder,
   },
   watch: {
@@ -494,7 +496,10 @@ export default {
       }
       if (typeof o === 'boolean') {
         return 'boolean';
-      }      
+      }
+      if (this.fieldKey === 'shelfControlNumber') {
+        return 'shelfControlNumber';
+      }
       if (this.fieldKey === '@type' || VocabUtil.getContextValue(this.fieldKey, '@type', this.resources.context) === '@vocab') {
         return 'vocab';
       }
@@ -912,6 +917,17 @@ export default {
           :parent-path="path" 
           :show-action-buttons="actionButtonsShown"
           :is-expanded="isExpanded"></item-value>
+
+        <!-- shelfControlNumber -->
+        <item-shelf-control-number
+          v-if="getDatatype(item) == 'shelfControlNumber'"
+          :is-last-added="isLastAdded"
+          :is-locked="locked"
+          :field-value="item"
+          :field-key="fieldKey"
+          :index="index"
+          :parent-path="path"
+          :is-expanded="isExpanded"></item-shelf-control-number>
       </div>
       <portal-target :name="`typeSelect-${path}`" />
     </div>

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -15,6 +15,7 @@ import ItemVocab from './item-vocab';
 import ItemType from './item-type';
 import ItemSibling from './item-sibling';
 import ItemBoolean from './item-boolean';
+import ItemNumeric from './item-numeric';
 import ItemGrouped from './item-grouped';
 import ItemShelfControlNumber from './item-shelf-control-number';
 import * as VocabUtil from '@/utils/vocab';
@@ -127,6 +128,7 @@ export default {
     'item-error': ItemError,
     'item-vocab': ItemVocab,
     'item-boolean': ItemBoolean,
+    'item-numeric': ItemNumeric,
     'item-grouped': ItemGrouped,
     'item-shelf-control-number': ItemShelfControlNumber,
     'entity-adder': EntityAdder,
@@ -511,6 +513,9 @@ export default {
       }
       if (this.isPlainObject(o) && !this.isLinked(o)) {
         return 'local';
+      }
+      if (this.range && this.range.length > 0 && this.range.every(r => Object.keys(VocabUtil.XSD_NUMERIC_TYPES).includes(r))) {
+        return 'numeric';
       }
       if (!this.isPlainObject(o) && !this.isLinked(o)) {
         return 'value';
@@ -903,6 +908,17 @@ export default {
           :entity-type="entityType" 
           :index="index" 
           :parent-path="path"></item-boolean>
+
+        <!-- Numeric value -->
+        <item-numeric
+          v-if="getDatatype(item) == 'numeric'"
+          :is-locked="locked"
+          :field-key="fieldKey"
+          :field-value="item"
+          :entity-type="entityType"
+          :index="index"
+          :parent-path="path"
+          :range="range"/>
 
         <!-- Not linked, local child strings -->
         <item-value 

--- a/viewer/vue-client/src/components/inspector/item-entity.vue
+++ b/viewer/vue-client/src/components/inspector/item-entity.vue
@@ -47,6 +47,9 @@ export default {
     fullPath() {
       return `${this.parentPath}.{"@id":"${this.item['@id']}"}`;
     },
+    isMaybeMagicShelfMark() {
+      return this.focusData['@type'] === 'ShelfMarkSequence';
+    },
   },
   watch: {
     'inspector.event'(val) {
@@ -99,6 +102,9 @@ export default {
   },
   mounted() {
     this.$nextTick(() => {
+      if (this.isMaybeMagicShelfMark) {
+        this.$root.$emit('create-maybe-magic-shelf-mark', { path: this.actualParentPath, id: this.item['@id'] });
+      }
       if (this.isNewlyAdded) {
         setTimeout(() => {
           const element = this.$el;
@@ -111,6 +117,11 @@ export default {
         }, 200);
       }
     });
+  },
+  beforeDestroy() {
+    if (this.isMaybeMagicShelfMark) {
+      this.$root.$emit('remove-maybe-magic-shelf-mark', { path: this.actualParentPath, id: this.item['@id'] });
+    }
   },
 };
 </script>

--- a/viewer/vue-client/src/components/inspector/item-entity.vue
+++ b/viewer/vue-client/src/components/inspector/item-entity.vue
@@ -103,7 +103,7 @@ export default {
   mounted() {
     this.$nextTick(() => {
       if (this.isMaybeMagicShelfMark) {
-        this.$root.$emit('create-maybe-magic-shelf-mark', { path: this.actualParentPath, id: this.item['@id'] });
+        this.$root.$emit('maybe-magic-shelf-mark-created', { path: this.actualParentPath, id: this.item['@id'] });
       }
       if (this.isNewlyAdded) {
         setTimeout(() => {
@@ -120,7 +120,7 @@ export default {
   },
   beforeDestroy() {
     if (this.isMaybeMagicShelfMark) {
-      this.$root.$emit('remove-maybe-magic-shelf-mark', { path: this.actualParentPath, id: this.item['@id'] });
+      this.$root.$emit('maybe-magic-shelf-mark-removed', { path: this.actualParentPath, id: this.item['@id'] });
     }
   },
 };

--- a/viewer/vue-client/src/components/inspector/item-entity.vue
+++ b/viewer/vue-client/src/components/inspector/item-entity.vue
@@ -1,6 +1,7 @@
 <script>
 import { size } from 'lodash-es';
 import { mapGetters } from 'vuex';
+import { hasAutomaticShelfControlNumber } from '@/utils/shelfmark';
 import * as LayoutUtil from '@/utils/layout';
 import ItemMixin from '@/components/mixins/item-mixin';
 import LensMixin from '@/components/mixins/lens-mixin';
@@ -103,7 +104,11 @@ export default {
   mounted() {
     this.$nextTick(() => {
       if (this.isMaybeMagicShelfMark) {
-        this.$root.$emit('maybe-magic-shelf-mark-created', { path: this.actualParentPath, id: this.item['@id'] });
+        hasAutomaticShelfControlNumber(this.item['@id'], this.settings).then((hasAutomatic) => {
+          if (hasAutomatic) {
+            this.$store.commit('addMagicShelfMark', this.actualParentPath);
+          }
+        }).catch(error => console.error(error));
       }
       if (this.isNewlyAdded) {
         setTimeout(() => {
@@ -120,7 +125,7 @@ export default {
   },
   beforeDestroy() {
     if (this.isMaybeMagicShelfMark) {
-      this.$root.$emit('maybe-magic-shelf-mark-removed', { path: this.actualParentPath, id: this.item['@id'] });
+      this.$store.commit('removeMagicShelfMark', this.actualParentPath);
     }
   },
 };

--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -531,7 +531,7 @@ export default {
     <ul class="ItemLocal-list js-itemLocalFields" v-show="expanded">
       <field
         v-show="k !== '_uid'" 
-        v-for="(v, k) in filteredItem" 
+        v-for="(v, k) in filteredItem"
         :parent-path="getPath" 
         :entity-type="item['@type']" 
         :is-inner="true" 

--- a/viewer/vue-client/src/components/inspector/item-numeric.vue
+++ b/viewer/vue-client/src/components/inspector/item-numeric.vue
@@ -1,0 +1,264 @@
+<script>
+import { isArray, debounce, cloneDeep, get } from 'lodash-es';
+import { mapGetters } from 'vuex';
+import * as StringUtil from '@/utils/string';
+import ItemMixin from '@/components/mixins/item-mixin';
+import LensMixin from '@/components/mixins/lens-mixin';
+import { XSD_NUMERIC_TYPES } from '@/utils/vocab';
+
+export default {
+  name: 'item-numeric',
+  mixins: [ItemMixin, LensMixin],
+  props: {
+    fieldValue: {
+      type: [String, Number],
+      default: '',
+    },
+    isLocked: {
+      type: Boolean,
+      default: false,
+    },
+    isRemovable: {
+      type: Boolean,
+      default: false,
+    },
+    showActionButtons: {
+      type: Boolean,
+      default: false,
+    },
+    isExpanded: {
+      type: Boolean,
+      default: false,
+    },
+    range: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  data() {
+    return {
+      inEdit: false,
+      removeHover: false,
+    };
+  },
+  computed: {
+    ...mapGetters([
+      'user',
+    ]),
+    value: {
+      get() {
+        if (this.fieldValue === null) {
+          return [];
+        }
+        let valueArray = this.fieldValue;
+        if (!isArray(this.fieldValue)) {
+          valueArray = [this.fieldValue];
+        }
+        return valueArray;
+      },
+      set: debounce(function debounceUpdate(newValue) {
+        this.update(newValue);
+      }, 1000),
+    },
+    newWindowText() {
+      return StringUtil.getUiPhraseByLang('Opens in new window', this.user.settings.language);
+    },
+    shouldFocus() {
+      const lastAdded = this.inspector.status.lastAdded;
+      if (lastAdded === this.path || lastAdded === this.parentPath) {
+        return true;
+      }
+      return false;
+    },
+    isLastAdded() {
+      if (this.inspector.status.lastAdded === this.path) {
+        return true;
+      }
+      return false;
+    },
+    // Handling multiple ranges doesn't actually really make sense...
+    min() {
+      return Math.min(...this.range.map(r => XSD_NUMERIC_TYPES[r]).map(t => (t.min ? t.min : NaN)));
+    },
+    max() {
+      return Math.max(...this.range.map(r => XSD_NUMERIC_TYPES[r]).map(t => (t.max ? t.max : NaN)));
+    },
+    isDecimal() {
+      return this.range.map(r => XSD_NUMERIC_TYPES[r]).some(t => (t.decimal));
+    }
+  },
+  methods: {
+    removeHighlight(event, active) {
+      if (active) {
+        let item = event.target;
+        while ((item = item.parentElement) && !item.classList.contains('js-value'));
+        item.classList.add('is-removeable');
+      } else {
+        let item = event.target;
+        while ((item = item.parentElement) && !item.classList.contains('js-value'));
+        item.classList.remove('is-removeable');
+      }
+    },
+    handleEnter(e) {
+      e.target.blur();
+      return false;
+    },
+    readyForSave(value) {
+      this.$store.dispatch('setInspectorStatusValue', { property: 'readyForSave', value: value });
+    },
+    update(newValue) {
+      const oldValue = cloneDeep(get(this.inspector.data, this.path));
+
+      this.readyForSave(true);
+      if (newValue !== oldValue) {
+        this.$store.dispatch('updateInspectorData', {
+          changeList: [
+            {
+              path: this.path,
+              value: newValue,
+            },
+          ],
+          addToHistory: true,
+        });
+      }
+    },
+    highLightLastAdded() {
+      if (this.isLastAdded === true) {
+        const element = this.$el;
+        element.classList.add('is-lastAdded');
+        setTimeout(() => {
+          element.classList.remove('is-lastAdded');
+          if (this.isLastAdded) {
+            this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+          }
+        }, 1000);
+      }
+    },
+    isEmpty() {
+      return false;
+    },
+    addFocus() {
+      this.$refs.textarea.focus({ preventScroll: true }); // Prevent scroll as we will handle this ourselves
+    },
+  },
+  components: {
+  },
+  mounted() {
+    this.$nextTick(() => {
+      if (!this.isLocked) {
+        this.highLightLastAdded();
+        if (!this.status.isNew && this.shouldFocus) {
+          this.addFocus();
+        }
+      }
+      return false;
+    });
+  },
+};
+</script>
+
+<template>
+  <div class="ItemValue js-value" 
+    v-bind:class="{'is-locked': isLocked, 'unlocked': !isLocked, 'is-removed': removed}"
+    :id="`formPath-${path}`">
+    <input class="ItemValue-input js-itemValueInput"
+           rows="1"
+           v-model="value"
+           :aria-label="fieldKey | labelByLang"
+           @focus="readyForSave(false)"
+           @blur="update($event.target.value)"
+           @keydown.exact="readyForSave(false)"
+           @keydown.enter.prevent="handleEnter"
+           v-if="!isLocked"
+           type="number"
+           :min="min"
+           :max="max"
+           :step="isDecimal ? 0.01 : 1"
+           ref="textarea"/>
+    <span class="ItemValue-text"
+      v-if="isLocked">{{fieldValue}}</span>
+    <div class="ItemValue-remover"
+      v-show="!isLocked && isRemovable"
+      role="button"
+      :aria-label="'Remove' | translatePhrase"
+      v-on:click="removeThis()"
+      v-tooltip.top="translate('Remove')"
+      @focus="removeHover = true, removeHighlight($event, true)"
+      @blur="removeHover = false, removeHighlight($event, false)"
+      @mouseover="removeHover = true, removeHighlight($event, true)"
+      @mouseout="removeHover = false, removeHighlight($event, false)">
+      <i class="fa fa-trash-o icon icon--sm">
+      </i>
+    </div>
+  </div>
+</template>
+
+<style lang="less">
+
+.ItemValue {
+  display: flex;
+  flex: 1;
+  flex-shrink: 0;
+  margin-left: -5px;
+  padding: 5px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+
+  &-input {
+    width: 100%;
+    display: block;
+    border: 1px solid @grey-light;
+    border-radius: 2px;
+    padding: 2px 10px;
+    resize: none;
+    transition: border .25s ease-out;
+
+    &:focus {
+      border: 1px solid @grey-dark;
+    }
+  }
+
+  &-text {
+    word-break: break-word;
+    position: relative;
+  }
+
+  &.is-removed {
+    transition: all 0.5s ease;
+    max-height: 0px;
+    margin: 0px;
+    border: none;
+    overflow: hidden;
+  }
+
+  &-remover {
+    font-size: 16px;
+    font-size: 1.6rem;
+    float: right;
+    display: inline-block;
+    cursor: pointer;
+    color: @grey;
+    min-width: 20px;
+    margin-left: 5px;
+
+
+    &:hover {
+      color: @black;
+    }
+  }
+
+  &.is-removeable {
+    background-color: @form-remove;
+  }
+
+  &.is-lastAdded {
+    background-color: @form-add;
+    -webkit-animation-duration: 1s;
+    animation-duration: 1s;
+    -webkit-animation-fill-mode: both;
+    animation-fill-mode: both;
+    -webkit-animation-name: pulse;
+    animation-name: pulse;
+  }
+}
+</style>

--- a/viewer/vue-client/src/components/inspector/item-shelf-control-number.vue
+++ b/viewer/vue-client/src/components/inspector/item-shelf-control-number.vue
@@ -47,7 +47,7 @@ export default {
       if (val && this.shelfMarkUnlinkedAtLeastOnce) {
         this.mode = 'generate';
       }
-    }
+    },
   },
   data() {
     return {

--- a/viewer/vue-client/src/components/inspector/item-shelf-control-number.vue
+++ b/viewer/vue-client/src/components/inspector/item-shelf-control-number.vue
@@ -39,6 +39,15 @@ export default {
     mode() {
       this.update(this.value);
     },
+    hasAutomaticCounter(val) {
+      // if we get linked to another counter we should switch mode to 'generate' 
+      if (!val) {
+        this.shelfMarkUnlinkedAtLeastOnce = true;
+      }
+      if (val && this.shelfMarkUnlinkedAtLeastOnce) {
+        this.mode = 'generate';
+      }
+    }
   },
   data() {
     return {
@@ -46,6 +55,7 @@ export default {
       removeHover: false,
       manualValue: '',
       mode: undefined,
+      shelfMarkUnlinkedAtLeastOnce: false,
     };
   },
   computed: {
@@ -192,7 +202,7 @@ export default {
                 @blur="update($event.target.value)"
                 @keydown.exact="readyForSave(false)"
                 @keydown.enter.prevent="handleEnter"
-                :disabled="hasAutomaticCounter && mode == 'generate'"
+                :disabled="hasAutomaticCounter && mode === 'generate'"
                 ref="textarea"></textarea>
     </div>
     <span class="ItemShelfControlNumber-text"

--- a/viewer/vue-client/src/components/inspector/item-shelf-control-number.vue
+++ b/viewer/vue-client/src/components/inspector/item-shelf-control-number.vue
@@ -1,0 +1,248 @@
+<script>
+import AutoSize from 'autosize';
+import { debounce, cloneDeep, get } from 'lodash-es';
+import { mapGetters } from 'vuex';
+import ItemMixin from '@/components/mixins/item-mixin';
+
+export default {
+  name: 'item-shelf-control-number',
+  mixins: [ItemMixin],
+  props: {
+    fieldValue: {
+      type: [String, Number],
+      default: '',
+    },
+    isLocked: {
+      type: Boolean,
+      default: false,
+    },
+    isExpanded: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  watch: {
+    isLocked(val) {
+      if (!val) {
+        this.initializeTextarea();
+        this.initializeForEditing();
+      }
+    },
+    isExpanded(val) {
+      if (val) {
+        this.initializeTextarea();
+      }
+    },
+    fieldValue() {
+      this.initializeForEditing();
+    },
+    mode() {
+      this.update(this.value);
+    },
+  },
+  data() {
+    return {
+      inEdit: false,
+      removeHover: false,
+      manualValue: '',
+      mode: undefined,
+    };
+  },
+  computed: {
+    ...mapGetters([
+      'user',
+    ]),
+    value() {
+      return this.mode === 'generate' ? '' : this.textFieldValue;
+    },
+    textFieldValue: {
+      get() {
+        return this.mode === 'generate' || !this.fieldValue ? this.manualValue : this.fieldValue;
+      },
+      set: debounce(function debounceUpdate(newValue) {
+        this.manualValue = newValue;
+        this.update(newValue);
+      }, 1000),
+    },
+    hasAutomaticCounter() {
+      return this.$store.state.inspector.magicShelfMarks.includes(this.actualParentPath);
+    },
+    shouldFocus() {
+      const lastAdded = this.inspector.status.lastAdded;
+      if (lastAdded === this.path || lastAdded === this.parentPath) {
+        return true;
+      }
+      return false;
+    },
+    isLastAdded() {
+      if (this.inspector.status.lastAdded === this.path) {
+        return true;
+      }
+      return false;
+    },
+  },
+  methods: {
+    removeHighlight(event, active) {
+      if (active) {
+        let item = event.target;
+        while ((item = item.parentElement) && !item.classList.contains('js-value'));
+        item.classList.add('is-removeable');
+      } else {
+        let item = event.target;
+        while ((item = item.parentElement) && !item.classList.contains('js-value'));
+        item.classList.remove('is-removeable');
+      }
+    },
+    handleEnter(e) {
+      e.target.blur();
+      return false;
+    },
+    readyForSave(value) {
+      this.$store.dispatch('setInspectorStatusValue', { property: 'readyForSave', value: value });
+    },
+    update(newValue) {
+      const oldValue = cloneDeep(get(this.inspector.data, this.path));
+
+      this.readyForSave(true);
+      if (newValue !== oldValue) {
+        this.$store.dispatch('updateInspectorData', {
+          changeList: [
+            {
+              path: this.path,
+              value: newValue,
+            },
+          ],
+          addToHistory: true,
+        });
+      }
+    },
+    highLightLastAdded() {
+      if (this.isLastAdded === true) {
+        const element = this.$el;
+        element.classList.add('is-lastAdded');
+        setTimeout(() => {
+          element.classList.remove('is-lastAdded');
+          if (this.isLastAdded) {
+            this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+          }
+        }, 1000);
+      }
+    },
+    initializeTextarea() {
+      this.$nextTick(() => {
+        const textarea = this.$refs.textarea;
+        AutoSize(textarea);
+        AutoSize.update(textarea);
+      });
+    },
+    initializeForEditing() {
+      if (this.fieldValue) {
+        this.mode = 'manual';
+        this.manualValue = this.fieldValue;
+      } else {
+        this.mode = 'generate';
+      }
+    },
+    isEmpty() {
+      return false;
+    },
+    addFocus() {
+      this.$refs.textarea.focus({ preventScroll: true }); // Prevent scroll as we will handle this ourselves
+    },
+  },
+  components: {
+  },
+  mounted() {
+    this.$nextTick(() => {
+      if (!this.isLocked) {
+        this.highLightLastAdded();
+        this.initializeTextarea();
+        this.initializeForEditing();
+        if (!this.status.isNew && this.shouldFocus) {
+          this.addFocus();
+        }
+      }
+      return false;
+    });
+  },
+};
+</script>
+
+<template>
+  <div class="ItemShelfControlNumber js-value" 
+    v-bind:class="{'is-locked': isLocked, 'unlocked': !isLocked}"
+    :id="`formPath-${path}`">
+    <div v-if="!isLocked">
+      <fieldset v-if="hasAutomaticCounter">
+        <label class="ItemShelfControlNumber-label">
+          <input type="radio" value="generate" v-model="mode">
+          {{translate("Generate control number when item is saved")}}
+        </label>
+        <br>
+        <label class="ItemShelfControlNumber-label">
+          <input type="radio" value="manual" v-model="mode">
+          {{translate("Enter manual control number")}}
+        </label>
+      </fieldset>
+      <textarea class="ItemShelfControlNumber-input js-itemValueInput"
+                rows="1"
+                v-model="textFieldValue"
+                :aria-label="fieldKey | labelByLang"
+                @focus="readyForSave(false)"
+                @blur="update($event.target.value)"
+                @keydown.exact="readyForSave(false)"
+                @keydown.enter.prevent="handleEnter"
+                :disabled="hasAutomaticCounter && mode == 'generate'"
+                ref="textarea"></textarea>
+    </div>
+    <span class="ItemShelfControlNumber-text"
+      v-if="isLocked">{{fieldValue}}</span>
+  </div>
+</template>
+
+<style lang="less">
+
+.ItemShelfControlNumber {
+  display: flex;
+  flex: 1;
+  flex-shrink: 0;
+  margin-left: -5px;
+  padding: 5px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+
+  &-input {
+    width: 100%;
+    display: block;
+    border: 1px solid @grey-light;
+    border-radius: 2px;
+    padding: 2px 10px;
+    resize: none;
+    transition: border .25s ease-out;
+
+    &:focus {
+      border: 1px solid @grey-dark;
+    }
+  }
+
+  &-text {
+    word-break: break-word;
+    position: relative;
+  }
+
+  &-label {
+    font-weight: normal;
+  }
+  
+  &.is-lastAdded {
+    background-color: @form-add;
+    -webkit-animation-duration: 1s;
+    animation-duration: 1s;
+    -webkit-animation-fill-mode: both;
+    animation-fill-mode: both;
+    -webkit-animation-name: pulse;
+    animation-name: pulse;
+  }
+}
+
+</style>

--- a/viewer/vue-client/src/components/inspector/toolbar.vue
+++ b/viewer/vue-client/src/components/inspector/toolbar.vue
@@ -4,6 +4,7 @@
 */
 import { mixin as clickaway } from 'vue-clickaway';
 import { mapGetters } from 'vuex';
+import { get } from 'lodash-es';
 import * as VocabUtil from '@/utils/vocab';
 import * as RecordUtil from '@/utils/record';
 import * as HttpUtil from '@/utils/http';
@@ -387,6 +388,10 @@ export default {
         || !this.user.uriMinter.findContainerForEntity(mainEntity,
           { '@id': this.user.getActiveLibraryUri() }))) {
         return false;
+      }
+      if (mainEntity['@type'] === 'ShelfMarkSequence') {
+        const ownedBy = get(this.inspector, ['data', 'record', 'descriptionCreator', '@id']);
+        return this.user.getActiveLibraryUri() === ownedBy;
       }
       return true;
     },

--- a/viewer/vue-client/src/components/mixins/item-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/item-mixin.vue
@@ -1,5 +1,5 @@
 <script>
-import { cloneDeep, isArray, get, isObject } from 'lodash-es';
+import { cloneDeep, isArray, get, isObject, dropRight } from 'lodash-es';
 import { mapGetters } from 'vuex';
 import * as DataUtil from '@/utils/data';
 import * as VocabUtil from '@/utils/vocab';
@@ -154,6 +154,9 @@ export default {
       const uriParts = this.recordId.split('/');
       const fnurgel = uriParts[uriParts.length - 1];
       return `/${fnurgel}`;
+    },
+    actualParentPath() {
+      return dropRight(this.path.split('.')).join('.');
     },
   },
   watch: {

--- a/viewer/vue-client/src/components/mixins/lens-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/lens-mixin.vue
@@ -51,7 +51,7 @@ export default {
         this.user.settings.language,
         this.resources.vocab,
         this.resources.context,
-      )
+      );
     },
     getChip() {
       const chip = DisplayUtil.getChip(

--- a/viewer/vue-client/src/components/mixins/lens-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/lens-mixin.vue
@@ -1,5 +1,6 @@
 <script>
 import * as DisplayUtil from '@/utils/display';
+import * as StringUtil from '@/utils/string';
 
 export default {
   props: {
@@ -43,6 +44,14 @@ export default {
         this.settings,
         this.resources.context,
       );
+    },
+    getStringLabel() {
+      return StringUtil.getLabelByLang(
+        this.focusData,
+        this.user.settings.language,
+        this.resources.vocab,
+        this.resources.context,
+      )
     },
     getChip() {
       const chip = DisplayUtil.getChip(

--- a/viewer/vue-client/src/components/shared/entity-summary.vue
+++ b/viewer/vue-client/src/components/shared/entity-summary.vue
@@ -364,7 +364,7 @@ export default {
         <template v-if="node.value !== null">
           <span class="EntitySummary-detailsKey" :title="node.property | labelByLang">{{ node.property | labelByLang | capitalize }}</span>
           <span class="EntitySummary-detailsValue">
-            <SummaryNode :hover-links="hoverLinks" v-for="(value, index) in node.value" :is-last="index === node.value.length - 1" :key="index" :item="value" :parent-id="focusData['@id']" />
+            <SummaryNode :hover-links="hoverLinks" v-for="(value, index) in node.value" :is-last="index === node.value.length - 1" :key="index" :item="value" :parent-id="focusData['@id']" :field-key="node.property"/>
           </span>
         </template>
         <template v-else-if="isReplacedBy !== ''">

--- a/viewer/vue-client/src/components/shared/summary-node.vue
+++ b/viewer/vue-client/src/components/shared/summary-node.vue
@@ -60,7 +60,7 @@ export default {
 <template>
   <div class="SummaryNode">
     <span class="SummaryNode-label" v-if="!isLinked">
-      {{ typeof item === 'string' ? item : getItemLabel }}{{ isLast ? '' : ',&nbsp;' }}
+      {{ typeof item === 'string' ? getStringLabel : getItemLabel }}{{ isLast ? '' : ',&nbsp;' }}
     </span>
     <v-popover v-if="isLinked" :disabled="!hoverLinks" @show="$refs.previewCard.populateData()" placement="bottom-start">
       <span class="SummaryNode-link tooltip-target">

--- a/viewer/vue-client/src/models/user.js
+++ b/viewer/vue-client/src/models/user.js
@@ -30,6 +30,7 @@ export class User {
       searchParam: false,
       searchType: null,
       sort: false,
+      shelfMarkSearch: '',
     };
     this.uriMinter = null;
   }

--- a/viewer/vue-client/src/resources/json/combinedTemplates.json
+++ b/viewer/vue-client/src/resources/json/combinedTemplates.json
@@ -3724,5 +3724,30 @@
         }
       }
     }
+  },
+  "other": {
+    "shelfMarkSequence": {
+      "label": "Hyllkodssvit",
+      "description": "Hyllkodssvit med automatiskt löpnummer",
+      "value": {
+        "record": {
+          "@id": "https://id.kb.se/TEMPID",
+          "@type": "Record",
+          "mainEntity": {
+            "@id": "https://id.kb.se/TEMPID#it"
+          }
+        },
+        "mainEntity": {
+          "@type": "ShelfMarkSequence",
+          "@id": "https://id.kb.se/TEMPID#it",
+          "heldBy": "",
+          "label": "",
+          "description": "",
+          "shelfMarkStatus": "ActiveShelfMark",
+          "nextShelfControlNumber": 1,
+          "qualifier": ""
+        }
+      }
+    }
   }
 }

--- a/viewer/vue-client/src/resources/json/combinedTemplates.json
+++ b/viewer/vue-client/src/resources/json/combinedTemplates.json
@@ -3740,7 +3740,6 @@
         "mainEntity": {
           "@type": "ShelfMarkSequence",
           "@id": "https://id.kb.se/TEMPID#it",
-          "heldBy": "",
           "label": "",
           "description": "",
           "shelfMarkStatus": "ActiveShelfMark",

--- a/viewer/vue-client/src/resources/json/displayGroups.json
+++ b/viewer/vue-client/src/resources/json/displayGroups.json
@@ -23,7 +23,11 @@
       "lifeSpan",
       "marc:attributionQualifier",
       "isPartOf",
-      "marc:subordinateUnit"
+      "marc:subordinateUnit",
+      "qualifier"
+    ],
+    "hidden": [
+      "shelfMarkStatus"
     ]
   },
   "reverse": {

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -190,6 +190,7 @@
     "Select sources": "Välj källor",
     "Databases": "Databaser",
     "Other sources": "Andra källor",
+    "Other": "Övrigt",
     "No sources chosen": "Inga källor valda",
     "Something went wrong": "Något gick snett",
     "Verify structure in template": "Kontrollera strukturen i mallen",

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -374,6 +374,8 @@
     "Create concept": "Skapa koncept",
     "To create concepts, you need to switch to a seal with correct authority.": "För att skapa koncept behöver du växla till ett sigel med rättigheter.",
     "Switch sigel": "Växla sigel",
-    "Accessibility statement": "Tillgänglighetsredogörelse"
+    "Accessibility statement": "Tillgänglighetsredogörelse",
+    "Generate control number when item is saved": "Generera löpnummer när bestånd sparas",
+    "Enter manual control number": "Ange löpnummer manuellt"
     }
 }

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -61,6 +61,7 @@ const store = new Vuex.Store({
       clipboard: null,
       changeHistory: [],
       event: [],
+      magicShelfMarks: [], 
     },
     status: {
       panelOpen: false,
@@ -620,6 +621,12 @@ const store = new Vuex.Store({
     },
     setDirectoryCare(state, data) {
       state.directoryCare = data;
+    },
+    addMagicShelfMark(state, path) {
+      state.inspector.magicShelfMarks.push(path);
+    },
+    removeMagicShelfMark(state, path) {
+      state.inspector.magicShelfMarks = state.inspector.magicShelfMarks.filter(p => p !== path);
     },
   },
   getters: {

--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -332,10 +332,12 @@ export function getItemSummary(item, displayDefs, quoted, vocab, settings, conte
   each(card, (value, key) => {
     if (value !== null) {
       const v = isArray(value) ? value : [value];
-      if (cardDisplayGroups.header.indexOf(key) !== -1) {
+      if (cardDisplayGroups.header.includes(key)) {
         summary.header.push({ property: key, value: v });
-      } else if (cardDisplayGroups.categorization.indexOf(key) !== -1) {
+      } else if (cardDisplayGroups.categorization.includes(key)) {
         summary.categorization.push({ property: key, value: v });
+      } else if (cardDisplayGroups.hidden.includes(key)) {
+        // drop it
       } else {
         const translated = tryGetValueByLang(item, key, settings.language, context);
         const itemValue = translated !== null ? translated : item[key];

--- a/viewer/vue-client/src/utils/record.js
+++ b/viewer/vue-client/src/utils/record.js
@@ -222,7 +222,7 @@ export function getItemObject(itemOf, heldBy, instance) {
           heldBy: {
             '@id': heldBy,
           },
-          shelfMark: {
+          shelfMark: heldBy === 'https://libris.kb.se/library/S' ? null : {
             '@type': 'ShelfMark',
             label: [''],
           },

--- a/viewer/vue-client/src/utils/shelfmark.js
+++ b/viewer/vue-client/src/utils/shelfmark.js
@@ -1,0 +1,59 @@
+import { get } from 'lodash-es';
+import * as md5 from 'md5';
+import * as HttpUtil from './http';
+
+export async function hasAutomaticShelfControlNumber(shelfMarkId, settings) {
+  return HttpUtil.get({
+    url: `${settings.apiPath}/${shelfMarkId}`,
+    accept: 'application/ld+json',
+  }).then(shelfMark => Promise.resolve(shelfMark['@graph'][1].hasOwnProperty('nextShelfControlNumber')));
+}
+
+export async function checkAutoShelfControlNumber(obj, settings, user) {
+  const mainEntity = obj['@graph'][1];
+
+  if (mainEntity['@type'] === 'Item') {
+    const items = (mainEntity.hasComponent || []).filter(c => c['@type'] === 'Item');
+    items.push(mainEntity);
+    for (const item of items) {
+      // we actually want to do these sequentially in case they link to the same shelf mark
+      await _insertShelfControlNumber(item, settings, user); // eslint-disable-line no-await-in-loop
+    }
+  }
+  return obj;
+}
+
+async function _insertShelfControlNumber(item, settings, user) {
+  if (item.shelfControlNumber || !get(item, ['shelfMark', 0, '@id'])) {
+    return;
+  }
+
+  const id = item.shelfMark[0]['@id'].split('#')[0];
+  if (await hasAutomaticShelfControlNumber(id, settings)) {
+    item.shelfControlNumber = await _generateShelfControlNumber(id, settings, user);
+  }
+}
+
+async function _generateShelfControlNumber(shelfMarkId, settings, user) {
+  let result = -1;
+  const noCache = md5(Math.random() * 100000000);
+  const fetchUrl = `${settings.apiPath}/${shelfMarkId}?${noCache}`;
+  await HttpUtil.get({
+    url: fetchUrl,
+    accept: 'application/ld+json',
+  }).then((response) => {
+    const newDoc = { '@graph': response['@graph'] };
+    const number = newDoc['@graph'][1].nextShelfControlNumber;
+    newDoc['@graph'][1].nextShelfControlNumber = Number(number) + 1;
+    const prefix = newDoc['@graph'][1].qualifier;
+    result = prefix ? `${prefix} ${number}` : number;
+
+    return HttpUtil.put({
+      url: shelfMarkId,
+      ETag: response.ETag,
+      activeSigel: user.settings.activeSigel,
+      token: user.token,
+    }, newDoc);
+  });
+  return result;
+}

--- a/viewer/vue-client/src/utils/vocab.js
+++ b/viewer/vue-client/src/utils/vocab.js
@@ -474,16 +474,37 @@ export function getPropertiesFromArray(typeArray, vocabClasses, vocabProperties,
 
 export function isEmbedded(classId, vocab, settings, context) {
   if (!classId || typeof classId === 'undefined') {
-    throw new Error('isEmbedded was called with an undedfined class id');
+    throw new Error('isEmbedded was called with an undefined class id');
   }
   if (isObject(classId)) {
     throw new Error('isEmbedded was called with an object as class id (should be a string)');
+  }
+  if (isDistinct(classId, vocab, settings, context)) {
+    return false;
   }
   const embeddedTypes = settings.embeddedTypes;
   const typeChain = getBaseClasses(classId, vocab, context);
   if (typeChain.length > 0) {
     for (const item of embeddedTypes) {
       if (typeChain.indexOf(item) > -1) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function isDistinct(classId, vocab, settings, context) {
+  if (!classId || typeof classId === 'undefined') {
+    throw new Error('isDistinct was called with an undefined class id');
+  }
+  if (isObject(classId)) {
+    throw new Error('isDistinct was called with an object as class id (should be a string)');
+  }
+  const typeChain = getBaseClasses(classId, vocab, context);
+  if (typeChain.length > 0) {
+    for (const termObj of typeChain.map(t => getTermObject(t, vocab, context))) {
+      if (termObj.hasOwnProperty('category') && termObj.category['@id'] === 'https://id.kb.se/vocab/distinct') {
         return true;
       }
     }

--- a/viewer/vue-client/src/utils/vocab.js
+++ b/viewer/vue-client/src/utils/vocab.js
@@ -170,6 +170,9 @@ export function getRecordType(mainEntityType, vocab, context) {
   if (isSubClassOf(mainEntityType, 'Concept', vocab, context)) {
     return 'Concept';
   }
+  if (isSubClassOf(mainEntityType, 'ShelfMarkSequence', vocab, context)) {
+    return 'ShelfMarkSequence';
+  }
   return 'Other';
 }
 

--- a/viewer/vue-client/src/utils/vocab.js
+++ b/viewer/vue-client/src/utils/vocab.js
@@ -504,7 +504,7 @@ export function isDistinct(classId, vocab, settings, context) {
   const typeChain = getBaseClasses(classId, vocab, context);
   if (typeChain.length > 0) {
     for (const termObj of typeChain.map(t => getTermObject(t, vocab, context))) {
-      if (termObj.hasOwnProperty('category') && termObj.category['@id'] === 'https://id.kb.se/vocab/distinct') {
+      if (termObj.category && [].concat(termObj.category).some(c => c['@id'] === 'https://id.kb.se/vocab/distinct')) {
         return true;
       }
     }

--- a/viewer/vue-client/src/utils/vocab.js
+++ b/viewer/vue-client/src/utils/vocab.js
@@ -2,6 +2,23 @@ import { isObject, uniq, isArray, find, sortBy, each, isPlainObject, cloneDeep, 
 import * as httpUtil from '@/utils/http';
 import * as StringUtil from '@/utils/string';
 
+export const XSD_NUMERIC_TYPES = Object.freeze({
+  'xsd:byte': { min: -128, max: 127 },
+  'xsd:decimal': { decimal: true },
+  'xsd:int': { min: -2147483649, max: 2147483648 },
+  'xsd:integer': {},
+  'xsd:long': { min: -9223372036854775809, max: 9223372036854775808 },
+  'xsd:negativeInteger': { max: -1 },
+  'xsd:nonNegativeInteger': { min: 0 },
+  'xsd:nonPositiveInteger': { max: 0 },
+  'xsd:positiveInteger': { min: 1 },
+  'xsd:short': { min: -32768, max: 32767 },
+  'xsd:unsignedLong': { min: 0, max: 18446744073709551616 },
+  'xsd:unsignedInt': { min: 0, max: 4294967296 },
+  'xsd:unsignedShort': { min: 0, max: 65536 },
+  'xsd:unsignedByte': { min: 0, max: 255 },
+});
+
 export function getVocab(apiPath) {
   return new Promise((resolve, reject) => {
     httpUtil.getResourceFromCache(`${apiPath}/vocab/data.jsonld`).then((result) => {

--- a/viewer/vue-client/src/views/Create.vue
+++ b/viewer/vue-client/src/views/Create.vue
@@ -106,6 +106,7 @@ export default {
       if (this.userIsAllowedToEditConcepts()) {
         list.push({ id: 'Concept', text: 'Concept', excludeBase: true });
       }
+      list.push({ id: 'Other', text: 'Other', excludeBase: true });
       list.push({ id: 'File', text: 'From file' });
 
       return list;

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -924,14 +924,14 @@ export default {
       this.initJsonOutput();
     });
     
-    this.$root.$on('create-maybe-magic-shelf-mark', (data) => {
+    this.$root.$on('maybe-magic-shelf-mark-created', (data) => {
       this.hasAutomaticShelfControlNumber(data.id).then((result) => {
         if (result) {
           this.$store.commit('addMagicShelfMark', data.path);
         }
       }).catch(error => console.error(error));
     });
-    this.$root.$on('remove-maybe-magic-shelf-mark', (data) => {
+    this.$root.$on('maybe-magic-shelf-mark-removed', (data) => {
       this.$store.commit('removeMagicShelfMark', data.path);
     });
   },

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -434,7 +434,7 @@ export default {
     },
     checkForAutomaticFixes() {
       // If this is a holding, add the heldBy property
-      if (this.inspector.data.mainEntity['@type'] === 'Item' || this.inspector.data.mainEntity['@type'] === 'ShelfMarkSequence') {
+      if (this.inspector.data.mainEntity['@type'] === 'Item') {
         this.checkForMissingHeldBy();
       }
       // If this is a *new* work, add an empty cataloguersNote property to the record

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -389,7 +389,7 @@ export default {
       HttpUtil._delete({ url, activeSigel: this.user.settings.activeSigel, token: this.user.token }).then(() => {
         this.$store.dispatch('pushNotification', { 
           type: 'success', 
-          message: `${StringUtil.getUiPhraseByLang(this.recordType, this.user.settings.language)} ${StringUtil.getUiPhraseByLang('was deleted', this.user.settings.language)}!`, 
+          message: `${this.$options.filters.labelByLang(this.recordType)} ${StringUtil.getUiPhraseByLang('was deleted', this.user.settings.language)}!`, 
         });
         // Force reload
         this.$router.go(-1);
@@ -658,7 +658,7 @@ export default {
           setTimeout(() => {
             this.$store.dispatch('pushNotification', { 
               type: 'success', 
-              message: `${StringUtil.getUiPhraseByLang(this.recordType, this.user.settings.language)} ${StringUtil.getUiPhraseByLang('was created', this.user.settings.language)}!`,
+              message: `${this.$options.filters.labelByLang(this.recordType)}  ${StringUtil.getUiPhraseByLang('was created', this.user.settings.language)}!`,
             });
           }, 10);
           this.warnOnSave();
@@ -668,7 +668,7 @@ export default {
           setTimeout(() => {
             this.$store.dispatch('pushNotification', {
               type: 'success', 
-              message: `${StringUtil.getUiPhraseByLang(this.recordType, this.user.settings.language)} ${StringUtil.getUiPhraseByLang('was saved', this.user.settings.language)}!`,
+              message: `${this.$options.filters.labelByLang(this.recordType)} ${StringUtil.getUiPhraseByLang('was saved', this.user.settings.language)}!`,
             });
           }, 10);
           this.warnOnSave();

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -433,7 +433,7 @@ export default {
     },
     checkForAutomaticFixes() {
       // If this is a holding, add the heldBy property
-      if (this.inspector.data.mainEntity['@type'] === 'Item') {
+      if (this.inspector.data.mainEntity['@type'] === 'Item' || this.inspector.data.mainEntity['@type'] === 'ShelfMarkSequence') {
         this.checkForMissingHeldBy();
       }
       // If this is a *new* work, add an empty cataloguersNote property to the record


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Add support for linked shelfMark with automatic generation of shelfControlNumber.

### Tickets involved
[LXL-3465](https://jira.kb.se/browse/LXL-3465)

### Summary of changes
* Allow linking for classes with category `distinct` (`https://id.kb.se/vocab/distinct`)
* Generate `shelfControlNumber` for each `Item` on save if it has a linked `shelfMark` with `nextShelfControlNumber`.
* Add a custom component `shelfControlNumber` which displays the option to generate it if applicable.
* Add template for ShelfMarkSequence (class name may change) in the new template section "Other".
* Limit entity-adder search to active ShelfMarks owned by current sigel

TODO:
* Restrict input `nextShelfControlNumber` to number. (restrict all `xsd:integer`)
* Disallow creating local entities for classes with category `distinct`