### PR TITLE
Feature/paste links

### DIFF
--- a/viewer/vue-client/src/components/inspector/create-item-button.vue
+++ b/viewer/vue-client/src/components/inspector/create-item-button.vue
@@ -50,6 +50,7 @@ export default {
         this.resources.context,
       );
       embellishedReference['@id'] = this.mainEntity['@id'];
+      embellishedReference['@type'] = this.mainEntity['@type']; // fixes broken itemOf chip FIXME: why does getCard drop @type?
 
       this.itemData = RecordUtil.getItemObject(
         this.mainEntity['@id'],

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -421,7 +421,6 @@ export default {
     pasteClipboardItem() {
       const obj = this.clipboardValue;
       DataUtil.fetchMissingLinkedToQuoted(obj, this.$store)
-        .catch(e => console.log(e))
         .finally(() => this._pasteClipboardItem(obj));
     },
     _pasteClipboardItem(obj) {

--- a/viewer/vue-client/src/components/inspector/field.vue
+++ b/viewer/vue-client/src/components/inspector/field.vue
@@ -21,6 +21,7 @@ import ItemShelfControlNumber from './item-shelf-control-number';
 import * as VocabUtil from '@/utils/vocab';
 import * as LayoutUtil from '@/utils/layout';
 import * as StringUtil from '@/utils/string';
+import * as DataUtil from '@/utils/data';
 import LodashProxiesMixin from '../mixins/lodash-proxies-mixin';
 
 export default {
@@ -419,6 +420,11 @@ export default {
   methods: {
     pasteClipboardItem() {
       const obj = this.clipboardValue;
+      DataUtil.fetchMissingLinkedToQuoted(obj, this.$store)
+        .catch(e => console.log(e))
+        .finally(() => this._pasteClipboardItem(obj));
+    },
+    _pasteClipboardItem(obj) {
       let currentValue = cloneDeep(get(this.inspector.data, this.path));
       if (currentValue === null) {
         currentValue = obj;

--- a/viewer/vue-client/src/components/inspector/item-numeric.vue
+++ b/viewer/vue-client/src/components/inspector/item-numeric.vue
@@ -85,7 +85,7 @@ export default {
     },
     isDecimal() {
       return this.range.map(r => XSD_NUMERIC_TYPES[r]).some(t => (t.decimal));
-    }
+    },
   },
   methods: {
     removeHighlight(event, active) {

--- a/viewer/vue-client/src/utils/data.js
+++ b/viewer/vue-client/src/utils/data.js
@@ -1,4 +1,4 @@
-import { isEmpty, cloneDeep, isArray, isObject, forEach, uniq } from 'lodash-es';
+import { isEmpty, cloneDeep, isArray, isObject, forEach, uniq, difference } from 'lodash-es';
 import * as HttpUtil from '@/utils/http';
 
 export function getEmbellished(id, quotedIndex = {}) {
@@ -106,7 +106,7 @@ export function getExternalLinks(obj) {
       }
     });
   }
-  return uniq(links).filter(l => !entities.includes(l)); // # entities should be small...
+  return difference(uniq(links), entities);
 }
 
 export async function fetchMissingLinkedToQuoted(obj, store) {

--- a/viewer/vue-client/src/utils/data.js
+++ b/viewer/vue-client/src/utils/data.js
@@ -1,4 +1,5 @@
-import { isEmpty, cloneDeep, isArray, isObject } from 'lodash-es';
+import { isEmpty, cloneDeep, isArray, isObject, forEach } from 'lodash-es';
+import * as HttpUtil from '@/utils/http';
 
 export function getEmbellished(id, quotedIndex = {}) {
   if (typeof id === 'undefined' || id === '') {
@@ -83,6 +84,40 @@ export function rewriteValueOfKey(obj, key, newValue, deep = false) {
     }
   }
   return newObj;
+}
+
+export function getExternalLinks(obj) {
+  if (!isArray(obj) && !isObject(obj)) {
+    return [];
+  }
+  
+  const links = [];
+  const entities = [];
+  const stack = [];
+  stack.push(obj);
+  let o;
+  while (o = stack.pop()) {
+    if (o['@id']) {
+      (Object.keys(o).length > 1 ? entities : links).push(o['@id']);
+    }
+    forEach(o, (child) => { 
+      if (isArray(child) || isObject(child)) {
+        stack.push(child);
+      }
+    });
+  }
+  return links.filter(l => !entities.includes(l)); // # entities should be small...
+}
+
+export async function fetchMissingLinkedToQuoted(obj, store) {
+  const quoted = store.state.inspector.data.quoted || {};
+  const missingLinks = getExternalLinks(obj).filter(l => !quoted.hasOwnProperty(l));
+  Promise.allSettled(missingLinks.map(l => HttpUtil.getDocument(l, undefined, false))).then((results) => {
+    results
+      .filter(r => r.status === 'fulfilled')
+      .map(r => r.value.data)
+      .forEach(doc => doc['@graph'].forEach(o => store.commit('addToQuoted', o)));
+  });
 }
 
 // Changes XML to JSON

--- a/viewer/vue-client/src/utils/http.js
+++ b/viewer/vue-client/src/utils/http.js
@@ -130,12 +130,17 @@ export function getRelatedRecords(queryPairs, apiPath) {
   });
 }
 
-export async function getDocument(uri, contentType = 'application/ld+json') {
+export async function getDocument(uri, contentType = 'application/ld+json', embellished = true) {
   let translatedUri = uri;
   if (uri.startsWith('https://id.kb.se')) {
     translatedUri = uri.replace('https://id.kb.se', process.env.VUE_APP_ID_PATH);
   }
 
+  if (!uri.includes('embellished=')) {
+    const query = `${uri.includes('?') ? '&' : '?'}embellished=${embellished}`;
+    translatedUri = `${translatedUri}${query}`;
+  }
+  
   const headers = new Headers();
   headers.append('Accept', contentType);
   const responseObject = {};

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -418,6 +418,7 @@ export default {
         this.$store.dispatch('setInspectorData', RecordUtil.splitJson(insertData));
         this.startEditing();
         this.onPostLoaded();
+        DataUtil.fetchMissingLinkedToQuoted(insertData, this.$store);
       }
     },
     onPostLoaded() {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
This fixes the problem when the target of a link is not available to the client leading to a broken chip (and sometimes broken "hover card"). Fixes these cases:
* Pasting an object/entity
* Creating a new doc from a template

Doing a separate HTTP request for each missing thing might be less effective that round-tripping the whole template through embellish? But we don't have an API for that.

Also fixes broken itemOf chip in 'new holding' view.

### Tickets involved
[LXL-3465](https://jira.kb.se/browse/LXL-3465), [LXL-3286](https://jira.kb.se/browse/LXL-3286)