### PR TITLE
Add settings.defaultExpandedProperties

### DIFF
--- a/viewer/vue-client/src/components/inspector/item-entity.vue
+++ b/viewer/vue-client/src/components/inspector/item-entity.vue
@@ -100,6 +100,9 @@ export default {
     this.$on('expand-item', () => {
       this.expand();
     });
+    if (this.$store.state.settings.defaultExpandedProperties.includes(this.fieldKey)) {
+      this.expand();
+    }
   },
   mounted() {
     this.$nextTick(() => {

--- a/viewer/vue-client/src/components/inspector/item-grouped.vue
+++ b/viewer/vue-client/src/components/inspector/item-grouped.vue
@@ -58,7 +58,7 @@ export default {
     },
   },
   mounted() {
-    if (this.isInForm) {
+    if (this.isInForm || this.$store.state.settings.defaultExpandedProperties.includes(this.fieldKey)) {
       this.expand();
     }
   },

--- a/viewer/vue-client/src/components/inspector/item-local.vue
+++ b/viewer/vue-client/src/components/inspector/item-local.vue
@@ -390,6 +390,9 @@ export default {
         this.expand();
       }
     });
+    if (this.$store.state.settings.defaultExpandedProperties.includes(this.fieldKey)) {
+      this.expand();
+    }
   },
   mounted() {
     if (this.isSpecialHeading) {

--- a/viewer/vue-client/src/components/inspector/item-sibling.vue
+++ b/viewer/vue-client/src/components/inspector/item-sibling.vue
@@ -348,6 +348,9 @@ export default {
         this.expand();
       }
     });
+    if (this.$store.state.settings.defaultExpandedProperties.includes(this.fieldKey)) {
+      this.expand();
+    }
   },
   mounted() {
     if (this.isSpecialHeading) {

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -162,6 +162,11 @@ const store = new Vuex.Store({
         'generationProcess',
         'recordStatus',
       ],
+      defaultExpandedProperties: [
+        'hasComponent',
+        '@reverse/reproductionOf',
+        '@reverse/supplementTo',
+      ],
       dataSetFilters: {
         libris: [
           {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
* Add `defaultExpandedProperties` to settings. These properties/fields while be expanded from the start when opening a form.
* Add some default expanded properties
    * `hasComponent`
    * `@reverse/reproductionOf`
    * `@reverse/supplementTo`
    
### Solves
e.g. newly generated `hasComponent.shelfControlNumber` not being visible when saving an `Item`
