### PR TITLE
Don't hide itemOf in relation side panel unless viewing Instance

### DIFF
--- a/viewer/vue-client/src/components/inspector/relations-list.vue
+++ b/viewer/vue-client/src/components/inspector/relations-list.vue
@@ -230,7 +230,7 @@ export default {
           class="RelationsList-resultListContainer"
           :results="resultItems"
           :is-compact="isCompact"
-          :list-item-settings="{ excludeProperties: ['itemOf'], excludeComponents: hiddenComponents }"
+          :list-item-settings="{ excludeProperties: this.listContextType === 'Instance' ? ['itemOf'] : [], excludeComponents: hiddenComponents }"
           icon="chain"
           text="Link entity"
           v-if="!loading && searchResult !== null && error == null"


### PR DESCRIPTION

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
itemOf in card is useless if viewing incoming links for an Instance (since itemOf it will be the same Instance).
It is useful if viewing incoming links for other types.