### PR TITLE
Fix not possible to save digital reproduction with single identifiedBy

### DIFF
--- a/viewer/vue-client/src/resources/json/combinedTemplates.json
+++ b/viewer/vue-client/src/resources/json/combinedTemplates.json
@@ -256,7 +256,7 @@
             }
           ],
           "responsibilityStatement": "",
-          "identifiedBy": null,
+          "identifiedBy": [],
           "editionStatement": [""],
           "publication": [
             {


### PR DESCRIPTION
`identifiedBy` became an object instead of an array with one object which
backend chokes on for this specific property when creating a new doc (HTTP 500).