### PR TITLE
Handle sameAs in fetchMissingLinkedToQuoted

### DIFF
--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -509,6 +509,12 @@ const store = new Vuex.Store({
     addToQuoted(state, data) {
       const quoted = cloneDeep(state.inspector.data.quoted);
       quoted[data['@id']] = data;
+      (data.sameAs || []).forEach((sameAs) => {
+        if (sameAs.hasOwnProperty('@id')) {
+          quoted[sameAs['@id']] = data;
+        }
+      });
+      
       state.inspector.data.quoted = quoted;
     },
     updateInspectorData(state, payload) {


### PR DESCRIPTION
e.g. old links in templates that are now `sameAs`
