### PR TITLE
LXL-2357 Add button to filter by heldBy for active sigel

### DIFF
--- a/viewer/vue-client/src/App.vue
+++ b/viewer/vue-client/src/App.vue
@@ -525,7 +525,7 @@ body {
       }
     }
   }
-  input, textarea, img, select, .ItemEntity, .ItemLocal, .EntityAction, .ItemSibling, .icon, .icon i, li, i.fa {
+  input, textarea, img, select, .ItemEntity, .ItemLocal, .EntityAction, .ItemSibling, .icon, .icon i, li, i.fa, div {
     &:focus {
       .focus-mixin-border();
     }

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -377,6 +377,8 @@
     "Switch sigel": "Växla sigel",
     "Accessibility statement": "Tillgänglighetsredogörelse",
     "Generate control number when item is saved": "Generera löpnummer när bestånd sparas",
-    "Enter manual control number": "Ange löpnummer manuellt"
+    "Enter manual control number": "Ange löpnummer manuellt",
+    "Filter by held items for active sigel": "Filtrera på hållna bestånd för aktivt sigel",
+    "Remove filter by held items for active sigel": "Ta bort filtrering på hållna bestånd för aktivt sigel"
     }
 }


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint` (didn't fix this, lots of LF errors)

## Description

### Tickets involved
[LXL-2357](https://jira.kb.se/browse/LXL-2357)

### Solves

Adds a button to add and remove `@reverse.heldBy.@id` filter

### Summary of changes

- Added button to result-controls
- Fixed focus-state for divs
- Added translations
