### PR TITLE
Use _sortKeyByLang as sort option in Agent/Concept/All

### DIFF
--- a/viewer/vue-client/src/components/search/sort.vue
+++ b/viewer/vue-client/src/components/search/sort.vue
@@ -97,7 +97,7 @@ export default {
       @change="handleSortChange">
       <option 
         v-for="(option, index) in options" 
-        :value="option.query"
+        :value="option.query.endsWith('_sortKeyByLang') ? `${option.query}.${user.settings.language || 'sv'}` : option.query"
         :key="index">
         {{ option.label | translatePhrase }}
       </option>

--- a/viewer/vue-client/src/resources/json/i18n.json
+++ b/viewer/vue-client/src/resources/json/i18n.json
@@ -351,6 +351,8 @@
     "Label": "Benämning",
     "Sigel (A-Z)": "Sigel (A-Ö)",
     "Sigel (Z-A)": "Sigel (Ö-A)",
+    "A-Z": "A-Ö",
+    "Z-A": "Ö-A",
     "Free text": "Fritext",
     "Title": "Titel",
     "Main title": "Huvudtitel",

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -387,12 +387,12 @@ const store = new Vuex.Store({
             label: 'Relevance',
           },
           {
-            query: 'prefLabel',
-            label: 'Preferred label (A-Z)',
+            query: '_sortKeyByLang',
+            label: 'A-Z',
           },
           {
-            query: '-prefLabel',
-            label: 'Preferred label (Z-A)',
+            query: '-_sortKeyByLang',
+            label: 'Z-A',
           },
           {
             query: '-meta.modified',
@@ -423,6 +423,14 @@ const store = new Vuex.Store({
             label: 'Relevance',
           },
           {
+            query: '_sortKeyByLang',
+            label: 'A-Z',
+          },
+          {
+            query: '-_sortKeyByLang',
+            label: 'Z-A',
+          },
+          {
             query: '-meta.modified',
             label: 'Last updated',
           },
@@ -435,6 +443,14 @@ const store = new Vuex.Store({
           {
             query: '',
             label: 'Relevance',
+          },
+          {
+            query: '_sortKeyByLang',
+            label: 'A-Z',
+          },
+          {
+            query: '-_sortKeyByLang',
+            label: 'Z-A',
           },
           {
             query: '-meta.modified',
@@ -451,12 +467,12 @@ const store = new Vuex.Store({
             label: 'Relevance',
           },
           {
-            query: 'prefLabel',
-            label: 'Preferred label (A-Z)',
+            query: '_sortKeyByLang',
+            label: 'A-Z',
           },
           {
-            query: '-prefLabel',
-            label: 'Preferred label (Z-A)',
+            query: '-_sortKeyByLang',
+            label: 'Z-A',
           },
           {
             query: '-meta.modified',


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3508](https://jira.kb.se/browse/LXL-3508)
### Solves

Previously it wasn't possible to sort results with agents or mixed types alphabetically. This was solved in the backend with two new fields, `_sortKeyByLang.sv` and `_sortKeyByLang.en`, that try to be approximately the same as what would be shown in the header in the UI. This simply makes use of these new fields when sorting.

### Summary of changes

* Concept, Common: use `_sortKeyByLang` instead of `prefLabel` 
* Agent, Other: add `_sortKeyByLang` (A-Z) sort option

`query` in `store.json` is `_sortKeyByLang`, but what actually needs to be sent to the server is `_sortKeyByLang.<lang>`, which depends on the user setting. Right now `user.settings.language` is simply appended in `sort.vue`, with a default of 'sv' if language isn't set. There might very well be a better solution.
