### PR TITLE
Don't choke on types outside known class hierarchies

### DIFF
--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -206,6 +206,7 @@ export default {
         <sort 
           v-if="searchedTypes && $route.params.perimeter != 'remote'"
           :currentSort="currentSortOrder ? currentSortOrder : ''"
+          :common-sort-fallback="true"
           :recordTypes="searchedTypes"
           @change="$emit('sortChange', $event)"/>
         <div class="ResultControls-listTypes">

--- a/viewer/vue-client/src/components/search/sort.vue
+++ b/viewer/vue-client/src/components/search/sort.vue
@@ -41,16 +41,20 @@ export default {
       const sortOptions = this.$store.getters.settings.sortOptions[this.commonBaseType];
       if (sortOptions) {
         return sortOptions;
-      }      
+      }
       return false;
     },
     commonBaseType() {      
       if (typeof this.recordTypes === 'string') {
-        return VocabUtil.getRecordType(
+        const type = VocabUtil.getRecordType(
           this.recordTypes,
           this.resources.vocab, 
           this.resources.context,
         );
+        if (this.$store.getters.settings.sortOptions[type]) {
+          return type;
+        }
+        return this.commonSortFallback ? 'Common' : false;
       }      
       if (Array.isArray(this.recordTypes)) {
         const baseTypes = this.recordTypes.reduce((accumulator, currType) => {

--- a/viewer/vue-client/src/components/shared/entity-summary.vue
+++ b/viewer/vue-client/src/components/shared/entity-summary.vue
@@ -215,11 +215,11 @@ export default {
         this.resources.vocab, 
         this.resources.context,
       );
-      if (this.recordType === 'Item') {
-        return translatedBaseType;
+      if (type === this.recordType && ['Instance', 'Work'].indexOf(type) !== -1) {
+        return `${this.$options.filters.translatePhrase('Unspecified')}, ${translatedBaseType}`;
       }
       if (type === this.recordType) {
-        return `${this.$options.filters.translatePhrase('Unspecified')}, ${translatedBaseType}`;
+        return translatedBaseType;
       }
       let translatedType = '';
       if (isArray(type)) {

--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -444,28 +444,6 @@ const store = new Vuex.Store({
             label: 'Most linked',
           },
         ],
-        Other: [
-          {
-            query: '',
-            label: 'Relevance',
-          },
-          {
-            query: '_sortKeyByLang',
-            label: 'A-Z',
-          },
-          {
-            query: '-_sortKeyByLang',
-            label: 'Z-A',
-          },
-          {
-            query: '-meta.modified',
-            label: 'Last updated',
-          },
-          {
-            query: '-reverseLinks.totalItems',
-            label: 'Most linked',
-          },
-        ],
         Common: [
           {
             query: '',

--- a/viewer/vue-client/src/utils/vocab.js
+++ b/viewer/vue-client/src/utils/vocab.js
@@ -187,10 +187,7 @@ export function getRecordType(mainEntityType, vocab, context) {
   if (isSubClassOf(mainEntityType, 'Concept', vocab, context)) {
     return 'Concept';
   }
-  if (isSubClassOf(mainEntityType, 'ShelfMarkSequence', vocab, context)) {
-    return 'ShelfMarkSequence';
-  }
-  return 'Other';
+  return mainEntityType;
 }
 
 function isFiltered(termObj, settings) {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Make it possible to edit docs with mainEntity `@type` that is not a subclass of Item/Instance/Work/Agent/Concept. 

We probably want to rework some getRecordType use later.

### Tickets involved
[LXL-3531](https://jira.kb.se/browse/LXL-3531)

### Solves
Used to get an exception on e.g. DataCatalog

### Summary of changes
Main change is in `getRecordType` in vocab.js. The others are just to make it work everywhere.
* `getRecordType` returns the type passed instead of 'Other' if not found among base classes.
* In top of cards: Only show "Unspecified" (e.g. "Unspecified, Work") for Work and Instance  
* Remove sort options for  "Other", use "Common".

