### PR TITLE
Don't set _offset for new searches

### DIFF
--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -12,10 +12,7 @@ import re
 import string
 import time
 import requests
-try:
-    from urllib.parse import urlparse, urljoin
-except ImportError:
-    from urlparse import urlparse, urljoin
+from urllib.parse import urlparse, urljoin, urlencode, unquote, parse_qs, ParseResult
 from datetime import datetime, timedelta
 
 from flask import Flask, Response
@@ -70,7 +67,6 @@ app.config.from_pyfile('config.cfg', silent=True)
 
 CORS(app, methods=HTTP_METHODS, expose_headers=['ETag', 'Location'])
 
-
 try:
     import builtins
 except ImportError:
@@ -97,6 +93,18 @@ def format_number(n):
 def first(value):
     for v in as_iterable(value):
         return v
+
+@app.template_filter('modify_query')
+def modify_query(url, new_params):
+    parsed_url = urlparse(unquote(url))
+    parsed_qs = parse_qs(parsed_url.query)
+    parsed_qs.update(new_params)
+    encoded_qs = urlencode(parsed_qs, doseq=True)
+
+    return ParseResult(
+        parsed_url.scheme, parsed_url.netloc, parsed_url.path,
+        parsed_url.params, encoded_qs, parsed_url.fragment
+    ).geturl()
 
 ##
 # About XL

--- a/viewer/templates/search.html
+++ b/viewer/templates/search.html
@@ -20,7 +20,7 @@
       <div class="form">
         <div class="form-group">
           % for param, value in request.args.items(multi=True)
-            % if param != 'q' and param != '_sort'
+            % if param != 'q' and param != '_sort' and param != "_offset"
               <input type="hidden" name="${param}" value="${value}" />
             % endif
           % endfor
@@ -72,7 +72,7 @@
             % else
               % set label = item.value
             % endif
-              <a href="${item.up['@id']}" class="activated-facet semibold" title="Ta bort filter" aria-label="Ta bort filter ${vocab_term(label)}">
+              <a href="${item.up['@id'] | modify_query({'_offset': 0})}" class="activated-facet semibold" title="Ta bort filter" aria-label="Ta bort filter ${vocab_term(label)}">
               ${vocab_term(label)}
               <span class="fa fa-fw fa-times-circle" aria-hidden="true"></span>
             </a>


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
None (afaik), this was just a quick pre-sprint fix.

### Solves

Currently the `_offset` form value for the _current_ search is included when performing a _new_ search, so if you're on page two of something, e.g.,

https://id.kb.se/find?q=*&_limit=200&inScheme.@id=https://id.kb.se/term/sao&inScheme.@id=https://id.kb.se/term/barn&inScheme.@id=https://id.kb.se/term/saogf&inScheme.@id=https://id.kb.se/marc&inScheme.@id=https://id.kb.se/term/gmgpc/swe&inScheme.@id=https://id.kb.se/term/barngf&inScheme.@id=https://id.kb.se/term/rda&_offset=200

...and then search for say "marsvin", the resulting page will say "Visar 201-6 av 6 träffar" and not actually show any results.

Similarly, if you're on [this](https://id.kb.se/find?_limit=200&inScheme.%40id=https%3A%2F%2Fid.kb.se%2Fterm%2Fsao&inScheme.%40id=https%3A%2F%2Fid.kb.se%2Fterm%2Fbarn&inScheme.%40id=https%3A%2F%2Fid.kb.se%2Fterm%2Fsaogf&inScheme.%40id=https%3A%2F%2Fid.kb.se%2Fmarc&inScheme.%40id=https%3A%2F%2Fid.kb.se%2Fterm%2Fgmgpc%2Fswe&inScheme.%40id=https%3A%2F%2Fid.kb.se%2Fterm%2Fbarngf&inScheme.%40id=https%3A%2F%2Fid.kb.se%2Fterm%2Frda&_offset=200&q=sverige&_sort=) page and remove the filter `https://id.kb.se/term/sao`, it'll show "Visar 201-5 av 5 träffar" and no actual results.

### Summary of changes

Fixes the above-mentioned issues by not including `_offset` in the search form and by removing the `_offset` query parameter from "remove filter" links.
