### PR TITLE
Sort: use _sortKeyByLang instead of hasTitle.mainTitle for Instance/Work

### DIFF
--- a/viewer/vue-client/src/store.js
+++ b/viewer/vue-client/src/store.js
@@ -346,12 +346,12 @@ const store = new Vuex.Store({
             label: 'Relevance',
           },
           {
-            query: 'hasTitle.mainTitle',
-            label: 'Main title (A-Z)',
+            query: '_sortKeyByLang',
+            label: 'A-Z',
           },
           {
-            query: '-hasTitle.mainTitle',
-            label: 'Main title (Z-A)',
+            query: '-_sortKeyByLang',
+            label: 'Z-A',
           },
           {
             query: '-publication.year',
@@ -372,12 +372,12 @@ const store = new Vuex.Store({
             label: 'Relevance',
           },
           {
-            query: 'hasTitle.mainTitle',
-            label: 'Main title (A-Z)',
+            query: '_sortKeyByLang',
+            label: 'A-Z',
           },
           {
-            query: '-hasTitle.mainTitle',
-            label: 'Main title (Z-A)',
+            query: '-_sortKeyByLang',
+            label: 'Z-A',
           },
           {
             query: '-meta.modified',


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-2290](https://jira.kb.se/browse/LXL-2290)

### Solves

In Instance/Work, `hasTitle.mainTitle` was used for A-Z sorting. Elsewhere, the new `_sortKeyByLang` field (to which we do various things to make it better for sorting) is used. This is a bit inconsistent and needlessly confusing, as the `_sortKeyByLang` field should be fine everywhere (`hasTitle.mainTitle` would appear first in an Instance/Work's `_sortKeyByLang`). 

### Summary of changes

Makes it so that Work and Instance uses  `_sortKeyByLang` for A-Z/Z-A sorting.
