### PR TITLE
Search: respect maxItems when generating pagination links

### DIFF
--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -539,6 +539,7 @@ export default {
             <modal-pagination
               @go="go"
               :total-items="totalItems"
+              :max-items="maxItems"
               :max-per-page="maxResults"
               :current-page="currentPage"
             >

--- a/viewer/vue-client/src/components/inspector/modal-pagination.vue
+++ b/viewer/vue-client/src/components/inspector/modal-pagination.vue
@@ -7,6 +7,10 @@ export default {
       default: 0,
       type: Number,
     },
+    maxItems: {
+      default: Number.MAX_VALUE,
+      type: Number,
+    },
     maxPerPage: {
       default: 10,
       type: Number,
@@ -25,7 +29,7 @@ export default {
   },
   computed: {
     numberOfPages() {
-      return Math.ceil(this.totalItems / this.maxPerPage);
+      return Math.ceil(Math.min(this.totalItems, this.maxItems) / this.maxPerPage);
     },
     lastPageIndex() {
       return this.numberOfPages - 1;

--- a/viewer/vue-client/src/components/inspector/relations-list.vue
+++ b/viewer/vue-client/src/components/inspector/relations-list.vue
@@ -53,6 +53,7 @@ export default {
             response.json().then((result) => {
               this.searchResult = result;
               this.totalItems = result.totalItems;
+              this.maxItems = result.maxItems;
               if (this.selectedQuery === this.query) {
                 this.allOption = this.buildAllOption();
                 this.selectedFacet = this.allOption;
@@ -244,7 +245,8 @@ export default {
           <modal-pagination 
             v-if="searchResult.totalItems > maxResults"
             @go="go" 
-            :total-items="totalItems" 
+            :total-items="totalItems"
+            :max-items="maxItems" 
             :max-per-page="maxResults"
             :current-page="currentPage"
           >

--- a/viewer/vue-client/src/components/inspector/search-window.vue
+++ b/viewer/vue-client/src/components/inspector/search-window.vue
@@ -290,6 +290,7 @@ export default {
             <modal-pagination
               @go="go"
               :total-items="totalItems"
+              :max-items="maxItems"
               :max-per-page="maxResults"
               :current-page="currentPage"
             >

--- a/viewer/vue-client/src/components/mixins/sidesearch-mixin.vue
+++ b/viewer/vue-client/src/components/mixins/sidesearch-mixin.vue
@@ -18,6 +18,8 @@ export default {
       active: false,
       currentPage: 0,
       maxResults: 20,
+      totalItems: 0,
+      maxItems: 0,
       sort: '',
       isCompact: false,
     };
@@ -133,6 +135,7 @@ export default {
     loadResults(result) {
       this.searchResult = result.items;
       this.totalItems = result.totalItems;
+      this.maxItems = result.maxItems;
     },
     go(n) {
       this.fetch(n);

--- a/viewer/vue-client/src/components/search/result-controls.vue
+++ b/viewer/vue-client/src/components/search/result-controls.vue
@@ -89,7 +89,8 @@ export default {
       }
       const first = this.pageData.first['@id'];
       const offset = this.pageData.itemOffset;
-      const noOfPages = Math.ceil(this.pageData.totalItems / parseInt(this.limit)) || 1;
+      const maxResult = Math.min(this.pageData.totalItems, this.pageData.maxItems);
+      const noOfPages = Math.ceil(maxResult / parseInt(this.limit)) || 1;
       const currentPage = parseInt(offset / this.limit);
       let paddedPages = 3;
       if (currentPage < paddedPages) {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Search result pagination links for first, prev, next and last are generated by backend but lxlviewer creates the numbered pages between first and last. Elasticsearch has a maximum number of results that can be accessed (now configured to 100k). This number is included in the search response as `maxItems`. Consider it when generating page links. 
i.e. don't show a link for page 5001 if `maxItems` is 100 000 and `_limit` is 20

### Tickets involved
[LXL-3588](https://jira.kb.se/browse/LXL-3588)