### PR TITLE
Display link to login if login expired while editing

### DIFF
--- a/viewer/vue-client/src/components/search/sort.vue
+++ b/viewer/vue-client/src/components/search/sort.vue
@@ -43,7 +43,7 @@ export default {
         return sortOptions;
       }
       if (this.commonSortFallback) {
-        sortOptions = this.$store.getters.settings.sortOptions['Common']
+        sortOptions = this.$store.getters.settings.sortOptions.Common;
       }
       if (sortOptions) {
         return sortOptions;

--- a/viewer/vue-client/src/components/shared/notification.vue
+++ b/viewer/vue-client/src/components/shared/notification.vue
@@ -16,12 +16,14 @@ export default {
       setTimeout(() => {
         this.shouldShow = true;
       }, 1);
-      setTimeout(() => {
-        this.shouldShow = false;
-      }, this.TTL - 500);
-      setTimeout(() => {
-        this.remove();
-      }, this.TTL);
+      if (!this.content.sticky) {
+        setTimeout(() => {
+          this.shouldShow = false;
+        }, this.TTL - 500);
+        setTimeout(() => {
+          this.remove();
+        }, this.TTL);
+      }
     });
   },
   methods: {
@@ -53,7 +55,26 @@ export default {
         <i class="fa fa-circle fa-stack-2x"></i>
         <i class="fa fa-info fa-stack-1x Notification-icon"></i>
       </span>
-    {{ content.message }}
+      
+      {{ content.message }}
+    
+      <router-link class="Notification-link"
+                   v-if="content.link && !content.link.external"
+                   :to="content.link.to"
+                   :title="content.link.title"
+                   :target="content.link.newTab ? '_blank' : '' ">
+        {{ content.link.title }}
+        <i v-if="content.link.newTab" class="fa fa-external-link" aria-hidden="true"></i>
+      </router-link>
+      <a
+        class="Notification-link"
+        v-if="content.link && content.link.external"
+        :href="content.link.to" 
+        :target="content.link.newTab ? '_blank' : '' ">
+        {{ content.link.title }}
+        <i v-if="content.link.newTab" class="fa fa-external-link" aria-hidden="true"></i>
+      </a>
+      
   </div>
 </template>
 
@@ -81,6 +102,19 @@ export default {
   color: @info-color-text;
   .notification-icon {
     color: @info-color;
+  }
+  
+  &-link {
+    color: @info-color-text;
+    text-decoration: underline;
+
+    .Notification--error & {
+      color: @error-color-text;
+    }
+
+    .Notification--success & {
+      color: @success-color-text;
+    }
   }
 
   &--error {

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -694,14 +694,25 @@ export default {
         switch (error.status) {
           case 412:
             errorMessage = `${StringUtil.getUiPhraseByLang('The resource has been modified by another user', this.user.settings.language)}`;
+            this.$store.dispatch('pushNotification', { type: 'danger', message: `${errorBase}. ${errorMessage}.` });
             break;
           case 401:
+            localStorage.removeItem('lastPath');
             errorMessage = `${StringUtil.getUiPhraseByLang('Your login has expired', this.user.settings.language)}`;
+            this.$store.dispatch('pushNotification', { type: 'danger', 
+              message: `${errorBase}. ${errorMessage}.`, 
+              sticky: true, 
+              link: { 
+                to: this.$store.getters.oauth2Client.token.getUri(), 
+                title: `${StringUtil.getUiPhraseByLang('Log in', this.user.settings.language)}`, 
+                newTab: false, 
+                external: true,
+              } });
             break;
           default:
             errorMessage = `${StringUtil.getUiPhraseByLang('Something went wrong', this.user.settings.language)} - ${error.status}: ${StringUtil.getUiPhraseByLang(error.statusText, this.user.settings.language)}`;
+            this.$store.dispatch('pushNotification', { type: 'danger', message: `${errorBase}. ${errorMessage}.` });
         }
-        this.$store.dispatch('pushNotification', { type: 'danger', message: `${errorBase}. ${errorMessage}.` });
       });
     },
     warnOnSave() {

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -705,7 +705,7 @@ export default {
               link: { 
                 to: this.$store.getters.oauth2Client.token.getUri(), 
                 title: `${StringUtil.getUiPhraseByLang('Log in', this.user.settings.language)}`, 
-                newTab: false, 
+                newTab: true, 
                 external: true,
               } });
             break;


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Give the user a chance to log in again if the session has expired when trying to save.
This is done by including a login link in the error message.
The link opens in an new tab, so the user has to login there and then come back to the editor tab. 
Basic solution. It would probably be nicer to stash the edited doc and do the login flow in the same tab.

### Tickets involved
[LXL-2865](https://jira.kb.se/browse/LXL-2865)

Summary of changes
- Add `sticky` mode to notifications. No timeout, only closes on click.
- Add links to notifications.
- Include login link in error notification for 401 on save 