### PR TITLE
Add ISNI type in auth templates instead of typeNote

### DIFF
--- a/viewer/vue-client/src/resources/json/combinedTemplates.json
+++ b/viewer/vue-client/src/resources/json/combinedTemplates.json
@@ -3152,8 +3152,7 @@
           ],
           "seeAlso": [],
           "identifiedBy": [{
-            "@type": "Identifier",
-            "typeNote": "isni",
+            "@type": "ISNI",
             "value": ""
           }],
           "nationality": [{
@@ -3213,8 +3212,7 @@
         ],
           "seeAlso": [],
           "identifiedBy": [{
-            "@type": "Identifier",
-            "typeNote": "isni",
+            "@type": "ISNI",
             "value": ""
           }],
           "nationality": [{
@@ -3266,8 +3264,7 @@
           "hasOccupation": [],
           "description": "",
           "identifiedBy": [{
-            "@type": "Identifier",
-            "typeNote": "isni",
+            "@type": "ISNI",
             "value": ""
           }],
           "nationality": [{


### PR DESCRIPTION
Add ISNI as identifier type in template, remove typeNote "isni".

See https://github.com/libris/librisxl/pull/930
