### PR TITLE
Format ISNI and ORCID (nnnn nnnn nnnn nnnn)

### DIFF
--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -168,8 +168,8 @@ export function getItemLabel(item, displayDefs, quoted, vocab, settings, context
   }
   let rendered = StringUtil.formatLabel(displayObject).trim();
   if (item['@type'] && VocabUtil.isSubClassOf(item['@type'], 'Identifier', vocab, context)) {
-    if (item['@type'] === 'ISNI' || item['@type'] === 'ORCID') {
-          rendered = formatIsni(rendered);
+    if (item['@type'] === 'ISNI' || item['@type'] === 'ORCID') { 
+      rendered = formatIsni(rendered);
     }
 
     if (inClass.toLowerCase() !== item['@type'].toLowerCase()) {
@@ -181,9 +181,9 @@ export function getItemLabel(item, displayDefs, quoted, vocab, settings, context
 }
 
 export function formatIsni(isni) {
-  return typeof isni === 'string' && isni.length == 16
+  return typeof isni === 'string' && isni.length === 16
     ? `${isni.slice(0, 4)} ${isni.slice(4, 8)} ${isni.slice(8, 12)} ${isni.slice(12, 16)}`
-    : isni
+    : isni;
 }
 
 export function getSortedProperties(formType, formObj, settings, resources) {

--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -168,12 +168,22 @@ export function getItemLabel(item, displayDefs, quoted, vocab, settings, context
   }
   let rendered = StringUtil.formatLabel(displayObject).trim();
   if (item['@type'] && VocabUtil.isSubClassOf(item['@type'], 'Identifier', vocab, context)) {
+    if (item['@type'] === 'ISNI' || item['@type'] === 'ORCID') {
+          rendered = formatIsni(rendered);
+    }
+
     if (inClass.toLowerCase() !== item['@type'].toLowerCase()) {
       const translatedType = StringUtil.getLabelByLang(item['@type'], settings.language, vocab, context);
       rendered = `${translatedType} ${rendered}`;
     }
   }
   return rendered;
+}
+
+export function formatIsni(isni) {
+  return typeof isni === 'string' && isni.length == 16
+    ? `${isni.slice(0, 4)} ${isni.slice(4, 8)} ${isni.slice(8, 12)} ${isni.slice(12, 16)}`
+    : isni
 }
 
 export function getSortedProperties(formType, formObj, settings, resources) {


### PR DESCRIPTION
## Checklist:
- [x] I have run the linter. `yarn lint`

## Description
Group digits in ISNI and ORCID 
For example display "ISNI 0000 0001 2279 6052" instead of "ISNI 0000000122796052".
Only where `getItemLabel` is used e.g. in cards and non-expanded item-local. (see screenshot in [LXL-586](https://jira.kb.se/browse/LXL-586))

Backend normalizes them to the form without spaces. Search handles both forms.
There is no way to specify this type of formatting with fresnel so let's hardcode it.

### Tickets involved
[LXL-2422](https://jira.kb.se/browse/LXL-NNNN), [LXL-586](https://jira.kb.se/browse/LXL-586)

### Solves

Makes ISNI and ORCID more readable.
