### PR TITLE
Sort sigels in sigel select alphabetically

### DIFF
--- a/viewer/vue-client/src/components/usersettings/select-sigel.vue
+++ b/viewer/vue-client/src/components/usersettings/select-sigel.vue
@@ -14,9 +14,10 @@ export default {
   methods: {
     getSigelLabel(sigel, len) {
       let label = '';
-      label += sigel.code;
       if (sigel.friendly_name) {
-        label += ` - ${sigel.friendly_name}`;
+        label += `${sigel.friendly_name} (${sigel.code})`;
+      } else {
+        label += sigel.code;
       }
       return label.length > len ? `${label.substr(0, len - 2)}...` : label;
     },

--- a/viewer/vue-client/src/components/usersettings/select-sigel.vue
+++ b/viewer/vue-client/src/components/usersettings/select-sigel.vue
@@ -58,6 +58,9 @@ export default {
     selectValue() {
       return this.preselectedValue ? this.preselectedValue : this.user.settings.activeSigel;
     },
+    sortedSigels() {
+      return [...this.user.collections].sort((a, b) => this.getSigelLabel(a).localeCompare(this.getSigelLabel(b)));
+    },
   },
 };
 </script>
@@ -73,7 +76,7 @@ export default {
       ref="selectSigel"
       :value="selectValue" 
       @change="onChange">
-      <option v-for="sigel in user.collections" 
+      <option v-for="sigel in sortedSigels"
         :key="sigel.code" 
         :value="sigel.code">{{ getSigelLabel(sigel, 50) }} {{ sigel.global_registrant == true ? '👑' : '' }}</option>
     </select>


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3552](https://jira.kb.se/browse/LXL-3552)

### Solves

In the sigel selector, sigels were not in alphabetical order.

### Summary of changes

Sigels are now in alphabetical order (the displayed label - "Library name - SIGEL" - is used for sorting).
