### PR TITLE
Feature/lxl 3617 long library names

### DIFF
--- a/viewer/vue-client/src/components/care/holding-list.vue
+++ b/viewer/vue-client/src/components/care/holding-list.vue
@@ -402,6 +402,7 @@ export default {
   & .EntitySummary-title {
     font-size: 18px;
     font-size: 1.8rem;
+    white-space: unset;
   }
 
   & .EntitySummary-info {

--- a/viewer/vue-client/src/components/search/facet.vue
+++ b/viewer/vue-client/src/components/search/facet.vue
@@ -25,6 +25,27 @@ export default {
     compactNumber() {
       return MathUtil.getCompactNumber(this.facet.amount);
     },
+    label() {
+      if (this.facet.label.indexOf('•') >= 0 && this.alwaysShowLabelTail) {
+        const label = this.facet.label;
+        return label.substring(0, label.lastIndexOf('•'));
+      }
+
+      return this.facet.label;
+    },
+    labelTail() {
+      if (this.facet.label.indexOf('•') >= 0 && this.alwaysShowLabelTail) {
+        const label = this.facet.label;
+        const label2 = label.substring(label.lastIndexOf('•') + 1, label.length);
+        const nbsp = '\xa0';
+        return `${nbsp}• ${label2}`;
+      }
+      
+      return '';
+    },
+    alwaysShowLabelTail() {
+      return this.facet.object && (this.facet.object['@type'] === 'Library' || this.facet.object['@type'] === 'Bibliography');
+    },
   },
   components: {
   },
@@ -44,7 +65,10 @@ export default {
       :title="facet.label | capitalize">
       <span class="Facet-label"
         :title="facet.label | capitalize">
-        {{facet.label | capitalize}}</span>
+        {{label | capitalize}}</span>
+      <span class="Facet-labelTail" 
+        :title="facet.label | capitalize">
+        {{labelTail}}</span>
       <span class="Facet-badge badge">{{compactNumber}}</span>
     </router-link>
   </li>
@@ -71,6 +95,9 @@ export default {
       & .Facet-label {
         text-decoration: underline;
       }
+      & .Facet-labelTail {
+        text-decoration: underline;
+      }
     }
   }
 
@@ -80,11 +107,18 @@ export default {
 
   &-label {
     cursor: pointer;
-    margin-right: 10px;
     color: @black;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  &-labelTail {
+    cursor: pointer;
+    color: @black;
+    flex-shrink: 0;
+    flex-grow: 20;
+    margin-right: 10px;
   }
 }
 


### PR DESCRIPTION
## Checklist:
- [x] I have run the linter. `yarn lint`

## Description
* Handle long library names in directory care (let card titles wrap)
* Always display sigel in library/bibliography facets 

### Tickets involved
[LXL-3617](https://jira.kb.se/browse/LXL-3617)

### Summary of changes
Keep the logic for which part of the label to shorten (ellipsis) local to facet.vue for now.