### PR TITLE
Sort directory care holding list by card heading, not id/sigel

### DIFF
--- a/viewer/vue-client/src/components/care/holding-list.vue
+++ b/viewer/vue-client/src/components/care/holding-list.vue
@@ -2,6 +2,7 @@
 import { mapGetters } from 'vuex';
 import { each, isObject, orderBy } from 'lodash-es';
 import * as StringUtil from '@/utils/string';
+import * as DisplayUtil from '@/utils/display';
 
 export default {
   name: 'holding-list',
@@ -35,6 +36,7 @@ export default {
     ...mapGetters([
       'directoryCare',
       'settings',
+      'resources',
       'user',
     ]),
     registrantPermissions() {
@@ -73,11 +75,22 @@ export default {
     },
     sortedHoldings() {
       const holdings = this.directoryCare[`${this.name}Holdings`];
+      each(holdings, (h) => { 
+        h._label = DisplayUtil.getItemLabel(
+          h,
+          this.resources.display,
+          [],
+          this.resources.vocab,
+          this.settings,
+          this.resources.context,
+        );
+      });
+      
       const sorted = orderBy(holdings, [(o) => {
         const parts = o.heldBy['@id'].split('/');
         const code = parts[parts.length - 1];
         return this.registrantPermissions.indexOf(code) > -1;
-      }, o => o.heldBy['@id']], ['desc', 'asc']);
+      }, o => o._label], ['desc', 'asc']);
       return sorted;
     },
   },


### PR DESCRIPTION
## Checklist:
- [x] I have run the linter. `yarn lint`

## Description
Now that we have library names available, sorting the holding list in directory care on `@id` (library URI) gives the wrong order.
It should be sorted on what is displayed in the card heading (library name).

### Tickets involved
[LXL-3617](https://jira.kb.se/browse/LXL-3617)
