### PR TITLE
Fix ghost data in 'create digital reproduction'

### DIFF
--- a/viewer/vue-client/src/utils/record.js
+++ b/viewer/vue-client/src/utils/record.js
@@ -135,7 +135,7 @@ export function getDigitalReproductionObject(original, resources) {
   let digitalReproObject;
   for (let i = 0; i < instanceTemplates.length; i++) {
     if (instanceTemplates[i].key === 'digitizedMonographText') {
-      digitalReproObject = instanceTemplates[i].value;
+      digitalReproObject = cloneDeep(instanceTemplates[i].value);
     }
   }
   // Copying instanceOf explicitly cause of how #work works


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Data is leaking between different invocations of "Create digital reproduction".

Steps to reproduce:
* Click on "Create digital reproduction" on an instance with `responsibilityStatement`
* Click on "Create digital reproduction" on an instance without `responsibilityStatement`
* `responsibilityStatement` from the first instance will appear in the reproduction

### Tickets involved
[LXL-3480](https://jira.kb.se/browse/LXL-3480)