### PR TITLE
Fix lens inheritance

### DIFF
--- a/viewer/vue-client/src/utils/display.js
+++ b/viewer/vue-client/src/utils/display.js
@@ -71,7 +71,6 @@ function expandInherited(display) {
       lens.showProperties = uniqWith(flattenedProps(lens, []), isEqual);
     });
   });
-  debugger;
   return cloned;
 }
 


### PR DESCRIPTION
- Extended lens should be looked up via `@id`
- Same inheritance behavior when mocking display
- Remove duplicate lens inheritance code

Lenses specified in `fresnel:extends` should be looked up via `@id`, not by splitting the `@id` string into lens group and key.

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

### Solves

The old code crashes on this display file ("SummaryType-chips" != "marc:SummaryType-chips").
```
    "chips": {
      "@id": "chips",
      "@type": "fresnel:Group",
      "lenses": {
        ...
        "marc:SummaryType": {
          "@id": "SummaryType-chips",
          "@type": "fresnel:Lens",
          "classLensDomain": "marc:SummaryType",
          "showProperties": [ "label" ]
        },
...

    "cards": {
      "@id": "cards",
      "@type": "fresnel:Group",
      "lenses": {
        ...
        "marc:SummaryType": {
          "@id": "SummaryType-cards",
          "@type": "fresnel:Lens",
          "fresnel:extends": {"@id": "SummaryType-chips"},
          "showProperties": [ "fresnel:super" ]
        },

```

But it worked with local/mocked display file because of different behavior in that case.