### PR TITLE
Fix bad shelfMarkSequences visible when linking

### DIFF
--- a/viewer/vue-client/src/components/inspector/entity-adder.vue
+++ b/viewer/vue-client/src/components/inspector/entity-adder.vue
@@ -177,13 +177,14 @@ export default {
   },
   methods: {
     getSearchParams(searchPhrase) {
+      let params;
       if (this.currentSearchParam == null) {
-        return { q: searchPhrase };
+        params = { q: searchPhrase };
+      } else {
+        params = Object.assign({}, this.currentSearchParam.mappings || {});
+        this.currentSearchParam.searchProps.forEach((param) => { params[param] = searchPhrase; });
       }
-
-      const params = Object.assign({}, this.currentSearchParam.mappings || {});
-      this.currentSearchParam.searchProps.forEach((param) => { params[param] = searchPhrase; });
-
+      
       if (this.fieldKey === 'shelfMark') {
         params['meta.descriptionCreator.@id'] = this.user.getActiveLibraryUri();
         params.shelfMarkStatus = 'ActiveShelfMark';


### PR DESCRIPTION
Fix regresion:
ShelfMarkSequences that are inactive and owned by other libraries are
visible in the list when linking shelfMark. Because search parameters
are never set.

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3628](https://jira.kb.se/browse/LXL-3628)