### PR TITLE
Fix sigel not visible in selector for long library names

### DIFF
--- a/viewer/vue-client/src/components/usersettings/select-sigel.vue
+++ b/viewer/vue-client/src/components/usersettings/select-sigel.vue
@@ -13,13 +13,16 @@ export default {
   },
   methods: {
     getSigelLabel(sigel, len) {
-      let label = '';
-      if (sigel.friendly_name) {
-        label += `${sigel.friendly_name} (${sigel.code})`;
-      } else {
-        label += sigel.code;
+      if (!sigel.friendly_name) {
+        return sigel.code;
       }
-      return label.length > len ? `${label.substr(0, len - 2)}...` : label;
+      
+      const sigelPart = ` (${sigel.code})`;
+      const fName = sigel.friendly_name.length + sigelPart.length > len
+        ? `${sigel.friendly_name.substr(0, len - sigelPart.length - 3)}...`
+        : sigel.friendly_name;
+      
+      return `${fName}${sigelPart}`;
     },
     updateSigel(value) {
       const doUpdate = () => {


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Fix sigel not visible in selector for very long library names
See screenshot of fix in issue.

### Tickets involved
[LXL-3633](https://jira.kb.se/browse/LXL-3633)

### Summary of changes
Do ellipsis on library name ("friendly_name") instead of on whole label.
Still the same max length, 50 chars.