### PR TITLE
Enable HTTP caching for (embellished) documents

### DIFF
--- a/viewer/vue-client/src/utils/record.js
+++ b/viewer/vue-client/src/utils/record.js
@@ -1,5 +1,4 @@
 import { cloneDeep, each, unset, get, set } from 'lodash-es';
-import * as md5 from 'md5';
 import * as httpUtil from './http';
 import * as DataUtil from './data';
 
@@ -265,8 +264,7 @@ export function getItemObject(itemOf, heldBy, instance) {
 }
 
 export function moveHolding(holdingId, destinationId, user) {
-  const randomHash = md5(new Date());
-  const getUrl = `${holdingId.replace('#it', '')}/data.jsonld?${randomHash}`;
+  const getUrl = `${holdingId.replace('#it', '')}/data.jsonld`;
   let ETag = '';
   return new Promise((resolve, reject) => {
     fetch(getUrl).then((response) => {

--- a/viewer/vue-client/src/views/Inspector.vue
+++ b/viewer/vue-client/src/views/Inspector.vue
@@ -1,7 +1,6 @@
 
 <script>
 import { cloneDeep, each, get } from 'lodash-es';
-import * as md5 from 'md5';
 import { mapGetters, mapActions } from 'vuex';
 import * as StringUtil from '@/utils/string';
 import * as DataUtil from '@/utils/data';
@@ -161,8 +160,7 @@ export default {
         });
     },
     fetchDocument() {
-      const randomHash = md5(new Date());
-      const fetchUrl = `${this.settings.apiPath}/${this.documentId}/data.jsonld?${randomHash}`;
+      const fetchUrl = `${this.settings.apiPath}/${this.documentId}/data.jsonld`;
       fetch(fetchUrl).then((response) => {
         if (response.status === 200) {
           this.documentETag = response.headers.get('ETag');
@@ -222,8 +220,7 @@ export default {
     prepareDetailedEnrichment(id = null, data = null) {
       if (id !== null) {
         const fixedId = RecordUtil.extractFnurgel(id);
-        const randomHash = md5(new Date());
-        const fetchUrl = `${this.settings.apiPath}/${fixedId}/data.jsonld?${randomHash}`;
+        const fetchUrl = `${this.settings.apiPath}/${fixedId}/data.jsonld`;
         fetch(fetchUrl).then((response) => {
           if (response.status === 200) {
             return response.json();
@@ -263,8 +260,7 @@ export default {
     },
     applyPostAsTemplate(id) {
       const fixedId = RecordUtil.extractFnurgel(id);
-      const randomHash = md5(new Date());
-      const fetchUrl = `${this.settings.apiPath}/${fixedId}/data.jsonld?${randomHash}`;
+      const fetchUrl = `${this.settings.apiPath}/${fixedId}/data.jsonld`;
       fetch(fetchUrl).then((response) => {
         if (response.status === 200) {
           return response.json();


### PR DESCRIPTION
Backend now handles ETag/If-None-Match for embellished responses.
Remove random URI suffix to take advantage of this.

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`
