### PR TITLE
Update 'create digital reproduction' to new practice

### DIFF
--- a/vue-client/src/resources/json/combinedTemplates.json
+++ b/vue-client/src/resources/json/combinedTemplates.json
@@ -245,29 +245,15 @@
               "subtitle": ""
             }
           ],
-          "responsibilityStatement": "",
           "identifiedBy": [],
-          "editionStatement": [""],
-          "publication": [
-            {
-              "@type": "PrimaryPublication",
-              "year": "",
-              "date": "",
-              "country": [ {"@id": "https://id.kb.se/country/sw"} ],
-              "place": {
-                "@type": "Place",
-                "label": ""
-              },
-              "agent": {
-                "@type": "Agent",
-                "label": ""
-              }
+          "genreForm": [
+            { 
+              "@id": "https://id.kb.se/term/saogf/Digitala%20faksimiler"
             }
           ],
           "production": [
             {
-              "@type": "DigitalReproduction",
-              "typeNote": "",
+              "@type": "Reproduction",
               "date": "",
               "place": [
                 {
@@ -287,17 +273,9 @@
             "@type": "Copyright",
             "date": ""
           }],
-          "mediaType": [{"@id": "https://id.kb.se/term/rda/Computer"}],
           "carrierType": [
-            {"@id": "https://id.kb.se/term/rda/OnlineResource"},
-            {"@id": "https://id.kb.se/marc/Online"},
-            {"@id": "https://id.kb.se/marc/OnlineResource"}
+            {"@id": "https://id.kb.se/term/rda/OnlineResource"}
           ],
-          "extent": [{
-            "@type": "Extent",
-            "label": ""
-          }],
-          "physicalDetailsNote": "",
           "seriesMembership": [
             {
               "@type": "SeriesMembership",
@@ -337,12 +315,6 @@
           "associatedMedia": [
             {
               "@type": "MediaObject",
-              "cataloguersNote": [
-                ""
-              ],
-              "marc:publicNote": [
-                ""
-              ],
               "uri": [
                 ""
               ]

--- a/vue-client/src/resources/json/combinedTemplates.json
+++ b/vue-client/src/resources/json/combinedTemplates.json
@@ -246,11 +246,6 @@
             }
           ],
           "identifiedBy": [],
-          "genreForm": [
-            { 
-              "@id": "https://id.kb.se/term/saogf/Digitala%20faksimiler"
-            }
-          ],
           "production": [
             {
               "@type": "Reproduction",

--- a/vue-client/src/utils/record.js
+++ b/vue-client/src/utils/record.js
@@ -165,38 +165,16 @@ export function getDigitalReproductionObject(original, resources) {
       digitalReproObject.mainEntity.instanceOf = original.mainEntity.instanceOf;
     }
   }
-
-  // Copy the PrimaryPublication if there is one
-  function getPrimaryPublication(mainEntity) {
-    if (mainEntity.hasOwnProperty('publication')) {
-      for (let i = 0; i < mainEntity.publication.length; i++) {
-        if (mainEntity.publication[i]['@type'] === 'PrimaryPublication') {
-          return mainEntity.publication[i];
-        }
-      }
-    }
-    return null;
-  }
-  const primaryPublication = getPrimaryPublication(original.mainEntity);
-  if (primaryPublication !== null) {
-    digitalReproObject.mainEntity.publication = [primaryPublication];
-  }
-
+  
   // Copy the other keys we want to copy
   const keysToCopy = [
     'mainEntity.hasTitle',
-    'mainEntity.responsibilityStatement',
-    'mainEntity.extent',
   ];
   for (let i = 0; i < keysToCopy.length; i++) {
     const originalValue = get(original, keysToCopy[i]);
     if (typeof originalValue !== 'undefined') {
       set(digitalReproObject, keysToCopy[i], originalValue);
     }
-  }
-  // Add "indirectly identified by" with the "identified by" value from original
-  if (original.mainEntity.hasOwnProperty('identifiedBy')) {
-    digitalReproObject.mainEntity.indirectlyIdentifiedBy = original.mainEntity.identifiedBy;
   }
   // Add "reproduction of" and link it to original document
   digitalReproObject.mainEntity.reproductionOf = { '@id': original.mainEntity['@id'] };


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Change "create digital reproduction" maneuver to use the new simplified form for digital reproductions.

TODO: extract and link work

### Tickets involved
[LXL-3673](https://jira.kb.se/browse/LXL-3673), [LXL-LXL-2807](https://jira.kb.se/browse/LXL-LXL-2807)

### Summary of changes
* Update template
* Only copy title from physical
