### PR TITLE
lxl 3643 inScheme as array

### DIFF
--- a/vue-client/src/utils/uriminter.js
+++ b/vue-client/src/utils/uriminter.js
@@ -55,7 +55,10 @@ export default class URIMinter {
       }
       const containerMemberMap = containerRelationMap[relation];
       if (mainEntity.hasOwnProperty(relation) && mainEntity[relation] !== null) {
-        const relationId = mainEntity[relation][ID];
+        let relationId = mainEntity[relation][ID]
+        if (Array.isArray(mainEntity[relation])) {
+          relationId = mainEntity[relation][0][ID];
+        }
         const container = containerMemberMap[relationId];
         if (container) {
           if (container.administeredBy.find(it => it[ID] === library[ID])) {

--- a/vue-client/src/utils/uriminter.js
+++ b/vue-client/src/utils/uriminter.js
@@ -49,10 +49,7 @@ export default class URIMinter {
       containerRelationMap = this.containerMap[type];
       if (containerRelationMap) break;
     }
-    for (const relation in containerRelationMap) {
-      if (!containerRelationMap.hasOwnProperty(relation)) {
-        continue;
-      }
+    for (const relation of Object.keys(containerRelationMap)) {
       const containerMemberMap = containerRelationMap[relation];
       if (mainEntity.hasOwnProperty(relation) && mainEntity[relation] !== null) {
         let relationId = mainEntity[relation][ID];

--- a/vue-client/src/utils/uriminter.js
+++ b/vue-client/src/utils/uriminter.js
@@ -55,7 +55,7 @@ export default class URIMinter {
       }
       const containerMemberMap = containerRelationMap[relation];
       if (mainEntity.hasOwnProperty(relation) && mainEntity[relation] !== null) {
-        let relationId = mainEntity[relation][ID]
+        let relationId = mainEntity[relation][ID];
         if (Array.isArray(mainEntity[relation])) {
           relationId = mainEntity[relation][0][ID];
         }

--- a/vue-client/src/utils/uriminter.js
+++ b/vue-client/src/utils/uriminter.js
@@ -54,6 +54,10 @@ export default class URIMinter {
       if (mainEntity.hasOwnProperty(relation) && mainEntity[relation] !== null) {
         let relationId = mainEntity[relation][ID];
         if (Array.isArray(mainEntity[relation])) {
+          const len = mainEntity[relation].length;
+          if (len !== 1) {
+            throw new Error(`Unexpected number of values for: ${relation}: ${len}`);
+          }
           relationId = mainEntity[relation][0][ID];
         }
         const container = containerMemberMap[relationId];

--- a/vue-client/src/utils/uriminter.js
+++ b/vue-client/src/utils/uriminter.js
@@ -50,7 +50,7 @@ export default class URIMinter {
       if (containerRelationMap) break;
     }
     for (const relation in containerRelationMap) {
-      if (Object.hasOwnProperty(containerRelationMap)) {
+      if (!containerRelationMap.hasOwnProperty(relation)) {
         continue;
       }
       const containerMemberMap = containerRelationMap[relation];


### PR DESCRIPTION
## Checklist:
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3643](https://jira.kb.se/browse/LXL-3643)

### Solves

The UI will handle most values as arrays as often as it can, but limiting them to a length of 1 if the property only takes one value. `uriminter` wasn't able to handle this before this change.

### Summary of changes

* Make uriminter able to handle relations being in arrays
