### PR TITLE
Remove API_PATH from nuxt-app

### DIFF
--- a/nuxt-app/.env.in
+++ b/nuxt-app/.env.in
@@ -1,3 +1,2 @@
-API_PATH=http://id.kblocalhost.kb.se:5000
 SITE_ALIAS={"http://id.kblocalhost.kb.se:5000": "https://id.kb.se"}
 SITE_CONFIG={"libris.kb.se": {"baseUri": "http://kblocalhost.kb.se:5000", "title": "Libris"}, "id.kb.se": {"baseUri": "https://id.kb.se", "title": "id.kb.se"}}

--- a/nuxt-app/components/EntityTable.vue
+++ b/nuxt-app/components/EntityTable.vue
@@ -22,7 +22,7 @@
     <template v-if="isMainEntity">
       <div class="PropertyRow d-md-flex" v-if="showDownload">
         <div class="PropertyRow-bodyKey d-block d-md-inline">{{ translateUi('Download') }}</div>
-        <div class="PropertyRow-bodyValue"><a :href="`${ documentId }/data.jsonld` | replaceBaseWithApi">JSON-LD</a> • <a :href="`${ documentId }/data.ttl` | replaceBaseWithApi">Turtle</a> • <a :href="`${ documentId }/data.rdf` | replaceBaseWithApi">RDF/XML</a></div>
+        <div class="PropertyRow-bodyValue"><a :href="`${ documentId }/data.jsonld` | translateAliasedUri">JSON-LD</a> • <a :href="`${ documentId }/data.ttl` | translateAliasedUri">Turtle</a> • <a :href="`${ documentId }/data.rdf` | translateAliasedUri">RDF/XML</a></div>
       </div>
       <div class="PropertyRow d-md-flex" v-if="showOtherServices">
         <div class="PropertyRow-bodyKey d-block d-md-inline">{{ translateUi('Other sites') }}</div>

--- a/nuxt-app/components/SearchBar.vue
+++ b/nuxt-app/components/SearchBar.vue
@@ -112,7 +112,7 @@ export default {
     async doSuggestSearch() {
       this.clearSuggest();
       const searchPath = `find.jsonld?q=${this.keyword}&_lens=chips&_suggest=${this.settings.language}&_limit=7`;
-      const suggestData = await fetch(`${process.env.API_PATH}/${searchPath}`).then(res => res.json());
+      const suggestData = await fetch(`${this.activeHost()}/${searchPath}`).then(res => res.json());
       this.suggestedItems = suggestData.items;
       // const suggestData = mockSuggest;
       // this.suggestedItems = suggestData;
@@ -143,7 +143,7 @@ export default {
         	const compName = vNode.context.name
           let warn = `[Vue-click-outside:] provided expression '${binding.expression}' is not a function, but has to be`
           if (compName) { warn += `Found in component '${compName}'` }
-          
+
           console.warn(warn)
         }
         // Define Handler and cache it on the element
@@ -158,7 +158,7 @@ export default {
         // add Event Listeners
         document.addEventListener('click', handler)
 			},
-      
+
       unbind: function(el, binding) {
         // Remove Event Listeners
         document.removeEventListener('click', el.__vueClickOutside__)

--- a/nuxt-app/layouts/default.vue
+++ b/nuxt-app/layouts/default.vue
@@ -15,8 +15,8 @@
 import Navbar from '@/components/Navbar';
 import SearchBar from '@/components/SearchBar';
 import Footer from '@/components/Footer';
-import { hostPath } from '../plugins/env';
-const HOST_PATH = hostPath();
+import { defaultHostPath } from '../plugins/env';
+const HOST_PATH = defaultHostPath();
 
 export default {
   data() {

--- a/nuxt-app/layouts/libris.vue
+++ b/nuxt-app/layouts/libris.vue
@@ -11,8 +11,8 @@
 
 <script>
 import Navbar from '@/components/Navbar';
-import { hostPath } from '../plugins/env';
-const HOST_PATH = hostPath();
+import { defaultHostPath } from '../plugins/env';
+const HOST_PATH = defaultHostPath();
 
 export default {
   data() {

--- a/nuxt-app/mixins/lxl.js
+++ b/nuxt-app/mixins/lxl.js
@@ -53,6 +53,9 @@ if (!Vue.__lxl_global_mixin__) {
       translateUriEnv(uri) {
         return translateAliasedUri(uri)
       },
+      activeHost() {
+        return translateAliasedUri(this.baseUri())
+      },
       getEntityTitle(entity) {
         if (entity != null) {
           if (entity.prefLabel) {

--- a/nuxt-app/nuxt.config.js
+++ b/nuxt-app/nuxt.config.js
@@ -81,7 +81,6 @@ export default {
   },
 
   publicRuntimeConfig: {
-    apiPath: process.env.API_PATH || 'http://localhost:5000',
     siteName: 'id.kb.se',
     environment: process.env.ENV,
   },

--- a/nuxt-app/nuxt.config.js
+++ b/nuxt-app/nuxt.config.js
@@ -1,6 +1,6 @@
 const { gitDescribeSync } = require('git-describe');
-import { hostPath } from './plugins/env';
-const HOST_PATH = hostPath();
+import { defaultHostPath } from './plugins/env';
+const HOST_PATH = defaultHostPath();
 process.env.APP_VERSION = require('./package.json').version;
 
 process.env.GIT_DESCRIBE = JSON.stringify(gitDescribeSync({

--- a/nuxt-app/pages/_.vue
+++ b/nuxt-app/pages/_.vue
@@ -32,6 +32,8 @@ import * as DataUtil from 'lxljs/data';
 import LensMixin from '@/mixins/lens';
 import ResultItem from '@/components/ResultItem';
 
+import { translateAliasedUri } from '../plugins/env';
+
 export default {
   mixins: [LensMixin],
   layout (context) {
@@ -91,8 +93,11 @@ export default {
     ...mapActions(['setCurrentDocument']),
   },
   async asyncData({ $config, error, route, params, $http, store }) {
+    const domain = store.getters.appState.domain
+    const siteConfig = store.getters.settings.siteConfig
+    const host = translateAliasedUri(siteConfig[domain].baseUri)
     const path = route.path.replace(/\(/g, '%28').replace(/\)/g, '%29');
-    const pageData = await $http.$get(`${$config.apiPath}${path}/data.jsonld`,
+    const pageData = await $http.$get(`${host}${path}/data.jsonld`,
       {
         headers: { 'Accept': 'application/ld+json' }
       }

--- a/nuxt-app/pages/doc/_article.vue
+++ b/nuxt-app/pages/doc/_article.vue
@@ -11,6 +11,8 @@
 
 <script>
 import { mapGetters } from 'vuex';
+import { hostPath } from '../../plugins/env';
+const HOST_PATH = hostPath();
 
 export default {
   head() {
@@ -29,7 +31,7 @@ export default {
     ...mapGetters(['settings']),
   },
   async asyncData({ $config, error, route, params, $http }) {
-    const pageData = await $http.$get(`${$config.apiPath}/doc/${params.article}/data.jsonld`).catch((err) => {
+    const pageData = await $http.$get(`${HOST_PATH}/doc/${params.article}/data.jsonld`).catch((err) => {
       error({ statusCode: err.statusCode, message: err.message })
     });
     return { pageData }

--- a/nuxt-app/pages/doc/_article.vue
+++ b/nuxt-app/pages/doc/_article.vue
@@ -11,8 +11,8 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import { hostPath } from '../../plugins/env';
-const HOST_PATH = hostPath();
+import { defaultHostPath } from '../../plugins/env';
+const HOST_PATH = defaultHostPath();
 
 export default {
   head() {

--- a/nuxt-app/pages/doc/_article.vue
+++ b/nuxt-app/pages/doc/_article.vue
@@ -11,8 +11,7 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import { defaultHostPath } from '../../plugins/env';
-const HOST_PATH = defaultHostPath();
+import {translateAliasedUri} from '../../plugins/env';
 
 export default {
   head() {
@@ -30,8 +29,12 @@ export default {
   computed: {
     ...mapGetters(['settings']),
   },
-  async asyncData({ $config, error, route, params, $http }) {
-    const pageData = await $http.$get(`${HOST_PATH}/doc/${params.article}/data.jsonld`).catch((err) => {
+  async asyncData({ $config, error, route, params, $http, store }) {
+    const domain = store.getters.appState.domain
+    const siteConfig = store.getters.settings.siteConfig
+    const host = translateAliasedUri(siteConfig[domain].baseUri)
+
+    const pageData = await $http.$get(`${host}/doc/${params.article}/data.jsonld`).catch((err) => {
       error({ statusCode: err.statusCode, message: err.message })
     });
     return { pageData }

--- a/nuxt-app/pages/find/index.vue
+++ b/nuxt-app/pages/find/index.vue
@@ -38,6 +38,7 @@ import SortSelect from '@/components/SortSelect';
 import PageStatus from '@/components/PageStatus';
 import ResultItem from '@/components/ResultItem';
 import Pagination from '@/components/Pagination';
+import {translateAliasedUri} from "../../plugins/env";
 
 export default {
   head() {
@@ -65,12 +66,16 @@ export default {
     ...mapGetters(['collections', 'appState']),
   },
   async asyncData({ $config, route, params, $http, store }) {
+    const domain = store.getters.appState.domain
+    const siteConfig = store.getters.settings.siteConfig
+    const host = translateAliasedUri(siteConfig[domain].baseUri)
+
     const query = route.query;
     let queryString = '';
 
     Object.entries(query).forEach(([key, val]) => queryString += `${key}=${val}&`);
-    const pageData = await $http.$get(`${$config.apiPath}/find.jsonld?${queryString}`);
-    const collectionResults = await $http.$get(`${$config.apiPath}/find.jsonld?q=${route.query.q}&_limit=0`);
+    const pageData = await $http.$get(`${host}/find.jsonld?${queryString}`);
+    const collectionResults = await $http.$get(`${host}/find.jsonld?q=${route.query.q}&_limit=0`);
     return {
       pageData,
       collectionResults,

--- a/nuxt-app/pages/index.vue
+++ b/nuxt-app/pages/index.vue
@@ -15,8 +15,8 @@
 
 <script>
 import CollectionCard from '@/components/CollectionCard';
-import { hostPath } from '../plugins/env';
-const HOST_PATH = hostPath();
+import { defaultHostPath } from '../plugins/env';
+const HOST_PATH = defaultHostPath();
 
 export default {
   data() {

--- a/nuxt-app/pages/marcframe/index.vue
+++ b/nuxt-app/pages/marcframe/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="Marcframe-codeDetails">
     <h1>{{ translateUi('MARC mappings') }}</h1>
-    <p v-if="settings.language == 'sv'">KB/Libris mappningar av MARC till RDF-vokabulär. För mer information, se 
+    <p v-if="settings.language == 'sv'">KB/Libris mappningar av MARC till RDF-vokabulär. För mer information, se
       <a class="ext" target="_blank" rel="noopener noreferrer" href="https://github.com/libris/librisxl/blob/master/whelk-core/src/main/resources/ext/marcframe.json">källfil</a>
       och <a class="ext" target="_blank" rel="noopener noreferrer" href="https://github.com/libris/librisxl/blob/master/whelk-core/src/main/resources/ext/marcframe.md">dokumentation</a>.
     </p>
@@ -44,12 +44,6 @@ export default {
   },
   methods: {
   },
-  // async asyncData({ $config, route, params, $http }) {
-  //   const pageData = await $http.$get(`${$config.apiPath}/vocab/data.jsonld`);
-  //   return {
-  //     pageData,
-  //   };
-  // },
   // call fetch only on client-side
   fetchOnServer: false,
   watchQuery: true,

--- a/nuxt-app/pages/vocab/_term.vue
+++ b/nuxt-app/pages/vocab/_term.vue
@@ -79,12 +79,6 @@ export default {
   },
   methods: {
   },
-  // async asyncData({ $config, route, params, $http }) {
-  //   const pageData = await $http.$get(`${$config.apiPath}/vocab/data.jsonld`);
-  //   return {
-  //     pageData,
-  //   };
-  // },
   // call fetch only on client-side
   fetchOnServer: false,
   watchQuery: true,

--- a/nuxt-app/plugins/env.js
+++ b/nuxt-app/plugins/env.js
@@ -3,8 +3,12 @@ import { each, findKey } from "lodash-es";
 const SITE_ALIAS = JSON.parse(process.env.SITE_ALIAS || '{}');
 const SITE_CONFIG = JSON.parse(process.env.SITE_CONFIG);
 
-export function hostPath() {
-  const baseUri = siteConfig()[defaultSite()]['baseUri'];
+export function defaultHostPath() {
+  return hostPath(defaultSite())
+}
+
+export function hostPath(site) {
+  const baseUri = siteConfig()[site]['baseUri'];
   return translateAliasedUri(baseUri);
 }
 

--- a/nuxt-app/plugins/filters.js
+++ b/nuxt-app/plugins/filters.js
@@ -1,7 +1,9 @@
 import Vue from 'vue'
 
-Vue.filter('replaceBaseWithApi', (uri) => {
-  return uri.replace('https://id.kb.se', process.env.API_PATH);
+import { translateAliasedUri } from './env';
+
+Vue.filter('translateAliasedUri', (uri) => {
+  return translateAliasedUri(uri);
 });
 
 Vue.filter('fixMarcUri', (uri) => {

--- a/nuxt-app/store/index.js
+++ b/nuxt-app/store/index.js
@@ -21,7 +21,6 @@ export const state = () => ({
   },
   settings: {
     language: 'sv',
-    hostPath: defaultHostPath(),
     version: process.env.APP_VERSION,
     gitDescribe: process.env.GIT_DESCRIBE,
     siteConfig: siteConfig(),


### PR DESCRIPTION
## Description
Remove API_PATH from nuxt-app. Instead just fetch resources based on the domain we are serving.

Still TODO: 
Remove all usages of "defaultHostPath", i.e:
* make sure all required static resources can be loaded from both libris and id
* make layout switching and index page more generic

### Tickets involved
[LXL-3738](https://jira.kb.se/browse/LXL-3738)