### PR TITLE
Bugfix/nuxt redirects

### DIFF
--- a/nuxt-app/components/EntityNode.vue
+++ b/nuxt-app/components/EntityNode.vue
@@ -5,7 +5,7 @@
         {{ getItemLabel }}
       </span>
       <template v-else-if="entityData['@id']">
-        <template v-if="isInternalUri(entityData['@id'])">
+        <template v-if="isInternalUri(entityData['@id']) && parentKey !== 'sameAs'">
           <NuxtLink :to="removeBaseUri(entityData['@id'])">
             <template v-if="Object.keys(entityData).length > 1">{{ getItemLabel }}</template>
             <template v-else>{{ translateUriEnv(decodeURI(translateUriEnv(entityData['@id']))) }}</template>

--- a/nuxt-app/components/EntityTable.vue
+++ b/nuxt-app/components/EntityTable.vue
@@ -22,7 +22,7 @@
     <template v-if="isMainEntity">
       <div class="PropertyRow d-md-flex" v-if="showDownload">
         <div class="PropertyRow-bodyKey d-block d-md-inline">{{ translateUi('Download') }}</div>
-        <div class="PropertyRow-bodyValue"><a :href="`${ documentId }/data.jsonld` | translateAliasedUri">JSON-LD</a> • <a :href="`${ documentId }/data.ttl` | translateAliasedUri">Turtle</a> • <a :href="`${ documentId }/data.rdf` | translateAliasedUri">RDF/XML</a></div>
+        <div class="PropertyRow-bodyValue"><a :href="`${ recordId }/data.jsonld` | translateAliasedUri">JSON-LD</a> • <a :href="`${ recordId }/data.ttl` | translateAliasedUri">Turtle</a> • <a :href="`${ recordId }/data.rdf` | translateAliasedUri">RDF/XML</a></div>
       </div>
       <div class="PropertyRow d-md-flex" v-if="showOtherServices">
         <div class="PropertyRow-bodyKey d-block d-md-inline">{{ translateUi('Other sites') }}</div>

--- a/nuxt-app/pages/_.vue
+++ b/nuxt-app/pages/_.vue
@@ -107,7 +107,10 @@ export default {
         return response.json()
       }
 
-      if (response.status === 302) {
+      if (response.status === 0) {
+        // We're on the client side and got redirected to the page we're already on
+      }
+      else if (response.status === 302) {
         const url = translateAliasedUri(response.headers.get('Location'))
         console.log (`REDIRECTING: ${host}${path} -> ${url}`)
         redirect(url);
@@ -117,6 +120,7 @@ export default {
       }
     })
     .catch((err) => {
+      console.log(`ERROR: ${err}`)
       error({ statusCode: 500, message: err })
     });
 

--- a/nuxt-app/plugins/env.js
+++ b/nuxt-app/plugins/env.js
@@ -1,5 +1,9 @@
 import { each, findKey } from "lodash-es";
 
+if (!process.env.XL_SITE_CONFIG) {
+  throw 'env.XL_SITE_CONFIG not defined (fix for development: copy .env.in to .env)'
+}
+
 const SITE_ALIAS = JSON.parse(process.env.XL_SITE_ALIAS || '{}');
 const SITE_CONFIG = JSON.parse(process.env.XL_SITE_CONFIG);
 

--- a/nuxt-app/store/index.js
+++ b/nuxt-app/store/index.js
@@ -240,31 +240,33 @@ function catcher(error) {
 export const actions = {
   async nuxtServerInit({ commit, dispatch }, { req, error }) {
     dispatch('setAppState', { property: 'domain', value: activeSite(req.headers['x-forwarded-host']) });
-
-    await fetch(translateAliasedUri(CONTEXT))
+    
+    await Promise.all([
+      fetch(translateAliasedUri(CONTEXT))
       .then(toJson)
       .then(contextData => {
         const processed = VocabUtil.preprocessContext(contextData);
         commit('SET_VOCAB_CONTEXT', processed['@context']);
       })
-      .catch(catcher(error));
+      .catch(catcher(error)),
 
-    await fetch(translateAliasedUri(VOCAB))
+      fetch(translateAliasedUri(VOCAB))
       .then(toJson)
       .then(vocab => {
         commit('SET_VOCAB', vocab);
         commit('SET_VOCAB_CLASSES', vocab);
         commit('SET_VOCAB_PROPERTIES', vocab);
       })
-      .catch(catcher(error));
+      .catch(catcher(error)),
 
-    await fetch(translateAliasedUri(DISPLAY))
+      fetch(translateAliasedUri(DISPLAY))
       .then(toJson)
       .then(display => {
         const expanded = DisplayUtil.expandInherited(display);
         commit('SET_DISPLAY', expanded);
       })
-      .catch(catcher(error));
+      .catch(catcher(error))
+    ]);
   },
   setMarcframe({ commit }, data) {
     commit('SET_MARCFRAME_DATA', data);

--- a/nuxt-app/store/index.js
+++ b/nuxt-app/store/index.js
@@ -240,7 +240,7 @@ function catcher(error) {
 export const actions = {
   async nuxtServerInit({ commit, dispatch }, { req, error }) {
     dispatch('setAppState', { property: 'domain', value: activeSite(req.headers['x-forwarded-host']) });
-    
+
     await Promise.all([
       fetch(translateAliasedUri(CONTEXT))
       .then(toJson)

--- a/vue-client/.env.development.in
+++ b/vue-client/.env.development.in
@@ -1,7 +1,7 @@
 VUE_APP_API_PATH=http://kblocalhost.kb.se:5000
 VUE_APP_VERIFY_PATH=https://login-dev.libris.kb.se/oauth/verify
 VUE_APP_AUTHORIZE_PATH=https://login-dev.libris.kb.se/oauth/authorize
-VUE_APP_REDIRECT_PATH=http://localhost:8080/katalogisering/login/authorized
+VUE_APP_REDIRECT_PATH=http://kblocalhost.kb.se:5000/katalogisering/login/authorized
 VUE_APP_CLIENT_ID=<get-from-developer>
 VUE_APP_SCOPES=read write
 VUE_APP_ID_PATH=http://id.kblocalhost.kb.se:5000

--- a/vue-client/vue.config.js
+++ b/vue-client/vue.config.js
@@ -14,6 +14,9 @@ module.exports = {
   publicPath: '/katalogisering/',
   parallel: false,
   configureWebpack: {
+    devServer: {
+      public: 'kblocalhost.kb.se'
+    },
     resolve: {
       extensions: ['.js', '.vue', '.json'],
       alias: {

--- a/vue-client/vue.config.js
+++ b/vue-client/vue.config.js
@@ -15,7 +15,7 @@ module.exports = {
   parallel: false,
   configureWebpack: {
     devServer: {
-      public: 'kblocalhost.kb.se'
+      public: process.env.VUE_APP_DEV_SERVER || 'kblocalhost.kb.se'
     },
     resolve: {
       extensions: ['.js', '.vue', '.json'],


### PR DESCRIPTION
## Description
* When nuxt-app gets a redirect from the backend for a resource it should also send a redirect to the browser.

* Download links should be constructed from record id not thing id
  * ie https://libris.kb.se/86lnm8ns2nd7c62/data.jsonld, not https://id.kb.se/term/sao/H%C3%A4star/data.jsonld

Mixed bag of other fixes (see individual commits):
* Error message if XL_SITE_CONFIG is not defined

* Make cat client work on kblocalhost.kb.se:5000/katalogisering

* Handle errors when fetching vocab

* Handle click on nuxt link with redirects

* Always render sameAs links as normal links (not nuxt links)

* Fetch vocab stuff in parallel (no big improvement)

* Make webpack dev server host configurable
