### PR TITLE
Don't accidentally translate sigel; fix lint error

### DIFF
--- a/vue-client/src/components/inspector/create-item-button.vue
+++ b/vue-client/src/components/inspector/create-item-button.vue
@@ -84,8 +84,10 @@ export default {
       'status',
     ]),
     tooltipText() {
-      const str = this.hasHolding ? [this.user.settings.activeSigel, 'has holding'] : ['Add holding for', this.user.settings.activeSigel];
-      return StringUtil.getUiPhraseByLang(str, this.user.settings.language, this.resources.i18n);
+      if (this.hasHolding) {
+        return `${this.user.settings.activeSigel} ${StringUtil.getUiPhraseByLang('has holding', this.user.settings.language, this.resources.i18n)}`;
+      }
+      return `${StringUtil.getUiPhraseByLang('Add holding for', this.user.settings.language, this.resources.i18n)} ${this.user.settings.activeSigel}`;
     },
     keyBindText() {
       return LayoutUtil.getKeybindingText('add-holding');
@@ -149,8 +151,8 @@ export default {
         :icon="hasHolding ? 'check' : 'plus'"
         :indicator="hasHolding"
         :label="hasHolding ? 
-              [user.settings.activeSigel, 'has holding'] : 
-              ['Add holding for', user.settings.activeSigel]"
+              `${user.settings.activeSigel} ${$options.filters.translatePhrase('has holding')}` :
+              `${$options.filters.translatePhrase('Add holding for')} ${user.settings.activeSigel}`"
         @click="performItemAction()">
       </rounded-button>
     </template>

--- a/vue-client/vue.config.js
+++ b/vue-client/vue.config.js
@@ -15,7 +15,7 @@ module.exports = {
   parallel: false,
   configureWebpack: {
     devServer: {
-      public: process.env.VUE_APP_DEV_SERVER || 'kblocalhost.kb.se'
+      public: process.env.VUE_APP_DEV_SERVER || 'kblocalhost.kb.se',
     },
     resolve: {
       extensions: ['.js', '.vue', '.json'],


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3863](https://jira.kb.se/browse/LXL-3863)

### Solves

The sigel "No" would accidentally be translated to "Nej", because e.g. "No" and "has holding" were passed individually to the translation method, which then looked up and found "No" in the i18n file.

### Summary of changes

Don't pass the sigel to the translation method. Also covers translation of aria-label (in this case it passes label to rounded-button, which then runs the label through translatePhrase; but since we now pre-translate the string, translatePhrase (actually StringUtil.getUiPhraseByLang) doesn't find it in i18n.json and so returns it untouched. Seemed like the least messy solution)
