### PR TITLE
Make terms with & in prefLabel be searchable and not 404

### DIFF
--- a/nuxt-app/components/SearchBar.vue
+++ b/nuxt-app/components/SearchBar.vue
@@ -29,6 +29,7 @@
 // import mockSuggest from '@/resources/json/mockSuggest.json';
 import { mapGetters } from 'vuex';
 import SuggestItem from '@/components/SuggestItem';
+import { encodeSpecialChars } from '../plugins/env';
 
 export default {
   data() {
@@ -111,7 +112,7 @@ export default {
     },
     async doSuggestSearch() {
       this.clearSuggest();
-      const searchPath = `find.jsonld?q=${this.keyword}&_lens=chips&_suggest=${this.settings.language}&_limit=7`;
+      const searchPath = `find.jsonld?q=${encodeSpecialChars(this.keyword)}&_lens=chips&_suggest=${this.settings.language}&_limit=7`;
       const suggestData = await fetch(`${this.activeHost()}/${searchPath}`).then(res => res.json());
       this.suggestedItems = suggestData.items;
       // const suggestData = mockSuggest;

--- a/nuxt-app/pages/_.vue
+++ b/nuxt-app/pages/_.vue
@@ -33,6 +33,7 @@ import LensMixin from '@/mixins/lens';
 import ResultItem from '@/components/ResultItem';
 
 import { translateAliasedUri } from '../plugins/env';
+import { encodeSpecialChars } from '../plugins/env';
 
 export default {
   mixins: [LensMixin],
@@ -96,7 +97,7 @@ export default {
     const domain = store.getters.appState.domain
     const siteConfig = store.getters.settings.siteConfig
     const host = translateAliasedUri(siteConfig[domain].baseUri)
-    const path = route.path.replace(/\(/g, '%28').replace(/\)/g, '%29');
+    const path = encodeSpecialChars(route.path);
     const pageData = await fetch(`${host}${path}`,
       {
         headers: { 'Accept': 'application/ld+json' },

--- a/nuxt-app/pages/find/index.vue
+++ b/nuxt-app/pages/find/index.vue
@@ -39,6 +39,7 @@ import PageStatus from '@/components/PageStatus';
 import ResultItem from '@/components/ResultItem';
 import Pagination from '@/components/Pagination';
 import {translateAliasedUri} from "../../plugins/env";
+import {encodeSpecialChars} from "../../plugins/env";
 
 export default {
   head() {
@@ -73,9 +74,9 @@ export default {
     const query = route.query;
     let queryString = '';
 
-    Object.entries(query).forEach(([key, val]) => queryString += `${key}=${val}&`);
+    Object.entries(query).forEach(([key, val]) => queryString += `${key}=${encodeSpecialChars(val)}&`);
     const pageData = await $http.$get(`${host}/find.jsonld?${queryString}`);
-    const collectionResults = await $http.$get(`${host}/find.jsonld?q=${route.query.q}&_limit=0`);
+    const collectionResults = await $http.$get(`${host}/find.jsonld?q=${encodeSpecialChars(route.query.q)}&_limit=0`);
     return {
       pageData,
       collectionResults,

--- a/nuxt-app/plugins/env.js
+++ b/nuxt-app/plugins/env.js
@@ -39,6 +39,16 @@ export function translateAliasedUri(uri) {
   return translatedUri;
 }
 
+export function encodeSpecialChars(path) {
+  if (typeof path !== 'string') {
+    return '';
+  }
+  return path
+    .replace(/\(/g, '%28')
+    .replace(/\)/g, '%29')
+    .replace(/&/g, '%26');
+}
+
 export function defaultSite() {
   return process.env.DEFAULT_SITE || 'id.kb.se';
 }


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3787](https://jira.kb.se/browse/LXL-3787)

### Solves

Terms with '&' would 404, and would also not be searchable:

* https://id.kb.se/term/saogf/Rhythm%20%26%20blues
* https://id.kb.se/find?q=Rhythm%20%26%20blues

### Summary of changes

I noticed that this worked: `curl -H "Accept: application/ld+json" "http://id.kblocalhost.kb.se:5000/https://id.kb.se/term/saogf/Rhythm%20%26%20blues"`

But this didn't: `curl -H "http://id.kblocalhost.kb.se:5000/https://id.kb.se/term/saogf/Rhythm%20%26%20blues"`

The first one is caught by `ProxyPassMatch ^/(http.*)$ http://localhost:8180/$1 nocanon`;, resulting in the request (from Apache to the backend) `GET /https://id.kb.se/term/saogf/Rhythm%20%26%20blues HTTP/1.1`.

The second one is caught by `RewriteRule ^/(.*)$ http://localhost:3000/$1 [P,L]`, resulting in the request (from Apache to nuxt-app) `GET /https:/id.kb.se/term/saogf/Rhythm%20&%20blues HTTP/1.1`

`%26` was turned into `&` (before even reaching Nuxt).

That part could be solved by changing the RewriteRule to something like
```
    RewriteCond %{THE_REQUEST} ^\S+\s+\/(.*)\s
    RewriteRule ^/(.*)$ http://localhost:3000/%1 [P,NE,L]
```
...but Nuxt, somewhere deep down, would decode the `%26` anyway before making the request to the XL backend.

So, instead: just replace `&` with `%26` where appropriate -- we already did this for `(` and `)`. Seems to work (individual pages and searching) and doesn't seem to break anything :shrug: 