### PR TITLE
Display type coeced properties correctly

### DIFF
--- a/lxljs/display.js
+++ b/lxljs/display.js
@@ -1,4 +1,4 @@
-import { cloneDeep, each, isObject, uniq, includes, remove, isArray, isEmpty, uniqWith, isEqual } from 'lodash-es';
+import { cloneDeep, each, isObject, uniq, includes, remove, isArray, isEmpty, uniqWith, isEqual, get, indexOf, map, flatten } from 'lodash-es';
 import * as VocabUtil from './vocab';
 import * as StringUtil from './string';
 import { lxlLog, lxlWarning } from './debug';
@@ -238,18 +238,28 @@ export function formatIsni(isni) {
 }
 
 export function getSortedProperties(formType, formObj, settings, resources) {
-  const propertyList = getDisplayProperties(
+  let propertyList = getDisplayProperties(
     formType,
     resources,
     settings,
     'full',
   );
+  
+  propertyList = uniq(flatten(map(propertyList, k => get(k, 'alternateProperties', k))));
+
+  const realKey = k => get(resources, ['context', '1', k, '@id'], k); 
   each(formObj, (v, k) => {
     if (!includes(propertyList, k)) {
-      propertyList.push(k);
+      const ix = indexOf(propertyList, realKey(k));
+      if (ix > -1) {
+        propertyList.splice(ix + 1, 0, k);
+      } else {
+        propertyList.push(k);  
+      }
     }
   });
   remove(propertyList, k => (settings.hiddenProperties.indexOf(k) !== -1));
+  
   return propertyList;
 }
 

--- a/vue-client/src/components/inspector/field.vue
+++ b/vue-client/src/components/inspector/field.vue
@@ -423,6 +423,9 @@ export default {
       }
       return false;
     },
+    fieldRdfType() {
+      return get(this.resources, ['context', '1', this.fieldKey, '@type'], '');
+    },
   },
   methods: {
     pasteClipboardItem() {
@@ -703,8 +706,9 @@ export default {
         <div class="Field-label uppercaseHeading" v-bind:class="{ 'is-locked': locked }">
           <span v-show="fieldKey === '@id'">{{ 'ID' | translatePhrase | capitalize }}</span>
           <span v-show="fieldKey === '@type'">{{ entityTypeArchLabel | translatePhrase | capitalize }}</span>
-          <span v-show="fieldKey !== '@id' && fieldKey !== '@type'" 
-            :title="fieldKey">{{ fieldKey | labelByLang | capitalize }}</span>          
+          <span v-show="fieldKey !== '@id' && fieldKey !== '@type' && !fieldRdfType" 
+            :title="fieldKey">{{ fieldKey | labelByLang | capitalize }}</span>
+          <span :title="fieldKey">{{ fieldRdfType | labelByLang | capitalize }}</span>
           <div class="Field-reverse uppercaseHeading--secondary" v-if="isReverseProperty && !isLocked">
             <span :title="fieldKey">{{ 'Incoming links' | translatePhrase | capitalize }}</span>          
             <div class="Field-comment">
@@ -724,7 +728,6 @@ export default {
       <span v-show="fieldKey === '@type'">{{ entityTypeArchLabel | translatePhrase | capitalize }}</span>
       <span v-show="fieldKey !== '@id' && fieldKey !== '@type'" 
         :title="fieldKey">{{ fieldKey | labelByLang | capitalize }}</span>
-
       <!-- Is inner -->
       <div class="Field-actions is-nested">
         <div class="Field-action Field-comment" v-if="propertyComment && !locked" >

--- a/vue-client/src/components/inspector/field.vue
+++ b/vue-client/src/components/inspector/field.vue
@@ -8,6 +8,7 @@ import { mixin as clickaway } from 'vue-clickaway';
 import { mapGetters } from 'vuex';
 import * as VocabUtil from 'lxljs/vocab';
 import * as StringUtil from 'lxljs/string';
+import * as DisplayUtil from 'lxljs/display';
 import EntityAdder from './entity-adder';
 import ItemEntity from './item-entity';
 import ItemValue from './item-value';
@@ -424,7 +425,7 @@ export default {
       return false;
     },
     fieldRdfType() {
-      return get(this.resources, ['context', '1', this.fieldKey, '@type'], '');
+      return DisplayUtil.rdfDisplayType(this.fieldKey, this.resources);
     },
   },
   methods: {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
* Sort properties correctly in for
  * Type coercion in JSON-LD context (`langCodeFull` -> `code`+`ISO-639-3` should be placed where `code` is)
  * e.g. language containers `prefLabelByLang`
  * `alternateProperties`
* Show label of type for fields with type coercion (`langCodeFull` -> `ISO-639-3` instead of "Code")