### PR TITLE
Fix side panel still open after user saved/cancelled editing

### DIFF
--- a/vue-client/src/components/inspector/item-local.vue
+++ b/vue-client/src/components/inspector/item-local.vue
@@ -357,6 +357,12 @@ export default {
     },
   },
   watch: {
+    'inspector.status.editing'(val) {
+      if (!val) {
+        this.closePropertyAdder();
+        this.closeExtractDialog();
+      }
+    },
     'inspector.event'(val) {
       this.$emit(`${val.value}`);
     },
@@ -367,7 +373,7 @@ export default {
       }
     },
     extractDialogActive(val) {
-      if (!val) {
+      if (!val && this.inspector.status.editing) {
         this.$refs.linkAction.$el.focus();
       }
     },

--- a/vue-client/src/components/inspector/item-sibling.vue
+++ b/vue-client/src/components/inspector/item-sibling.vue
@@ -323,6 +323,12 @@ export default {
     'inspector.event'(val) {
       this.$emit(`${val.value}`);
     },
+    'inspector.status.editing'(val) {
+      if (!val) {
+        this.closePropertyAdder();
+        this.closeExtractDialog();
+      }
+    },
     shouldExpand(val) {
       if (val) {
         this.expand();
@@ -330,7 +336,7 @@ export default {
       }
     },
     extractDialogActive(val) {
-      if (!val) {
+      if (!val && this.inspector.status.editing) {
         this.$refs.linkAction.$el.focus();
       }
     },


### PR DESCRIPTION
Affected "Add property" and "Create/link" panels.

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3775](https://jira.kb.se/browse/LXL-3775)