### PR TITLE
Display integral properties as cards inside form

### DIFF
--- a/vue-client/src/components/inspector/entity-form.vue
+++ b/vue-client/src/components/inspector/entity-form.vue
@@ -103,6 +103,13 @@ export default {
     keyIsLocked(key) {
       return (this.isLocked || key === '@id');
     },
+    isIntegral(key) {
+      if (key.indexOf('@reverse/') >= 0) {
+        key = key.split('/').pop();
+      }
+      
+      return VocabUtil.hasCategory(key, 'integral', this.resources);
+    }
   },
   components: {
   },
@@ -125,6 +132,7 @@ export default {
         :is-removable="true" 
         :is-locked="keyIsLocked(k)" 
         :parent-accepted-types="acceptedTypes"
+        :is-card="isIntegral(k)"
         :is-distinguished="k === 'instanceOf'"
         :key="k" 
         :field-key="k" 
@@ -149,6 +157,7 @@ export default {
           :is-inner="false" 
           :is-removable="false" 
           :is-locked="true" 
+          :is-card="isIntegral(k)"
           :parent-accepted-types="acceptedTypes"
           :key="k" 
           :field-key="k" 

--- a/vue-client/src/components/inspector/field.vue
+++ b/vue-client/src/components/inspector/field.vue
@@ -49,6 +49,10 @@ export default {
       type: String,
       default: '',
     },
+    overrideLabel: {
+      type: String,
+      default: null,
+    },
     fieldValue: {
       type: [Object, String, Array, Boolean, Number],
       default: null,
@@ -86,6 +90,10 @@ export default {
       default: null,
     },
     isDistinguished: {
+      type: Boolean,
+      default: false,
+    },
+    isCard: {
       type: Boolean,
       default: false,
     },
@@ -144,6 +152,9 @@ export default {
   computed: {
     isReverseProperty() {
       return this.fieldKey.indexOf('@reverse') > -1;
+    },
+    reverseProperty() {
+      return this.isReverseProperty ? this.fieldKey.split('/').pop() : null;
     },
     isFieldDiff() {
       return this.isDiff && this.newDiffValues.length === 0;
@@ -708,7 +719,7 @@ export default {
           <span v-show="fieldKey === '@id'">{{ 'ID' | translatePhrase | capitalize }}</span>
           <span v-show="fieldKey === '@type'">{{ entityTypeArchLabel | translatePhrase | capitalize }}</span>
           <span v-show="fieldKey !== '@id' && fieldKey !== '@type' && !fieldRdfType" 
-            :title="fieldKey">{{ fieldKey | labelByLang | capitalize }}</span>
+            :title="fieldKey">{{ (overrideLabel || fieldKey) | labelByLang | capitalize }}</span>
           <span :title="fieldKey">{{ fieldRdfType | labelByLang | capitalize }}</span>
           <div class="Field-reverse uppercaseHeading--secondary" v-if="isReverseProperty && !isLocked">
             <span :title="fieldKey">{{ 'Incoming links' | translatePhrase | capitalize }}</span>          
@@ -817,7 +828,7 @@ export default {
         v-for="(item, index) in valueAsArray" 
         :key="index"
         v-bind:class="{
-          'is-entityContent': getDatatype(item) == 'entity' && !isLinkedInstanceOf,
+          'is-entityContent': getDatatype(item) == 'entity' && !isCard,
           'is-new': newDiffValues.indexOf(item) > -1,
         }">
 
@@ -831,6 +842,7 @@ export default {
         <item-grouped 
           v-if="getDatatype(item) == 'grouped'"
           :field-key="fieldKey" 
+          :is-card="isCard"
           :entity-type="entityType" 
           :parent-path="path"
           :index="index" 
@@ -852,8 +864,9 @@ export default {
         <item-entity 
           v-if="getDatatype(item) == 'entity'" 
           :is-locked="locked" 
-          :is-distinguished="isDistinguished"
-          :is-expanded="isLinkedInstanceOf"
+          :is-card="isCard"
+          :is-expanded="isCard"
+          :exclude-properties="isReverseProperty ? [reverseProperty] : []"
           :item="item" 
           :field-key="fieldKey" 
           :index="index" 

--- a/vue-client/src/components/inspector/item-entity.vue
+++ b/vue-client/src/components/inspector/item-entity.vue
@@ -16,7 +16,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    isDistinguished: {
+    isCard: {
       type: Boolean,
       default: false,
     },
@@ -155,7 +155,7 @@ export default {
     class="ItemEntity-container"
     :class="{ 'is-expanded': expanded }">
     <div 
-      v-if="isDistinguished"
+      v-if="isCard"
       class="ItemEntity-expander"
       tabindex="0"
       @click="toggleExpanded()"
@@ -165,16 +165,16 @@ export default {
     <div
       :id="`formPath-${path}`"
       class="ItemEntity-content"
-      v-show="!isDistinguished || !expanded">
+      v-show="!isCard || !expanded">
       <v-popover class="ItemEntity-popover" placement="bottom-start" @show="$refs.previewCard.populateData()">
         <div class="ItemEntity chip" 
           tabindex="0"
           ref="chip"
-          v-if="!isDistinguished || !expanded" 
+          v-if="!isCard || !expanded" 
           :class="{ 'is-locked': isLocked, 'is-marc': isMarc, 'is-newlyAdded': animateNewlyAdded, 'is-removeable': removeHover, 'is-cache': recordType === 'CacheRecord', 'is-placeholder': recordType === 'PlaceholderRecord', 'is-ext-link': !isLibrisResource}">
           <span class="ItemEntity-label chip-label">
-            <span v-if="(!isDistinguished || !expanded) && isLibrisResource"><router-link :to="routerPath">{{getItemLabel}}</router-link></span>
-            <span v-if="(!isDistinguished || !expanded) && !isLibrisResource"><a :href="item['@id'] | convertResourceLink">{{getItemLabel}} <span class="fa fa-arrow-circle-right"></span></a></span>
+            <span v-if="(!isCard || !expanded) && isLibrisResource"><router-link :to="routerPath">{{getItemLabel}}</router-link></span>
+            <span v-if="(!isCard || !expanded) && !isLibrisResource"><a :href="item['@id'] | convertResourceLink">{{getItemLabel}} <span class="fa fa-arrow-circle-right"></span></a></span>
             <span class="placeholder"></span></span>
           <div class="ItemEntity-removeButton chip-removeButton" v-if="!isLocked">
             <i class="fa fa-times-circle icon icon--sm chip-icon" 
@@ -195,8 +195,9 @@ export default {
     </div>
     
     <entity-summary 
-      v-if="isDistinguished && expanded"
+      v-if="isCard && expanded"
       :focus-data="focusData" 
+      :exclude-properties="excludeProperties"
       :should-link="true"
       :should-open-tab="true"
       :show-all-keys="true"

--- a/vue-client/src/components/inspector/item-grouped.vue
+++ b/vue-client/src/components/inspector/item-grouped.vue
@@ -19,6 +19,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    isCard: {
+      type: Boolean,
+      default: false,
+    },
     entityType: {
       type: String,
       default: '',
@@ -30,7 +34,7 @@ export default {
   },
   data() {
     return {
-      expanded: false,
+      expanded: this.isCard,
     };
   },
   computed: {
@@ -111,8 +115,10 @@ export default {
       :is-locked="true" 
       :is-removable="false" 
       :is-grouped="true"
+      :is-card="isCard"
       :show-key="showKeys"
-      :field-key="key"
+      :override-label="key"
+      :field-key="fieldKey"
       :field-value="value"></field>
     </ul>  
   </div>


### PR DESCRIPTION
For example instanceOf, translationOf
Including reverse integral properties, e.g. `@reverse/instanceOf`

The cards could be sorted in a better way, for example publication.year
for instances of a work. Define that mechanism later.

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3864](https://jira.kb.se/browse/LXL-3864)

### Solves
- Makes instances of a work distinguishable by displaying them as cards instead of chips.
- Makes e.g. reproductions nicer by displaying the integral `reproductionOf` as a card

### Summary of changes
- Separate the concept of "distinguished" (i.e. displaying the work as a separate section) from being displayed as a card
- Display all "integral" properties as cards
- Auto-expand all cards
- Maybe fields should decide themselves if they should be cards instead of passing it from entity-form?