### PR TITLE
Make error pages more user-friendly

### DIFF
--- a/nuxt-app/layouts/error.vue
+++ b/nuxt-app/layouts/error.vue
@@ -3,10 +3,12 @@
     <div class="row">
       <div class="col-12 col-md-12 col-lg-10 col-xl-8 col-xxl-6 py-4">
         <div v-if="error.statusCode">
-          <h1>{{ error.statusCode }}</h1>
-          <p>{{ translateUi(codeText) }}</p>
+          <h1>{{ translateUi(codeText.heading) }}</h1>
+          <p v-for="extra in codeText.extra">
+            {{ translateUi(extra) }}
+          </p>
         </div>
-        <h1 v-else>An error occurred</h1>
+        <h1 v-else>{{ translateUi('An error occurred') }}</h1>
         <a href="" @click.prevent="$router.back()">{{ translateUi('Go back') }}</a>
         <hr>
         <a href="/">{{ translateUi('Return to homepage') }}</a>
@@ -20,16 +22,28 @@
 export default {
   props: ['error'],
   layout: 'error', // you can set a custom layout for the error page
+  head() {
+    return { title: `${this.translateUi(this.codeText.heading)} | ${this.appState.domain}` }
+  },
   computed: {
     codeText() {
-      switch(this.error.statusCode) {
-        case 404:
-          return 'Page not found';
-          break;
-        default:
-          return this.error.message || '';
+      if (this.error.statusCode == 404) {
+        return {
+          heading: "Page not found",
+          extra: [
+            "If you entered a web address, check that it is correct.",
+            "If you got here by following a link on our website, you can report it to us. See contact information in the footer."
+          ]
+        };
+      } else {
+        return {
+          heading: "There is a problem with the service",
+          extra: [
+            "Try again later."
+          ]
+        };
       }
-    },
-  },
+    }
+  }
 }
 </script>

--- a/nuxt-app/resources/json/i18n.json
+++ b/nuxt-app/resources/json/i18n.json
@@ -39,6 +39,10 @@
     "Z-A": "Ö-A",
     "Relevance": "Relevans",
     "search all of id.kb.se": "sök i hela id.kb.se",
-    "suggested": "förslag"
+    "suggested": "förslag",
+    "If you entered a web address, check that it is correct.": "Om du skrev in adressen, kontrollera att den är korrekt.",
+    "If you got here by following a link on our website, you can report it to us. See contact information in the footer.": "Om du hamnade här genom att följa en länk på vår webbplats, meddela oss gärna. Se kontaktinformation i sidfoten.",
+    "There is a problem with the service": "Det är ett problem med tjänsten",
+    "Try again later.": "Försök igen senare."
   }
 }


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3887](https://jira.kb.se/browse/LXL-3887)

### Solves

Error pages (e.g. 500) should not expose internal details to visitors and shouldn't use technical jargon.

### Summary of changes

Clear headings (e.g. "There is a problem with the service" rather than "500"), possibility to have additional (and translatable) information, proper <title> (e.g. "Page not found | id.kb.se" rather than "id.kb.se").
