### PR TITLE
Better error message when holding already exists

### DIFF
--- a/vue-client/src/resources/json/i18n.json
+++ b/vue-client/src/resources/json/i18n.json
@@ -47,6 +47,7 @@
     "Form updated, don't forget to save": "Formulär uppdaterat, glöm inte att spara posten",
     "Save failed": "Kunde inte spara",
     "The resource has been modified by another user": "Resursen har ändrats av en annan användare",
+    "The resource already exists": "Resursen finns redan",
     "Your login has expired": "Din inloggning har löpt ut",
     "Renew": "Förnya",
     "New search": "Ny sökning",

--- a/vue-client/src/views/Inspector.vue
+++ b/vue-client/src/views/Inspector.vue
@@ -696,6 +696,10 @@ export default {
             errorMessage = `${StringUtil.getUiPhraseByLang('The resource has been modified by another user', this.user.settings.language, this.resources.i18n)}`;
             this.$store.dispatch('pushNotification', { type: 'danger', message: `${errorBase}. ${errorMessage}.` });
             break;
+          case 409:
+            errorMessage = `${StringUtil.getUiPhraseByLang('The resource already exists', this.user.settings.language, this.resources.i18n)}`;
+            this.$store.dispatch('pushNotification', { type: 'danger', message: `${errorBase}. ${errorMessage}.` });
+            break;
           case 401:
             localStorage.removeItem('lastPath');
             errorMessage = `${StringUtil.getUiPhraseByLang('Your login has expired', this.user.settings.language, this.resources.i18n)}`;


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-2078](https://jira.kb.se/browse/LXL-2078)

### Solves

"Something went wrong" is not a useful error when trying to save a holding that already exists for the current sigel.

### Summary of changes

Adds a human-friendly error message if status 409 is encountered when saving.
