### PR TITLE
Feature/handle old works

### DIFF
--- a/lxljs/string.js
+++ b/lxljs/string.js
@@ -189,6 +189,7 @@ export function arrayPathToString(arrayPath) {
   }
   path = path.replace('@graph[0]', 'record');
   path = path.replace('@graph[1]', 'mainEntity');
+  path = path.replace('@graph[2]', 'mainEntity.instanceOf');
   return path;
 }
 

--- a/vue-client/src/components/inspector/version-history.vue
+++ b/vue-client/src/components/inspector/version-history.vue
@@ -170,7 +170,7 @@ export default {
         .then(response => response.json())
         .then((result) => {
           DataUtil.fetchMissingLinkedToQuoted(result, this.$store);
-          return LxlDataUtil.splitJson(result);
+          return DataUtil.moveWorkToInstance(LxlDataUtil.splitJson(result));
         });
 
       const previousChangeSet = this.changeSetsReversed[number + 1];
@@ -182,11 +182,12 @@ export default {
         .then(response => response.json())
         .then((result) => {
           DataUtil.fetchMissingLinkedToQuoted(result, this.$store);
-          return LxlDataUtil.splitJson(result);
+          return DataUtil.moveWorkToInstance(LxlDataUtil.splitJson(result));
         });
 
       const diff = this.currentVersionDiff;
       const compositeVersionData = cloneDeep(this.currentVersionData);
+
       if (!isEmpty(diff.removed)) {
         diff.removed.forEach((r) => {
           const isListItem = r.path.slice(-1) === ']';

--- a/vue-client/src/components/inspector/version-history.vue
+++ b/vue-client/src/components/inspector/version-history.vue
@@ -61,12 +61,12 @@ export default {
     },
     currentVersionDiff() {
       return {
-        added: this.addedPathsInCurrentVersion,
-        removed: this.removedPathsInCurrentVersion,
+        added: this.addedPathsAndObjects,
+        removed: this.removedPathsAndObjects,
         modified: [],
       };
     },
-    addedPathsInCurrentVersion() {
+    addedPathsAndObjects() {
       if (this.selectedChangeSet.hasOwnProperty('addedPaths') === false) return [];
       const added = this.selectedChangeSet.addedPaths;
       const convertedAdded = [];
@@ -82,7 +82,7 @@ export default {
       });
       return convertedAdded;
     },
-    removedPathsInCurrentVersion() {
+    removedPathsAndObjects() {
       if (this.selectedChangeSet.hasOwnProperty('removedPaths') === false) return [];
       const removed = this.selectedChangeSet.removedPaths;
       const convertedRemoved = [];
@@ -159,7 +159,6 @@ export default {
     },
     async setDisplayDataFor(number) {
       if (this.changeSetsReversed == null) return;
-      
       const options = {
         headers: {
           Accept: 'application/ld+json',

--- a/vue-client/src/utils/data.js
+++ b/vue-client/src/utils/data.js
@@ -164,6 +164,15 @@ export async function fetchMissingLinkedToQuoted(obj, store) {
     .catch(e => console.log(e));
 }
 
+export function moveWorkToInstance(data) {
+  const oldWork = data.work;
+  if (oldWork !== undefined) {
+    delete oldWork['@id']; // Get rid of <record-id>#work
+    data.mainEntity.instanceOf = oldWork;
+  }
+  return data;
+}
+
 // Changes XML to JSON
 // Modified version from here: http://davidwalsh.name/convert-xml-json
 export function xmlToJson(xml) {


### PR DESCRIPTION
Modify the backend response to be able to show it in a uniform way when the work is at graph[2]. 

Tested with a mocked backend response that corresponds to the old form:
```
          // Fake backend response ============================
          const instance = get(result, ['@graph', 1, 'instanceOf']);
          const id = get(result, ['@graph', 0, '@id']);
          instance['@id'] = id.concat('#work');
          set(result, ['@graph', 2], instance);
          set(result, ['@graph', 1, 'instanceOf'], { '@id': instance['@id'] });
          console.log('FAKE BACKEND RESPONSE:', JSON.stringify(result));
          // ==================================================
```