### PR TITLE
Show subclasses and -properties in the vocab view

### DIFF
--- a/lxljs/vocab.js
+++ b/lxljs/vocab.js
@@ -770,3 +770,34 @@ export function computeContainerMap(contextList) {
 
   return containerMap;
 }
+
+export function preprocessVocab(vocab) {
+  const vocabMap = new Map(vocab['@graph'].map(entry => [entry['@id'], entry]));
+  vocabMap.forEach((termObj) => {
+    if (termObj && termObj.hasOwnProperty('@id')) {
+      let bases = null;
+      for (const baserel of ['subClassOf', 'subPropertyOf']) {
+        if (termObj.hasOwnProperty(baserel)) {
+          bases = termObj[baserel];
+          break;
+        }
+      }
+      if (!Array.isArray(bases)) {
+        return;
+      }
+      bases.forEach((obj) => {
+        if (obj['@id']) {
+          const baseClass = vocabMap.get(obj['@id']);
+          if (baseClass) {
+            if (!Array.isArray(baseClass.baseClassOf)) {
+              baseClass.baseClassOf = [];
+            }
+            baseClass.baseClassOf.push(termObj);
+          }
+        }
+      });
+    }
+  });
+
+  return vocabMap;
+}

--- a/lxljs/vocab.js
+++ b/lxljs/vocab.js
@@ -776,9 +776,13 @@ export function preprocessVocab(vocab) {
   vocabMap.forEach((termObj) => {
     if (termObj && termObj.hasOwnProperty('@id')) {
       let bases = null;
+      let subRel = 'baseClassOf';
       for (const baserel of ['subClassOf', 'subPropertyOf']) {
         if (termObj.hasOwnProperty(baserel)) {
           bases = termObj[baserel];
+          if (baserel === 'subPropertyOf') {
+            subRel = 'basePropertyOf';
+          }
           break;
         }
       }
@@ -789,10 +793,10 @@ export function preprocessVocab(vocab) {
         if (obj['@id']) {
           const baseClass = vocabMap.get(obj['@id']);
           if (baseClass) {
-            if (!Array.isArray(baseClass.baseClassOf)) {
-              baseClass.baseClassOf = [];
+            if (!Array.isArray(baseClass[subRel])) {
+              baseClass[subRel] = [];
             }
-            baseClass.baseClassOf.push(termObj);
+            baseClass[subRel].push(termObj);
           }
         }
       });

--- a/nuxt-app/components/EntityNode.vue
+++ b/nuxt-app/components/EntityNode.vue
@@ -73,8 +73,8 @@ export default {
           return VocabUtil.getTermObject(this.entity['@id'], this.vocab, this.vocabContext);
         }
       }
-      if (this.vocabLinkProperties.includes(this.parentKey)) {
-        return VocabUtil.getTermObject(this.entity, this.vocab, this.vocabContext);
+      if (this.vocabLinkProperties.includes(this.parentKey) && this.entity['@id']) {
+        return VocabUtil.getTermObject(this.entity['@id'], this.vocab, this.vocabContext);
       }
       return this.entity;
     }

--- a/nuxt-app/modules/vocab-cache.js
+++ b/nuxt-app/modules/vocab-cache.js
@@ -25,7 +25,7 @@ async function fetchVocab() {
       [context, vocab, display] = v;
 
       vocabCache.context = VocabUtil.preprocessContext(context)['@context'];
-      vocabCache.vocab = vocab;
+      vocabCache.vocab = VocabUtil.preprocessVocab(vocab);
       vocabCache.display = DisplayUtil.expandInherited(display);
     })
     .catch(err => {

--- a/nuxt-app/resources/json/rdfTranslations.json
+++ b/nuxt-app/resources/json/rdfTranslations.json
@@ -1,7 +1,7 @@
 {
   "sv": {
-    "baseClassOf": "Specialisering",
-    "basePropertyOf": "Specialisering",
+    "baseClassOf": "Subklasser",
+    "basePropertyOf": "Subegenskaper",
     "subClassOf": "Härledd från",
     "subPropertyOf": "Härledd från",
     "isDefinedBy": "Definieras av",
@@ -14,8 +14,8 @@
     "equivalentProperty": "Motsvarar"
   },
   "en": {
-    "baseClassOf": "Base of",
-    "basePropertyOf": "Base of",
+    "baseClassOf": "Subclasses",
+    "basePropertyOf": "Subproperties",
     "subClassOf": "Sub class of",
     "subPropertyOf": "Sub property of",
     "isDefinedBy": "Is defined by",

--- a/nuxt-app/resources/json/rdfTranslations.json
+++ b/nuxt-app/resources/json/rdfTranslations.json
@@ -1,7 +1,7 @@
 {
   "sv": {
-    "baseClassOf": "Härleds till",
-    "basePropertyOf": "Härleds till",
+    "baseClassOf": "Specialisering",
+    "basePropertyOf": "Specialisering",
     "subClassOf": "Härledd från",
     "subPropertyOf": "Härledd från",
     "isDefinedBy": "Definieras av",
@@ -14,8 +14,8 @@
     "equivalentProperty": "Motsvarar"
   },
   "en": {
-    "baseClassOf": "Base class of",
-    "basePropertyOf": "Base property of",
+    "baseClassOf": "Base of",
+    "basePropertyOf": "Base of",
     "subClassOf": "Sub class of",
     "subPropertyOf": "Sub property of",
     "isDefinedBy": "Is defined by",

--- a/nuxt-app/store/index.js
+++ b/nuxt-app/store/index.js
@@ -184,28 +184,25 @@ export const mutations = {
   SET_COLLECTIONS(state, data) {
     state.collections = data;
   },
-  SET_VOCAB(state, data) {
+  SET_VOCAB(state, vocabMap) {
     // Set vocab to a map
-    const vocabMap = new Map(data['@graph'].map(entry => [entry['@id'], entry]));
     state.vocab = vocabMap;
   },
-  SET_VOCAB_CLASSES(state, data) {
+  SET_VOCAB_CLASSES(state, vocabMap) {
     // Set vocabClasses to an array of objects
-    const vocabJson = data['@graph'];
     const classTerms = [].concat(
-      VocabUtil.getTermByType('Class', vocabJson, state.vocabContext, state.settings),
-      VocabUtil.getTermByType('marc:CollectionClass', vocabJson, state.vocabContext, state.settings),
+      VocabUtil.getTermByType('Class', vocabMap, state.vocabContext, state.settings),
+      VocabUtil.getTermByType('marc:CollectionClass', vocabMap, state.vocabContext, state.settings),
     );
     state.vocabClasses = classTerms;
   },
-  SET_VOCAB_PROPERTIES(state, data) {
+  SET_VOCAB_PROPERTIES(state, vocabMap) {
     // Set vocabProperties to an array of objects
-    const vocabJson = data['@graph'];
     let props = [];
-    props = props.concat(VocabUtil.getTermByType('Property', vocabJson, state.vocabContext, state.settings));
-    props = props.concat(VocabUtil.getTermByType('DatatypeProperty', vocabJson, state.vocabContext, state.settings));
-    props = props.concat(VocabUtil.getTermByType('ObjectProperty', vocabJson, state.vocabContext, state.settings));
-    props = props.concat(VocabUtil.getTermByType('owl:SymmetricProperty', vocabJson, state.vocabContext, state.settings));
+    props = props.concat(VocabUtil.getTermByType('Property', vocabMap, state.vocabContext, state.settings));
+    props = props.concat(VocabUtil.getTermByType('DatatypeProperty', vocabMap, state.vocabContext, state.settings));
+    props = props.concat(VocabUtil.getTermByType('ObjectProperty', vocabMap, state.vocabContext, state.settings));
+    props = props.concat(VocabUtil.getTermByType('owl:SymmetricProperty', vocabMap, state.vocabContext, state.settings));
     state.vocabProperties = props;
   },
   SET_DISPLAY(state, data) {


### PR DESCRIPTION
Done by preprocessing the vocab data upon initial fetch.

Needs more testing:

- [x] Run the unit tests. `yarn test:unit`
- [x] Run the linter. `yarn lint`
- [x] Test the application more (having `baseClassOf` around (again?) should not interfere with the cataloguing client, but that must be verified)