### PR TITLE
Prepopulate language tagging side panel

### DIFF
--- a/vue-client/src/components/inspector/field.vue
+++ b/vue-client/src/components/inspector/field.vue
@@ -368,7 +368,7 @@ export default {
       return valueArray;
     },
     firstInValueAsArray() {
-      return typeof this.valueAsArray[0] || "";
+      return typeof this.valueAsArray[0] || '';
     },
     isUriType() {
       return VocabUtil.getContextValue(this.fieldKey, '@id', this.resources.context) === 'uri';

--- a/vue-client/src/store.js
+++ b/vue-client/src/store.js
@@ -46,6 +46,7 @@ const store = new Vuex.Store({
       originalData: {},
       compositeHistoryData: {},
       languageCache: {},
+      langTagSearch: '',
       title: '',
       status: {
         detailedEnrichmentModal: {
@@ -164,6 +165,9 @@ const store = new Vuex.Store({
         languageCache[key] = value;
       }
       state.inspector.languageCache = languageCache;
+    },
+    saveLangTagSearch(state, data) {
+      state.inspector.langTagSearch = data;
     },
     addToQuoted(state, data) {
       const quoted = cloneDeep(state.inspector.data.quoted);
@@ -665,6 +669,9 @@ const store = new Vuex.Store({
     },
     addToLanguageCache({ commit }, data) {
       commit('addToLanguageCache', data);
+    },
+    saveLangTagSearch({ commit }, data) {
+      commit('saveLangTagSearch', data);
     },
     addToQuoted({ commit }, data) {
       commit('addToQuoted', data);

--- a/vue-client/src/views/Inspector.vue
+++ b/vue-client/src/views/Inspector.vue
@@ -424,6 +424,7 @@ export default {
     onRecordLoaded() {
       this.$store.dispatch('setInsertData', '');
       this.$store.dispatch('flushChangeHistory');
+      this.$store.dispatch('saveLangTagSearch', '');
       this.recordLoaded = true;
       this.$store.dispatch('removeLoadingIndicator', 'Loading document');
       this.$nextTick(() => {


### PR DESCRIPTION
In language tagging side panel:
* Prepopulate search field with label of language of resource
  * (for now instanceOf.language)
* If search field is modified, prepopulate with same value next time

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`