### PR TITLE
Bugs/lxl 4036 fix resource history route

### DIFF
--- a/vue-client/src/App.vue
+++ b/vue-client/src/App.vue
@@ -4,23 +4,33 @@
     <EnvironmentBanner />
     <navbar-component />
     <search-bar v-if="resourcesLoaded" :class="{ 'stick-to-top': stickToTop }" />
+
     <main class="MainContent" :style="{ 'margin-top': stickToTop ? `${searchBarHeight}px` : '0px' }" :class="{ 'container': (!status.panelOpen && user.settings.fullSiteWidth === false), 'container-fluid': (status.panelOpen || user.settings.fullSiteWidth), 'debug-mode': user.settings.appTech }">
       <div class="debug-mode-indicator" v-if="user.settings.appTech" @click="disableDebugMode">
         {{ 'Debug mode activated. Click here to disable.' | translatePhrase }}
       </div>
-        <div v-if="status.loadingIndicators.length > 0" class="text-center MainContent-spinner">
-          <vue-simple-spinner size="large" :message="status.loadingIndicators[0] | translatePhrase"></vue-simple-spinner>
+
+      <div v-if="status.loadingIndicators.length > 0" class="text-center MainContent-spinner">
+        <vue-simple-spinner size="large" :message="status.loadingIndicators[0] | translatePhrase"></vue-simple-spinner>
+      </div>
+
+      <div v-if="resourcesLoadingError" class="ResourcesLoadingError">
+        <i class="fa fa-warning fa-4x text-danger"></i>
+        <div>
+          <h2>Kunde inte hämta nödvändiga resurser</h2>
+          <p>Testa att ladda om sidan.</p>
+          <p>Om felet kvarstår, kontakta <a href="mailto:libris@kb.se">libris@kb.se</a>.</p>
         </div>
-        <div v-if="resourcesLoadingError" class="ResourcesLoadingError">
-          <i class="fa fa-warning fa-4x text-danger"></i>
-          <div>
-            <h2>Kunde inte hämta nödvändiga resurser</h2>
-            <p>Testa att ladda om sidan.</p>
-            <p>Om felet kvarstår, kontakta <a href="mailto:libris@kb.se">libris@kb.se</a>.</p>
-          </div>
-        </div>
-        <router-view ref="routerView" v-if="resourcesLoaded" v-show="status.loadingIndicators.length === 0" @ready="onRouterViewReady"></router-view>
+      </div>
+
+      <router-view
+        ref="routerView"
+        v-if="resourcesLoaded"
+        v-show="status.loadingIndicators.length === 0"
+        @ready="onRouterViewReady"
+      />
     </main>
+
     <portal-target name="sidebar" multiple />
     <footer-component></footer-component>
     <notification-list></notification-list>
@@ -74,6 +84,10 @@ export default {
       this.setFocusTarget();
     },
     setFocusTarget() {
+      if (this.$refs.routerView == null) {
+        return false;
+      }
+
       // get component's "routeFocusTarget" ref
       // if not existent, use router view container
       const focusTarget = (this.$refs.routerView.$refs.componentFocusTarget !== undefined) 
@@ -88,7 +102,7 @@ export default {
         preventScroll: true,
       });
 
-      // remove tabindex from focustarget. 
+      // remove tabindex from focustarget.
       // reason: https://axesslab.com/skip-links/#update-3-a-comment-from-gov-uk
       focusTarget.removeAttribute('tabindex');
     },
@@ -98,6 +112,7 @@ export default {
       const resetTimer = () => {
         this.userIdleTimer = 0;
       };
+
       setInterval(() => {
         this.userIdleTimer += updateTimer;
         if (this.userIdleTimer > 5 && this.status.userIdle === false) {
@@ -112,7 +127,9 @@ export default {
           });
         }
       }, updateTimer * 1000);
+
       window.addEventListener('load', resetTimer, true);
+
       const events = ['mousedown', 'mousemove', 'keypress', 'scroll', 'touchstart'];
       events.forEach((name) => {
         document.addEventListener(name, resetTimer, true); 
@@ -127,12 +144,15 @@ export default {
       const $SearchBar = document.getElementById('SearchBar');
       const elementsAboveSearchBar = document.getElementsByClassName('top-scroll-past');
       let margin = 0;
+
       for (let i = 0; i < elementsAboveSearchBar.length; i++) {
         margin += elementsAboveSearchBar[i].getBoundingClientRect().height;
       }
+
       if ($SearchBar) {
         this.searchBarHeight = $SearchBar.getBoundingClientRect().height;
       }
+
       if (event) {
         if (event.target.scrollingElement && event.target.scrollingElement.scrollTop > margin) {
           this.stickToTop = true;
@@ -146,11 +166,13 @@ export default {
     this.$nextTick(() => {
       this.setupIdleTimer();
       this.checkSearchBar();
-      this.$store.dispatch('setStatusValue', { 
-        property: 'keybindState', 
-        value: 'default', 
+
+      this.$store.dispatch('setStatusValue', {
+        property: 'keybindState',
+        value: 'default',
       });
     });
+
     window.addEventListener('scroll', (e) => {
       this.checkSearchBar(e);
     });

--- a/vue-client/src/App.vue
+++ b/vue-client/src/App.vue
@@ -105,6 +105,7 @@ export default {
       // remove tabindex from focustarget.
       // reason: https://axesslab.com/skip-links/#update-3-a-comment-from-gov-uk
       focusTarget.removeAttribute('tabindex');
+      return focusTarget;
     },
     setupIdleTimer() {
       // USER IDLE TIMER

--- a/vue-client/src/components/inspector/entity-changelog.vue
+++ b/vue-client/src/components/inspector/entity-changelog.vue
@@ -48,6 +48,7 @@ export default {
         <span class="EntityChangelog-unknown" v-else>{{ "Unknown" | translatePhrase | lowercase }}</span>
       </span>
     </div>
+
     <div class="EntityChangelog-item">
       <span class="EntityChangelog-key uppercaseHeading--bold">{{ 'Changed' | translatePhrase}}:</span> 
       <span class="EntityChangelog-value">
@@ -56,7 +57,10 @@ export default {
         <span class="EntityChangelog-unknown" v-else>{{ "Unknown" | translatePhrase | lowercase }}</span>
       </span>
     </div>
-    <router-link :to="{ path: `${this.$route.path}/history` }"><button-component :inverted="true" class="Button-default" :label="'View version history' | translatePhrase" icon="clock-o" size="medium" /></router-link>
+
+    <router-link :to="{ path: `${this.$route.path}/history` }">
+      <button-component :inverted="true" class="Button-default" :label="'View version history' | translatePhrase" icon="clock-o" size="medium" />
+    </router-link>
   </div>
 </template>
 

--- a/vue-client/src/router.js
+++ b/vue-client/src/router.js
@@ -13,7 +13,7 @@ const router = new Router({
   scrollBehavior(to, from, savedPosition) {
     if (savedPosition) {
       return savedPosition;
-    } 
+    }
     return { x: 0, y: 0 };
   },
   routes: [
@@ -62,7 +62,7 @@ const router = new Router({
       path: '/directory-care/:tool?',
       name: 'Directory care',
       component: () => import(/* webpackChunkName: "UserPage" */ './views/DirectoryCare.vue'),
-      meta: { 
+      meta: {
         requiresAuth: true,
       },
     },
@@ -70,7 +70,7 @@ const router = new Router({
       path: '/user',
       name: 'User settings',
       component: () => import(/* webpackChunkName: "UserPage" */ './views/UserPage.vue'),
-      meta: { 
+      meta: {
         requiresAuth: true,
       },
     },
@@ -78,7 +78,7 @@ const router = new Router({
       path: '/create',
       name: 'Create new',
       component: () => import(/* webpackChunkName: "Create" */ './views/Create.vue'),
-      meta: { 
+      meta: {
         requiresAuth: true,
       },
     },
@@ -101,10 +101,22 @@ const router = new Router({
 });
 
 router.beforeEach((to, from, next) => {
+  // Remove trailing slashes from route path (if any)
+  if (to.fullPath.substring(to.fullPath.length - 1, to.fullPath.length) === '/') {
+    next({
+      path: to.fullPath.slice(0, -1),
+    });
+  }
+
+  next();
+});
+
+router.beforeEach((to, from, next) => {
   const newToken = StringUtil.getParamValueFromUrl(to.hash, 'access_token');
   if (newToken) {
     localStorage.setItem('at', newToken);
   }
+
   store.dispatch('verifyUser').then(() => {
     // authed
     next();
@@ -114,6 +126,7 @@ router.beforeEach((to, from, next) => {
       if (to.fullPath.indexOf('login') < 0) {
         localStorage.setItem('lastPath', to.fullPath);
       }
+
       next({
         path: '/login/expired',
       });

--- a/vue-client/src/views/Inspector.vue
+++ b/vue-client/src/views/Inspector.vue
@@ -204,7 +204,7 @@ export default {
       this.$store.dispatch('flushChangeHistory');
       this.$store.dispatch('setInspectorStatusValue', { property: 'focus', value: 'mainEntity' });
 
-      if (this.$route.name === 'Inspector' || this.$route.name == 'DocumentHistory') {
+      if (this.$route.name === 'Inspector' || this.$route.name === 'DocumentHistory') {
         console.log('Initializing view for existing document');
         this.documentId = this.$route.params.fnurgel;
         this.loadDocument();

--- a/vue-client/src/views/Inspector.vue
+++ b/vue-client/src/views/Inspector.vue
@@ -164,6 +164,7 @@ export default {
     },
     fetchDocument() {
       const fetchUrl = `${this.settings.apiPath}/${this.documentId}/data.jsonld`;
+
       fetch(fetchUrl).then((response) => {
         if (response.status === 200) {
           this.documentETag = response.headers.get('ETag');
@@ -202,7 +203,8 @@ export default {
       this.recordLoaded = false;
       this.$store.dispatch('flushChangeHistory');
       this.$store.dispatch('setInspectorStatusValue', { property: 'focus', value: 'mainEntity' });
-      if (this.$route.name === 'Inspector') {
+
+      if (this.$route.name === 'Inspector' || this.$route.name == 'DocumentHistory') {
         console.log('Initializing view for existing document');
         this.documentId = this.$route.params.fnurgel;
         this.loadDocument();
@@ -404,12 +406,14 @@ export default {
     },
     loadDocument() {
       this.$store.dispatch('setInspectorStatusValue', { property: 'isNew', value: false });
+
       this.stopEditing();
       this.fetchDocument();
     },
     loadNewDocument() {
       const insertData = this.inspector.insertData;
       this.$store.dispatch('setInspectorStatusValue', { property: 'isNew', value: true });
+
       if (!insertData.hasOwnProperty('@graph') || insertData['@graph'].length === 0) {
         this.$store.dispatch('removeLoadingIndicator', 'Loading document');
         this.$router.go(-1);
@@ -425,8 +429,10 @@ export default {
       this.$store.dispatch('setInsertData', '');
       this.$store.dispatch('flushChangeHistory');
       this.$store.dispatch('saveLangTagSearch', '');
-      this.recordLoaded = true;
       this.$store.dispatch('removeLoadingIndicator', 'Loading document');
+
+      this.recordLoaded = true;
+
       this.$nextTick(() => {
         this.$store.dispatch('pushInspectorEvent', {
           name: 'record-events',
@@ -750,7 +756,6 @@ export default {
       return obj;
     },
   },
-  
   watch: {
     'inspector.data'(val, oldVal) {
       if (val !== oldVal) {
@@ -896,26 +901,30 @@ export default {
         this.initializeRecord();
         this.$emit('ready');
       }
+
       this.initializeWarnBeforeUnload();
       this.initJsonOutput();
     });
   },
 };
 </script>
+
 <template>
   <div class="Inspector row">
-    <div 
-      v-if="recordLoaded" 
-      class="col-sm-12" 
+    <div
+      v-if="recordLoaded"
+      class="col-sm-12"
       :class="{'col-md-11': !status.panelOpen, 'col-md-7': status.panelOpen, 'hideOnPrint': marcPreview.active}">
         <breadcrumb v-if="$route.meta.breadcrumb" class="Inspector-breadcrumb" />
     </div>
+
     <div ref="componentFocusTarget" class="col-12 col-sm-12" :class="{'col-md-1 col-md-offset-11': !status.panelOpen, 'col-md-5 col-md-offset-7': status.panelOpen }">
       <div v-if="recordLoaded && isDocumentAvailable" class="Toolbar-placeholder" ref="ToolbarPlaceholder"></div>
       <div v-if="recordLoaded && isDocumentAvailable" class="Toolbar-container" ref="ToolbarTest">
         <toolbar></toolbar>
       </div>
     </div>
+
     <div class="col-sm-12" :class="{'col-md-11': !status.panelOpen, 'col-md-7': status.panelOpen, 'hideOnPrint': marcPreview.active}" ref="Inspector">
       <div v-if="!recordLoaded && loadFailure">
         <h2>{{loadFailure.status}}</h2>
@@ -929,6 +938,7 @@ export default {
           {{ 'Back to home page' | translatePhrase }}
         </router-link>
       </div>
+
       <div v-if="recordLoaded && isDocumentAvailable == false">
         <h2>{{ 'Something went wrong' | translatePhrase }}</h2>
         <p>{{ 'The document was found but failed to load' | translatePhrase }}.</p>
@@ -936,6 +946,7 @@ export default {
           {{ 'Back to home page' | translatePhrase }}
         </router-link>
       </div>
+
       <div v-if="recordLoaded && isDocumentAvailable" class="Inspector-entity">
         <div class="Inspector-admin">
           <div class="Inspector-header">
@@ -964,9 +975,11 @@ export default {
         </entity-form>
       </div>
     </div>
+
     <portal to="sidebar" v-if="marcPreview.active">
       <marc-preview @hide="marcPreview.active = false" :error="marcPreview.error" :marc-obj="marcPreview.data" v-if="marcPreview.active"></marc-preview>
     </portal>
+
     <modal-component title="Error" modal-type="danger" @close="closeRemoveModal" class="RemoveRecordModal"
       v-if="removeInProgress">
       <div slot="modal-header" class="RemoveRecordModal-header">
@@ -984,6 +997,7 @@ export default {
         </div>
       </div>
     </modal-component>
+
     <modal-component class="EmbellishFromIdModal" :title="[embellishFromIdModal.detailed ? 'Detailed enrichment' : 'Enrich from ID']" v-if="embellishFromIdModal.open" @close="embellishFromIdModal.open = false">
       <div slot="modal-body" class="EmbellishFromIdModal-body">
         <div class="EmbellishFromIdModal-infoText" v-if="embellishFromIdModal.detailed === true">
@@ -1011,6 +1025,7 @@ export default {
     <modal-component class="DetailedEnrichmentModal" :title="'Detailed enrichment' | translatePhrase" v-if="inspector.status.detailedEnrichmentModal.open === true" @close="closeDetailedEnrichmentModal" :backdrop-close="false">
       <DetailedEnrichment slot="modal-body" :floating-dialogs="true" />
     </modal-component>
+
     <fullscreen-panel v-if="$route.params.view == 'history'">
       <version-history slot="content" />
     </fullscreen-panel>


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
Fixes the issue with user navigating to resource history view directly and page redirecting unexpectedly.

### Tickets involved
[LXL-4036](https://jira.kb.se/browse/LXL-4036)

### Solves
Mounting Inspector view in history view

### Summary of changes
* Add support for "DocumentHistory" view when initializing resource inspector view
* Add null check for missing refs in App component
* Small formatting in documents