### PR TITLE
fix .env file location

### DIFF
--- a/nuxt-app/nuxt.config.js
+++ b/nuxt-app/nuxt.config.js
@@ -58,7 +58,12 @@ export default {
 
   // Modules for dev and build (recommended): https://go.nuxtjs.dev/config-modules
   buildModules: [
-    '@nuxtjs/dotenv'
+    [
+      '@nuxtjs/dotenv',
+      {
+        'path': "./"
+      }
+    ]
   ],
 
   // Modules: https://go.nuxtjs.dev/config-modules


### PR DESCRIPTION
## Checklist:
- [ x] I have run unit tests. `yarn test`

## Description

Noticed a regression currently present on id-dev.kb.se (after moving all source to src/).
Console log says: "[Error] env.XL_SITE_CONFIG not defined (fix for development: copy .env.in to .env)"

By pointing out location of .env the problem seems to be fixed.