### PR TITLE
Don't fail when a repeatable property isn't an array

### DIFF
--- a/vue-client/src/components/mixins/language-mixin.vue
+++ b/vue-client/src/components/mixins/language-mixin.vue
@@ -168,7 +168,7 @@ export default {
       const lastIndex = this.path.lastIndexOf('.');
       const parentsPath = this.path.slice(0, lastIndex);
       const parent = cloneDeep(get(this.inspector.data, parentsPath));
-      if (this.isRepeatable) {
+      if (Array.isArray(this.prop)) {
         const prop = parent[this.getPropKey()];
         prop.splice(this.prop.indexOf(sourceValue), 1);
         if (isEmpty(prop)) {


### PR DESCRIPTION
## Checklist:
- [ x] I have run the unit tests. `yarn test:unit`
- [ x] I have run the linter. `yarn lint`

## Description
During QA-testing some users noticed that it language tags cannot be added in some cases, e.g. in PrimaryPublication->Place on https://libris-qa.kb.se/ctr9t1f798vdw4r 

### Tickets involved
[LXL-4009](https://jira.kb.se/browse/LXL-4009)

### Solves
No longer fail when a repeatable property isn't an array.

### Summary of changes

Replace check for repeatability with check if we are dealing with an array.