### PR TITLE
Make it possible to inject env variables at runtime

### DIFF
--- a/nuxt-app/nuxt.config.js
+++ b/nuxt-app/nuxt.config.js
@@ -1,8 +1,6 @@
 const { gitDescribeSync } = require('git-describe');
-import { defaultHostPath } from './src/plugins/env';
-const HOST_PATH = defaultHostPath();
-process.env.APP_VERSION = require('./package.json').version;
 
+process.env.APP_VERSION = require('./package.json').version;
 process.env.GIT_DESCRIBE = JSON.stringify(gitDescribeSync({
   longSemver: true,
   dirtySemver: false,
@@ -12,28 +10,30 @@ process.env.GIT_DESCRIBE = JSON.stringify(gitDescribeSync({
 
 export default {
   // Global page headers: https://go.nuxtjs.dev/config-head
-  head: {
-    title: 'id.kb.se',
-    htmlAttrs: {
-      lang: 'sv'
-    },
-    meta: [
-      { charset: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { hid: 'description', name: 'description', content: 'Grundstenar för länkade data hos Kungliga biblioteket.' },
-      { hid:'og:title', property:'og:title', content:'id.kb.se' },
-      { hid:'og:site_name', property:'og:site_name', content:'id.kb.se' },
-      { hid:'og:description', property:'og:description', content:'Grundstenar för länkade data hos Kungliga biblioteket.' },
-      { hid:'og:image', property:'og:image', content:`${HOST_PATH}/opengraph_id.png` },
-      { hid:'og:image:width', property:'og:image:width', content:'1200' },
-      { hid:'og:image:height', property:'og:image:height', content:'600' },
-      { hid:'twitter:image', property:'twitter:image', content:`${HOST_PATH}/opengraph_id.png` },
-      { hid:'twitter:card', name:'twitter:card', content:'summary_large_image' },
-    ],
-    link: [
-      { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
-      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
-    ]
+  head() {
+    return {
+      title: 'id.kb.se',
+      htmlAttrs: {
+        lang: 'sv'
+      },
+      meta: [
+        { charset: 'utf-8' },
+        { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+        { hid: 'description', name: 'description', content: 'Grundstenar för länkade data hos Kungliga biblioteket.' },
+        { hid:'og:title', property:'og:title', content:'id.kb.se' },
+        { hid:'og:site_name', property:'og:site_name', content:'id.kb.se' },
+        { hid:'og:description', property:'og:description', content:'Grundstenar för länkade data hos Kungliga biblioteket.' },
+        { hid:'og:image', property:'og:image', content:`${this.$defaultHostPath()}/opengraph_id.png` },
+        { hid:'og:image:width', property:'og:image:width', content:'1200' },
+        { hid:'og:image:height', property:'og:image:height', content:'600' },
+        { hid:'twitter:image', property:'twitter:image', content:`${this.$defaultHostPath()}/opengraph_id.png` },
+        { hid:'twitter:card', name:'twitter:card', content:'summary_large_image' },
+      ],
+      link: [
+        { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
+        { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
+      ]
+    }
   },
 
   // Global CSS: https://go.nuxtjs.dev/config-css
@@ -45,6 +45,7 @@ export default {
   plugins: [
     '~plugins/filters.js',
     '~mixins/lxl.js',
+    '~plugins/envInjects.js',
   ],
 
   router: {
@@ -88,7 +89,13 @@ export default {
 
   publicRuntimeConfig: {
     siteName: 'id.kb.se',
-    environment: process.env.ENV,
+    environment: process.env.ENV || 'local',
+    defaultSite: process.env.DEFAULT_SITE || 'id.kb.se',
+    siteAlias: JSON.parse(process.env.XL_SITE_ALIAS || '{}'),
+    siteConfig: JSON.parse(process.env.XL_SITE_CONFIG || '{}'),
+    vocab: process.env.XL_VOCAB || 'https://id.kb.se/vocab/data.jsonld',
+    context: process.env.XL_CONTEXT || 'https://id.kb.se/context.jsonld',
+    display: process.env.XL_DISPLAY || 'https://id.kb.se/vocab/display/data.jsonld'
   },
 
   privateRuntimeConfig: {

--- a/nuxt-app/src/components/EntityTable.vue
+++ b/nuxt-app/src/components/EntityTable.vue
@@ -22,7 +22,7 @@
     <template v-if="isMainEntity">
       <div class="PropertyRow d-md-flex" v-if="showDownload">
         <div class="PropertyRow-bodyKey d-block d-md-inline">{{ translateUi('Download') }}</div>
-        <div class="PropertyRow-bodyValue"><a :href="`${ recordId }/data.jsonld` | translateAliasedUri">JSON-LD</a> • <a :href="`${ recordId }/data.ttl` | translateAliasedUri">Turtle</a> • <a :href="`${ recordId }/data.rdf` | translateAliasedUri">RDF/XML</a></div>
+        <div class="PropertyRow-bodyValue"><a :href="this.$translateAliasedUri(`${ recordId }/data.jsonld`)">JSON-LD</a> • <a :href="this.$translateAliasedUri(`${ recordId }/data.ttl`)">Turtle</a> • <a :href="this.$translateAliasedUri(`${ recordId }/data.rdf`)">RDF/XML</a></div>
       </div>
       <div class="PropertyRow d-md-flex" v-if="showOtherServices">
         <div class="PropertyRow-bodyKey d-block d-md-inline">{{ translateUi('Other sites') }}</div>

--- a/nuxt-app/src/components/NavMenu.vue
+++ b/nuxt-app/src/components/NavMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="{ 'collapse': !expanded }" class="navbar-collapse NavMenu" id="navbarNav">
-    <ul class="navbar-nav" v-if="appState.domain === settings.defaultSite">
+    <ul class="navbar-nav" v-if="appState.domain === $config.defaultSite">
       <li class="nav-item">
         <NuxtLink @click.native="linkActivated" to="/" class="nav-link" :class="{'active': $route.name == 'find' || $route.name == 'index' }">{{ translateUi('Search') }}</NuxtLink>
       </li>

--- a/nuxt-app/src/components/Navbar.vue
+++ b/nuxt-app/src/components/Navbar.vue
@@ -32,6 +32,9 @@ export default {
   data() {
     return {
       expanded: false,
+      defaultSite: this.$config.defaultSite,
+      siteConfig: this.$config.siteConfig,
+      environment: this.$config.environment
     }
   },
   computed: {
@@ -44,7 +47,7 @@ export default {
       return hash.substr(1, hash.length);
     },
     siteTitle() {
-      return this.settings.siteConfig[this.appState.domain].title || this.settings.defaultSite;
+      return this.siteConfig[this.appState.domain].title || this.defaultSite;
     },
     version() {
       return this.settings.version;
@@ -53,8 +56,8 @@ export default {
       return `${this.environmentLabel.toUpperCase()} ${this.version}`;
     },
     environmentLabel() {
-      if (this.settings.environment !== 'prod') {
-        return this.settings.environment;
+      if (this.environment !== 'prod') {
+        return this.environment;
       }
       return '';
     },

--- a/nuxt-app/src/components/SearchBar.vue
+++ b/nuxt-app/src/components/SearchBar.vue
@@ -29,7 +29,6 @@
 // import mockSuggest from '@/resources/json/mockSuggest.json';
 import { mapGetters } from 'vuex';
 import SuggestItem from '@/components/SuggestItem';
-import { encodeSpecialChars } from '../plugins/env';
 
 export default {
   data() {
@@ -112,7 +111,7 @@ export default {
     },
     async doSuggestSearch() {
       this.clearSuggest();
-      const searchPath = `find.jsonld?q=${encodeSpecialChars(this.keyword)}&_lens=chips&_suggest=${this.settings.language}&_limit=7`;
+      const searchPath = `find.jsonld?q=${this.$encodeSpecialChars(this.keyword)}&_lens=chips&_suggest=${this.settings.language}&_limit=7`;
       const suggestData = await fetch(`${this.activeHost()}/${searchPath}`).then(res => res.json());
       this.suggestedItems = suggestData.items;
       // const suggestData = mockSuggest;

--- a/nuxt-app/src/layouts/default.vue
+++ b/nuxt-app/src/layouts/default.vue
@@ -15,23 +15,23 @@
 import Navbar from '@/components/Navbar';
 import SearchBar from '@/components/SearchBar';
 import Footer from '@/components/Footer';
-import { defaultHostPath } from '../plugins/env';
-const HOST_PATH = defaultHostPath();
 
 export default {
   data() {
     return {
     }
   },
-  head: {
-    meta: [
-      { hid: 'description', name: 'description', content: 'Grundstenar för länkade data hos Kungliga biblioteket.' },
-      { hid:'og:title', property:'og:title', content:'id.kb.se' },
-      { hid:'og:site_name', property:'og:site_name', content:'id.kb.se' },
-      { hid:'og:description', property:'og:description', content:'Grundstenar för länkade data hos Kungliga biblioteket.' },
-      { hid:'og:image', property:'og:image', content:`${HOST_PATH}/opengraph_id.png` },
-      { hid:'twitter:image', property:'twitter:image', content:`${HOST_PATH}/opengraph_id.png` },
-    ],
+  head() {
+    return {
+      meta: [
+        { hid: 'description', name: 'description', content: 'Grundstenar för länkade data hos Kungliga biblioteket.' },
+        { hid:'og:title', property:'og:title', content:'id.kb.se' },
+        { hid:'og:site_name', property:'og:site_name', content:'id.kb.se' },
+        { hid:'og:description', property:'og:description', content:'Grundstenar för länkade data hos Kungliga biblioteket.' },
+        { hid:'og:image', property:'og:image', content:`${this.$defaultHostPath()}/opengraph_id.png` },
+        { hid:'twitter:image', property:'twitter:image', content:`${this.$defaultHostPath()}/opengraph_id.png` },
+      ]
+    }
   },
   computed: {
   },

--- a/nuxt-app/src/layouts/libris.vue
+++ b/nuxt-app/src/layouts/libris.vue
@@ -11,23 +11,23 @@
 
 <script>
 import Navbar from '@/components/Navbar';
-import { defaultHostPath } from '../plugins/env';
-const HOST_PATH = defaultHostPath();
 
 export default {
   data() {
     return {
     }
   },
-  head: {
-    meta: [
-      { hid: 'description', name: 'description', content: 'Länkad data hos Libris' },
-      { hid:'og:title', property:'og:title', content:'Libris' },
-      { hid:'og:site_name', property:'og:site_name', content:'Libris' },
-      { hid:'og:description', property:'og:description', content:'Länkad data hos Libris' },
-      { hid:'og:image', property:'og:image', content:`${HOST_PATH}/opengraph_libris.png` },
-      { hid:'twitter:image', property:'twitter:image', content:`${HOST_PATH}/opengraph_libris.png` },
-    ],
+  head() {
+    return {
+      meta: [
+        { hid: 'description', name: 'description', content: 'Länkad data hos Libris' },
+        { hid:'og:title', property:'og:title', content:'Libris' },
+        { hid:'og:site_name', property:'og:site_name', content:'Libris' },
+        { hid:'og:description', property:'og:description', content:'Länkad data hos Libris' },
+        { hid:'og:image', property:'og:image', content:`${this.$defaultHostPath()}/opengraph_libris.png` },
+        { hid:'twitter:image', property:'twitter:image', content:`${this.$defaultHostPath()}/opengraph_libris.png` },
+      ]
+    }
   },
   computed: {
   },

--- a/nuxt-app/src/mixins/lxl.js
+++ b/nuxt-app/src/mixins/lxl.js
@@ -3,7 +3,6 @@ import * as StringUtil from 'lxljs/string';
 import Vue from "vue"
 import rdfTranslations from '@/resources/json/rdfTranslations.json';
 import i18n from '@/resources/json/i18n.json';
-import { translateAliasedUri } from '../plugins/env';
 
 // Make sure to pick a unique name for the flag
 // so it won't conflict with any other mixin.
@@ -48,13 +47,13 @@ if (!Vue.__lxl_global_mixin__) {
         return uri.startsWith(this.baseUri());
       },
       baseUri() {
-        return this.settings.siteConfig[this.appState.domain].baseUri;
+        return this.$config.siteConfig[this.appState.domain].baseUri;
       },
       translateUriEnv(uri) {
-        return translateAliasedUri(uri)
+        return this.$translateAliasedUri(uri)
       },
       activeHost() {
-        return translateAliasedUri(this.baseUri())
+        return this.$translateAliasedUri(this.baseUri())
       },
       getEntityTitle(entity) {
         if (entity != null) {

--- a/nuxt-app/src/modules/vocab-cache.js
+++ b/nuxt-app/src/modules/vocab-cache.js
@@ -1,5 +1,5 @@
 import fetch from "node-fetch";
-import {CONTEXT, DISPLAY, translateAliasedUri, VOCAB} from "../plugins/env";
+import {translateAliasedUri} from "../plugins/env";
 import * as VocabUtil from "lxljs/vocab";
 import * as DisplayUtil from "lxljs/display";
 
@@ -12,13 +12,13 @@ const toJson = response => {
   }
 }
 
-async function fetchVocab() {
+async function fetchVocab(publicRuntimeConfig) {
   const vocabCache = {};
 
   await Promise.all([
-    fetch(translateAliasedUri(CONTEXT)).then(toJson),
-    fetch(translateAliasedUri(VOCAB)).then(toJson),
-    fetch(translateAliasedUri(DISPLAY)).then(toJson)
+    fetch(translateAliasedUri(publicRuntimeConfig.context, publicRuntimeConfig.siteAlias)).then(toJson),
+    fetch(translateAliasedUri(publicRuntimeConfig.vocab, publicRuntimeConfig.siteAlias)).then(toJson),
+    fetch(translateAliasedUri(publicRuntimeConfig.display, publicRuntimeConfig.siteAlias)).then(toJson)
   ])
     .then(v => {
       let context, vocab, display;
@@ -39,9 +39,9 @@ export default function (_moduleOptions) {
   // shared by all requests
   let cache;
 
-  async function getVocab() {
+  async function getVocab(publicRuntimeConfig) {
     if (!cache || cache.error) {
-      cache = await fetchVocab();
+      cache = await fetchVocab(publicRuntimeConfig);
     }
 
     return cache;
@@ -49,6 +49,6 @@ export default function (_moduleOptions) {
 
   // called before server-side rendering
   this.nuxt.hook("vue-renderer:ssr:prepareContext", async (ssrContext) => {
-    ssrContext.$vocab = await getVocab();
+    ssrContext.$vocab = await getVocab(this.options.publicRuntimeConfig);
   });
 }

--- a/nuxt-app/src/pages/_.vue
+++ b/nuxt-app/src/pages/_.vue
@@ -32,9 +32,6 @@ import * as DataUtil from 'lxljs/data';
 import LensMixin from '@/mixins/lens';
 import ResultItem from '@/components/ResultItem';
 
-import { translateAliasedUri } from '../plugins/env';
-import { encodeSpecialChars } from '../plugins/env';
-
 export default {
   mixins: [LensMixin],
   layout (context) {
@@ -93,11 +90,11 @@ export default {
   methods: {
     ...mapActions(['setCurrentDocument']),
   },
-  async asyncData({ error, route, store, redirect }) {
+  async asyncData({ error, route, store, redirect, app, $config }) {
     const domain = store.getters.appState.domain
-    const siteConfig = store.getters.settings.siteConfig
-    const host = translateAliasedUri(siteConfig[domain].baseUri)
-    const path = encodeSpecialChars(route.path);
+    const siteConfig = $config.siteConfig
+    const host = app.$translateAliasedUri(siteConfig[domain].baseUri)
+    const path = app.$encodeSpecialChars(route.path);
     const pageData = await fetch(`${host}${path}`,
       {
         headers: { 'Accept': 'application/ld+json' },
@@ -112,7 +109,7 @@ export default {
         // We're on the client side and got redirected to the page we're already on
       }
       else if (response.status === 302) {
-        const url = translateAliasedUri(response.headers.get('Location'))
+        const url = app.$translateAliasedUri(response.headers.get('Location'))
         console.log (`REDIRECTING: ${host}${path} -> ${url}`)
         redirect(url);
       }

--- a/nuxt-app/src/pages/doc/_article.vue
+++ b/nuxt-app/src/pages/doc/_article.vue
@@ -11,7 +11,6 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import {translateAliasedUri} from '../../plugins/env';
 
 export default {
   head() {
@@ -29,10 +28,10 @@ export default {
   computed: {
     ...mapGetters(['settings']),
   },
-  async asyncData({ $config, error, route, params, $http, store }) {
+  async asyncData({ $config, error, route, params, $http, store, app }) {
     const domain = store.getters.appState.domain
-    const siteConfig = store.getters.settings.siteConfig
-    const host = translateAliasedUri(siteConfig[domain].baseUri)
+    const siteConfig = $config.siteConfig
+    const host = app.$translateAliasedUri(siteConfig[domain].baseUri)
 
     const pageData = await $http.$get(`${host}/doc/${params.article}/data.jsonld`).catch((err) => {
       error({ statusCode: err.statusCode, message: err.message })

--- a/nuxt-app/src/pages/find/index.vue
+++ b/nuxt-app/src/pages/find/index.vue
@@ -38,8 +38,6 @@ import SortSelect from '@/components/SortSelect';
 import PageStatus from '@/components/PageStatus';
 import ResultItem from '@/components/ResultItem';
 import Pagination from '@/components/Pagination';
-import {translateAliasedUri} from "../../plugins/env";
-import {encodeSpecialChars} from "../../plugins/env";
 
 export default {
   head() {
@@ -66,17 +64,16 @@ export default {
   computed: {
     ...mapGetters(['collections', 'appState']),
   },
-  async asyncData({ $config, route, params, $http, store }) {
+  async asyncData({ $config, route, params, $http, store, app }) {
     const domain = store.getters.appState.domain
-    const siteConfig = store.getters.settings.siteConfig
-    const host = translateAliasedUri(siteConfig[domain].baseUri)
-
+    const siteConfig = $config.siteConfig
+    const host = app.$translateAliasedUri(siteConfig[domain].baseUri)
     const query = route.query;
     let queryString = '';
 
-    Object.entries(query).forEach(([key, val]) => queryString += `${key}=${encodeSpecialChars(val)}&`);
+    Object.entries(query).forEach(([key, val]) => queryString += `${key}=${app.$encodeSpecialChars(val)}&`);
     const pageData = await $http.$get(`${host}/find.jsonld?${queryString}`);
-    const collectionResults = await $http.$get(`${host}/find.jsonld?q=${encodeSpecialChars(route.query.q)}&_limit=0`);
+    const collectionResults = await $http.$get(`${host}/find.jsonld?q=${app.$encodeSpecialChars(route.query.q)}&_limit=0`);
     return {
       pageData,
       collectionResults,

--- a/nuxt-app/src/pages/index.vue
+++ b/nuxt-app/src/pages/index.vue
@@ -15,19 +15,17 @@
 
 <script>
 import CollectionCard from '@/components/CollectionCard';
-import { defaultHostPath } from '../plugins/env';
-const HOST_PATH = defaultHostPath();
 
 export default {
   data() {
     return {
     }
   },
-  async asyncData({ $config, params, $http }) {
-    const pageData = await $http.$get(`${HOST_PATH}/data.jsonld`);
+  async asyncData({ $config, params, $http, app}) {
+    const pageData = await $http.$get(`${app.$defaultHostPath()}/data.jsonld`);
     let summary;
     try {
-      summary = await $http.$get(`${HOST_PATH}/doc/summary/data.jsonld`);
+      summary = await $http.$get(`${app.$defaultHostPath()}/doc/summary/data.jsonld`);
     } catch (e) {
       summary = null;
     }

--- a/nuxt-app/src/plugins/env.js
+++ b/nuxt-app/src/plugins/env.js
@@ -1,35 +1,16 @@
 import { each, findKey } from "lodash-es";
 
-if (!process.env.XL_SITE_CONFIG) {
-  throw 'env.XL_SITE_CONFIG not defined (fix for development: copy .env.in to .env)'
+export function hostPath(site, siteAlias, siteConfig) {
+  const baseUri = siteConfig[site]['baseUri'];
+  return translateAliasedUri(baseUri, siteAlias);
 }
 
-const SITE_ALIAS = JSON.parse(process.env.XL_SITE_ALIAS || '{}');
-const SITE_CONFIG = JSON.parse(process.env.XL_SITE_CONFIG);
-
-export const VOCAB = process.env.XL_VOCAB || 'https://id.kb.se/vocab/data.jsonld'
-export const CONTEXT = process.env.XL_CONTEXT || 'https://id.kb.se/context.jsonld'
-export const DISPLAY = process.env.XL_DISPLAY || 'https://id.kb.se/vocab/display/data.jsonld'
-
-export function defaultHostPath() {
-  return hostPath(defaultSite())
-}
-
-export function hostPath(site) {
-  const baseUri = siteConfig()[site]['baseUri'];
-  return translateAliasedUri(baseUri);
-}
-
-export function siteConfig() {
-  return SITE_CONFIG;
-}
-
-export function translateAliasedUri(uri) {
+export function translateAliasedUri(uri, siteAlias) {
   if (typeof uri == 'undefined' || uri.length === 0) {
     return null;
   }
   let translatedUri = uri
-  each(SITE_ALIAS, (from, to) => {
+  each(siteAlias, (from, to) => {
     if (uri.startsWith(from)) {
       translatedUri = uri.replace(from, to);
       return false;
@@ -49,16 +30,12 @@ export function encodeSpecialChars(path) {
     .replace(/&/g, '%26');
 }
 
-export function defaultSite() {
-  return process.env.DEFAULT_SITE || 'id.kb.se';
-}
-
-export function activeSite(xForwardedHost) {
+export function activeSite(xForwardedHost, siteAlias, siteConfig, defaultSite) {
   if (!xForwardedHost) {
-    return defaultSite();
+    return defaultSite;
   }
 
-  return findKey(siteConfig(), c => xForwardedHost.startsWith(host(translateAliasedUri(c.baseUri)))) || defaultSite();
+  return findKey(siteConfig, c => xForwardedHost.startsWith(host(translateAliasedUri(c.baseUri, siteAlias)))) || defaultSite;
 }
 
 function host(url) {

--- a/nuxt-app/src/plugins/envInjects.js
+++ b/nuxt-app/src/plugins/envInjects.js
@@ -1,0 +1,12 @@
+import { hostPath, translateAliasedUri, encodeSpecialChars, activeSite } from '../plugins/env';
+
+export default (context, inject) => {
+  if (Object.keys(context.$config.siteConfig).length === 0) {
+    throw 'env.XL_SITE_CONFIG not defined (fix for development: copy .env.in to .env)'
+  }
+
+  inject('defaultHostPath', () => hostPath(context.$config.defaultSite, context.$config.siteAlias, context.$config.siteConfig));
+  inject('translateAliasedUri', uri => translateAliasedUri(uri, context.$config.siteAlias)),
+  inject('encodeSpecialChars', path => encodeSpecialChars(path)),
+  inject('activeSite', xForwardedHost => activeSite(xForwardedHost, context.$config.siteAlias, context.$config.siteConfig,  context.$config.defaultSite))
+}

--- a/nuxt-app/src/plugins/filters.js
+++ b/nuxt-app/src/plugins/filters.js
@@ -1,11 +1,5 @@
 import Vue from 'vue'
 
-import { translateAliasedUri } from './env';
-
-Vue.filter('translateAliasedUri', (uri) => {
-  return translateAliasedUri(uri);
-});
-
 Vue.filter('fixMarcUri', (uri) => {
   const newUri = uri.replace('/marc/', '/vocab/marc:');
   return newUri;

--- a/nuxt-app/src/store/index.js
+++ b/nuxt-app/src/store/index.js
@@ -1,7 +1,6 @@
 import * as VocabUtil from 'lxljs/vocab';
 import * as DisplayUtil from 'lxljs/display';
 import translationsFile from '@/resources/json/i18n.json';
-import {VOCAB, CONTEXT, DISPLAY, siteConfig, activeSite, defaultSite, translateAliasedUri} from '../plugins/env';
 
 export const state = () => ({
   vocab: null,
@@ -23,9 +22,6 @@ export const state = () => ({
     language: 'sv',
     version: process.env.APP_VERSION,
     gitDescribe: process.env.GIT_DESCRIBE,
-    siteConfig: siteConfig(),
-    defaultSite: defaultSite(),
-    environment: process.env.ENV || 'local',
     filteredCategories: [
       'pending',
       'shorthand',
@@ -220,8 +216,8 @@ export const mutations = {
 }
 
 export const actions = {
-  async nuxtServerInit({ commit, dispatch }, { req, error, ssrContext }) {
-    dispatch('setAppState', { property: 'domain', value: activeSite(req.headers['x-forwarded-host']) });
+  async nuxtServerInit({ commit, dispatch,  }, { req, error, ssrContext, app }) {
+    dispatch('setAppState', { property: 'domain', value: app.$activeSite(req.headers['x-forwarded-host']) });
 
     const vocab = ssrContext.$vocab;
     if (vocab.error) {


### PR DESCRIPTION
## Checklist:
- [x ] I have run the unit tests. `yarn test`

## Description
*DEPENDS ON:* https://github.com/libris/devops/pull/154

### Tickets involved
[LXL-3956](https://jira.kb.se/browse/LXL-3956)


### Summary of changes

Moved build-time state from env.js. Instead inject functions and make use of publicRuntimeConfig, which can be retrieved in different ways depending of the context.
