### PR TITLE
Check for conflicting ids before adding to path object in version-history

### DIFF
--- a/vue-client/src/components/inspector/version-history.vue
+++ b/vue-client/src/components/inspector/version-history.vue
@@ -274,9 +274,17 @@ export default {
             if (!conflictingPathNames) {
               // Under the same parent property but not the same key
               if (Array.isArray(addedEntity)) {
-                objAtPath.push(...addedEntity);
+                addedEntity.forEach((entity) => {
+                  const inPath = objAtPath.find(pathObject => pathObject['@id'] == entity['@id']);
+                  if (inPath == null) {
+                    objAtPath.push(entity);
+                  }
+                });
               } else {
-                objAtPath.push(addedEntity);
+                const inPath = objAtPath.find(pathObject => pathObject['@id'] == entity['@id']);
+                if (inPath == null) {
+                  objAtPath.push(addedEntity);
+                }
               }
 
               return parentPath;

--- a/vue-client/src/components/inspector/version-history.vue
+++ b/vue-client/src/components/inspector/version-history.vue
@@ -275,13 +275,13 @@ export default {
               // Under the same parent property but not the same key
               if (Array.isArray(addedEntity)) {
                 addedEntity.forEach((entity) => {
-                  const inPath = objAtPath.find(pathObject => pathObject['@id'] == entity['@id']);
+                  const inPath = objAtPath.find(pathObject => pathObject['@id'] === entity['@id']);
                   if (inPath == null) {
                     objAtPath.push(entity);
                   }
                 });
               } else {
-                const inPath = objAtPath.find(pathObject => pathObject['@id'] == entity['@id']);
+                const inPath = objAtPath.find(pathObject => pathObject['@id'] === addedEntity['@id']);
                 if (inPath == null) {
                   objAtPath.push(addedEntity);
                 }


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

### Description
Makes sure no duplicate data is displayed in history view when e.g. one genre is added and others already exists.

### Tickets involved
[LXL-3991](https://jira.kb.se/browse/LXL-3991)
