### PR TITLE
Cache bust runtimeConfig.js using app version

### DIFF
--- a/vue-client/public/index.html
+++ b/vue-client/public/index.html
@@ -15,7 +15,7 @@
     <meta property="og:image:height" content="600">
     <meta property="twitter:image" content="https://libris.kb.se<%= BASE_URL %>opengraph.png">
     <meta name="twitter:card" content="summary_large_image">
-    <script src="<%= BASE_URL %>runtimeConfig.js"></script>
+    <script src="<%= BASE_URL %>runtimeConfig.js?v=<%= VUE_APP_VERSION %>"></script>
   </head>
   <body>
     <div id="oldbrowsermsg" style="display:none">


### PR DESCRIPTION
## Description

VUE_APP_VERSION contains the git tag, set via vue.config.js and injected in dist/index.html at build time. The index file has no cache set by the server, but we use this pattern since most of the built files have similar (albeit hash-based) cache-busting URL:s.

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`


### Solves
Risk of using browser-cached and stale runtime config.

### Summary of changes
Add GET-parameter with app version (ignored by apache but considered as a different URL by browsers).