### PR TITLE
Fix set focus for newly added lang-tagged fields

### DIFF
--- a/vue-client/src/components/inspector/field.vue
+++ b/vue-client/src/components/inspector/field.vue
@@ -85,6 +85,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    isFirstField: {
+      type: Boolean,
+      default: false,
+    },
     oldValue: {
       type: [Array, String, Object],
       default: null,
@@ -902,6 +906,7 @@ export default {
       <item-bylang
         v-if="getDatatype(firstInValueAsArray) == 'language'"
         :is-locked="locked"
+        :is-first-field="isFirstField"
         :field-value="valueAsArray"
         :field-key="fieldKey"
         :parent-path="path"
@@ -1012,6 +1017,7 @@ export default {
         <item-bylang
           v-if="getDatatype(firstInValueAsArray) == 'language'"
           :is-locked="locked"
+          :is-first-field="isFirstField"
           :field-value="valueAsArray"
           :field-key="fieldKey"
           :parent-path="path"

--- a/vue-client/src/components/inspector/item-bylang.vue
+++ b/vue-client/src/components/inspector/item-bylang.vue
@@ -19,6 +19,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    isFirstField: {
+      type: Boolean,
+      default: false,
+    },
     diff: {
       type: Object,
       default: null,
@@ -316,6 +320,7 @@ export default {
         :tag="entry.tag"
         :id="entry.id"
         :is-locked="isLocked"
+        :is-first-field="isFirstField"
         :remove-is-allowed="removeIsAllowed"
         :uri="uriFor(entry.tag)"
         :label="getLabelFromCache(entry.tag)"

--- a/vue-client/src/components/inspector/item-local.vue
+++ b/vue-client/src/components/inspector/item-local.vue
@@ -572,12 +572,13 @@ export default {
     <ul class="ItemLocal-list js-itemLocalFields" v-show="expanded">
       <field
         v-show="k !== '_uid'" 
-        v-for="(v, k) in filteredItem"
+        v-for="(v, k, i) in filteredItem"
         :parent-path="getPath" 
         :entity-type="item['@type']" 
         :is-inner="true" 
         :is-locked="isLocked" 
         :is-removable="false" 
+        :is-first-field="i===0"
         :parent-key="fieldKey" 
         :parent-index="index" 
         :parent-accepted-types="acceptedTypes"

--- a/vue-client/src/components/inspector/language-entry.vue
+++ b/vue-client/src/components/inspector/language-entry.vue
@@ -60,6 +60,7 @@ export default {
       'settings',
       'resources',
       'supportedTags',
+      'status',
     ]),
     isByLang() {
       return this.itemPath.includes('ByLang');
@@ -93,6 +94,19 @@ export default {
       if (this.diff == null) return false;
       return this.diff.modified.some(m => isEqual(m.path, this.exactPath));
     },
+    shouldFocus() {
+      const lastAdded = this.inspector.status.lastAdded;
+      if (lastAdded === this.exactPath || this.itemPath.startsWith(lastAdded)) {
+        return true;
+      }
+      return false;
+    },
+    isLastAdded() {
+      if (this.inspector.status.lastAdded === this.exactPath) {
+        return true;
+      }
+      return false;
+    },
   },
   components: {
     PreviewCard,
@@ -116,6 +130,22 @@ export default {
         AutoSize.update(textarea);
       });
     },
+    addFocus() {
+      this.$refs.textarea.focus({ preventScroll: true }); // Prevent scroll as we will handle this ourselves
+    },
+    highLightLastAdded() {
+      if (this.isLastAdded === true) {
+        const element = this.$el;
+        // FIXME: the highlighting is not visible
+        element.classList.add('is-lastAdded');
+        setTimeout(() => {
+          element.classList.remove('is-lastAdded');
+          if (this.isLastAdded) {
+            this.$store.dispatch('setInspectorStatusValue', { property: 'lastAdded', value: '' });
+          }
+        }, 1000);
+      }
+    },
   },
   mounted() {
     if (this.tag !== 'none') {
@@ -128,7 +158,11 @@ export default {
 
     this.$nextTick(() => {
       if (!this.isLocked) {
+        this.highLightLastAdded();
         this.initializeTextarea();
+        if (!this.status.isNew && this.shouldFocus) {
+          this.addFocus();
+        }
       }
     });
   },
@@ -447,6 +481,16 @@ export default {
   }
   &-popover > .trigger {
     max-width: 100%;
+  }
+
+  &.is-lastAdded {
+    background-color: @form-add;
+    -webkit-animation-duration: 1s;
+    animation-duration: 1s;
+    -webkit-animation-fill-mode: both;
+    animation-fill-mode: both;
+    -webkit-animation-name: pulse;
+    animation-name: pulse;
   }
 }
 </style>

--- a/vue-client/src/components/inspector/language-entry.vue
+++ b/vue-client/src/components/inspector/language-entry.vue
@@ -25,6 +25,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    isFirstField: {
+      type: Boolean,
+      default: false,
+    },
     removeIsAllowed: {
       type: Boolean,
       default: false,
@@ -96,7 +100,7 @@ export default {
     },
     shouldFocus() {
       const lastAdded = this.inspector.status.lastAdded;
-      if (lastAdded === this.exactPath || this.itemPath.startsWith(lastAdded)) {
+      if (lastAdded === this.exactPath || (this.isFirstField && this.itemPath.startsWith(lastAdded))) {
         return true;
       }
       return false;

--- a/vue-client/src/components/mixins/language-mixin.vue
+++ b/vue-client/src/components/mixins/language-mixin.vue
@@ -244,6 +244,10 @@ export default {
         } else {
           updateVal = [].concat(updateVal, '');
         }
+        this.$store.dispatch('setInspectorStatusValue', {
+          property: 'lastAdded',
+          value: `${this.getPropPath()}[${updateVal.length - 1}]`,
+        });
         this.$store.dispatch('updateInspectorData', {
           changeList: [
             {
@@ -254,6 +258,10 @@ export default {
           addToHistory: true,
         });
       } else {
+        this.$store.dispatch('setInspectorStatusValue', {
+          property: 'lastAdded',
+          value: `${this.getPropPath()}[0]`,
+        });
         this.$store.dispatch('updateInspectorData', {
           changeList: [
             {


### PR DESCRIPTION
Newly added text input fields should be focused.

Still not working:
- highlighting

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4076](https://jira.kb.se/browse/LXL-4076)

### Solves

Input fields for properties that can be language tagged did not get their focus set.

### Summary of changes
Works in the same way as all other item-foo controls
