### PR TITLE
Back button -> navigate to record

### DIFF
--- a/vue-client/src/components/inspector/version-history.vue
+++ b/vue-client/src/components/inspector/version-history.vue
@@ -168,6 +168,10 @@ export default {
     isListItem(path) {
       return path.slice(-1) === ']';
     },
+    goToRecord() {
+      const fnurgel = this.$route.params.fnurgel;
+      this.$router.push({ path: `/${fnurgel}` });
+    },
     changeSelectedVersion(val) {
       this.selectedVersion = val;
       this.closeSideCol();
@@ -398,7 +402,7 @@ export default {
         <div class="VersionHistory-mainCol">
           <div class="VersionHistory-header">
             <span class="VersionHistory-backLink">
-              <a @click="$router.go(-1)" @keyup.enter="$router.go(-1)" tabindex="0">
+              <a @click="goToRecord" @keyup.enter="goToRecord" tabindex="0">
                 <i class="fa fa-arrow-left VersionHistory-back-icon"></i>{{ 'Back' | translatePhrase }}
               </a>
             </span>


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4079](https://jira.kb.se/browse/LXL-4079)

### Solves

The back button in the history view navigates the user back to the previous page visited. This is a problem when going to the history view by directly specifying the path with `/history`.
### Summary of changes

Summary of changes
The back-button always leads back to the record to which the history is associated.