### PR TITLE
Update data on blur; this fixes drag and drop not working correctly

### DIFF
--- a/vue-client/src/components/inspector/item-bylang.vue
+++ b/vue-client/src/components/inspector/item-bylang.vue
@@ -335,7 +335,8 @@ export default {
         @remove="remove(entry.tag, entry.val)"
         @removeval="removeVal(entry.tag, entry.val)"
         @addLangTag="setValueFromEntityAdder(...arguments, entry.val)"
-        @addToCache="updateLangCache(entry.tag)">
+        @addToCache="updateLangCache(entry.tag)"
+        @update="update(entries)">
       </language-entry>
     </div>
   </div>

--- a/vue-client/src/components/inspector/language-entry.vue
+++ b/vue-client/src/components/inspector/language-entry.vue
@@ -182,6 +182,7 @@ export default {
           rows="1"
           v-bind:value="val"
           v-on:input="$emit('input', $event.target.value)"
+          @blur="$emit('update')"
           ref="textarea"
         ></textarea>
       </span>


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4080](https://jira.kb.se/browse/LXL-4080)

### Solves

Description of what this solves
Drag and dropping text between instances of the item-bylang.vue component did not work properly. The text was copied but not removed from the field it was taken from.

### Summary of changes

Summary of changes
Update on blur.