### PR TITLE
Stop item-vocab in locked view (and history view) from modifying insp…

### DIFF
--- a/vue-client/src/components/inspector/item-vocab.vue
+++ b/vue-client/src/components/inspector/item-vocab.vue
@@ -76,7 +76,7 @@ export default {
       }
     },
     selected(value, oldValue) {
-      if (value !== oldValue && this.initialized) {
+      if (value !== oldValue && this.initialized && !this.isLocked) {
         this.$store.dispatch('updateInspectorData', {
           changeList: [
             {


### PR DESCRIPTION
…ector.data

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
-
### Solves
Stop item-vocab.vue from modifying inspector.data.

### Summary of changes

Check if locked view in item-vocab.vue