### PR TITLE
Fix version history

### DIFF
--- a/vue-client/src/components/inspector/field.vue
+++ b/vue-client/src/components/inspector/field.vue
@@ -162,15 +162,15 @@ export default {
   computed: {
     diffAdded() {
       if (this.diff == null) return false;
-      return this.diff.added.some(a => isEqual(a.path, this.path));
+      return this.diff.added.includes(this.path);
     },
     diffRemoved() {
       if (this.diff == null) return false;
-      return this.diff.removed.some(r => isEqual(r.path, this.path));
+      return this.diff.removed.includes(this.path);
     },
     diffModified() {
       if (this.diff == null) return false;
-      return this.diff.modified.some(m => isEqual(m.path, this.path));
+      return this.diff.modified.includes(this.path);
     },
     isReverseProperty() {
       return this.fieldKey.indexOf('@reverse') > -1;
@@ -1024,7 +1024,7 @@ export default {
           :diff="diff">
         </item-bylang>
       </div>
-
+            
       <div class="Field-contentItem"
         v-for="(item, index) in valueAsArray"
         :key="index">

--- a/vue-client/src/components/inspector/item-local.vue
+++ b/vue-client/src/components/inspector/item-local.vue
@@ -477,8 +477,8 @@ export default {
       'is-entity': !isEmbedded,
       'is-extractable': isExtractable && !isEmbedded,
       'has-failed-validations': failedValidations.length > 0,
-      'is-diff-removed': diffRemoved && !diffAdded,
-      'is-diff-added': diffAdded && !diffRemoved,
+      'is-diff-removed': diffRemoved,
+      'is-diff-added': diffAdded,
       'is-modified': diffModified}"
     :tabindex="isEmpty ? -1 : 0"
     @keyup.enter="checkFocus()"

--- a/vue-client/src/components/inspector/language-entry.vue
+++ b/vue-client/src/components/inspector/language-entry.vue
@@ -88,15 +88,15 @@ export default {
     },
     diffRemoved() {
       if (this.diff == null) return false;
-      return this.diff.removed.some(r => isEqual(r.path, this.exactPath));
+      return this.diff.removed.some(p => isEqual(p, this.exactPath));
     },
     diffAdded() {
       if (this.diff == null) return false;
-      return this.diff.added.some(a => isEqual(a.path, this.exactPath));
+      return this.diff.added.some(p => isEqual(p, this.exactPath));
     },
     diffModified() {
       if (this.diff == null) return false;
-      return this.diff.modified.some(m => isEqual(m.path, this.exactPath));
+      return this.diff.modified.some(p => isEqual(p, this.exactPath));
     },
     shouldFocus() {
       const lastAdded = this.inspector.status.lastAdded;

--- a/vue-client/src/components/mixins/item-mixin.vue
+++ b/vue-client/src/components/mixins/item-mixin.vue
@@ -92,45 +92,41 @@ export default {
     },
     diffAdded() {
       if (this.diff == null) return false;
-      const parentValue = get(this.inspector.compositeHistoryData, this.parentPath);
-      if (isArray(parentValue)) {
-        const obj = parentValue[this.index];
-        return this.diff.added.some(a => isEqual(obj, a.val));
-      }
-      return false;
+      return this.diff.added.includes(this.myPath);
     },
     diffRemoved() {
       if (this.diff == null) return false;
-      const parentValue = get(this.inspector.compositeHistoryData, this.parentPath);
-      if (isArray(parentValue)) {
-        const obj = parentValue[this.index];
-        return this.diff.removed.some(r => isEqual(obj, r.val));
-      }
-      return false;
+      return this.diff.removed.includes(this.myPath);
     },
     diffModified() {
       if (this.diff == null) return false;
-      const parentValue = get(this.inspector.compositeHistoryData, this.parentPath);
-      if (isArray(parentValue)) {
-        const obj = parentValue[this.index];
-        return this.diff.modified.some(m => isEqual(obj, m.val));
-      }
-      return false;
+      return this.diff.modified.includes(this.myPath);
+    },
+    myPath() {
+      return this.index !== undefined
+        ? `${this.parentPath}[${this.index}]`
+        : this.path;
     },
     diffAddedChildren() {
       if (this.diff == null) return false;
       return this.diff.added
-        .filter(a => !isEqual(a.path, this.path))
-        .some(a => a.path.includes(this.path));
+        .filter(p => !isEqual(p, this.path))
+        .some(p => p.includes(this.path));
     },
     diffRemovedChildren() {
       if (this.diff == null) return false;
       return this.diff.removed
-        .filter(r => !isEqual(r.path, this.path))
-        .some(r => r.path.includes(this.path));
+        .filter(p => !isEqual(p, this.path))
+        .some(p => p.includes(this.path));
+    },
+    diffModifiedChildren() {
+      if (this.diff == null) return false;
+      return this.diff.modified
+        .filter(p => !isEqual(p, this.path))
+        .some(p => p.includes(this.path));
     },
     diffChangedChildren() {
-      return this.diffAddedChildren || this.diffRemovedChildren;
+      return this.diffAddedChildren || this.diffRemovedChildren || this.diffModifiedChildren;
     },
     inClassAndProperty() {
       return `${this.entityType}.${this.fieldKey}`;

--- a/vue-client/src/utils/history.js
+++ b/vue-client/src/utils/history.js
@@ -1,0 +1,122 @@
+import { cloneDeep, get, initial as parent, last, remove, set, take, range } from 'lodash-es';
+import { arrayPathToString as str } from 'lxljs/string';
+
+// build display data: previous version + everything added in current version
+export function buildDisplayData(previousVersionData, currentVersionData, addedPaths, removedPaths, getLabel) {
+  const added = cloneDeep(addedPaths).sort();
+  const removed = cloneDeep(removedPaths).sort();
+  
+  const displayData = cloneDeep(previousVersionData);
+  
+  const operations = [];
+  
+  const [modified, replaceAdded, replaceRemoved] = insertReplaced(
+    displayData, operations, previousVersionData, currentVersionData, added, removed, getLabel,
+  );
+  
+  insertAdded(displayData, operations, previousVersionData, currentVersionData, added, 
+    removed, modified, getLabel);
+  
+  operations.forEach(op => op(displayData));
+  
+  const displayPaths = {
+    added: [...added.map(p => currentToDisplay(p, removed)).map(str), ...replaceAdded.map(str)],
+    removed: [...removed.map(p => previousToDisplay(p, added)).map(str), ...replaceRemoved.map(str)],
+    modified: modified.map(str),
+  };
+  
+  return [displayData, displayPaths];
+}
+
+function insertReplaced(displayData, operations, previousVersionData, currentVersionData, added, removed, getLabel) {
+  const modified = [];
+  const replaceAdded = [];
+  const replaceRemoved = [];
+
+  added.slice(0).forEach((path) => {
+    const pathStr = str(path);
+    const isReplaced = removed.find(p => str(p) === pathStr);
+    if (!isReplaced) {
+      return;
+    }
+    
+    const newVal = get(currentVersionData, pathStr);
+    const oldVal = get(previousVersionData, pathStr);
+    if (typeof oldVal === 'string' && typeof newVal === 'string') {
+      // string replaced
+      const displayPath = currentToDisplay(path, removed);
+      const v = `${getLabel(oldVal)} → ${getLabel(newVal)}`;
+      operations.push(data => set(data, str(displayPath), v));
+
+      modified.push(displayPath);
+
+      remove(added, p => str(p) === pathStr);
+      remove(removed, p => str(p) === pathStr);
+    } else if (!isArrayIndex(path)) {
+      // non-array replaced
+      // put in array so that we can show old and new values side-by-side
+      const displayPath = currentToDisplay(path, removed);
+      const n = asArray(newVal);
+      const o = asArray(oldVal);
+      operations.push(data => set(data, str(displayPath), [...n, ...o]));
+
+      replaceAdded.push(...range(n.length).map(i => [...displayPath, i]));
+      replaceRemoved.push(...range(o.length).map(i => [...displayPath, n.length + i]));
+
+      remove(added, p => str(p) === pathStr);
+      remove(removed, p => str(p) === pathStr);
+    }
+  });
+  
+  return [modified, replaceAdded, replaceRemoved];
+}
+
+function insertAdded(displayData, operations, previousVersionData, currentVersionData, added, removed) {
+  added.forEach((path) => {
+    const newVal = get(currentVersionData, str(path));
+    const displayPath = currentToDisplay(path, removed);
+    if (isArrayIndex(path)) {
+      // insert added value in array
+      const ix = last(displayPath);
+      get(displayData, str(parent(displayPath))).splice(ix, 0, newVal);
+    } else {
+      // new path, just add it
+      operations.push(data => set(data, str(displayPath), newVal));
+    }
+  });
+}
+
+function previousToDisplay(path, added) {
+  return pathWithDisplayIndices(path, added, (addedIx, ix) => addedIx <= ix);
+}
+
+function currentToDisplay(path, removed) {
+  return pathWithDisplayIndices(path, removed, (removedIx, ix) => removedIx < ix);
+}
+
+function pathWithDisplayIndices(path, comparePaths, cmp) {
+  const result = [];
+  for (let i = 0; i < path.length; i++) {
+    const subPath = take(path, i + 1);
+    if (isArrayIndex(subPath)) {
+      const parentStr = str(parent(subPath));
+      const ix = last(subPath);
+      const pathsBefore = comparePaths.filter(p => subPath.length === p.length 
+        && isArrayIndex(p) 
+        && str(parent(p)) === parentStr 
+        && cmp(last(p), ix));
+      result.push(ix + pathsBefore.length);
+    } else {
+      result.push(last(subPath));
+    }
+  }
+  return result;
+}
+
+function isArrayIndex(path) {
+  return typeof last(path) === 'number';
+}
+
+function asArray(v) {
+  return Array.isArray(v) ? v : [v];
+}

--- a/vue-client/src/utils/history.js
+++ b/vue-client/src/utils/history.js
@@ -14,8 +14,7 @@ export function buildDisplayData(previousVersionData, currentVersionData, addedP
     displayData, operations, previousVersionData, currentVersionData, added, removed, getLabel,
   );
   
-  insertAdded(displayData, operations, previousVersionData, currentVersionData, added, 
-    removed, modified, getLabel);
+  insertAdded(displayData, operations, previousVersionData, currentVersionData, added, removed);
   
   operations.forEach(op => op(displayData));
   

--- a/vue-client/tests/unit/HistoryUtil.spec.js
+++ b/vue-client/tests/unit/HistoryUtil.spec.js
@@ -1,0 +1,380 @@
+const HistoryUtil = require('@/utils/history');
+
+const getLabel = s => `L:${s}`;
+
+test('empty data and paths', () => {
+  const prev = {};
+  const curr = {};
+  const added = [];
+  const removed = [];
+  
+  const [data, paths] = HistoryUtil.buildDisplayData(prev, curr, added, removed, getLabel);
+  
+  expect(data).toEqual({});
+  expect(paths).toEqual({
+    added: [],
+    removed: [],
+    modified: [],
+  });
+});
+
+
+test('modify string', () => {
+  const prev = { a: 'x' };
+  const curr = { a: 'y' };
+  const added = [['a']];
+  const removed = [['a']];
+
+  const [data, paths] = HistoryUtil.buildDisplayData(prev, curr, added, removed, getLabel);
+
+  expect(data).toEqual({
+    a: 'L:x → L:y',
+  });
+  expect(paths).toEqual({
+    added: [],
+    removed: [],
+    modified: ['a'],
+  });
+});
+
+
+test('property added', () => {
+  const prev = {
+    p1: 'x',
+  };
+  const curr = {
+    p1: 'x',
+    p2: 'y',
+  };
+  const added = [['p2']];
+  const removed = [];
+
+  const [data, paths] = HistoryUtil.buildDisplayData(prev, curr, added, removed, getLabel);
+
+  expect(data).toEqual({
+    p1: 'x',
+    p2: 'y',
+  });
+  expect(paths).toEqual({
+    added: ['p2'],
+    removed: [],
+    modified: [],
+  });
+});
+
+
+test('remove + add in array', () => {
+  const prev = {
+    p: [
+      { '@id': 'x' },
+    ],
+  };
+  const curr = {
+    p: [
+      { '@id': 'y' },
+    ],
+  };
+  const added = [['p', 0]];
+  const removed = [['p', 0]];
+
+  const [data, paths] = HistoryUtil.buildDisplayData(prev, curr, added, removed, getLabel);
+
+  expect(data).toEqual({
+    p: [
+      { '@id': 'y' },
+      { '@id': 'x' },
+    ],
+  });
+  expect(paths).toEqual({
+    added: ['p[0]'],
+    removed: ['p[1]'],
+    modified: [],
+  });
+});
+
+
+test('remove + add in array', () => {
+  const prev = {
+    p: [
+      { '@id': 'r1' },
+      { '@id': '-1' },
+      { '@id': 'r2' },
+      { '@id': '-2' },
+      { '@id': 'r3' },
+      { '@id': '-3' },
+    ],
+  };
+  const curr = {
+    p: [
+      { '@id': 'A1' },
+      { '@id': '-1' },
+      { '@id': 'A2' },
+      { '@id': '-2' },
+      { '@id': 'A3' },
+      { '@id': '-3' },
+    ],
+  };
+  const added = [['p', 0], ['p', 2], ['p', 4]];
+  const removed = [['p', 0], ['p', 2], ['p', 4]];
+
+  const [data, paths] = HistoryUtil.buildDisplayData(prev, curr, added, removed, getLabel);
+
+  expect(data).toEqual({
+    p: [
+      { '@id': 'A1' },
+      { '@id': 'r1' },
+      { '@id': '-1' },
+      { '@id': 'A2' },
+      { '@id': 'r2' },
+      { '@id': '-2' },
+      { '@id': 'A3' },
+      { '@id': 'r3' },
+      { '@id': '-3' },
+    ],
+  });
+  expect(paths).toEqual({
+    added: ['p[0]', 'p[3]', 'p[6]'],
+    removed: ['p[1]', 'p[4]', 'p[7]'],
+    modified: [],
+  });
+});
+
+
+test('object replaced', () => {
+  const prev = {
+    p: { '@id': 'a' },
+  };
+  const curr = {
+    p: { '@id': 'b' },
+  };
+  const added = [['p']];
+  const removed = [['p']];
+
+  const [data, paths] = HistoryUtil.buildDisplayData(prev, curr, added, removed, getLabel);
+
+  expect(data).toEqual({
+    p: [
+      { '@id': 'b' },
+      { '@id': 'a' },
+    ],
+  });
+  expect(paths).toEqual({
+    added: ['p[0]'],
+    removed: ['p[1]'],
+    modified: [],
+  });
+});
+
+
+test('string to array', () => {
+  const prev = {
+    p: '1',
+  };
+  const curr = {
+    p: [
+      '2',
+      '3',
+    ],
+  };
+  const added = [['p']];
+  const removed = [['p']];
+
+  const [data, paths] = HistoryUtil.buildDisplayData(prev, curr, added, removed, getLabel);
+
+  expect(data).toEqual({
+    p: [
+      '2',
+      '3',
+      '1',
+    ],
+  });
+  expect(paths).toEqual({
+    added: ['p[0]', 'p[1]'],
+    removed: ['p[2]'],
+    modified: [],
+  });
+});
+
+
+test('array to string', () => {
+  const prev = {
+    p: [
+      '1',
+      '2',
+    ],
+  };
+  const curr = {
+    p: '3',
+  };
+  const added = [['p']];
+  const removed = [['p']];
+
+  const [data, paths] = HistoryUtil.buildDisplayData(prev, curr, added, removed, getLabel);
+
+  expect(data).toEqual({
+    p: [
+      '3',
+      '1',
+      '2',
+    ],
+  });
+  expect(paths).toEqual({
+    added: ['p[0]'],
+    removed: ['p[1]', 'p[2]'],
+    modified: [],
+  });
+});
+
+test('remove + add in array + nested', () => {
+  const prev = {
+    p: [
+      { '@id': 'r1' },
+      { '@id': '-1' },
+      {
+        p: [
+          'a',
+          'b',
+          'c',
+        ],
+      },
+      { '@id': '-2' },
+      { '@id': 'r2' },
+      { '@id': '-3' },
+    ],
+  };
+  const curr = {
+    p: [
+      { '@id': 'A1' },
+      { '@id': '-1' },
+      {
+        p: [
+          'a',
+          'B',
+          'c',
+          'd',
+        ],
+      },
+      { '@id': '-2' },
+      { '@id': 'A2' },
+      { '@id': '-3' },
+    ],
+  };
+  const added = [['p', 0], ['p', 2, 'p', 1], ['p', 2, 'p', 3], ['p', 4]];
+  const removed = [['p', 0], ['p', 2, 'p', 1], ['p', 4]];
+
+  const [data, paths] = HistoryUtil.buildDisplayData(prev, curr, added, removed, getLabel);
+
+  expect(data).toEqual({
+    p: [
+      { '@id': 'A1' },
+      { '@id': 'r1' },
+      { '@id': '-1' },
+      {
+        p: [
+          'a',
+          'L:b → L:B',
+          'c',
+          'd',
+        ],
+      },
+      { '@id': '-2' },
+      { '@id': 'A2' },
+      { '@id': 'r2' },
+      { '@id': '-3' },
+    ],
+  });
+  expect(paths).toEqual({
+    added: ['p[0]', 'p[3].p[3]', 'p[5]'],
+    removed: ['p[1]', 'p[6]'],
+    modified: ['p[3].p[1]'],
+  });
+});
+
+
+test('replace object and modify string', () => {
+  const prev = {
+    p: [
+      '1a',
+      { '@id': 'i1a' },
+      '--',
+      '1b',
+      { '@id': 'i1b' },
+    ],
+  };
+  const curr = {
+    p: [
+      '2a',
+      { '@id': 'i2a' },
+      '--',
+      '2b',
+      { '@id': 'i2b' },
+    ],
+  };
+  const added = [['p', 0], ['p', 1], ['p', 3], ['p', 4]];
+  const removed = [['p', 0], ['p', 1], ['p', 3], ['p', 4]];
+
+  const [data, paths] = HistoryUtil.buildDisplayData(prev, curr, added, removed, getLabel);
+
+  expect(data).toEqual({
+    p: [
+      'L:1a → L:2a',
+      { '@id': 'i2a' },
+      { '@id': 'i1a' },
+      '--',
+      'L:1b → L:2b',
+      { '@id': 'i2b' },
+      { '@id': 'i1b' },
+    ],
+  });
+  
+ 
+  expect(paths).toEqual({
+    added: ['p[1]', 'p[5]'],
+    removed: ['p[2]', 'p[6]'],
+    modified: ['p[0]', 'p[4]'],
+  });
+});
+
+
+test('modify + add string', () => {
+  const prev = {
+    i: [
+      { a: 'b' },
+      { c: [
+        's1',
+        's2',
+      ] },
+    ],
+  };
+  const curr = {
+    i: [
+      { a: 'b' },
+      { c: [
+        's1',
+        's3',
+        's4', 
+      ] },
+    ],
+  };
+  const added = [['i', 1, 'c', 1], ['i', 1, 'c', 2]];
+  const removed = [['i', 1, 'c', 1]];
+
+  const [data, paths] = HistoryUtil.buildDisplayData(prev, curr, added, removed, getLabel);
+
+  expect(data).toEqual({
+    i: [
+      { a: 'b' },
+      { c: [
+        's1',
+        'L:s2 → L:s3',
+        's4',
+      ] },
+    ],
+  });
+  
+  expect(paths).toEqual({
+    added: ['i[1].c[2]'],
+    removed: [],
+    modified: ['i[1].c[1]'],
+  });
+});


### PR DESCRIPTION
Using the improved diffs from backend, simplify the diff display code.
Depends on https://github.com/libris/librisxl/pull/1235

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

### Tickets involved
[LXL-4065](https://jira.kb.se/browse/LXL-4065)

### Solves
Version history is displayed correctly.

### Summary of changes
* Move calculation of display data and diff paths to a plain js file
* Add unit tests

### TODO
* Fix path handling, e.g. remove the new `myPath`
