### PR TITLE
Change instruction video links from youtube to KB Play

### DIFF
--- a/vue-client/src/components/layout/footer.vue
+++ b/vue-client/src/components/layout/footer.vue
@@ -58,7 +58,7 @@ export default {
               </ul>
               <ul class="Footer-navList">
                 <li>
-                  <a href="https://www.youtube.com/playlist?list=PLZVkEICvA5-GRT2oJQmLgq_2Pksx6zYPy" class="Footer-link">{{ "Instruction videos" | translatePhrase }}</a>
+                  <a href="https://kbplay.mediaflowportal.com/folder/91512/" class="Footer-link">{{ "Instruction videos" | translatePhrase }}</a>
                 </li>
                 <li>
                   <a href="https://www.kb.se/libris/Om-LIBRIS/Introduktion-till-nya-Libris-och-XL/" class="Footer-link">{{ "Introduction material" | translatePhrase }}</a>

--- a/vue-client/src/resources/json/copy.json
+++ b/vue-client/src/resources/json/copy.json
@@ -44,10 +44,9 @@
     "linkText": "Till Nytt inom Libris"
   },
   "instructional-videos": {
-    "video": "https://www.youtube-nocookie.com/embed/?listType=playlist&list=PLZVkEICvA5-GRT2oJQmLgq_2Pksx6zYPy&html5=1&rel=0&showinfo=0&autoplay=1",
     "header": "Instruktionsfilmer",
-    "text": "För att underlätta katalogisering i XL producerar vi kontinuerligt instruktionsfilmer som vi lägger upp på Kungliga bibliotekets kanal på Youtube. Filmerna uppdateras vid förändringar och uppdateringar av de tjänster de visar. Navigera runt och titta på de filmer som stödjer ditt arbete i XL på bästa sätt.",
-    "linkUrl": "https://www.youtube.com/playlist?list=PLZVkEICvA5-GRT2oJQmLgq_2Pksx6zYPy",
+    "text": "För att underlätta katalogisering i XL producerar vi kontinuerligt instruktionsfilmer som vi lägger upp på Kungliga bibliotekets sida KB Play. Filmerna uppdateras vid förändringar och uppdateringar av de tjänster de visar. Navigera runt och titta på de filmer som stödjer ditt arbete i XL på bästa sätt.",
+    "linkUrl": "https://kbplay.mediaflowportal.com/folder/91512/",
     "linkText": "Till spellistan"
   },
   "studies": {

--- a/vue-client/src/views/LandingPage.vue
+++ b/vue-client/src/views/LandingPage.vue
@@ -55,21 +55,21 @@ export default {
           :text="copy['blog'].text" 
           :link-text="copy['blog'].linkText" 
           :link-url="copy['blog'].linkUrl"></link-card>
-        <link-card v-if="widgetShouldBeShown('link-studies')" 
-          :image="copy['studies'].image" 
+        <link-card v-if="widgetShouldBeShown('link-studies')"
+          :image="copy['studies'].image"
           :image-alt-text="copy['studies'].image_alt_text"
-          :header="copy['studies'].header" 
-          :text="copy['studies'].text" 
-          :link-text="copy['studies'].linkText" 
+          :header="copy['studies'].header"
+          :text="copy['studies'].text"
+          :link-text="copy['studies'].linkText"
           :link-url="copy['studies'].linkUrl"></link-card>
+        <link-card
+          v-if="widgetShouldBeShown('intro-component')"
+          :video-url="copy['instructional-videos'].video"
+          :header="copy['instructional-videos'].header"
+          :text="copy['instructional-videos'].text"
+          :link-text="copy['instructional-videos'].linkText"
+          :link-url="copy['instructional-videos'].linkUrl"></link-card>
       </div>
-      <link-card 
-        v-if="widgetShouldBeShown('intro-component')" 
-        :video-url="copy['instructional-videos'].video" 
-        :header="copy['instructional-videos'].header" 
-        :text="copy['instructional-videos'].text" 
-        :link-text="copy['instructional-videos'].linkText" 
-        :link-url="copy['instructional-videos'].linkUrl"></link-card>
     </div>
   </div>
 </template>


### PR DESCRIPTION
It is not possible to embed the whole playlist on KB Play, only individual videos. So I removed that part from the card.
Landing page is now one row with three cards and one row with one card of the same size.

I have not ripped out all the youtube embedding code in `link-card.vue`

## Checklist:
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4096](https://jira.kb.se/browse/LXL-4096) 
