### PR TITLE
Feature/lxl 4055 show transliterated title variants in card

### DIFF
--- a/lxljs/.eslintrc.js
+++ b/lxljs/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
     'airbnb-base',
   ],
   parserOptions: {
-    ecmaVersion: 8,
+    ecmaVersion: 9,
     sourceType: 'module',
   },
   rules: {

--- a/lxljs/display.js
+++ b/lxljs/display.js
@@ -284,7 +284,7 @@ export function getItemLabel(item, resources, quoted, settings, inClass = '') {
   }
 
   let rendered = (transliteratedFromDisplayObject && transliteratedToDisplayObjects)
-    ? `${transliteratedToDisplayObjects.map(ttdo => formatLabel(ttdo, item['@type'], resources)).join(' / ')} (${formatLabel(transliteratedFromDisplayObject, item['@type'], resources)})`
+    ? `${transliteratedToDisplayObjects.map(ttdo => formatLabel(ttdo, item['@type'], resources)).join(' — ')} — ${formatLabel(transliteratedFromDisplayObject, item['@type'], resources)}`
     : formatLabel(displayObject, item['@type'], resources);
 
   // let rendered = StringUtil.formatLabel(displayObject).trim();
@@ -365,7 +365,7 @@ export function getItemToken(item, resources, quoted, settings) {
   const transliteratedToDisplayObjects = transliteratedTo && transliteratedTo.map(language => getToken(item, resources, quoted, { ...settings, language }));
 
   let rendered = (transliteratedFromDisplayObject && transliteratedToDisplayObjects)
-    ? `${transliteratedToDisplayObjects.map(ttdo => StringUtil.formatLabel(ttdo).trim()).join(' / ')} (${StringUtil.formatLabel(transliteratedFromDisplayObject).trim()})`
+    ? `${transliteratedToDisplayObjects.map(ttdo => StringUtil.formatLabel(ttdo).trim()).join(' — ')} — ${StringUtil.formatLabel(transliteratedFromDisplayObject).trim()}`
     : StringUtil.formatLabel(displayObject).trim();
 
   if (item['@type'] && VocabUtil.isSubClassOf(item['@type'], 'Identifier', resources.vocab, resources.context)) {


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [X] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4055](https://jira.kb.se/browse/LXL-4055), [LXL-3978](https://jira.kb.se/browse/LXL-3978)

### Solves

Shows transliterated variants followed by the original non-transliterated string in parentheses.
Multiple transliterated variants are separated using slashes.

See screenshots:
<img width="1624" alt="Skärmavbild 2023-05-04 kl  18 20 11" src="https://user-images.githubusercontent.com/10220360/236264287-c52189ce-568b-4bce-9ed0-52474435491f.png">
<img width="1624" alt="Skärmavbild 2023-05-04 kl  18 20 13" src="https://user-images.githubusercontent.com/10220360/236264319-96b678ef-e65e-40eb-a532-df7244b71462.png">

### Summary of changes

- Show transliterated variants in cards
- Update parser options to support spread operator

