### PR TITLE
Feature/lxl 3723 show domain and range includes

### DIFF
--- a/lxljs/vocab.js
+++ b/lxljs/vocab.js
@@ -450,8 +450,9 @@ export function getLinkedProperties(linkType, classId, vocabClasses, vocabProper
     return [];
   }
 
-  if (termObj[`${linkType}Properties`]) {
-    return termObj[`${linkType}Properties`];
+  const capitilzedLinkType = linkType[0].toUpperCase() + linkType.slice(1);
+  if (termObj[`in${capitilzedLinkType}Of`]) {
+    return termObj[`in${capitilzedLinkType}Of`];
   }
 
   const linkedProperties = Array.from(vocabProperties.values())

--- a/nuxt-app/src/components/ResultItem.vue
+++ b/nuxt-app/src/components/ResultItem.vue
@@ -18,11 +18,13 @@
         <EntityNode :is-chip="true" :parent-key="'@type'" class="d-none" :class="{'d-xl-block': entity.inScheme, 'd-lg-block': !entity.inScheme }" :entity="entity['@type']" />
       </template>
     </div>
-    <EntityTable v-if="expanded" :entity="entityData" :show-download="showDownload" :show-other-services="showOtherServices" />
+    <EntityTable v-if="expanded" :entity="entityData" :show-download="showDownload" :show-other-services="showOtherServices" :classProperties="classProperties" />
   </div>
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
+import * as VocabUtil from 'lxljs/vocab';
 import LensMixin from '@/mixins/lens';
 import EntityNode from '@/components/EntityNode';
 import EntityTable from '@/components/EntityTable';
@@ -56,6 +58,7 @@ export default {
     },
   },
   computed: {
+    ...mapGetters(['vocabClasses', 'vocab', 'vocabProperties', 'vocabContext']),
     isDocumentView() {
       return this.$route.name == 'all' || this.$route.name == 'vocab-term';
     },
@@ -81,6 +84,11 @@ export default {
     expanded() {
       return this.forceExpanded || this.userExpanded;
     },
+    classProperties() {
+      if (this.$route.params.term) {
+        return VocabUtil.getProperties(this.$route.params.term, this.vocabClasses, this.vocabProperties, this.vocabContext)
+      }
+    }
   },
   props: {
     entity: {

--- a/nuxt-app/src/components/ResultItem.vue
+++ b/nuxt-app/src/components/ResultItem.vue
@@ -18,13 +18,11 @@
         <EntityNode :is-chip="true" :parent-key="'@type'" class="d-none" :class="{'d-xl-block': entity.inScheme, 'd-lg-block': !entity.inScheme }" :entity="entity['@type']" />
       </template>
     </div>
-    <EntityTable v-if="expanded" :entity="entityData" :show-download="showDownload" :show-other-services="showOtherServices" :classProperties="classProperties" />
+    <EntityTable v-if="expanded" :entity="entityData" :show-download="showDownload" :show-other-services="showOtherServices" />
   </div>
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
-import * as VocabUtil from 'lxljs/vocab';
 import LensMixin from '@/mixins/lens';
 import EntityNode from '@/components/EntityNode';
 import EntityTable from '@/components/EntityTable';
@@ -58,7 +56,6 @@ export default {
     },
   },
   computed: {
-    ...mapGetters(['vocabClasses', 'vocab', 'vocabProperties', 'vocabContext']),
     isDocumentView() {
       return this.$route.name == 'all' || this.$route.name == 'vocab-term';
     },
@@ -84,11 +81,6 @@ export default {
     expanded() {
       return this.forceExpanded || this.userExpanded;
     },
-    classProperties() {
-      if (this.$route.params.term) {
-        return VocabUtil.getProperties(this.$route.params.term, this.vocabClasses, this.vocabProperties, this.vocabContext)
-      }
-    }
   },
   props: {
     entity: {

--- a/nuxt-app/src/components/VocabTermlist.vue
+++ b/nuxt-app/src/components/VocabTermlist.vue
@@ -35,7 +35,6 @@ export default {
       const lowerCaseKeyword = keyword.toLowerCase();
       return list.filter((item) => {
         const itemLabel = StringUtil.getLabelByLang(item['@id'], this.settings.language, this.resources);
-        console.log(item['@id']);
         return item['@id'].toLowerCase().includes(lowerCaseKeyword) || itemLabel.toLowerCase().includes(lowerCaseKeyword);
       });
     },
@@ -85,10 +84,10 @@ export default {
       return this.filterList(list, this.termListFilter);
     },
     classes() {
-      return this.sortList([...this.vocabClasses]);
+      return this.sortList(Array.from(this.vocabClasses).map(([_, entry]) => (entry)));
     },
     properties() {
-      return this.sortList([...this.vocabProperties]);
+      return this.sortList(Array.from(this.vocabProperties).map(([_, entry]) => (entry)));
     },
   },
   props: {

--- a/nuxt-app/src/resources/json/rdfTranslations.json
+++ b/nuxt-app/src/resources/json/rdfTranslations.json
@@ -11,7 +11,8 @@
     "domainIncludes": "Förekommer på",
     "range": "Urval",
     "rangeIncludes": "Urval",
-    "equivalentProperty": "Motsvarar"
+    "equivalentProperty": "Motsvarar",
+    "allowedProperties": "Förekommer i"
   },
   "en": {
     "baseClassOf": "Subclasses",
@@ -25,6 +26,7 @@
     "domainIncludes": "Domain",
     "range": "Range",
     "rangeIncludes": "Range",
-    "equivalentProperty": "Equivalent property"
+    "equivalentProperty": "Equivalent property",
+    "allowedProperties": "Occurs in"
   }
 }

--- a/nuxt-app/src/resources/json/rdfTranslations.json
+++ b/nuxt-app/src/resources/json/rdfTranslations.json
@@ -13,15 +13,15 @@
     "rangeIncludes": "Urval",
     "equivalentProperty": "Motsvarar",
     "allowedProperties": "Förekommer i",
-    "domainProperties": "Tillhörande egenskaper",
-    "domainIncludesProperties": "Egenskaper som kan tillhöra",
-    "rangeProperties": "Egenskaper inom urval",
-    "rangeIncludesProperties": "Egenskaper som kan vara inom urval"
+    "inDomainOf": "Har",
+    "inDomainIncludesOf": "Kan ha",
+    "inRangeOf": "Förekommer som",
+    "inRangeIncludesOf": "Kan förekomma som"
   },
   "en": {
     "baseClassOf": "Subclasses",
     "basePropertyOf": "Subproperties",
-    "subClassOf": "Sub class of",
+    "subClassOf": "Subclass of",
     "subPropertyOf": "Sub property of",
     "isDefinedBy": "Is defined by",
     "abstract": "Abstract",
@@ -32,9 +32,9 @@
     "rangeIncludes": "Range",
     "equivalentProperty": "Equivalent property",
     "allowedProperties": "Occurs in",
-    "domainProperties": "In domain of",
-    "domainIncludesProperties": "Included in domain",
-    "rangeProperties": "In range of",
-    "rangeIncludesProperties": "Included in range"
+    "inDomainOf": "In domain of",
+    "inDomainIncludesOf": "In domain includes of",
+    "inRangeOf": "In range of",
+    "inRangeIncludesOf": "In range includes of"
   }
 }

--- a/nuxt-app/src/resources/json/rdfTranslations.json
+++ b/nuxt-app/src/resources/json/rdfTranslations.json
@@ -12,7 +12,11 @@
     "range": "Urval",
     "rangeIncludes": "Urval",
     "equivalentProperty": "Motsvarar",
-    "allowedProperties": "Förekommer i"
+    "allowedProperties": "Förekommer i",
+    "domainProperties": "Tillhörande egenskaper",
+    "domainIncludesProperties": "Egenskaper som kan tillhöra",
+    "rangeProperties": "Egenskaper inom urval",
+    "rangeIncludesProperties": "Egenskaper som kan vara inom urval"
   },
   "en": {
     "baseClassOf": "Subclasses",
@@ -27,6 +31,10 @@
     "range": "Range",
     "rangeIncludes": "Range",
     "equivalentProperty": "Equivalent property",
-    "allowedProperties": "Occurs in"
+    "allowedProperties": "Occurs in",
+    "domainProperties": "In domain of",
+    "domainIncludesProperties": "Included in domain",
+    "rangeProperties": "In range of",
+    "rangeIncludesProperties": "Included in range"
   }
 }

--- a/nuxt-app/src/store/index.js
+++ b/nuxt-app/src/store/index.js
@@ -205,6 +205,12 @@ export const mutations = {
           }
         });
       }
+      const compactUri = StringUtil.getCompactUri(classObj['@id'], state.vocabContext);
+      ['domain', 'domainIncludes', 'range', 'rangeIncludes'].forEach(linkType => {
+        const linkedProperties = VocabUtil.getLinkedProperties(linkType, compactUri, classes, state.vocabProperties, state.vocabContext);
+        classObj[`${linkType}Properties`] = linkedProperties;
+      });
+
     });
     state.vocabClasses = classes;
   },
@@ -216,11 +222,6 @@ export const mutations = {
     props = props.concat(VocabUtil.getTermByType('ObjectProperty', vocabMap, state.vocabContext, state.settings));
     props = props.concat(VocabUtil.getTermByType('owl:SymmetricProperty', vocabMap, state.vocabContext, state.settings));
     const vocabProperties = new Map(props.map(entry => [entry['@id'], entry]));
-
-    state.vocabClasses.forEach((classObj) => {
-      const compactClassUri = StringUtil.getCompactUri(classObj['@id'], state.vocabContext)
-      const allowedPropertiesInClass = VocabUtil.getProperties(compactClassUri, state.vocabClasses, vocabProperties, state.vocabContext)
-    });
     state.vocabProperties = vocabProperties;
   },
   SET_DISPLAY(state, data) {
@@ -249,8 +250,8 @@ export const actions = {
     else {
       commit('SET_VOCAB_CONTEXT', vocab.context);
       commit('SET_VOCAB', vocab.vocab);
-      commit('SET_VOCAB_CLASSES', vocab.vocab);
       commit('SET_VOCAB_PROPERTIES', vocab.vocab);
+      commit('SET_VOCAB_CLASSES', vocab.vocab);
       commit('SET_DISPLAY', vocab.display);
     }
   },

--- a/nuxt-app/src/store/index.js
+++ b/nuxt-app/src/store/index.js
@@ -192,7 +192,6 @@ export const mutations = {
       VocabUtil.getTermByType('marc:CollectionClass', vocabMap, state.vocabContext, state.settings),
     );
     const classes = new Map(classTerms.map(entry => [entry['@id'], entry]));
-
     classes.forEach((classObj) => {
       if (classObj.hasOwnProperty('subClassOf')) {
         each(classObj.subClassOf, (baseClass) => {
@@ -217,6 +216,11 @@ export const mutations = {
     props = props.concat(VocabUtil.getTermByType('ObjectProperty', vocabMap, state.vocabContext, state.settings));
     props = props.concat(VocabUtil.getTermByType('owl:SymmetricProperty', vocabMap, state.vocabContext, state.settings));
     const vocabProperties = new Map(props.map(entry => [entry['@id'], entry]));
+
+    state.vocabClasses.forEach((classObj) => {
+      const compactClassUri = StringUtil.getCompactUri(classObj['@id'], state.vocabContext)
+      const allowedPropertiesInClass = VocabUtil.getProperties(compactClassUri, state.vocabClasses, vocabProperties, state.vocabContext)
+    });
     state.vocabProperties = vocabProperties;
   },
   SET_DISPLAY(state, data) {

--- a/nuxt-app/src/store/index.js
+++ b/nuxt-app/src/store/index.js
@@ -208,7 +208,11 @@ export const mutations = {
       const compactUri = StringUtil.getCompactUri(classObj['@id'], state.vocabContext);
       ['domain', 'domainIncludes', 'range', 'rangeIncludes'].forEach(linkType => {
         const linkedProperties = VocabUtil.getLinkedProperties(linkType, compactUri, classes, state.vocabProperties, state.vocabContext);
-        classObj[`${linkType}Properties`] = linkedProperties;
+        // Add inDomainOf / inDomainIncludesOf / inRangeOf / inRangeIncludesOf to class object
+        if (linkedProperties.length) {
+          const capitilzedLinkType = linkType[0].toUpperCase() + linkType.slice(1);
+          classObj[`in${capitilzedLinkType}Of`] = linkedProperties;
+        }
       });
 
     });

--- a/nuxt-app/src/store/index.js
+++ b/nuxt-app/src/store/index.js
@@ -1,5 +1,6 @@
+import { each } from 'lodash-es'
 import * as VocabUtil from 'lxljs/vocab';
-import * as DisplayUtil from 'lxljs/display';
+import * as StringUtil from 'lxljs/string';
 import translationsFile from '@/resources/json/i18n.json';
 
 export const state = () => ({
@@ -185,21 +186,38 @@ export const mutations = {
     state.vocab = vocabMap;
   },
   SET_VOCAB_CLASSES(state, vocabMap) {
-    // Set vocabClasses to an array of objects
+    // Set vocabClasses to a map (as in vue-client/src/store.js)
     const classTerms = [].concat(
       VocabUtil.getTermByType('Class', vocabMap, state.vocabContext, state.settings),
       VocabUtil.getTermByType('marc:CollectionClass', vocabMap, state.vocabContext, state.settings),
     );
-    state.vocabClasses = classTerms;
+    const classes = new Map(classTerms.map(entry => [entry['@id'], entry]));
+
+    classes.forEach((classObj) => {
+      if (classObj.hasOwnProperty('subClassOf')) {
+        each(classObj.subClassOf, (baseClass) => {
+          const baseClassObj = classes.get(baseClass['@id']);
+          if (typeof baseClassObj !== 'undefined') {
+            if (baseClassObj.hasOwnProperty('baseClassOf')) {
+              baseClassObj.baseClassOf.push(StringUtil.convertToPrefix(classObj['@id'], state.vocabContext));
+            } else {
+              baseClassObj.baseClassOf = [StringUtil.convertToPrefix(classObj['@id'], state.vocabContext)];
+            }
+          }
+        });
+      }
+    });
+    state.vocabClasses = classes;
   },
   SET_VOCAB_PROPERTIES(state, vocabMap) {
-    // Set vocabProperties to an array of objects
+    // Set vocabProperties to a map (as in vue-client/src/store.js)
     let props = [];
     props = props.concat(VocabUtil.getTermByType('Property', vocabMap, state.vocabContext, state.settings));
     props = props.concat(VocabUtil.getTermByType('DatatypeProperty', vocabMap, state.vocabContext, state.settings));
     props = props.concat(VocabUtil.getTermByType('ObjectProperty', vocabMap, state.vocabContext, state.settings));
     props = props.concat(VocabUtil.getTermByType('owl:SymmetricProperty', vocabMap, state.vocabContext, state.settings));
-    state.vocabProperties = props;
+    const vocabProperties = new Map(props.map(entry => [entry['@id'], entry]));
+    state.vocabProperties = vocabProperties;
   },
   SET_DISPLAY(state, data) {
     state.display = data;


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [X] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3723](https://jira.kb.se/browse/LXL-3723)

### Solves

Shows properties that can occur on classes using `domain`, `domainIncludes`, `range` and `rangeIncludes`. 

### Summary of changes

- Use maps instead of arrays of objects for `vocabClasses`and `vocabProperties` in the vuex store.
- Show allowed properties on classes.
- Remove repetition of domain/range list methods (`getDomainList` and `getRangeList` is replaced with `getPropertiesList`).
