### PR TITLE
Feature/lxl 3723 show domain and range includes (using @reverse)

### DIFF
--- a/lxljs/vocab.js
+++ b/lxljs/vocab.js
@@ -416,6 +416,17 @@ export function getRangeFull(key, vocab, context, vocabClasses) {
   return allTypes;
 }
 
+export function getReversesByType(type, termObj, vocab) {
+  if (termObj.hasOwnProperty('@reverse') && termObj['@reverse'].hasOwnProperty(type)) {
+    return termObj['@reverse'][type];
+  }
+
+  // Find vocab items which has the type argument as a property wherein the current termObj is referenced
+  return Object.values(vocab)[0]
+    .filter(vocabItem => vocabItem.hasOwnProperty(type) && vocabItem[type].find(
+      typeItem => typeItem['@id'] === termObj['@id'],
+    ));
+}
 export function getDomainList(property, vocab, context) {
   if (property['@type'] === 'Class') {
     return false;
@@ -800,6 +811,19 @@ export function preprocessVocab(vocab) {
           }
         }
       });
+
+      if (termObj['@type'] === 'Class') {
+        ['domain', 'domainIncludes', 'range', 'rangeIncludes'].forEach((propertyLinkType) => {
+          const reverseProperties = getReversesByType(propertyLinkType, termObj, vocab);
+
+          if (reverseProperties.length) {
+            termObj['@reverse'] = {
+              ...termObj['@reverse'],
+              [propertyLinkType]: reverseProperties,
+            };
+          }
+        });
+      }
     }
   });
 

--- a/nuxt-app/src/components/EntityTable.vue
+++ b/nuxt-app/src/components/EntityTable.vue
@@ -143,8 +143,8 @@ export default {
           const reverseKey = termObj['inverseOf']['@id'].split('/').pop();
           extracted[reverseKey] = value;
         } else {
-          const capitilzedKey = key[0].toUpperCase() + key.slice(1);
-          extracted[`in${capitilzedKey}Of`] = value;
+          const capitalizedKey = key[0].toUpperCase() + key.slice(1);
+          extracted[`in${capitalizedKey}Of`] = value;
         }
       }
       const combinedData = Object.assign(this.itemData, extracted);

--- a/nuxt-app/src/components/EntityTable.vue
+++ b/nuxt-app/src/components/EntityTable.vue
@@ -139,8 +139,13 @@ export default {
       const extracted = {};
       for (const [key, value] of Object.entries(this.itemData['@reverse'])) {
         const termObj = VocabUtil.getTermObject(key, this.vocab, this.vocabContext);
-        const reverseKey = termObj['inverseOf']['@id'].split('/').pop();
-        extracted[reverseKey] = value;
+        if (termObj.hasOwnProperty('inverseOf')) {
+          const reverseKey = termObj['inverseOf']['@id'].split('/').pop();
+          extracted[reverseKey] = value;
+        } else {
+          const capitilzedKey = key[0].toUpperCase() + key.slice(1);
+          extracted[`in${capitilzedKey}Of`] = value;
+        }
       }
       const combinedData = Object.assign(this.itemData, extracted);
       delete combinedData['@reverse'];

--- a/nuxt-app/src/components/PropertyRow.vue
+++ b/nuxt-app/src/components/PropertyRow.vue
@@ -29,6 +29,7 @@ import LensMixin from '@/mixins/lens';
 import EntityNode from '@/components/EntityNode';
 import * as DisplayUtil from 'lxljs/display';
 import * as VocabUtil from 'lxljs/vocab';
+import * as StringUtil from 'lxljs/string';
 
 export default {
   name: 'PropertyRow',
@@ -68,6 +69,12 @@ export default {
       return VocabUtil.getContextValue(this.property, '@container', this.vocabContext);
     },
     finalizedValue() {
+      if (Array.isArray(this.withoutFilteredTypes)) {
+        return [...this.withoutFilteredTypes].sort((a, b) => {
+          return StringUtil.getLabelByLang(a['@id'], this.settings.language, this.resources)
+            .localeCompare(StringUtil.getLabelByLang(b['@id'], this.settings.language, this.resources))
+        })
+      }
       return this.withoutFilteredTypes;
     },
     withoutFilteredTypes() {

--- a/nuxt-app/src/resources/json/rdfTranslations.json
+++ b/nuxt-app/src/resources/json/rdfTranslations.json
@@ -11,12 +11,17 @@
     "domainIncludes": "Förekommer på",
     "range": "Urval",
     "rangeIncludes": "Urval",
-    "equivalentProperty": "Motsvarar"
+    "equivalentProperty": "Motsvarar",
+    "allowedProperties": "Förekommer i",
+    "inDomainOf": "Har",
+    "inDomainIncludesOf": "Kan ha",
+    "inRangeOf": "Förekommer som",
+    "inRangeIncludesOf": "Kan förekomma som"
   },
   "en": {
     "baseClassOf": "Subclasses",
     "basePropertyOf": "Subproperties",
-    "subClassOf": "Sub class of",
+    "subClassOf": "Subclass of",
     "subPropertyOf": "Sub property of",
     "isDefinedBy": "Is defined by",
     "abstract": "Abstract",
@@ -25,6 +30,11 @@
     "domainIncludes": "Domain",
     "range": "Range",
     "rangeIncludes": "Range",
-    "equivalentProperty": "Equivalent property"
+    "equivalentProperty": "Equivalent property",
+    "allowedProperties": "Occurs in",
+    "inDomainOf": "In domain of",
+    "inDomainIncludesOf": "In domain includes of",
+    "inRangeOf": "In range of",
+    "inRangeIncludesOf": "In range includes of"
   }
 }


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-3723](https://jira.kb.se/browse/LXL-LXL-3723),

### Solves

Shows properties on classes which references the class using the following: `domain`, `domainIncludes`, `range` and `rangeIncludes`.

### Summary of changes

This pull request replaces [#867](https://github.com/libris/lxlviewer/pull/867) (which has been reverted).

- We now populate the class objects in one place (`preprocessVocab`) and add the properties inside `@reverse` instead of directly on the class. This prevents code duplication and also solves the issue with duplicate subClasses.

- We now skip the conversion of `vocabClasses` and `vocabProperties` to Maps (to reduce the scope of the PR).

- Sorting of property values are also added.
