### PR TITLE
Prevent occasional multiple expand arrows

### DIFF
--- a/vue-client/src/components/shared/entity-summary.vue
+++ b/vue-client/src/components/shared/entity-summary.vue
@@ -372,8 +372,8 @@ export default {
         :key="node.property">
         <template v-if="node.value !== null">
           <span  v-if="labelStyle !== 'hidden'" :class="`EntitySummary-detailsKey-${labelStyle}`" :title="node.property | labelByLang | capitalize">{{ node.property | labelByLang | capitalize }}</span>
-          <span :class="`EntitySummary-detailsValue-${labelStyle} EntitySummary-twoLines`" :ref="`ovf-${node.property}`" @click.prevent.self="(e) => { if (handleOverflow) { e.target.classList.toggle('expanded'); } }">
-            <SummaryNode :hover-links="hoverLinks" :handle-overflow="handleOverflow" v-for="(value, index) in node.value" :is-last="index === node.value.length - 1" :key="index" :item="value" :parent-id="focusData['@id']" :field-key="node.property"/>
+          <span :class="`EntitySummary-detailsValue-${labelStyle} EntitySummary-twoLines`" :ref="`ovf-${node.property}`" @click.self.prevent="(e) => { if (handleOverflow) { e.target.classList.toggle('expanded'); } }">
+            <SummaryNode :hover-links="hoverLinks" :handle-overflow="false" v-for="(value, index) in node.value" :is-last="index === node.value.length - 1" :key="index" :item="value" :parent-id="focusData['@id']" :field-key="node.property"/>
           </span>
         </template>
         <template v-else-if="isReplacedBy !== ''">


### PR DESCRIPTION
Fixes occasional multiple expand errors when hammering clicks on a summary element

## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4176](https://jira.kb.se/browse/LXL-4176)

### Solves

Sometimes multiple expand icons could appear when hammering clicks on a summary element.
See screenshot of problem: 
![Skärmavbild 2023-05-31 kl  17 27 12](https://github.com/libris/lxlviewer/assets/10220360/8e542a8a-c006-46ba-aa8d-45cb3b533531)


### Summary of changes

- Set `handle-overflow` to false on nested summary nodes.
- Change order of event modifiers (see note on https://v2.vuejs.org/v2/guide/events.html#Event-Modifiers).
