### PR TITLE
Show work type in summary node

### DIFF
--- a/vue-client/src/components/shared/summary-node.vue
+++ b/vue-client/src/components/shared/summary-node.vue
@@ -32,6 +32,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    fieldKey: {
+      type: String,
+      default: '',
+    },
   },
   data() {
     return {
@@ -67,6 +71,9 @@ export default {
 <template>
   <div class="SummaryNode">
     <span class="SummaryNode-label" v-if="!isLinked || isStatic" ref="ovf-label" @click.prevent.self="e => e.target.classList.toggle('expanded')">
+      <span v-if="fieldKey === 'instanceOf'">
+        {{ item['@type'] | labelByLang | capitalize }} &bull; 
+      </span>
       {{ typeof item === 'string' ? getStringLabel : getItemLabel }}{{ isLast ? '' : ';&nbsp;' }}
       <resize-observer v-if="handleOverflow" @notify="calculateOverflow" />
     </span>


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [X] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4162](https://jira.kb.se/browse/LXL-4162)

### Solves

Shows the work type in instances' card (prepends item label for `instanceOf` ). See screenshot: ![Skärmavbild 2023-06-12 kl  16 58 24](https://github.com/libris/lxlviewer/assets/10220360/9792b06e-9cb3-414a-9aba-57d11590d612)

### Summary of changes

- Show work type in summary node