### PR TITLE
Feature/lxl-4161 Remove placeholder from work search string

### DIFF
--- a/vue-client/src/components/inspector/search-window.vue
+++ b/vue-client/src/components/inspector/search-window.vue
@@ -134,7 +134,7 @@ export default {
                 const cleanedChipString = DisplayUtil.getItemLabel(this.itemInfo, this.resources, this.inspector.data.quoted, this.settings)
                   .replace(/#|_|•|\[|\]/g, ' ')
                   .replace(/  +/g, ' ')
-                  .replace(new RegExp(`s?({(.*?)${StringUtil.getUiPhraseByLang('without', this.settings.language, this.resources.i18n)}(.*?)})`), '')
+                  .replace(new RegExp(`s?({(.*?)(${this.settings.availableUserSettings.languages.map(lang => StringUtil.getUiPhraseByLang('without', lang.value, this.resources.i18n)).join('|')})(.*?)})`, 'g'), '')
                   .trim();
                 this.keyword = cleanedChipString;
                 this.search();

--- a/vue-client/src/components/inspector/search-window.vue
+++ b/vue-client/src/components/inspector/search-window.vue
@@ -131,7 +131,11 @@ export default {
             this.$nextTick(() => {
               this.resetSearch();
               if (this.itemInfo !== null) {
-                const cleanedChipString = DisplayUtil.getItemLabel(this.itemInfo, this.resources, this.inspector.data.quoted, this.settings).replace(/#|_|•|\[|\]/g, ' ').replace(/  +/g, ' ');
+                const cleanedChipString = DisplayUtil.getItemLabel(this.itemInfo, this.resources, this.inspector.data.quoted, this.settings)
+                  .replace(/#|_|•|\[|\]/g, ' ')
+                  .replace(/  +/g, ' ')
+                  .replace(new RegExp(`s?({(.*?)${StringUtil.getUiPhraseByLang('without', this.settings.language, this.resources.i18n)}(.*?)})`), '')
+                  .trim();
                 this.keyword = cleanedChipString;
                 this.search();
               }


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [X] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4161](https://jira.kb.se/browse/LXL-4161)

### Solves

Removes placeholder (e.g. `{Primär medverkan utan agent}` or `{PrimaryContribution without agent}`) from work search string.

### Summary of changes

- Remove placeholder from work search string
- Trim search string
- Find and replace phrase in all languages found in `availableUserSettings`
