### PR TITLE
Fix/lxl-4055 Only show separator if there are transliterations

### DIFF
--- a/lxljs/display.js
+++ b/lxljs/display.js
@@ -3,7 +3,7 @@ import * as VocabUtil from './vocab';
 import * as StringUtil from './string';
 import { lxlLog, lxlWarning } from './debug';
 
-const TRANSLITERATION_SEPARATOR = '⬥';
+const TRANSLITERATION_SEPARATOR = '◦';
 
 export function expandInherited(display) {
   const cloned = cloneDeep(display);
@@ -246,7 +246,7 @@ function getTransliteratedLanguages(item) {
   return Object.entries(item).reduce((acc, itemEntry) => {
     if (itemEntry[0] && itemEntry[0].includes('ByLang')) {
       const transliteratedKeys = Object.keys(itemEntry[1]).filter(key => key.includes('Latn-t-'));
-      if (transliteratedKeys) {
+      if (transliteratedKeys.length) {
         return {
           from: Object.keys(itemEntry[1]).find(key => !transliteratedKeys.includes(key)),
           to: transliteratedKeys,


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [X] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4055](https://jira.kb.se/browse/LXL-4055)

### Solves

Removes the leftover transliteration separator if `transliteratedKeys` is empty.

### Summary of changes

- Only show separator if there are transliterations
- Change the transliteration separator character as the previous character could be rendered differently on different devices.
