### PR TITLE
Bugs/lxl 4089 remove only selected field on duplicate values

### DIFF
--- a/vue-client/src/components/inspector/item-bylang.vue
+++ b/vue-client/src/components/inspector/item-bylang.vue
@@ -292,8 +292,8 @@ export default {
     remove(tag, val) {
       this.removeLanguageTag(tag, val);
     },
-    removeVal(tag, val) {
-      this.removeValue(tag, val);
+    removeVal(tag, val, index) {
+      this.removeValue(tag, val, index);
     },
     uriFor(tag) {
       return `${this.settings.idPath}/i18n/lang/${tag}`;
@@ -316,7 +316,7 @@ export default {
 
 <template>
   <div class="ItemBylang-root">
-    <div v-for="entry in entries" :key="entry.id">
+    <div v-for="(entry, index) in entries" :key="entry.id">
       <language-entry
         v-model="entry.val"
         :val="entry.val"
@@ -333,7 +333,7 @@ export default {
         :item-path="getParentPath()"
         @romanize="romanize(entry.tag, entry.val)"
         @remove="remove(entry.tag, entry.val)"
-        @removeval="removeVal(entry.tag, entry.val)"
+        @removeval="removeVal(entry.tag, entry.val, index)"
         @addLangTag="setValueFromEntityAdder(...arguments, entry.val)"
         @addToCache="updateLangCache(entry.tag)"
         @update="update(entries)">

--- a/vue-client/src/components/mixins/language-mixin.vue
+++ b/vue-client/src/components/mixins/language-mixin.vue
@@ -133,7 +133,7 @@ export default {
         });
       }
     },
-    removeValue(tag, value) {
+    removeValue(tag, value, index) {
       let updateValue;
       let updatePath;
       if (tag !== 'none') {
@@ -164,11 +164,18 @@ export default {
           const lastIndex = this.path.lastIndexOf('.');
           const parentPath = this.path.slice(0, lastIndex);
           const parentValue = cloneDeep(get(this.inspector.data, parentPath));
-          delete parentValue[this.getPropKey()];
+
+          if (Array.isArray(parentValue[this.getPropKey()]) && index != null) {
+            parentValue[this.getPropKey()].splice(index, 1);
+          } else {
+            delete parentValue[this.getPropKey()];
+          }
+
           updateValue = parentValue;
           updatePath = parentPath;
         }
       }
+
       this.$store.dispatch('updateInspectorData', {
         changeList: [
           {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint` (Failed)

## Description
If a field has multiple values and one of them is removed, the entire field previously got removed. This PR adds support for removing only one of them using the item index. See example below:

![bild](https://github.com/libris/lxlviewer/assets/2635185/a6ab0eea-69fe-4ec4-97be-fc29c2eb4406)


### Tickets involved
[LXL-4089](https://jira.kb.se/browse/LXL-4089)
