### PR TITLE
Feature/4132 work in form

### DIFF
--- a/vue-client/src/components/care/detailed-enrichment.vue
+++ b/vue-client/src/components/care/detailed-enrichment.vue
@@ -529,12 +529,6 @@ export default {
       margin: -1px -4px 0px 0px;
     }
   }
-
-  .FieldList-item.is-linked {
-    &:not(.is-diff) {
-      background-color: @form-field;
-    }
-  }
 }
 
 </style>

--- a/vue-client/src/components/inspector/entity-form.vue
+++ b/vue-client/src/components/inspector/entity-form.vue
@@ -137,7 +137,6 @@ export default {
         :is-locked="keyIsLocked(k)" 
         :parent-accepted-types="acceptedTypes"
         :is-card="isIntegral(k)"
-        :is-distinguished="k === 'instanceOf'"
         :key="k" 
         :diff="diff"
         :field-key="k" 
@@ -233,12 +232,6 @@ export default {
     width: 100%;
     box-shadow: none;
   }
-
-  &-item.is-distinguished {    
-    border-bottom-width: 2px;
-    margin-bottom: 1rem;
-  }
-
   &-item.is-linked {
     border-color: rgba(@brand-primary, 23%);
     background-color: lighten(@form-add, 5%);

--- a/vue-client/src/components/inspector/entity-form.vue
+++ b/vue-client/src/components/inspector/entity-form.vue
@@ -211,12 +211,10 @@ export default {
         &:not(.is-highlighted) {
           &:not(.is-removeable) {
             &:not(.is-marked) {
-              &:not(.is-linked) {
-                &:not(.is-diff-removed) {
-                  &:not(.is-diff-added) {
-                    &:not(.is-diff-modified) {
-                      background-color: @form-field;
-                    }
+              &:not(.is-diff-removed) {
+                &:not(.is-diff-added) {
+                  &:not(.is-diff-modified) {
+                    background-color: @form-field;
                   }
                 }
               }
@@ -231,24 +229,6 @@ export default {
     list-style: none;
     width: 100%;
     box-shadow: none;
-  }
-  &-item.is-linked {
-    border-color: rgba(@brand-primary, 23%);
-    background-color: lighten(@form-add, 5%);
-    
-    &:hover {
-      & .icon:not(.is-disabled) {
-        color: rgba(@brand-primary, 80%);
-      }
-    }
-    & .icon {
-      color: rgba(@brand-primary, 40%);
-
-      &:hover:not(.is-disabled),
-      &:focus {
-        color: @brand-primary;
-      }
-    }
   }
 }
 

--- a/vue-client/src/components/inspector/field.vue
+++ b/vue-client/src/components/inspector/field.vue
@@ -97,10 +97,6 @@ export default {
       type: Object,
       default: null,
     },
-    isDistinguished: {
-      type: Boolean,
-      default: false,
-    },
     isCard: {
       type: Boolean,
       default: false,
@@ -694,7 +690,6 @@ export default {
       'is-highlighted': embellished,
       'is-grouped': isGrouped,
       'has-failed-validations': failedValidations.length > 0,
-      'is-distinguished': isDistinguished,
       'is-linked': isLinkedInstanceOf, 
     }"
     @mouseover="handleMouseEnter()" 

--- a/vue-client/src/components/inspector/field.vue
+++ b/vue-client/src/components/inspector/field.vue
@@ -454,17 +454,6 @@ export default {
         return embellished.some(el => el.path === this.path);
       } return false;
     },
-    forcedToArray() {
-      return this.forcedListTerms.indexOf(this.fieldKey) > -1;
-    },
-    isLinkedInstanceOf() {
-      if (this.fieldKey === 'instanceOf' && this.fieldValue !== null && this.parentPath === 'mainEntity') {
-        if (this.fieldValue.hasOwnProperty('@id') && this.fieldValue['@id'].split('#')[0] !== this.inspector.data.record['@id']) {
-          return true;
-        }
-      }
-      return false;
-    },
     fieldRdfType() {
       return DisplayUtil.rdfDisplayType(this.fieldKey, this.resources);
     },
@@ -690,7 +679,6 @@ export default {
       'is-highlighted': embellished,
       'is-grouped': isGrouped,
       'has-failed-validations': failedValidations.length > 0,
-      'is-linked': isLinkedInstanceOf, 
     }"
     @mouseover="handleMouseEnter()" 
     @mouseleave="handleMouseLeave()"

--- a/vue-client/src/components/inspector/item-entity.vue
+++ b/vue-client/src/components/inspector/item-entity.vue
@@ -280,10 +280,12 @@ li.FieldList-item >
     display: flex;
     flex-direction: column;
     width: 100%;
-    padding-bottom: 0.25em;
-    border-bottom: 2px solid @form-border;
-    
-    margin-bottom: 0.5em;
+
+    border-radius: 4px;
+    padding: 0.5em 1em 0.5em 1em;
+    margin: 0.6rem 0 0.6rem 0.6rem;
+    border: 1px solid @grey-lighter;
+    box-shadow: 0 2px 5px rgba(0,0,0,.08);
   }
 /*
   &-cardContainer:last-child {

--- a/vue-client/src/components/inspector/item-entity.vue
+++ b/vue-client/src/components/inspector/item-entity.vue
@@ -224,7 +224,7 @@ export default {
       </v-popover> 
     </div>
     
-    <div class="ItemEntity-cardContainer" v-if="isCardWithData && expanded">
+    <div class="ItemEntity-content ItemEntity-cardContainer" v-if="isCardWithData && expanded">
       <entity-summary
         :focus-data="focusData" 
         :exclude-properties="excludeProperties"

--- a/vue-client/src/components/inspector/item-entity.vue
+++ b/vue-client/src/components/inspector/item-entity.vue
@@ -246,21 +246,6 @@ export default {
 
 @linked-color: #daefec;
 
-// FIXME: ugly that we depend on Field-contentItem here?
-li.Field:last-child >
-.Field-content >
-.Field-contentItem >
-.ItemEntity-container >
-.ItemEntity-cardContainer,
-// Don't draw separator for the linked work card-view in a record
-li.FieldList-item >
-.Field-content >
-.Field-contentItem >
-.ItemEntity-container >
-.ItemEntity-cardContainer {
-  border-bottom: none;
-}
-
 .ItemEntity {
 
   &-container {

--- a/vue-client/src/components/mixins/form-mixin.vue
+++ b/vue-client/src/components/mixins/form-mixin.vue
@@ -157,12 +157,7 @@ export default {
       const propertyList = DisplayUtil.getSortedProperties(this.formType, this.formObj, this.settings, this.resources);
 
       if (this.showTypeChanger) {
-        // move instanceOf field to top
-        if (this.recordType === 'Instance') {
-          propertyList.splice(1, 0, '@type');
-        } else {
-          propertyList.splice(0, 0, '@type');
-        }
+        propertyList.splice(0, 0, '@type');
       }
       return propertyList;
     },

--- a/vue-client/src/components/shared/entity-summary.vue
+++ b/vue-client/src/components/shared/entity-summary.vue
@@ -399,7 +399,7 @@ export default {
   padding: 0.5em 0.75em 0.5em 0.75em;
 
   &.is-embedded-in-field {
-    padding: 0.5em 1.5em 0.5em 0;
+    padding: 0.5em 0 0.5em 0;
   }
 
   .EntityHeader & {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description
* Display `instanceOf` in the same way as every other property to make it clear that it is part of the instance
* Add the same shadow to linked entities displayed as embedded cards as the shadow on local entities

### Tickets involved
[LXL-4132](https://jira.kb.se/browse/LXL-4132)

### Summary of changes
* [Remove gap between instanceOf field and rest of form](https://github.com/libris/lxlviewer/commit/ab0d021ff8d85d1a73f25299202ace6c1f50e28d)
* [Don't place instanceOf field at top of form](https://github.com/libris/lxlviewer/commit/29700a407f1a072e0400cdc94dcf3ee8295ede37)
* [No additional styling for linked works](https://github.com/libris/lxlviewer/commit/2d64c72ef6c39a395a62514d411dfcd0779de281)
* [Add drop shadow to linked entities displayed as cards inside form](https://github.com/libris/lxlviewer/commit/e20ba37432c8d265aeebf619a3ab9f828a970185)