### PR TITLE
Fix-autosize-of-textarea-for-language-taggable-properties

### DIFF
--- a/vue-client/src/components/inspector/field.vue
+++ b/vue-client/src/components/inspector/field.vue
@@ -893,7 +893,8 @@ export default {
         :field-value="valueAsArray"
         :field-key="fieldKey"
         :parent-path="path"
-        :diff="diff">
+        :diff="diff"
+        :is-expanded="isExpanded">
       </item-bylang>
       </div>
       <div class="Field-contentItem"
@@ -1004,7 +1005,8 @@ export default {
           :field-value="valueAsArray"
           :field-key="fieldKey"
           :parent-path="path"
-          :diff="diff">
+          :diff="diff"
+          :is-expanded="isExpanded">
         </item-bylang>
       </div>
             

--- a/vue-client/src/components/inspector/item-bylang.vue
+++ b/vue-client/src/components/inspector/item-bylang.vue
@@ -27,6 +27,10 @@ export default {
       type: Object,
       default: null,
     },
+    isExpanded: {
+      type: Boolean,
+      default: false,
+    },
   },
   components: {
     'language-entry': LanguageEntry,
@@ -331,6 +335,7 @@ export default {
         :record-id="getRecordIdFromCache(entry.tag)"
         :diff="diff"
         :item-path="getParentPath()"
+        :is-expanded="isExpanded"
         @romanize="romanize(entry.tag, entry.val)"
         @remove="remove(entry.tag, entry.val)"
         @removeval="removeVal(entry.tag, entry.val, index)"

--- a/vue-client/src/components/inspector/language-entry.vue
+++ b/vue-client/src/components/inspector/language-entry.vue
@@ -57,6 +57,10 @@ export default {
       type: String,
       default: '',
     },
+    isExpanded: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     ...mapGetters([
@@ -122,6 +126,11 @@ export default {
   watch: {
     isLocked(val) {
       if (!val) {
+        this.initializeTextarea();
+      }
+    },
+    isExpanded(val) {
+      if (val) {
         this.initializeTextarea();
       }
     },


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4078](https://jira.kb.se/browse/LXL-4078)

### Solves
Text areas with more than one line of text don't properly resize when starting to edit a property that is not expanded. 

### Summary of changes

Listen to changes of isExpanded in language-entry.vue