### PR TITLE
Don't save empty fields to inspector.data

### DIFF
--- a/vue-client/src/components/inspector/item-bylang.vue
+++ b/vue-client/src/components/inspector/item-bylang.vue
@@ -150,7 +150,7 @@ export default {
       return false;
     },
     update(viewObjects) {
-      if (this.isHistoryView()) {
+      if (this.isHistoryView() || this.isLocked) {
         return;
       }
 
@@ -176,7 +176,7 @@ export default {
       }
       const newData = this.dataForm(viewObjects);
       const oldData = cloneDeep(get(this.inspector.data, this.path));
-      if (!isEqual(oldData, newData)) {
+      if (newData && !isEqual(oldData, newData)) {
         this.$store.dispatch('updateInspectorData', {
           changeList: [
             {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

### Tickets involved
[LXL-4074](https://jira.kb.se/browse/LXL-4074)

### Solves
Fixes a bug where unstyled empty labels show up when saving records with empty language taggable fields, as described in [LXL-4074](https://jira.kb.se/browse/LXL-4074). 

### Summary of changes
* Don't save to inspector.data, while editing, if field content is empty. 
* Added extra isLocked-check so that nothing can be saved be mistake when the user is out of edit mode. This possibly solves some of the issues described in the comments of [LXL-4074](https://jira.kb.se/browse/LXL-4074) --- however, I was unable to reproduce those issues locally.

