### PR TITLE
Feature/lxl-4162 Show type on linked items and replace colon with bullet

### DIFF
--- a/vue-client/src/components/shared/summary-node.vue
+++ b/vue-client/src/components/shared/summary-node.vue
@@ -72,14 +72,19 @@ export default {
   <div class="SummaryNode">
     <span class="SummaryNode-label" v-if="!isLinked || isStatic" ref="ovf-label" @click.prevent.self="e => e.target.classList.toggle('expanded')">
       <span v-if="fieldKey === 'instanceOf' && item['@type'] !== 'Work'">
-        {{ item['@type'] | labelByLang | capitalize }}: 
+        {{ item['@type'] | labelByLang | capitalize }} •
       </span>
       {{ typeof item === 'string' ? getStringLabel : getItemLabel }}{{ isLast ? '' : ';&nbsp;' }}
       <resize-observer v-if="handleOverflow" @notify="calculateOverflow" />
     </span>
     <v-popover v-if="isLinked && !isStatic" :disabled="!hoverLinks" @show="$refs.previewCard.populateData()" placement="bottom-start">
       <span class="SummaryNode-link tooltip-target">
-        <router-link v-if="isLibrisResource" :to="routerPath">{{getItemLabel}}</router-link>
+        <router-link v-if="isLibrisResource" :to="routerPath">
+          <span v-if="fieldKey === 'instanceOf'">
+            {{ item['@type'] | labelByLang | capitalize }} •
+          </span>
+          {{getItemLabel}}
+        </router-link>
         <a v-if="!isLibrisResource" :href="focusData['@id'] | convertResourceLink">{{getItemLabel}}</a>
       </span>
       <template slot="popover" v-if="hoverLinks">


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4162](https://jira.kb.se/browse/LXL-4162)

### Solves

Show type on linked items and replace colon with bullet character

### Summary of changes

- Show type on linked items and replace colon with bullet

![Skärmavbild 2023-07-05 kl  17 11 37](https://github.com/libris/lxlviewer/assets/10220360/b0f97f61-1928-4146-9a96-b717395a0257)


