### PR TITLE
Fix marcframe display for auth och hold

### DIFF
--- a/nuxt-app/src/pages/marcframe.vue
+++ b/nuxt-app/src/pages/marcframe.vue
@@ -48,7 +48,8 @@ export default {
   },
   async asyncData({ $config, store, $http }) {
     if (!store.getters.resources.marcframe) {
-      const marcframePath = 'https://raw.githubusercontent.com/libris/librisxl/master/whelk-core/src/main/resources/ext/marcframe.json';
+      const baseUri = $config.siteConfig['libris.kb.se']?.baseUri;
+      const marcframePath = `${baseUri}/sys/marcframe.json`;
       const pageData = await fetch(
         marcframePath
       ).then(res => res.json());

--- a/nuxt-app/src/pages/marcframe/index.vue
+++ b/nuxt-app/src/pages/marcframe/index.vue
@@ -2,12 +2,12 @@
   <div class="Marcframe-codeDetails">
     <h1>{{ translateUi('MARC mappings') }}</h1>
     <p v-if="settings.language == 'sv'">KB/Libris mappningar av MARC till RDF-vokabulär. För mer information, se
-      <a class="ext" target="_blank" rel="noopener noreferrer" href="https://github.com/libris/librisxl/blob/master/whelk-core/src/main/resources/ext/marcframe.json">källfil</a>
+      <a class="ext" target="_blank" rel="noopener noreferrer" :href="marcFrameUri">källfil</a>
       och <a class="ext" target="_blank" rel="noopener noreferrer" href="https://github.com/libris/librisxl/blob/master/whelk-core/src/main/resources/ext/marcframe.md">dokumentation</a>.
     </p>
     <p v-else>
       KB/Libris mappings for MARC to RDF. For more information see
-      <a class="ext" target="_blank" rel="noopener noreferrer" href="https://github.com/libris/librisxl/blob/master/whelk-core/src/main/resources/ext/marcframe.json">source file</a>
+      <a class="ext" target="_blank" rel="noopener noreferrer" :href="marcFrameUri">source file</a>
       and <a class="ext" target="_blank" rel="noopener noreferrer" href="https://github.com/libris/librisxl/blob/master/whelk-core/src/main/resources/ext/marcframe.md">documentation</a>.
     </p>
   </div>
@@ -41,6 +41,10 @@ export default {
     termTitle() {
       return this.getEntityTitle(this.termData);
     },
+    marcFrameUri() {
+      const baseUri = this.$config.siteConfig['libris.kb.se']?.baseUri;
+      return `${baseUri}/sys/marcframe.json`;
+    }
   },
   methods: {
   },


### PR DESCRIPTION
Get marcframe.json (expanded) from system and not from github.

Depends on https://github.com/libris/devops/commit/69675957dfc60a5cdc1bed5ec00e3360067b6efe

### Tickets involved
[LXL-4103](https://jira.kb.se/browse/LXL-4103)

### Solves
Marcframe view was broken for auth and hold.

