### PR TITLE
Fix 410 Gone message on id.kb.se

### DIFF
--- a/nuxt-app/src/layouts/error.vue
+++ b/nuxt-app/src/layouts/error.vue
@@ -35,6 +35,13 @@ export default {
             "If you got here by following a link on our website, you can report it to us. See contact information in the footer."
           ]
         };
+      } else if (this.error.statusCode == 410) {
+        return {
+          heading: "410 Gone",
+          extra: [
+            "The resource has been removed."
+          ]
+        };
       } else {
         return {
           heading: "There is a problem with the service",

--- a/nuxt-app/src/resources/json/i18n.json
+++ b/nuxt-app/src/resources/json/i18n.json
@@ -43,6 +43,7 @@
     "If you entered a web address, check that it is correct.": "Om du skrev in adressen, kontrollera att den är korrekt.",
     "If you got here by following a link on our website, you can report it to us. See contact information in the footer.": "Om du hamnade här genom att följa en länk på vår webbplats, meddela oss gärna. Se kontaktinformation i sidfoten.",
     "There is a problem with the service": "Det är ett problem med tjänsten",
-    "Try again later.": "Försök igen senare."
+    "Try again later.": "Försök igen senare.",
+    "The resource has been removed.": "Resursen har blivit borttagen."
   }
 }


### PR DESCRIPTION
### Tickets involved
[LXL-4250](https://jira.kb.se/browse/LXL-4250)

### Summary of changes

Previously the formal page of a deleted resource would have the correct HTTP status code but show the generic error "There is a problem with the service. Try again later." (example: https://libris.kb.se/tz4ttnm0251wshd#it). This adds a special case for 410 Gone (like in the cataloging client).