### PR TITLE
Don't exclude empty input when syncing inspector.data

### DIFF
--- a/vue-client/src/components/inspector/item-bylang.vue
+++ b/vue-client/src/components/inspector/item-bylang.vue
@@ -176,7 +176,7 @@ export default {
       }
       const newData = this.dataForm(viewObjects);
       const oldData = cloneDeep(get(this.inspector.data, this.path));
-      if (newData && !isEqual(oldData, newData)) {
+      if (!isEqual(oldData, newData)) {
         this.$store.dispatch('updateInspectorData', {
           changeList: [
             {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4080](https://jira.kb.se/browse/LXL-4080), [LXL-4074](https://jira.kb.se/browse/LXL-4074)

### Solves

The bug in [LXL-4080](https://jira.kb.se/browse/LXL-4080) where the input in a field jumps back again after being cut (if the resulting input is `""`). 

### Summary of changes

Don't exclude empty input when syncing inspector.data in item-bylang.vue.
