### PR TITLE
Feature/lxl 2513 filter roles depending on contribution parent

### DIFF
--- a/vue-client/src/components/mixins/sidesearch-mixin.vue
+++ b/vue-client/src/components/mixins/sidesearch-mixin.vue
@@ -146,6 +146,7 @@ export default {
       /**
        * If field is a kbv:predicate (e.g. role) then filter linkable items depending on field and parent type.
        * */
+      // A VocabUtil.isSubPropertyOf(field.subPropertyOf, 'predicate', ...) would be preferable here.
       if (field.subPropertyOf.find(subProp => subProp['@id'] === VocabUtil.getTermObject('predicate', this.resources.vocab, this.resources.context)['@id'])) {
         const statement = VocabUtil.getTermObject(field.domain[0]['@id'], this.resources.vocab, this.resources.context); // e.g. Contribution
         const statementOf = statement.allowedProperties.find(p => p.domain?.find(d => d['@id'] === statement['@id'])); // e.g. contributionOf

--- a/vue-client/src/components/mixins/sidesearch-mixin.vue
+++ b/vue-client/src/components/mixins/sidesearch-mixin.vue
@@ -153,7 +153,7 @@ export default {
         const statementOfRangeIncludes = statementOf.rangeIncludes[0]['@id']; // e.g. Endeavour
         const subClassesOfRangeIncludes = VocabUtil.getSubClassChain(statementOfRangeIncludes, this.resources.vocabClasses, this.resources.context); 
 
-        const fieldParentPath = [...(this.path.split('.').slice(0, -2))].join('.'); // Maybe too specific... are we always sure we need to go up two steps to find field parent path?
+        const fieldParentPath = this.path.split('.').slice(0, -2).join('.');
         const fieldParentType = get(this.inspector.data, fieldParentPath)['@type']; // e.g. Text
         const fieldParentBaseClasses = VocabUtil.getBaseClasses(
           VocabUtil.getTermObject(fieldParentType, this.resources.vocab, this.resources.context)['@id'],

--- a/vue-client/src/components/mixins/sidesearch-mixin.vue
+++ b/vue-client/src/components/mixins/sidesearch-mixin.vue
@@ -2,7 +2,6 @@
 import { mapGetters } from 'vuex';
 import * as DisplayUtil from 'lxljs/display';
 import * as VocabUtil from 'lxljs/vocab';
-import { buildQueryString } from '@/utils/http';
 
 export default {
   data() {
@@ -106,15 +105,6 @@ export default {
       }
       return q;
     },
-    getSearchParams(searchPhrase) {
-      if (this.currentSearchParam == null) {
-        return { q: searchPhrase };
-      }
-
-      const params = Object.assign({}, this.currentSearchParam.mappings || {});
-      this.currentSearchParam.searchProps.forEach((param) => { params[param] = searchPhrase; });
-      return params;
-    },
     fetch(pageNumber) {
       const self = this;
       self.currentPage = pageNumber;
@@ -136,16 +126,22 @@ export default {
       this.fetch(n);
     },
     getItems(keyword) {
-      let params = this.getSearchParams(this.getSearchPhrase(keyword));
-      params = Object.assign(params, {
+      const searchPhrase = this.getSearchPhrase(keyword);
+      const urlSearchParams = new URLSearchParams({
+        q: searchPhrase,
         _limit: this.maxResults,
         _offset: this.currentPage * this.maxResults,
         _sort: this.sort,
+        ...(typeof this.typeArray !== 'undefined' && this.typeArray.length > 0 && { '@type': this.typeArray }),
+        ...this.currentSearchParam?.mappings,
+        ...this.currentSearchParam?.searchProps.reduce((acc, searchProp) => ({
+          ...acc,
+          [searchProp]: searchPhrase,
+        }), {}),
       });
-      if (typeof this.typeArray !== 'undefined' && this.typeArray.length > 0) {
-        params['@type'] = this.typeArray;
-      }
-      const searchUrl = `${this.settings.apiPath}/find.jsonld?${buildQueryString(params)}`;
+
+      const searchUrl = `${this.settings.apiPath}/find.jsonld?${urlSearchParams.toString()}`;
+
       return new Promise((resolve, reject) => {
         // Check if abortcontroller is available
         // ie11 doesn't have it atm so they don't get cancellable fetches...


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [X] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-2513](https://jira.kb.se/browse/LXL-2513)

### Solves

Filters roles depending on contribution parent.

### Summary of changes
- Filter linkable items if field is a `kbv:predicate`
- Use `URLSearchParams` interface to allow duplicate keys (`or-domain.@id`). This probably needs some QA to ensure it doesn't break something else.
