### PR TITLE
Fix MARC preview for unsaved records

### DIFF
--- a/vue-client/src/utils/record.js
+++ b/vue-client/src/utils/record.js
@@ -295,8 +295,6 @@ export function convertToMarc(inspectorData, settings, user) {
   const editorObj = DataUtil.getMergedItems(
     DataUtil.removeNullValues(inspectorData.record),
     DataUtil.removeNullValues(inspectorData.mainEntity),
-    DataUtil.removeNullValues(inspectorData.work),
-    inspectorData.quoted,
   );
   const apiPath = settings.apiPath;
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Parts of the MARC preview were sometimes missing in unsaved records. 
Because MARC conversion was done on the record + "quoted" which was sometimes incomplete
instead of on a freshly embellished copy of the record.
(I'm not sure this is still a problem since we fetch all links in templates to quoted nowadays.)

Embellish is already performed on the server side so no need to send quoted/embellished data. 
Embellish on the server side failed when passed already embellished data.

TODO: make backend embellish or at least MARC `/_convert` handle embellished data.

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-2476](https://jira.kb.se/browse/LXL-2476)

### Summary of changes
Only send the record being edited to `/_convert`.
