### PR TITLE
Lxl 4162 show type on linked item in single view

### DIFF
--- a/vue-client/src/components/shared/summary-node.vue
+++ b/vue-client/src/components/shared/summary-node.vue
@@ -71,7 +71,7 @@ export default {
 <template>
   <div class="SummaryNode">
     <span class="SummaryNode-label" v-if="!isLinked || isStatic" ref="ovf-label" @click.prevent.self="e => e.target.classList.toggle('expanded')">
-      <span v-if="fieldKey === 'instanceOf' && item['@type'] !== 'Work'">
+      <span v-if="fieldKey === 'instanceOf' && focusData['@type'] !== 'Work'">
         {{ focusData['@type'] | labelByLang | capitalize }} •
       </span>
       {{ typeof item === 'string' ? getStringLabel : getItemLabel }}{{ isLast ? '' : ';&nbsp;' }}
@@ -80,7 +80,7 @@ export default {
     <v-popover v-if="isLinked && !isStatic" :disabled="!hoverLinks" @show="$refs.previewCard.populateData()" placement="bottom-start">
       <span class="SummaryNode-link tooltip-target">
         <router-link v-if="isLibrisResource" :to="routerPath">
-          <span v-if="fieldKey === 'instanceOf' && item['@type'] !== 'Work'">
+          <span v-if="fieldKey === 'instanceOf' && focusData['@type'] !== 'Work'">
             {{ focusData['@type'] | labelByLang | capitalize }} •
           </span>
           {{getItemLabel}}

--- a/vue-client/src/components/shared/summary-node.vue
+++ b/vue-client/src/components/shared/summary-node.vue
@@ -72,7 +72,7 @@ export default {
   <div class="SummaryNode">
     <span class="SummaryNode-label" v-if="!isLinked || isStatic" ref="ovf-label" @click.prevent.self="e => e.target.classList.toggle('expanded')">
       <span v-if="fieldKey === 'instanceOf' && item['@type'] !== 'Work'">
-        {{ item['@type'] | labelByLang | capitalize }} •
+        {{ focusData['@type'] | labelByLang | capitalize }} •
       </span>
       {{ typeof item === 'string' ? getStringLabel : getItemLabel }}{{ isLast ? '' : ';&nbsp;' }}
       <resize-observer v-if="handleOverflow" @notify="calculateOverflow" />
@@ -80,8 +80,8 @@ export default {
     <v-popover v-if="isLinked && !isStatic" :disabled="!hoverLinks" @show="$refs.previewCard.populateData()" placement="bottom-start">
       <span class="SummaryNode-link tooltip-target">
         <router-link v-if="isLibrisResource" :to="routerPath">
-          <span v-if="fieldKey === 'instanceOf'">
-            {{ item['@type'] | labelByLang | capitalize }} •
+          <span v-if="fieldKey === 'instanceOf' && item['@type'] !== 'Work'">
+            {{ focusData['@type'] | labelByLang | capitalize }} •
           </span>
           {{getItemLabel}}
         </router-link>


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4162](https://jira.kb.se/browse/LXL-4162)

Duplicate of closed PR #888, now with `develop` as base instead of `1.32.0`.

### Solves

Show type of linked item in single/full view. Reads the type from `focusData` instead of `item`

### Summary of changes

- Show type of linked item in single/full view

Single view:
<img width="1624" alt="Skärmavbild 2023-08-23 kl  14 49 19" src="https://github.com/libris/lxlviewer/assets/10220360/fb9258ca-db18-47e7-a3de-c3559edff66d">

List view:
<img width="1624" alt="Skärmavbild 2023-08-23 kl  14 48 17" src="https://github.com/libris/lxlviewer/assets/10220360/9efb5184-c965-4467-890e-b0adc807c6bf">
