### PR TITLE
Use vocab term object for display if available

### DIFF
--- a/lxljs/display.js
+++ b/lxljs/display.js
@@ -391,6 +391,11 @@ export function getDisplayObject(item, level, resources, quoted, settings) {
 
   // Is this a link?
   if (trueItem.hasOwnProperty('@id') && !trueItem.hasOwnProperty('@type')) {
+    const termObj = VocabUtil.getTermObject(trueItem['@id'], resources.vocab, resources.context);
+    if (termObj != null) {
+      const label = termObj.labelByLang ? termObj.labelByLang[settings.language] : termObj.label;
+      return label ? { label } : trueItem;
+    }
     if (trueItem['@id'] === 'https://id.kb.se/vocab/') {
       return {};
     }


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4265](https://jira.kb.se/browse/LXL-4265)

### Solves

When showing linked vocabulary terms, the label available in the vocab data is not used, and a generic "leaf from URI" fallback is used.

### Summary of changes

Use vocab term object in  `getDisplayObject` if available. Otherwise show full URI (to clearly show that no label for the term is available).