### PR TITLE
Fix undo history when extracting items

### DIFF
--- a/vue-client/src/store.js
+++ b/vue-client/src/store.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import { cloneDeep, each, set, get, assign, filter, isObject, isEqual } from 'lodash-es';
+import { cloneDeep, each, set, get, assign, filter, isObject } from 'lodash-es';
 import ClientOAuth2 from 'client-oauth2';
 import * as VocabUtil from 'lxljs/vocab';
 import * as StringUtil from 'lxljs/string';
@@ -196,7 +196,9 @@ const store = new Vuex.Store({
         const changes = [];
         each(payload.changeList, (node) => {
           let oldValue;
-          if (node.path === '') {
+          if (node.value === EXTRACT_ON_SAVE) {
+            oldValue = EXTRACT_ON_SAVE;
+          } else if (node.path === '') {
             oldValue = inspectorData;
           } else {
             oldValue = cloneDeep(get(inspectorData, node.path));
@@ -209,7 +211,7 @@ const store = new Vuex.Store({
       // Set the new values
       each(payload.changeList, (node) => {
         // Do nothing if id indicates that the item should be extracted when saving (as the value will otherwise be the same as before).
-        if (node.value?.['@id'] !== EXTRACT_ON_SAVE) {
+        if (node.value !== EXTRACT_ON_SAVE) {
           if (node.path === '') {
             inspectorData = node.value;
           } else {
@@ -419,7 +421,7 @@ const store = new Vuex.Store({
         changeList: [
           {
             path,
-            value: { '@id': EXTRACT_ON_SAVE },
+            value: EXTRACT_ON_SAVE,
           },
         ],
         addToHistory: true,
@@ -636,7 +638,7 @@ const store = new Vuex.Store({
             value: node.value,
           });
           if (
-            isEqual(node.value, lastNode?.[0].value) // why is lastNode an array?
+            node.value === EXTRACT_ON_SAVE
             && Object.keys(state.inspector.extractItemsOnSave).includes(node.path)
           ) {
             dispatch('removeExtractItemOnSave', { path: node.path });

--- a/vue-client/src/store.js
+++ b/vue-client/src/store.js
@@ -282,6 +282,9 @@ const store = new Vuex.Store({
     flushChangeHistory(state) {
       state.inspector.changeHistory = [];
     },
+    removeIndexFromChangeHistory(state, index) {
+      state.inspector.changeHistory = state.inspector.changeHistory.filter((_, i) => i !== index);
+    },
     logoutUser(state) {
       localStorage.removeItem('at');
       state.user = User.getUserObject();
@@ -434,6 +437,10 @@ const store = new Vuex.Store({
     removeExtractItemOnSave({ commit, state }, { path }) {
       const { [path]: itemToRemove, ...rest } = state.inspector.extractItemsOnSave;
       commit('setExtractItemsOnSave', rest);
+      const indexInChangeHistory = state.inspector.changeHistory.findIndex(item => item[0].path === path && item[0].value === EXTRACT_ON_SAVE);
+      if (indexInChangeHistory >= 0) {
+        commit('removeIndexFromChangeHistory', indexInChangeHistory);
+      }
     },
     flushExtractItemsOnSave({ commit }) {
       commit('setExtractItemsOnSave', {});

--- a/vue-client/src/store.js
+++ b/vue-client/src/store.js
@@ -210,7 +210,11 @@ const store = new Vuex.Store({
       }
       // Set the new values
       each(payload.changeList, (node) => {
-        // Do nothing if id indicates that the item should be extracted when saving (as the value will otherwise be the same as before).
+        /** 
+         * Skip updating inspector data if changeList value is EXTRACT_ON_SAVE, which indicates that the
+         * item should be extracted first while saving (the values of the item should be unchanged until the
+         * extraction has finished and there is a new id to link to).
+         */
         if (node.value !== EXTRACT_ON_SAVE) {
           if (node.path === '') {
             inspectorData = node.value;
@@ -416,7 +420,7 @@ const store = new Vuex.Store({
         ...state.inspector.extractItemsOnSave,
         [path]: item,
       });
-      // Change id to constant indicating that the item should be extracted when clicking save.
+      // Change value to constant indicating that the item should be extracted when clicking save.
       dispatch('updateInspectorData', {
         changeList: [
           {


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [X] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4190](https://jira.kb.se/browse/LXL-4190)

### Solves

Fixes undo history when extracting items.

The `changeHistory` state currently relies on implicit changes on the values of an item, this causes problems when waiting with extracting items until save as there shouldn't be any changes other than updating the id (which doesn't exist yet as it hasn't been extracted yet)...

So we need a work-around: the `changeList` payload is replaced with a constant (`EXTRACT_ON_SAVE`) indicating that the item should be extracted on save – this constant acts as an opt-out for the normal `changeList` functionality (it skips setting the inspector data with new values).

When cancelling an extraction the related `changeHistory` item is removed (even if it isn't the latest change).

### Summary of changes

- Fix undo history when extracting items
- Remove extraction from changeHistory
