### PR TITLE
Rewrite typeArray param as multiple keys

### DIFF
--- a/vue-client/src/components/mixins/sidesearch-mixin.vue
+++ b/vue-client/src/components/mixins/sidesearch-mixin.vue
@@ -133,13 +133,14 @@ export default {
         _limit: this.maxResults,
         _offset: this.currentPage * this.maxResults,
         _sort: this.sort,
-        ...(typeof this.typeArray !== 'undefined' && this.typeArray.length > 0 && { '@type': this.typeArray }),
         ...this.currentSearchParam?.mappings,
         ...this.currentSearchParam?.searchProps.reduce((acc, searchProp) => ({
           ...acc,
           [searchProp]: searchPhrase,
         }), {}),
       });
+
+      this.typeArray?.forEach(type => urlSearchParams.append('@type', type));
 
       if (this.fieldKey) {
         const field = VocabUtil.getTermObject(this.fieldKey, this.resources.vocab, this.resources.context);


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-2513](https://jira.kb.se/browse/LXL-2513)

### Solves

Rewrites comma-separated typeArray as multiple urlSearchParam keys.

### Summary of changes

- Rewrite typeArray param as multiple keys