### PR TITLE
Append searchProps and mappings into URLSearchParams

### DIFF
--- a/vue-client/src/components/mixins/sidesearch-mixin.vue
+++ b/vue-client/src/components/mixins/sidesearch-mixin.vue
@@ -129,18 +129,19 @@ export default {
     getItems(keyword) {
       const searchPhrase = this.getSearchPhrase(keyword);
       const urlSearchParams = new URLSearchParams({
-        q: searchPhrase,
+        ...(!this.currentSearchParam && { q: searchPhrase }),
         _limit: this.maxResults,
         _offset: this.currentPage * this.maxResults,
         _sort: this.sort,
-        ...this.currentSearchParam?.mappings,
-        ...this.currentSearchParam?.searchProps.reduce((acc, searchProp) => ({
-          ...acc,
-          [searchProp]: searchPhrase,
-        }), {}),
       });
 
       this.typeArray?.forEach(type => urlSearchParams.append('@type', type));
+      
+      this.currentSearchParam?.searchProps
+        .forEach(searchProp => urlSearchParams.append(searchProp, searchPhrase));
+    
+      Object.keys(this.currentSearchParam?.mappings || {})
+        .forEach(key => urlSearchParams.append(key, this.currentSearchParam.mappings[key]));
 
       if (this.fieldKey) {
         const field = VocabUtil.getTermObject(this.fieldKey, this.resources.vocab, this.resources.context);


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [X] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-2513](https://jira.kb.se/browse/LXL-2513)

### Solves

Uses the append method from the `URLSearchParams` interface for  `this.currentSearchParam.mappings` and `this.currentSearchParam.searchProps`. This allows multiple keys of the same type and replicates the functionality of the old [buildQueryString](https://github.com/libris/lxlviewer/blob/460884c8cb867e357718b15632233974ce31ee0c/vue-client/src/utils/http.js#L4-L19)-method.

Related PRs: #893 (where the `URLSearchParams` interface was introduced) and #899.

### Summary of changes

- Append search props and mappings into URLSearchParams
