### PR TITLE
Add Vue3 compat build again

### DIFF
--- a/vue-client/package.json
+++ b/vue-client/package.json
@@ -17,6 +17,7 @@
     "@babel/core": "^7.23.2",
     "@babel/polyfill": "^7.8.3",
     "@vitejs/plugin-vue": "^4.4.0",
+    "@vue/compat": "^3.3.8",
     "@vue/eslint-config-airbnb": "^7.0.0",
     "@vueuse/components": "^10.5.0",
     "@vueuse/core": "^10.5.0",

--- a/vue-client/src/components/search/search-form.vue
+++ b/vue-client/src/components/search/search-form.vue
@@ -1,4 +1,5 @@
 <script>
+import { configureCompat } from 'vue';
 import { isEmpty, cloneDeep, isArray } from 'lodash-es';
 import { marked } from 'marked';
 import { mapGetters } from 'vuex';
@@ -7,6 +8,12 @@ import PropertyMappings from '@/resources/json/propertymappings.json';
 import { buildQueryString } from '@/utils/http';
 import { translatePhrase } from '@/utils/filters';
 import RemoteDatabases from '@/components/search/remote-databases.vue';
+
+/* TODO: Remove when Vue compat is removed. See https://github.com/Akryum/floating-vue/issues/924. */
+configureCompat({
+  RENDER_FUNCTION: false,
+  WATCH_ARRAY: false,
+});
 
 export default {
   name: 'search-form',

--- a/vue-client/vite.config.js
+++ b/vue-client/vite.config.js
@@ -9,7 +9,15 @@ import autoprefixer from 'autoprefixer';
 export default defineConfig({
   base: '/katalogisering/',
   plugins: [
-    vue(),
+    vue({
+      template: {
+        compilerOptions: {
+          compatConfig: {
+            MODE: 2
+          }
+        }
+      }
+    })
   ],
   server: {
     port: 8080,
@@ -30,6 +38,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      vue: '@vue/compat',
       '@': fileURLToPath(new URL('./src', import.meta.url)),
       '~bootstrap': resolve(__dirname, 'node_modules/bootstrap'),
       '~font-awesome': resolve(__dirname, 'node_modules/font-awesome'),

--- a/vue-client/yarn.lock
+++ b/vue-client/yarn.lock
@@ -1469,6 +1469,15 @@
     loupe "^2.3.6"
     pretty-format "^29.5.0"
 
+"@vue/compat@^3.3.8":
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/@vue/compat/-/compat-3.3.8.tgz#20e7e657158af0ab58ea29436b07d556abcbf014"
+  integrity sha512-ywp40WMF1DKZ4X/HbLPd5gHDyxDk/itDHp8JiSodvI9OyiA53HQS2hstLCh652HDue58gTQlo80HJwQCj+hYRw==
+  dependencies:
+    "@babel/parser" "^7.23.0"
+    estree-walker "^2.0.2"
+    source-map-js "^1.0.2"
+
 "@vue/compiler-core@3.3.8":
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.3.8.tgz#301bb60d0245265a88ed5b30e200fbf223acb313"


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4088](https://jira.kb.se/browse/LXL-4088)
### Solves

Adds Vue3 compat build for easier debugging https://v3-migration.vuejs.org/migration-build.html

### Summary of changes

- Add Vue3 compat build again