### PR TITLE
Fix creation of local entities

### DIFF
--- a/vue-client/src/components/mixins/sidesearch-mixin.vue
+++ b/vue-client/src/components/mixins/sidesearch-mixin.vue
@@ -233,7 +233,7 @@ export default {
       for (let i = 0; i < classTree.length; i++) {
         const term = {};
         term.depth = classTree[i].depth;
-        term.abstract = classTree[i].abstract;
+        term.abstract = classTree[i].abstract || null;
         term.label = this.getLabelWithTreeDepth(classTree[i]);
         term.value = classTree[i].id;
         term.key = `${classTree[i].id}-${i}`;


### PR DESCRIPTION
Falsy options were coerced to the string `false`, resulting in a truthy value. In vue3 `null` or `undefined` should be used to explictly remove an attribute. See https://v3-migration.vuejs.org/breaking-changes/attribute-coercion.html#coercing-false-to-false-instead-of-removing-the-attribute

## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4339](https://jira.kb.se/browse/LXL-4339)

### Solves

Fix creation of local entities

### Summary of changes

Fix creation of local entities by using `null` instead of `false` inside the `selectOptions` method inside `sidesearch-mixin.vue`
