### PR TITLE
LXL-4341: Fix remove item bug

### DIFF
--- a/vue-client/src/components/inspector/item-bylang.vue
+++ b/vue-client/src/components/inspector/item-bylang.vue
@@ -46,8 +46,10 @@ export default {
         this.updateViewForm();
       }
     },
-    fieldOtherValue() {
-      this.updateViewForm();
+    fieldOtherValue(newVal, oldVal) {
+      if (!isEqual(newVal, oldVal)) {
+        this.updateViewForm();
+      }
     },
     entries: {
       handler: debounce(function debounceUpdate(val) {

--- a/vue-client/src/components/inspector/item-local.vue
+++ b/vue-client/src/components/inspector/item-local.vue
@@ -425,7 +425,9 @@ export default {
       const fieldAdder = this.$refs.fieldAdder;
       if (this.isEmpty) {
         LayoutUtil.enableTabbing();
-        fieldAdder.$refs.adderButton.focus();
+        if (fieldAdder) {
+          fieldAdder.$refs.adderButton.focus();
+        }
       } else {
         this.expand();
         this.expandAllChildren();

--- a/vue-client/src/components/inspector/language-entry.vue
+++ b/vue-client/src/components/inspector/language-entry.vue
@@ -198,7 +198,7 @@ export default {
           class="LanguageEntry-input js-itemValueInput"
           rows="1"
           v-bind:value="modelValue"
-          v-on:input="$emit('update:modelValue', $event.target.value)"
+          v-on:input="$emit('update:model-value', $event.target.value)"
           @blur="$emit('update')"
           ref="textarea"
         />

--- a/vue-client/src/components/search/search-form.vue
+++ b/vue-client/src/components/search/search-form.vue
@@ -199,7 +199,7 @@ export default {
       }
       if (this.searchTool === 'changes') {
         return 'Sök bland ändringar'; // TODO: i18n
-      }   
+      }
       return 'Search';
     },
     composedSearchParam() { // pair current search param with searchphrase
@@ -375,7 +375,7 @@ export default {
           v-show="hasInput"
           @keyup.enter="clearInputs()"
           @click="clearInputs()">
-          <i class="fa fa-fw fa-close"></i>
+          <i class="fa fa-fw fa-close" />
         </span>
         <div class="SearchForm-selectWrapper SearchForm-paramSelectWrapper hidden-xs" v-if="searchPerimeter === 'libris'">
           <select

--- a/vue-client/src/store.js
+++ b/vue-client/src/store.js
@@ -544,7 +544,7 @@ const store = createStore({
       } else if (notifications.length === 1) { // Unchecked & removing the last element
         notifications.forEach((n) => { n.heldBy = 'none'; });
       } else { // Unchecked => remove whole notification
-        notifications = notifications.filter(n => n.heldBy !== libraryId);
+        notifications = notifications.filter((n) => n.heldBy !== libraryId);
       }
 
       dispatch('modifyUserDatabase', { property: 'requestedNotifications', value: notifications });
@@ -558,7 +558,7 @@ const store = createStore({
         if (checked) {
           n.triggers.push(categoryId);
         } else { // Unchecked => remove from triggers
-          n.triggers = n.triggers.filter(id => id !== categoryId);
+          n.triggers = n.triggers.filter((id) => id !== categoryId);
         }
       });
       dispatch('modifyUserDatabase', { property: 'requestedNotifications', value: notifications });
@@ -573,7 +573,7 @@ const store = createStore({
             n.push({ heldBy: libraryId, triggers: [categoryId] });
           }
         } else { // Unchecked => remove from triggers
-          n.triggers = n.triggers.filter(id => id !== categoryId);
+          n.triggers = n.triggers.filter((id) => id !== categoryId);
         }
       });
       dispatch('modifyUserDatabase', { property: 'requestedNotifications', value: notifications });


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4341](https://jira.kb.se/browse/LXL-4341)

### Solves

Fixar bugg där ett fält man tagit bort dyker upp igen. Beskrivning finns i ticket.

### Summary of changes

Anledningen till buggen (som uppstod efter vue3-migreringen av någon anledning) är att 
watchern för `fieldOtherValue` i item-bylang triggas efter borttagningen. Denna sätter igång en kedja anrop (`updateviewform()` -> `entries` -> `update()` -> `updateInspectorData`) som slutar med att det gamla värdet skrivs tillbaks igen. Nu uppdaterar vi enbart om det nya värdet skiljer sig från det gamla (precis som i watchern för `fieldValue`).

övriga ändringar:
* Kolla att `$refs.fieldAdder` finns (det gör den inte) innan vi gör saker med den, förhindrar `referenceError`
* `update:modelValue` --> `update:model-value` (vue 3 gillar kebab-case på events)
* linting