### PR TITLE
Feature/change view

### DIFF
--- a/vue-client/src/components/mixins/facet-mixin.vue
+++ b/vue-client/src/components/mixins/facet-mixin.vue
@@ -86,6 +86,9 @@ export default {
     settings() {
       return this.$store.getters.settings;
     },
+    changeCategories() {
+      return this.$store.getters.userChangeCategories;
+    },
   },
 
 };

--- a/vue-client/src/components/search/facet-group.vue
+++ b/vue-client/src/components/search/facet-group.vue
@@ -102,7 +102,6 @@ export default {
       const self = this;
       const list = this.group.observation.map((o) => {
         let label;
-        console.log('observation', JSON.stringify(o));
         if (o.object.hasOwnProperty('@id')) {
           label = DisplayUtil.getItemLabel(
             o.object,

--- a/vue-client/src/components/search/facet-group.vue
+++ b/vue-client/src/components/search/facet-group.vue
@@ -115,7 +115,7 @@ export default {
           amount: o.totalItems,
           link: o.view['@id'],
           featured: self.featuredComparison(o),
-          selected: o.selected,
+          selected: o._selected,
         };
       });
       return list;

--- a/vue-client/src/components/search/facet-group.vue
+++ b/vue-client/src/components/search/facet-group.vue
@@ -2,7 +2,7 @@
 import { sortBy, orderBy } from 'lodash-es';
 import { vOnClickOutside } from '@vueuse/components';
 import * as DisplayUtil from 'lxljs/display';
-import { translatePhrase, capitalize } from '@/utils/filters';
+import { translatePhrase, capitalize, asAppPath } from '@/utils/filters';
 import EncodingLevelIcon from '@/components/shared/encoding-level-icon.vue';
 import TypeIcon from '@/components/shared/type-icon.vue';
 import CheckBox from '@/components/shared/check-box';
@@ -41,6 +41,7 @@ export default {
   methods: {
     translatePhrase,
     capitalize,
+    asAppPath,
     facetLabelByLang(facetType) {
       return (this.settings.propertyChains[facetType] || {})[this.user.settings.language] || facetType;
     },
@@ -76,6 +77,9 @@ export default {
     isCollectionGroup(dim) {
       return dim === '@reverse.itemOf.heldBy.@id' || dim === 'concerning.@reverse.itemOf.heldBy.@id';
     },
+    checkedChanged(facetLink) {
+      this.$router.push(asAppPath(facetLink, true));
+    }
   },
   computed: {
     settings() {
@@ -269,7 +273,7 @@ export default {
             :checkedProperty="facetItem.object['@id']"
             :selected="facetItem.selected"
             :showToolTip="false"
-            @changed="checked(facetItem.link, facetItem.object['@id'])"></check-box>
+            @changed="checkedChanged(facetItem.link)"></check-box>
         </template>
       </facet>
       <hr v-show="featuredFacets.length > 0">
@@ -293,7 +297,7 @@ export default {
             :checkedProperty="facetItem.object['@id']"
             :selected="facetItem.selected"
             :showToolTip="false"
-            @changed="checked(facetItem.link, facetItem.object['@id'])"></check-box>
+            @changed="checkedChanged(facetItem.link)"></check-box>
         </template>
       </facet>
     </ul>

--- a/vue-client/src/components/search/facet-group.vue
+++ b/vue-client/src/components/search/facet-group.vue
@@ -73,17 +73,6 @@ export default {
       }
       return false;
     },
-    defaultChecked(facet) {
-      if (this.isChangeFacetGroup) {
-        const id = facet.object['@id'];
-        return this.checkedCategoriesAndSigels.includes(id);
-      }
-      return false;
-    },
-    checked(link, id) {
-      console.log('link', JSON.stringify(link));
-      console.log('id', JSON.stringify(id));
-    },
     isCollectionGroup(dim) {
       return dim === '@reverse.itemOf.heldBy.@id' || dim === 'concerning.@reverse.itemOf.heldBy.@id';
     },
@@ -122,7 +111,7 @@ export default {
           amount: o.totalItems,
           link: o.view['@id'],
           featured: self.featuredComparison(o),
-          isDefaultChecked: self.defaultChecked(o),
+          selected: o.selected,
         };
       });
       return list;
@@ -194,6 +183,12 @@ export default {
     checkedCategoriesAndSigels() {
       return [...this.changeCategories.map(c => c.heldBy), ...this.changeCategories.find(c => c.hasOwnProperty('triggers')).triggers];
     },
+    show() {
+      if (this.isChangeView) {
+        return this.isChangeFacetGroup;
+      }
+      return true;
+    }
   },
   components: {
     Facet,
@@ -208,7 +203,8 @@ export default {
   <nav
     class="FacetGroup"
     :class="{ 'has-scroll': hasScroll, 'is-expanded': isExpanded }"
-    :aria-labelledby="facetLabelByLang(group.dimension)">
+    :aria-labelledby="facetLabelByLang(group.dimension)"
+    v-if="show">
     <div class="FacetGroup-header">
       <h4
         class="FacetGroup-title uppercaseHeading--bold"
@@ -258,7 +254,8 @@ export default {
         v-for="facetItem in featuredFacets"
         :facet="facetItem"
         :key="'featured_' + facetItem.link"
-        :is-link="!isChangeFacetGroup">
+        :is-change-facet="isChangeFacetGroup"
+        :is-default-active="facetItem.checkedInSettings">
         <template #icon>
           <encoding-level-icon
             v-if="group.dimension === 'meta.encodingLevel'"
@@ -270,7 +267,7 @@ export default {
           <check-box v-if="group.dimension === 'concerning.@reverse.itemOf.heldBy.@id' && isChangeView"
             slot="checkbox"
             :checkedProperty="facetItem.object['@id']"
-            :isChosen="facetItem.isDefaultChecked"
+            :selected="facetItem.selected"
             :showToolTip="false"
             @changed="checked(facetItem.link, facetItem.object['@id'])"></check-box>
         </template>
@@ -280,7 +277,7 @@ export default {
         v-for="facetItem in normalFacets"
         :facet="facetItem"
         :key="facetItem.link"
-        :is-link="!isChangeFacetGroup">
+        :is-change-facet="isChangeFacetGroup">
         <template #icon>
           <encoding-level-icon
             slot="icon"
@@ -291,10 +288,10 @@ export default {
             :show-iconless="false"
             v-if="group.dimension === 'instanceOf.@type' || group.dimension === '@type'"
             :type="facetItem.object['@id']" />
-          <check-box v-if="group.dimension === 'category.@id' || group.dimension === 'concerning.@reverse.itemOf.heldBy.@id'"
+          <check-box v-if="isChangeFacetGroup"
             slot="checkbox"
             :checkedProperty="facetItem.object['@id']"
-            :isChosen="facetItem.isDefaultChecked"
+            :selected="facetItem.selected"
             :showToolTip="false"
             @changed="checked(facetItem.link, facetItem.object['@id'])"></check-box>
         </template>

--- a/vue-client/src/components/search/facet-group.vue
+++ b/vue-client/src/components/search/facet-group.vue
@@ -5,7 +5,9 @@ import * as DisplayUtil from 'lxljs/display';
 import { translatePhrase, capitalize } from '@/utils/filters';
 import EncodingLevelIcon from '@/components/shared/encoding-level-icon.vue';
 import TypeIcon from '@/components/shared/type-icon.vue';
+import CheckBox from '@/components/shared/check-box';
 import FacetMixin from '@/components/mixins/facet-mixin.vue';
+
 import Facet from './facet.vue';
 
 export default {
@@ -21,6 +23,10 @@ export default {
     },
     expanded: {
       type: Boolean,
+    },
+    isChangeView: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {
@@ -172,6 +178,7 @@ export default {
     Facet,
     EncodingLevelIcon,
     TypeIcon,
+    CheckBox,
   },
 };
 </script>
@@ -254,6 +261,8 @@ export default {
             :show-iconless="false"
             v-if="group.dimension === 'instanceOf.@type' || group.dimension === '@type'"
             :type="facetItem.object['@id']" />
+          <check-box v-if="group.dimension === 'category.@id' || group.dimension === 'concerning.@reverse.itemOf.heldBy.@id'"
+              slot="checkbox"></check-box>
         </template>
       </facet>
     </ul>

--- a/vue-client/src/components/search/facet-group.vue
+++ b/vue-client/src/components/search/facet-group.vue
@@ -268,10 +268,11 @@ export default {
             v-if="group.dimension === 'instanceOf.@type' || group.dimension === '@type'"
             :type="facetItem.object['@id']" />
           <check-box v-if="group.dimension === 'concerning.@reverse.itemOf.heldBy.@id' && isChangeView"
-              slot="checkbox"
-              :checkedProperty="facetItem.object['@id']"
-              :isChosen="facetItem.isDefaultChecked"
-              @changed="checked(facetItem.link, facetItem.object['@id'])"></check-box>
+            slot="checkbox"
+            :checkedProperty="facetItem.object['@id']"
+            :isChosen="facetItem.isDefaultChecked"
+            :showToolTip="false"
+            @changed="checked(facetItem.link, facetItem.object['@id'])"></check-box>
         </template>
       </facet>
       <hr v-show="featuredFacets.length > 0">
@@ -291,10 +292,11 @@ export default {
             v-if="group.dimension === 'instanceOf.@type' || group.dimension === '@type'"
             :type="facetItem.object['@id']" />
           <check-box v-if="group.dimension === 'category.@id' || group.dimension === 'concerning.@reverse.itemOf.heldBy.@id'"
-              slot="checkbox"
-              :checkedProperty="facetItem.object['@id']"
-              :isChosen="facetItem.isDefaultChecked"
-              @changed="checked(facetItem.link, facetItem.object['@id'])"></check-box>
+            slot="checkbox"
+            :checkedProperty="facetItem.object['@id']"
+            :isChosen="facetItem.isDefaultChecked"
+            :showToolTip="false"
+            @changed="checked(facetItem.link, facetItem.object['@id'])"></check-box>
         </template>
       </facet>
     </ul>

--- a/vue-client/src/components/search/facet-group.vue
+++ b/vue-client/src/components/search/facet-group.vue
@@ -79,7 +79,7 @@ export default {
     },
     checkedChanged(facetLink) {
       this.$router.push(asAppPath(facetLink, true));
-    }
+    },
   },
   computed: {
     settings() {

--- a/vue-client/src/components/search/facet.vue
+++ b/vue-client/src/components/search/facet.vue
@@ -15,7 +15,7 @@ export default {
       type: Object,
       default: null,
     },
-    isLink: {
+    isChangeFacet: {
       type: Boolean,
       default: false,
     },
@@ -64,7 +64,7 @@ export default {
     <slot name="icon" />
     <router-link
       class="Facet-link"
-      :to="asAppPath(facet.link)"
+      :to="asAppPath(facet.link, isChangeFacet)"
       :title="capitalize(facet.label)">
       <span
         class="Facet-label"

--- a/vue-client/src/components/search/facet.vue
+++ b/vue-client/src/components/search/facet.vue
@@ -15,6 +15,10 @@ export default {
       type: Object,
       default: null,
     },
+    isLink: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {

--- a/vue-client/src/components/search/filter-badge.vue
+++ b/vue-client/src/components/search/filter-badge.vue
@@ -9,6 +9,10 @@ export default {
       type: Object,
       default: null,
     },
+    isChangeView: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
@@ -45,7 +49,7 @@ export default {
     <span v-if="filter.predicateLabel.length > 0">{{ filter.predicateLabel }}:</span>
     <span>{{ labelByLang(filter.label) }}</span>
     <router-link
-      :to="asAppPath(filter.up)">
+      :to="asAppPath(filter.up, isChangeView)">
       <i class="fa fa-fw fa-close icon"
       />
     </router-link>

--- a/vue-client/src/components/search/result-controls.vue
+++ b/vue-client/src/components/search/result-controls.vue
@@ -161,6 +161,9 @@ export default {
         this.addFilter('@reverse.itemOf.heldBy.@id', `https://libris.kb.se/library/${this.user.settings.activeSigel}`);
       }
     },
+    appPath(path) {
+      return this.asAppPath(path, this.$route.params.tool === 'changes');
+    },
     addFilter(key, value) {
       const newQuery = Object.assign({}, this.$route.query);
       newQuery[key] = value;
@@ -259,7 +262,7 @@ export default {
         <li
           class="ResultControls-pagItem"
           v-bind:class="{ 'is-disabled': !pageData.first || pageData['@id'] === pageData.first['@id'] }">
-          <router-link class="ResultControls-pagLink" v-if="pageData.first" :to="asAppPath(pageData.first['@id'])">{{ translatePhrase('First') }}</router-link>
+          <router-link class="ResultControls-pagLink" v-if="pageData.first" :to="appPath(pageData.first['@id'])">{{ translatePhrase('First') }}</router-link>
           <a class="ResultControls-pagLink" v-if="!pageData.first">{{ translatePhrase('First') }}</a>
         </li>
         <li
@@ -268,7 +271,7 @@ export default {
           <router-link
             class="ResultControls-pagLink"
             v-if="pageData.previous"
-            :to="asAppPath(pageData.previous['@id'])">{{ translatePhrase('Previous') }}</router-link>
+            :to="appPath(pageData.previous['@id'])">{{ translatePhrase('Previous') }}</router-link>
           <a class="ResultControls-pagLink" v-if="!pageData.previous">{{ translatePhrase('Previous') }}</a>
         </li>
         <li
@@ -279,7 +282,7 @@ export default {
           <span class="ResultControls-pagDecor" v-if="!page.link">...</span>
           <router-link
             class="ResultControls-pagLink"
-            :to="asAppPath(page.link)"
+            :to="appPath(page.link)"
             v-if="!page.active && page.link">{{page.pageLabel}}</router-link>
           <a class="ResultControls-pagLink" v-if="page.active">{{page.pageLabel}}</a>
         </li>
@@ -289,7 +292,7 @@ export default {
           <router-link
             class="ResultControls-pagLink"
             v-if="pageData.next"
-            :to="asAppPath(pageData.next['@id'])">{{ translatePhrase('Next') }}</router-link>
+            :to="appPath(pageData.next['@id'])">{{ translatePhrase('Next') }}</router-link>
           <a class="ResultControls-pagLink" v-if="!pageData.next">{{ translatePhrase('Next') }}</a>
         </li>
         <li
@@ -298,7 +301,7 @@ export default {
           <router-link
             class="ResultControls-pagLink"
             v-if="pageData.last"
-            :to="asAppPath(pageData.last['@id'])">{{ translatePhrase('Last') }}</router-link>
+            :to="appPath(pageData.last['@id'])">{{ translatePhrase('Last') }}</router-link>
           <a class="ResultControls-pagLink" v-if="!pageData.last">{{ translatePhrase('Last') }}</a>
         </li>
       </ul>

--- a/vue-client/src/components/search/result-controls.vue
+++ b/vue-client/src/components/search/result-controls.vue
@@ -149,6 +149,9 @@ export default {
       }
       return `${first}-${last}`;
     },
+    isChangeView() {
+      return this.$route.params.tool === 'changes';
+    },
   },
   emits: ['sortChange'],
   methods: {
@@ -162,7 +165,7 @@ export default {
       }
     },
     appPath(path) {
-      return this.asAppPath(path, this.$route.params.tool === 'changes');
+      return this.asAppPath(path, this.isChangeView);
     },
     addFilter(key, value) {
       const newQuery = Object.assign({}, this.$route.query);
@@ -254,7 +257,7 @@ export default {
     </div>
     <div class="ResultControls-secondary">
       <div class="ResultControls-filterWrapper" v-if="showDetails && filters.length > 0">
-        <FilterBadge class="ResultControls-filterBadge" v-for="(filter, index) in filters" :key="index" :filter="filter" />
+        <FilterBadge class="ResultControls-filterBadge" v-for="(filter, index) in filters" :key="index" :filter="filter" :is-change-view="isChangeView" />
       </div>
     </div>
     <nav v-if="hasPagination && showPages">

--- a/vue-client/src/components/search/result-list-item.vue
+++ b/vue-client/src/components/search/result-list-item.vue
@@ -7,6 +7,7 @@ import ReverseRelations from '@/components/inspector/reverse-relations.vue';
 import TagSwitch from '@/components/shared/tag-switch.vue';
 import LensMixin from '../mixins/lens-mixin.vue';
 import ResultMixin from '../mixins/result-mixin.vue';
+import CheckBox from "../shared/check-box.vue";
 
 export default {
   name: 'result-list-item',
@@ -21,6 +22,10 @@ export default {
     database: {
       type: String,
       default: '',
+    },
+    isChangeView: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {
@@ -99,6 +104,7 @@ export default {
     },
   },
   components: {
+    CheckBox,
     TagSwitch,
     ReverseRelations,
   },
@@ -134,15 +140,13 @@ export default {
           class=""
           :action-labels="{ on: 'Mark as', off: 'Unmark as' }"
           tag="Flagged" />
-        <tag-switch
-          :document="focusData"
-          class=""
-          :action-labels="{ on: 'Mark as', off: 'Unmark as' }"
-          tag="Handled" />
+
+        <check-box v-if="isChangeView">
+        </check-box>
       </div>
       <div
         class="ResultItem-relationsContainer"
-        v-if="isImport === false">
+        v-if="isImport === false && !isChangeView ">
         <reverse-relations
           v-show="showUsedIn"
           @numberOfRelations="allCount"

--- a/vue-client/src/components/search/result-list-item.vue
+++ b/vue-client/src/components/search/result-list-item.vue
@@ -134,6 +134,11 @@ export default {
           class=""
           :action-labels="{ on: 'Mark as', off: 'Unmark as' }"
           tag="Flagged" />
+        <tag-switch
+          :document="focusData"
+          class=""
+          :action-labels="{ on: 'Mark as', off: 'Unmark as' }"
+          tag="Handled" />
       </div>
       <div
         class="ResultItem-relationsContainer"

--- a/vue-client/src/components/search/result-list-item.vue
+++ b/vue-client/src/components/search/result-list-item.vue
@@ -140,8 +140,9 @@ export default {
           class=""
           :action-labels="{ on: 'Mark as', off: 'Unmark as' }"
           tag="Flagged" />
-
-        <check-box v-if="isChangeView">
+        <check-box
+          :action-labels="{ on: 'Mark as handled', off: 'Unmark as handled' }"
+          v-if="isChangeView">
         </check-box>
       </div>
       <div

--- a/vue-client/src/components/search/result-list-item.vue
+++ b/vue-client/src/components/search/result-list-item.vue
@@ -2,12 +2,14 @@
 import * as StringUtil from 'lxljs/string';
 import * as VocabUtil from 'lxljs/vocab';
 import * as RecordUtil from '@/utils/record';
+import * as HttpUtil from '@/utils/http';
 import { translatePhrase } from '@/utils/filters';
 import ReverseRelations from '@/components/inspector/reverse-relations.vue';
 import TagSwitch from '@/components/shared/tag-switch.vue';
 import LensMixin from '../mixins/lens-mixin.vue';
 import ResultMixin from '../mixins/result-mixin.vue';
 import CheckBox from "../shared/check-box.vue";
+import { getHandleAction } from "../../utils/record";
 
 export default {
   name: 'result-list-item',
@@ -102,6 +104,20 @@ export default {
     allCount(value) {
       this.totalReverseCount = value;
     },
+    async handleChanged(e, isChecked) {
+      if (isChecked) {
+        const handleActionRecord = getHandleAction(this.recordId);
+        const response = await HttpUtil.post({
+          url: `${this.settings.apiPath}/data`,
+          token: this.user.token,
+          activeSigel: this.user.settings.activeSigel,
+        }, handleActionRecord);
+        const recordUrl = `${response.getResponseHeader('Location')}`;
+        console.log('Created handle action: ', recordUrl);
+      } else {
+        //Remove record linking to this id, (we need to know this through reverse)
+      }
+    }
   },
   components: {
     CheckBox,
@@ -142,7 +158,8 @@ export default {
           tag="Flagged" />
         <check-box
           :action-labels="{ on: 'Mark as handled', off: 'Unmark as handled' }"
-          v-if="isChangeView">
+          v-if="isChangeView"
+          @changed="handleChanged">
         </check-box>
       </div>
       <div

--- a/vue-client/src/components/search/result-list.vue
+++ b/vue-client/src/components/search/result-list.vue
@@ -11,6 +11,7 @@ export default {
     results: Array,
     compact: Boolean,
     importData: Array,
+    isChangeView: Boolean,
   },
   data() {
     return {
@@ -67,6 +68,7 @@ export default {
       :show-compact="compact"
       :focus-data="item"
       :import-item="getImportItem(index)"
+      :isChangeView="isChangeView"
       v-for="(item, index) in results"
       :key="item['@id']"
       @relations-list-open="relationsListOpen" />

--- a/vue-client/src/components/search/search-form.vue
+++ b/vue-client/src/components/search/search-form.vue
@@ -57,7 +57,7 @@ export default {
       this.helpToggled = !this.helpToggled;
     },
     composeQuery() {
-      return buildQueryString(this.searchPerimeter === 'libris' || this.searchTool === 'changes'
+      return buildQueryString(this.searchPerimeter === 'libris'
         ? this.mergedParams
         : { q: this.searchPhrase, databases: this.status.remoteDatabases.join() });
     },
@@ -67,7 +67,14 @@ export default {
       if (this.searchPerimeter === 'libris' || this.searchPerimeter === 'remote') {
         path = `/search/${this.searchPerimeter}?${this.composeQuery()}`;
       } else if (this.searchTool === 'changes') {
-        path = `${this.$route.path}?${this.composeQuery()}`;
+        //Keep facets
+        if (!isEmpty(this.$route.query)) {
+          let queryObj = cloneDeep(this.$route.query);
+          queryObj.q = this.searchPhrase;
+          path = `${this.$route.path}?${buildQueryString(queryObj)}`;
+        } else {
+          path = `${this.$route.path}?${buildQueryString(this.mergedParams)}`;
+        }
       }
       this.$router.push(path);
     },

--- a/vue-client/src/components/search/search-form.vue
+++ b/vue-client/src/components/search/search-form.vue
@@ -205,8 +205,8 @@ export default {
         return 'ISBN eller valfria sökord';
       }
       if (this.searchTool === 'changes') {
-        return 'Sök bland ändringar'; // TODO: i18n
-      }   
+        return 'Search among changes';
+      }
       return 'Search';
     },
     composedSearchParam() { // pair current search param with searchphrase

--- a/vue-client/src/components/search/search-result.vue
+++ b/vue-client/src/components/search/search-result.vue
@@ -55,6 +55,9 @@ export default {
     totalItems() {
       return this.result.totalItems;
     },
+    isChangeView() {
+      return this.$route.params.tool === 'changes';
+    }
   },
   components: {
     'result-controls': ResultControls,
@@ -95,7 +98,9 @@ export default {
       v-if="!status.resultList.loading && !status.resultList.error"
       :results="result.items"
       :import-data="importData"
-      :compact="user.settings.resultListType === 'compact'" />
+      :compact="user.settings.resultListType === 'compact'"
+      :isChangeView="isChangeView"
+    />
     <result-controls
       class="SearchResult-controls"
       v-if="!status.resultList.loading && !status.resultList.error && hasPagination"

--- a/vue-client/src/components/search/search-result.vue
+++ b/vue-client/src/components/search/search-result.vue
@@ -100,7 +100,7 @@ export default {
       :import-data="importData"
       :compact="user.settings.resultListType === 'compact'"
       :isChangeView="isChangeView"
-    />
+    />  
     <result-controls
       class="SearchResult-controls"
       v-if="!status.resultList.loading && !status.resultList.error && hasPagination"

--- a/vue-client/src/components/shared/check-box.vue
+++ b/vue-client/src/components/shared/check-box.vue
@@ -27,7 +27,7 @@ export default {
   methods: {
     onChange(e) {
       this.isChecked = !this.isChecked;
-      this.$emit('changed', e);
+      this.$emit('changed', e, this.isChecked);
     },
   },
   computed: {

--- a/vue-client/src/components/shared/check-box.vue
+++ b/vue-client/src/components/shared/check-box.vue
@@ -41,15 +41,15 @@ export default {
 </script>
 
 <template>
-  <div class="TypeIcon">
+  <div class="CheckBox">
     <input id="test" class="customCheckbox-input" type="checkbox" @change="onChange" :checked="isChosen">
     <div class="customCheckbox-icon"></div>
   </div>
 </template>
 
 <style lang="less">
-.TypeIcon {
-  background-color: @grey-lightest;
+.CheckBox {
+  background-color: transparent;
   color: @brand-primary;
   display: flex;
   justify-content: center;

--- a/vue-client/src/components/shared/check-box.vue
+++ b/vue-client/src/components/shared/check-box.vue
@@ -9,7 +9,7 @@ export default {
       type: Object,
       default: () => ({ on: 'Mark', off: 'Unmark' }),
     },
-    isChosen: {
+    selected: {
       type: Boolean,
       default: false,
     },
@@ -59,7 +59,7 @@ export default {
     trigger: 'hover',
     placement: 'top',}">
     <input id="test" class="customCheckbox-input" type="checkbox" @change="onChange"
-      :checked="isChosen">
+      :checked="selected">
     <div class="customCheckbox-icon"></div>
   </div>
 </template>

--- a/vue-client/src/components/shared/check-box.vue
+++ b/vue-client/src/components/shared/check-box.vue
@@ -4,61 +4,33 @@ import { mapGetters } from 'vuex';
 export default {
   name: 'check-box',
   props: {
-    type: {
+    checkedProperty: {
       type: String,
-      required: true,
+      default: '',
     },
     tooltipText: {
       type: String,
       default: '',
     },
+    isChosen: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
-      iconMap: {
-        Text: 'file-text',
-        ManuscriptText: 'file-text',
-        Audio: 'volume-up',
-        Music: 'volume-up',
-        Kit: 'archive',
-        StillImage: 'picture-o',
-        MixedMaterial: 'cubes',
-        Object: 'cube',
-        MovingImage: 'film',
-        Cartography: 'map',
-        ManuscriptCartography: 'map',
-        Dataset: 'database',
-        Multimedia: 'laptop',
-        NotatedMusic: 'music',
-        ManuscriptNotatedMusic: 'music',
-        // Place: 'map-marker',
-      },
-      forcedUnspecified: [
-        'Work',
-      ],
     };
   },
   methods: {
+    onChange(e) {
+      this.$emit('changed', e);
+      // emit on change and let the parent handle it.
+    },
   },
   computed: {
     ...mapGetters([
       'resources',
     ]),
-    convertedType() {
-      return this.type.replace('https://id.kb.se/vocab/', '');
-    },
-    isForcedUnspecified() {
-      return this.forcedUnspecified.indexOf(this.convertedType) > -1;
-    },
-    iconClass() {
-      let iconName = '';
-      if (this.iconMap.hasOwnProperty(this.convertedType)) {
-        iconName = this.iconMap[this.convertedType];
-      } else {
-        return '';
-      }
-      return `fa fa-fw fa-${iconName}`;
-    },
   },
   components: {
   },
@@ -70,7 +42,7 @@ export default {
 
 <template>
   <div class="TypeIcon">
-    <input id="test" class="customCheckbox-input" type="checkbox">
+    <input id="test" class="customCheckbox-input" type="checkbox" @change="onChange" :checked="isChosen">
     <div class="customCheckbox-icon"></div>
   </div>
 </template>

--- a/vue-client/src/components/shared/check-box.vue
+++ b/vue-client/src/components/shared/check-box.vue
@@ -1,0 +1,96 @@
+<script>
+import { mapGetters } from 'vuex';
+
+export default {
+  name: 'check-box',
+  props: {
+    type: {
+      type: String,
+      required: true,
+    },
+    tooltipText: {
+      type: String,
+      default: '',
+    },
+  },
+  data() {
+    return {
+      iconMap: {
+        Text: 'file-text',
+        ManuscriptText: 'file-text',
+        Audio: 'volume-up',
+        Music: 'volume-up',
+        Kit: 'archive',
+        StillImage: 'picture-o',
+        MixedMaterial: 'cubes',
+        Object: 'cube',
+        MovingImage: 'film',
+        Cartography: 'map',
+        ManuscriptCartography: 'map',
+        Dataset: 'database',
+        Multimedia: 'laptop',
+        NotatedMusic: 'music',
+        ManuscriptNotatedMusic: 'music',
+        // Place: 'map-marker',
+      },
+      forcedUnspecified: [
+        'Work',
+      ],
+    };
+  },
+  methods: {
+  },
+  computed: {
+    ...mapGetters([
+      'resources',
+    ]),
+    convertedType() {
+      return this.type.replace('https://id.kb.se/vocab/', '');
+    },
+    isForcedUnspecified() {
+      return this.forcedUnspecified.indexOf(this.convertedType) > -1;
+    },
+    iconClass() {
+      let iconName = '';
+      if (this.iconMap.hasOwnProperty(this.convertedType)) {
+        iconName = this.iconMap[this.convertedType];
+      } else {
+        return '';
+      }
+      return `fa fa-fw fa-${iconName}`;
+    },
+  },
+  components: {
+  },
+  mounted() {
+    this.$nextTick(() => {});
+  },
+};
+</script>
+
+<template>
+  <div class="TypeIcon">
+    <input id="test" class="customCheckbox-input" type="checkbox">
+    <div class="customCheckbox-icon"></div>
+  </div>
+</template>
+
+<style lang="less">
+.TypeIcon {
+  background-color: @grey-lightest;
+  color: @brand-primary;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 20px;
+  height: 20px;
+  border-radius: 0.25rem;
+  margin-right: 5px;
+  font-size: 12px;
+
+  &-label {
+    font-weight: 800;
+  }
+}
+
+</style>

--- a/vue-client/src/components/shared/check-box.vue
+++ b/vue-client/src/components/shared/check-box.vue
@@ -1,36 +1,49 @@
 <script>
 import { mapGetters } from 'vuex';
+import * as StringUtil from 'lxljs/string';
 
 export default {
   name: 'check-box',
   props: {
-    checkedProperty: {
-      type: String,
-      default: '',
-    },
-    tooltipText: {
-      type: String,
-      default: '',
+    actionLabels: {
+      type: Object,
+      default: () => ({ on: 'Mark', off: 'Unmark' }),
     },
     isChosen: {
       type: Boolean,
       default: false,
     },
+    showToolTip: {
+      type: Boolean,
+      default: true,
+    }
   },
   data() {
     return {
+      isChecked : false,
     };
   },
+  emits: ['changed'],
   methods: {
     onChange(e) {
+      this.isChecked = !this.isChecked;
       this.$emit('changed', e);
-      // emit on change and let the parent handle it.
     },
   },
   computed: {
     ...mapGetters([
       'resources',
+      'user',
     ]),
+    tooltip() {
+      let str = '';
+      if (!this.isChecked) {
+        str += StringUtil.getUiPhraseByLang(this.actionLabels.on, this.user.settings.language, this.resources.i18n);
+      } else {
+        str += StringUtil.getUiPhraseByLang(this.actionLabels.off, this.user.settings.language, this.resources.i18n);
+      }
+      return str;
+    },
   },
   components: {
   },
@@ -41,8 +54,12 @@ export default {
 </script>
 
 <template>
-  <div class="CheckBox">
-    <input id="test" class="customCheckbox-input" type="checkbox" @change="onChange" :checked="isChosen">
+  <div class="CheckBox" v-tooltip="{
+    content: showToolTip ? tooltip : '',
+    trigger: 'hover',
+    placement: 'top',}">
+    <input id="test" class="customCheckbox-input" type="checkbox" @change="onChange"
+      :checked="isChosen">
     <div class="customCheckbox-icon"></div>
   </div>
 </template>

--- a/vue-client/src/components/shared/tag-switch.vue
+++ b/vue-client/src/components/shared/tag-switch.vue
@@ -73,6 +73,9 @@ export default {
         case 'Flagged':
           str += 'flag';
           break;
+        case 'Handled':
+          str += 'envelope';
+          break;
         default:
           return false;
       }

--- a/vue-client/src/components/usersettings/change-categories.vue
+++ b/vue-client/src/components/usersettings/change-categories.vue
@@ -21,8 +21,6 @@ export default {
   methods: {
     translatePhrase,
     updateSigel(e, sigel) {
-      console.log('available sigels', JSON.stringify(this.availableSigels));
-      console.log('sigelCode', sigel);
       this.$store.dispatch('updateSubscribedSigel', { libraryId: this.sigelUri(sigel), checked: e.target.checked });
     },
     updateCategory(e, categoryId) {

--- a/vue-client/src/components/usersettings/change-categories.vue
+++ b/vue-client/src/components/usersettings/change-categories.vue
@@ -21,6 +21,8 @@ export default {
   methods: {
     translatePhrase,
     updateSigel(e, sigel) {
+      console.log('available sigels', JSON.stringify(this.availableSigels));
+      console.log('sigelCode', sigel);
       this.$store.dispatch('updateSubscribedSigel', { libraryId: this.sigelUri(sigel), checked: e.target.checked });
     },
     updateCategory(e, categoryId) {
@@ -37,6 +39,7 @@ export default {
       return obj ? obj.triggers.includes(categoryId) : false;
     },
     isActiveSigel(sigel) {
+      console.log('this.userChangeCategories', JSON.stringify(this.userChangeCategories));
       const obj = this.userChangeCategories.find(c => c.heldBy === this.sigelUri(sigel));
       return !!obj;
     },

--- a/vue-client/src/resources/json/i18n.json
+++ b/vue-client/src/resources/json/i18n.json
@@ -410,6 +410,8 @@
     "Changes": "Ändringar",
     "Handled": "Hanterad",
     "Change categories": "Ändringskategorier",
-    "Collections": "Sigler"
+    "Collections": "Sigler",
+    "Mark as handled": "Markera som hanterad",
+    "Unmark as handled": "Avmarkera som hanterad"
     }
 }

--- a/vue-client/src/resources/json/i18n.json
+++ b/vue-client/src/resources/json/i18n.json
@@ -412,6 +412,7 @@
     "Change categories": "Ändringskategorier",
     "Collections": "Sigler",
     "Mark as handled": "Markera som hanterad",
-    "Unmark as handled": "Avmarkera som hanterad"
+    "Unmark as handled": "Avmarkera som hanterad",
+    "Search among changes": "Sök bland ändringar"
     }
 }

--- a/vue-client/src/store.js
+++ b/vue-client/src/store.js
@@ -539,7 +539,6 @@ const store = createStore({
         categories = notification.triggers;
       }
       if (checked) {
-        console.log('changed, pushing notication', { heldBy: libraryId, triggers: categories });
         notifications.push({ heldBy: libraryId, triggers: categories });
       } else if (notifications.length === 1) { // Unchecked & removing the last element
         notifications.forEach((n) => { n.heldBy = 'none'; });

--- a/vue-client/src/utils/filters.js
+++ b/vue-client/src/utils/filters.js
@@ -10,8 +10,13 @@ export const translatePhrase = (string) => StringUtil.getUiPhraseByLang(
 
 export const labelByLang = (label) => StringUtil.getLabelByLang(label, store.getters.user.settings.language, store.getters.resources);
 
-export const asAppPath = (path) => {
-  const appPaths = store.getters.settings.appPaths;
+export const asAppPath = (path, isChangeView = false) => {
+  let appPaths = store.getters.settings.appPaths;
+  if (isChangeView) {
+    appPaths =  {
+      '/find?': '/directory-care/changes?',
+    }
+  }
   let newPath = '';
   for (const key of Object.keys(appPaths)) {
     newPath = path.replace(key, appPaths[key]);

--- a/vue-client/src/utils/record.js
+++ b/vue-client/src/utils/record.js
@@ -232,20 +232,21 @@ export function moveHolding(holdingId, destinationId, user) {
     });
   });
 }
+
 export function getHandleAction(concerningId) {
-  return  {
+  return {
     '@graph': [{
       '@id': 'https://libris.kb.se/TEMPID',
-      '@type': "Record",
+      '@type': 'Record',
       mainEntity: {
         '@id': 'https://libris.kb.se/TEMPID#it',
       },
     },
       {
-        "@id": "https://libris.kb.se/TEMPID#it",
-        "@type": "HandleAction",
-        "concerning": {
-          "@id": concerningId
+        '@id': 'https://libris.kb.se/TEMPID#it',
+        '@type': 'HandleAction',
+        'concerning': {
+          '@id': concerningId
         }
       },
     ],

--- a/vue-client/src/utils/record.js
+++ b/vue-client/src/utils/record.js
@@ -232,6 +232,25 @@ export function moveHolding(holdingId, destinationId, user) {
     });
   });
 }
+export function getHandleAction(concerningId) {
+  return  {
+    '@graph': [{
+      '@id': 'https://libris.kb.se/TEMPID',
+      '@type': "Record",
+      mainEntity: {
+        '@id': 'https://libris.kb.se/TEMPID#it',
+      },
+    },
+      {
+        "@id": "https://libris.kb.se/TEMPID#it",
+        "@type": "HandleAction",
+        "concerning": {
+          "@id": concerningId
+        }
+      },
+    ],
+  };
+}
 
 export function getObjectAsRecord(mainEntity, record = {}) {
   const newMainEntity = cloneDeep(mainEntity);

--- a/vue-client/src/views/ChangeNotes.vue
+++ b/vue-client/src/views/ChangeNotes.vue
@@ -1,0 +1,24 @@
+<script>
+import Find from './Find.vue';
+
+export default {
+  name: 'ChangeNotes',
+  components: {
+    Find,
+  },
+  computed: {
+  },
+  methods: {
+  },
+  mounted() {
+  },
+};
+</script>
+
+<template>
+  <find v-if="$route.params.tool === 'changes'"></find>
+</template>
+
+<style lang="less">
+
+</style>

--- a/vue-client/src/views/ChangeNotes.vue
+++ b/vue-client/src/views/ChangeNotes.vue
@@ -16,7 +16,7 @@ export default {
 </script>
 
 <template>
-  <find v-if="$route.params.tool === 'changes'"></find>
+  <find></find>
 </template>
 
 <style lang="less">

--- a/vue-client/src/views/DirectoryCare.vue
+++ b/vue-client/src/views/DirectoryCare.vue
@@ -8,10 +8,12 @@ import { translatePhrase } from '@/utils/filters';
 import TabMenu from '@/components/shared/tab-menu.vue';
 import HoldingMover from '@/components/care/holding-mover.vue';
 import ModalComponent from '@/components/shared/modal-component.vue';
+import ChangeNotes from './ChangeNotes.vue';
 
 export default {
   name: 'DirectoryCare',
   components: {
+    ChangeNotes,
     'tab-menu': TabMenu,
     'holding-mover': HoldingMover,
     'modal-component': ModalComponent,
@@ -45,6 +47,10 @@ export default {
     tabs() {
       return [
         { id: 'holdings', text: 'Move holdings' },
+        {
+          id: 'changes',
+          text: StringUtil.getUiPhraseByLang('Changes', this.user.settings.language, this.resources.i18n),
+        },
         // { 'id': 'merge', 'text': 'Merge records' },
         // { 'id': 'remove', 'text': 'Batch remove' },
       ];
@@ -141,7 +147,8 @@ export default {
 <template>
   <div class="DirectoryCare">
     <div v-if="fetchComplete">
-      <tab-menu @go="switchTool" :tabs="tabs" :active="$route.params.tool" />
+      <tab-menu @go="switchTool" :tabs="tabs" :active="$route.params.tool"></tab-menu>
+      <change-notes v-if="$route.params.tool === 'changes'"></change-notes>
       <holding-mover
         v-if="$route.params.tool === 'holdings'"
         :flaggedInstances="flaggedInstances" />

--- a/vue-client/src/views/DirectoryCare.vue
+++ b/vue-client/src/views/DirectoryCare.vue
@@ -26,11 +26,6 @@ export default {
         removed: [],
         other: [],
       },
-      tabs: [
-        { id: 'holdings', text: 'Move holdings' },
-        // { 'id': 'merge', 'text': 'Merge records' },
-        // { 'id': 'remove', 'text': 'Batch remove' },
-      ],
       showModal: false,
     };
   },

--- a/vue-client/src/views/DirectoryCare.vue
+++ b/vue-client/src/views/DirectoryCare.vue
@@ -33,7 +33,7 @@ export default {
         { id: 'holdings', text: 'Move holdings' },
         // { 'id': 'merge', 'text': 'Merge records' },
         // { 'id': 'remove', 'text': 'Batch remove' },
-        { 'id': 'message', 'text': 'Create message' },
+        { id: 'message', text: 'Create message' },
         { id: 'changes', text: 'Changes' },
       ],
       showModal: false,
@@ -45,7 +45,7 @@ export default {
       'userFlagged',
       'user',
       'resources',
-      'templates'
+      'templates',
     ]),
     flaggedInstances() {
       return filter(this.fetchedItems, (o) => VocabUtil.getRecordType(o['@type'], this.resources.vocab, this.resources.context) === 'Instance');
@@ -55,7 +55,7 @@ export default {
         { id: 'holdings', text: 'Move holdings' },
         // { 'id': 'merge', 'text': 'Merge records' },
         // { 'id': 'remove', 'text': 'Batch remove' },
-        { 'id': 'message', 'text': 'Create message' },
+        { id: 'message', text: 'Create message' },
         { id: 'changes', text: 'Changes' },
       ];
     },

--- a/vue-client/src/views/Find.vue
+++ b/vue-client/src/views/Find.vue
@@ -5,7 +5,7 @@ import * as StringUtil from 'lxljs/string';
 import * as RecordUtil from '@/utils/record';
 import ServiceWidgetSettings from '@/resources/json/serviceWidgetSettings.json';
 import Spinner from '@/components/shared/spinner.vue';
-import { translatePhrase } from '@/utils/filters';
+import { translatePhrase, asAppPath } from '@/utils/filters';
 import FacetControls from '@/components/search/facet-controls.vue';
 import SearchResult from '@/components/search/search-result.vue';
 import TabMenu from '@/components/shared/tab-menu.vue';
@@ -44,6 +44,7 @@ export default {
     },
   },
   methods: {
+    asAppPath,
     translatePhrase,
     setSearchPerimeter(id) {
       this.$router.push({ path: `/search/${id}` }).catch(() => {});
@@ -64,6 +65,18 @@ export default {
     emptyResults() {
       this.result = null;
       this.importData = [];
+    },
+    getResultAndInitFacets() {
+      const fetchUrl = `${this.settings.apiPath}/find.jsonld?${this.query}`;
+      fetch(fetchUrl).then((response) => {
+        response.json().then((result) => {
+          this.result = result;
+          if (result.stats) {
+            this.applyChangeFacets(result.stats);
+          }
+          this.searchInProgress = false;
+        })
+      })
     },
     getLocalResult() {
       const fetchUrl = `${this.settings.apiPath}/find.jsonld?${this.query}`;
@@ -128,6 +141,25 @@ export default {
     },
     getChangesResult() {
       this.getLocalResult();
+    },
+    selectedInSettings(id) {
+      return this.checkedCategoriesAndSigels.includes(id);
+    },
+    applyChangeFacets(stats) {
+      let facetsString = '';
+      Object.entries(stats.sliceByDimension).forEach(([key, value]) => {
+        const facets = value.observation;
+        facets.forEach((facet) => {
+          const facetId = facet.object['@id'];
+          if (this.selectedInSettings(facetId)) {
+            const addedFacet = `&${key}=${facetId}`
+            if (!this.$route.fullPath.includes(addedFacet)) {
+              facetsString += addedFacet;
+            }
+          }
+        })
+      });
+       this.$router.push(asAppPath(this.$route.fullPath+facetsString, true));
     },
     convertRemoteResult(result) {
       let totalResults = 0;
@@ -201,6 +233,12 @@ export default {
       ];
       return tabs;
     },
+    changeCategories() {
+      return this.$store.getters.userChangeCategories;
+    },
+    checkedCategoriesAndSigels() {
+      return [...this.changeCategories.map(c => c.heldBy), ...this.changeCategories.find(c => c.hasOwnProperty('triggers')).triggers];
+    },
   },
   beforeCreate() {
   },
@@ -213,7 +251,11 @@ export default {
         this.$router.push({ path: '/search/' });
       }
       this.query = this.$route.fullPath.split('?')[1];
-      this.getResult();
+      if (this.$route.params.tool === 'changes') {
+        this.getResultAndInitFacets();
+      } else {
+        this.getResult();
+      }
       this.initialized = true;
     });
   },

--- a/vue-client/src/views/Find.vue
+++ b/vue-client/src/views/Find.vue
@@ -263,6 +263,7 @@ export default {
           :class="{ 'fa-caret-down': !hideFacetColumn, 'fa-caret-right': hideFacetColumn }" /></div>
       <facet-controls :class="{ 'hidden-xs hidden-sm': hideFacetColumn }"
           :result="result"
+          :isChangeView="$route.params.tool === 'changes'"
           v-if="result && result.stats && result.totalItems > 0 && ($route.params.perimeter === 'libris' || $route.params.tool === 'changes')" />
       <portal-target name="facetColumn" />
     </div>

--- a/vue-client/src/views/Find.vue
+++ b/vue-client/src/views/Find.vue
@@ -42,6 +42,12 @@ export default {
         }
       }
     },
+    query(newVal, oldVal) {
+      if (this.$route.params.tool === 'changes' && typeof oldVal === 'undefined' && typeof newVal !== 'undefined') {
+        
+        this.getResultAndInitFacets();
+      }
+    },
   },
   methods: {
     asAppPath,
@@ -67,6 +73,8 @@ export default {
       this.importData = [];
     },
     getResultAndInitFacets() {
+      this.emptyResults();
+      this.searchInProgress = true;
       const fetchUrl = `${this.settings.apiPath}/find.jsonld?${this.query}`;
       fetch(fetchUrl).then((response) => {
         response.json().then((result) => {
@@ -251,11 +259,7 @@ export default {
         this.$router.push({ path: '/search/' });
       }
       this.query = this.$route.fullPath.split('?')[1];
-      if (this.$route.params.tool === 'changes') {
-        this.getResultAndInitFacets();
-      } else {
-        this.getResult();
-      }
+      this.getResult();
       this.initialized = true;
     });
   },

--- a/vue-client/src/views/Find.vue
+++ b/vue-client/src/views/Find.vue
@@ -44,7 +44,6 @@ export default {
     },
     query(newVal, oldVal) {
       if (this.$route.params.tool === 'changes' && typeof oldVal === 'undefined' && typeof newVal !== 'undefined') {
-        
         this.getResultAndInitFacets();
       }
     },
@@ -83,8 +82,8 @@ export default {
             this.applyChangeFacets(result.stats);
           }
           this.searchInProgress = false;
-        })
-      })
+        });
+      });
     },
     getLocalResult() {
       const fetchUrl = `${this.settings.apiPath}/find.jsonld?${this.query}`;
@@ -160,14 +159,14 @@ export default {
         facets.forEach((facet) => {
           const facetId = facet.object['@id'];
           if (this.selectedInSettings(facetId)) {
-            const addedFacet = `&${key}=${facetId}`
+            const addedFacet = `&${key}=${facetId}`;
             if (!this.$route.fullPath.includes(addedFacet)) {
               facetsString += addedFacet;
             }
           }
-        })
+        });
       });
-       this.$router.push(asAppPath(this.$route.fullPath+facetsString, true));
+      this.$router.push(asAppPath(this.$route.fullPath + facetsString, true));
     },
     convertRemoteResult(result) {
       let totalResults = 0;
@@ -245,7 +244,7 @@ export default {
       return this.$store.getters.userChangeCategories;
     },
     checkedCategoriesAndSigels() {
-      return [...this.changeCategories.map(c => c.heldBy), ...this.changeCategories.find(c => c.hasOwnProperty('triggers')).triggers];
+      return [...this.changeCategories.map((c) => c.heldBy), ...this.changeCategories.find((c) => c.hasOwnProperty('triggers')).triggers];
     },
   },
   beforeCreate() {
@@ -295,7 +294,8 @@ export default {
 <template>
   <div class="row">
     <div class="col-sm-12 col-md-3 Column-facets" v-if="!status.panelOpen">
-      <tab-menu v-if="$route.params.tool !== 'changes'"
+      <tab-menu
+        v-if="$route.params.tool !== 'changes'"
         @go="setSearchPerimeter"
         :active="$route.params.perimeter"
         :tabs="findTabs"
@@ -307,11 +307,12 @@ export default {
         <i
           class="fa fa-fw hidden-md hidden-lg"
           :class="{ 'fa-caret-down': !hideFacetColumn, 'fa-caret-right': hideFacetColumn }" /></div>
-      <facet-controls :class="{ 'hidden-xs hidden-sm': hideFacetColumn }"
-          :result="result"
-          :isChangeView="$route.params.tool === 'changes'"
-          v-if="result && result.stats && result.totalItems > 0 && ($route.params.perimeter === 'libris' || $route.params.tool === 'changes')" />
-      <portal-target name="facetColumn" />
+      <facet-controls
+        :class="{ 'hidden-xs hidden-sm': hideFacetColumn }"
+        :result="result"
+        :isChangeView="$route.params.tool === 'changes'"
+        v-if="result && result.stats && result.totalItems > 0 && ($route.params.perimeter === 'libris' || $route.params.tool === 'changes')"/>
+      <portal-target name="facetColumn"/>
     </div>
     <div v-show="searchInProgress" class="col-sm-12 col-md-9">
       <div class="Find-progressText">


### PR DESCRIPTION
### Tickets involved
[LXL-4269](https://jira.kb.se/browse/LXL-4269)

### Solves
Let the user view and filter administrative notices / change notes.
TODO: marking a notice as handled works (by creating an administrative action on checked check-box), but removing it requires a coming backend fix. 

### Summary of changes

- New tab under directory care focused on searching among administrative notices / change notes.
- Facets in this view work as OR-facets
- Categories and collections that are checked in the user settings change note section are initialized as checked facets.

![Screenshot from 2023-11-20 10-54-02](https://github.com/libris/lxlviewer/assets/48950665/d235591b-0a14-4381-9c9a-f85fbd169d78)
