### PR TITLE
LXL-4383: item-value update bug

### DIFF
--- a/vue-client/src/components/inspector/entity-adder.vue
+++ b/vue-client/src/components/inspector/entity-adder.vue
@@ -40,10 +40,6 @@ export default {
     compositional: {
       default: null,
     },
-    showActionButtons: {
-      type: Boolean,
-      default: false,
-    },
     isPlaceholder: {
       type: Boolean,
       default: false,

--- a/vue-client/src/components/inspector/field.vue
+++ b/vue-client/src/components/inspector/field.vue
@@ -117,10 +117,6 @@ export default {
       type: String,
       default: '',
     },
-    showActionButtons: {
-      type: Boolean,
-      default: false,
-    },
     isExpanded: {
       type: Boolean,
       default: false,
@@ -133,7 +129,6 @@ export default {
   data() {
     return {
       activeModal: false,
-      shouldShowActionButtons: false,
       removeHover: false,
       pasteHover: false,
       foundChip: false,
@@ -303,12 +298,6 @@ export default {
         return 'Concept type';
       }
       return 'Type';
-    },
-    actionButtonsShown() {
-      if (this.shouldShowActionButtons || this.showActionButtons) {
-        return true;
-      }
-      return false;
     },
     ...mapGetters([
       'inspector',
@@ -625,14 +614,6 @@ export default {
       }
       return false;
     },
-    handleMouseEnter() {
-      this.shouldShowActionButtons = true;
-    },
-    handleMouseLeave() {
-      if (!this.isInner) {
-        this.shouldShowActionButtons = false;
-      }
-    },
     highLightLastAdded() {
       if (this.isLastAdded === true) {
         if (this.fieldValue === null || (isArray(this.fieldValue) && this.fieldValue.length === 0)) {
@@ -689,13 +670,11 @@ export default {
       'is-grouped': isGrouped,
       'has-failed-validations': failedValidations.length > 0,
     }"
-    @mouseover="handleMouseEnter()"
-    @mouseleave="handleMouseLeave()"
     v-if="!this.isHidden">
 
     <div
       class="Field-labelContainer"
-      :class="{ 'is-wide': inspector.status.editing || user.settings.appTech, 'is-hovered': shouldShowActionButtons }"
+      :class="{ 'is-wide': inspector.status.editing || user.settings.appTech }"
       v-if="showKey && !isInner">
       <div class="Field-labelWrapper" :class="{ sticky: !diff }">
         <div v-if="!isLocked" class="Field-actions">
@@ -731,7 +710,6 @@ export default {
             :some-values-from="someValuesFrom"
             :all-search-types="allSearchTypes"
             :property-types="propertyTypes"
-            :show-action-buttons="actionButtonsShown"
             :active="activeModal"
             :is-placeholder="false"
             :is-language="this.isLangMap || this.isLangTaggable"
@@ -831,7 +809,6 @@ export default {
           :some-values-from="someValuesFrom"
           :all-search-types="allSearchTypes"
           :property-types="propertyTypes"
-          :show-action-buttons="actionButtonsShown"
           :active="activeModal"
           :is-placeholder="true"
           :is-language="this.isLangMap || this.isLangTaggable"
@@ -990,8 +967,7 @@ export default {
           :parent-path="path"
           :in-array="valueIsArray"
           :diff="diff"
-          :should-expand="expandChildren || embellished"
-          :show-action-buttons="actionButtonsShown" />
+          :should-expand="expandChildren || embellished" />
 
         <item-sibling
           v-if="getDatatype(item) == 'sibling'"
@@ -1008,7 +984,6 @@ export default {
           :index="index"
           :in-array="valueIsArray"
           :diff="diff"
-          :show-action-buttons="actionButtonsShown"
           :should-expand="expandChildren || embellished"
           :parent-path="path" />
       </div>
@@ -1084,7 +1059,6 @@ export default {
           :index="index"
           :parent-path="path"
           :diff="diff"
-          :show-action-buttons="actionButtonsShown"
           :is-expanded="isExpanded" />
 
         <!-- shelfControlNumber -->
@@ -1279,10 +1253,6 @@ export default {
       @media screen and (max-width: @screen-sm) {
         max-width: 100%;
       }
-    }
-
-    &.is-hovered * {
-      z-index: 1;
     }
 
     .Field.is-grouped & {

--- a/vue-client/src/components/inspector/item-local.vue
+++ b/vue-client/src/components/inspector/item-local.vue
@@ -30,10 +30,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    showActionButtons: {
-      type: Boolean,
-      default: false,
-    },
     inArray: {
       type: Boolean,
       default: false,
@@ -621,7 +617,6 @@ export default {
         :field-value="v"
         :key="k"
         :diff="diff"
-        :show-action-buttons="showActionButtons"
         :expand-children="expandChildren"
         :is-expanded="expanded" />
     </ul>

--- a/vue-client/src/components/inspector/item-next-shelf-control-number.vue
+++ b/vue-client/src/components/inspector/item-next-shelf-control-number.vue
@@ -24,10 +24,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    showActionButtons: {
-      type: Boolean,
-      default: false,
-    },
     isExpanded: {
       type: Boolean,
       default: false,

--- a/vue-client/src/components/inspector/item-numeric.vue
+++ b/vue-client/src/components/inspector/item-numeric.vue
@@ -23,10 +23,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    showActionButtons: {
-      type: Boolean,
-      default: false,
-    },
     isExpanded: {
       type: Boolean,
       default: false,

--- a/vue-client/src/components/inspector/item-sibling.vue
+++ b/vue-client/src/components/inspector/item-sibling.vue
@@ -38,10 +38,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    showActionButtons: {
-      type: Boolean,
-      default: false,
-    },
     allSearchTypes: {
       type: Array,
       default: () => [],
@@ -501,8 +497,7 @@ export default {
         :field-key="k"
         :field-value="v"
         :key="k"
-        :expand-children="expandChildren"
-        :show-action-buttons="showActionButtons" />
+        :expand-children="expandChildren" />
     </ul>
 
     <property-adder

--- a/vue-client/src/components/inspector/item-value.vue
+++ b/vue-client/src/components/inspector/item-value.vue
@@ -27,10 +27,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    showActionButtons: {
-      type: Boolean,
-      default: false,
-    },
     isExpanded: {
       type: Boolean,
       default: false,


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`

## Description

### Tickets involved
[LXL-4383](https://jira.kb.se/browse/LXL-4383)

### Solves

Weird bug that causes some input fields (`item-value`) to revert to their previous value on mouseleave.
reproduce:
* create new --> 'agent' --> 'person'
* put the cursor in 'födelsedatum' and type something. Move the cursor to 'dödsdatum'. The text then disappears and re-appears after 1 sec.

### Summary of changes

Moving the cursor from the field causes the component to update (in Vue 2, it did not apparently) resetting to the prop value. But since the update function has a 1s debouncer, the current text has not yet been synced back from the store, causing the old value to be displayed for a short while.

the `@mouseover`/ `@mouseleave` in `field` is what causes the update in (some of!) the components. This is used for the `showActionButton` functionality that has been removed and does nothing. Seems to me that the easiest solution is to remove this altogether. There may even be a performance upside to stop listening to mouseover events on all the fields...


