### PR TITLE
Copy marc:nonfilingChars when extracting

### DIFF
--- a/vue-client/src/store.js
+++ b/vue-client/src/store.js
@@ -444,6 +444,7 @@ const store = createStore({
         const extractedHasTitle = [{
           '@type': 'Title',
           mainTitle: extractedMainTitle,
+          'marc:nonfilingChars': mainEntityHasTitle['marc:nonfilingChars'] || undefined,
         }];
 
         commit('updateInspectorData', {


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4297](https://jira.kb.se/browse/LXL-4297)

### Solves

Copies `marc:nonfilingChars` to extracted `hasTitle` if present in main entity.

### Summary of changes

- Copy marc:nonfilingChars when extracting 
