### PR TITLE
LXL-4384: Fix login lastPath

### DIFF
--- a/vue-client/src/router.js
+++ b/vue-client/src/router.js
@@ -120,11 +120,11 @@ router.beforeEach((to, from, next) => {
     next();
   }, () => {
     // notAuthed
-    if (to.matched.some((record) => record.meta.requiresAuth)) {
-      if (to.fullPath.indexOf('login') < 0) {
-        localStorage.setItem('lastPath', to.fullPath);
-      }
+    if (to.fullPath.indexOf('login') < 0) {
+      localStorage.setItem('lastPath', to.fullPath);
+    }
 
+    if (to.matched.some((record) => record.meta.requiresAuth)) {
       next({
         path: '/login/expired',
       });

--- a/vue-client/src/views/Login.vue
+++ b/vue-client/src/views/Login.vue
@@ -35,7 +35,7 @@ export default {
         this.loginExpired = true;
       } else if (this.user.isLoggedIn && token !== null) {
         const path = localStorage.getItem('lastPath') || '/';
-        this.$router.push({ path: path });
+        this.$router.push(path);
       } else window.location = this.$store.getters.oauth2Client.token.getUri();
     });
   },


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`

## Description

### Tickets involved
[LXL-4384](https://jira.kb.se/browse/LXL-4384)

### Solves

User being redirected to startpage (/) instead of last path after login.

### Summary of changes

The place where we save the `lastPath` was embedded in a condition where the `to` path had to `requireAuth` (/user, /create etc). This makes no sense to me, and I'm curious how this worked in the past.

Now we do separate checks; if the user is not authed we save the last path, and if they're headed for a protected route we send them to login/expired. Also, after login, we route them back to the full path (incl params for search results), not only the path. 


