### PR TITLE
Ensure highlight is removed when undoing extraction

### DIFF
--- a/vue-client/src/components/inspector/item-local.vue
+++ b/vue-client/src/components/inspector/item-local.vue
@@ -399,6 +399,11 @@ export default {
         this.$refs.linkAction.$el.focus();
       }
     },
+    isExtracting(val) {
+      if (val === false) {
+        this.removeHighlight('info');
+      }
+    },
   },
   beforeUnmount() {
     this.$store.dispatch('setValidation', { path: this.path, validates: true });


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Solves

Ensures the highlight is removed when undoing extraction actions (sometimes the blue highlight could be stuck which could confuse the user if the item will be extracted or not).

### Summary of changes

- Ensure highlight is removed when undoing extraction