### PR TITLE
Feature/undoable-linking-with-existing-works

### DIFF
--- a/vue-client/src/components/inspector/item-entity.vue
+++ b/vue-client/src/components/inspector/item-entity.vue
@@ -190,9 +190,8 @@ export default {
     <div
       :id="`formPath-${path}`"
       class="ItemEntity-content"
-      v-show="!isCardWithData || !expanded">
+      v-if="!isCardWithData || !expanded">
       <Menu
-        v-if="!expanded"
         class="ItemEntity-popover"
         placement="bottom-start"
         @apply-show="$refs.previewCard.populateData()"

--- a/vue-client/src/components/inspector/item-entity.vue
+++ b/vue-client/src/components/inspector/item-entity.vue
@@ -192,6 +192,7 @@ export default {
       class="ItemEntity-content"
       v-show="!isCardWithData || !expanded">
       <Menu
+        v-if="!expanded"
         class="ItemEntity-popover"
         placement="bottom-start"
         @apply-show="$refs.previewCard.populateData()"

--- a/vue-client/src/components/inspector/item-local.vue
+++ b/vue-client/src/components/inspector/item-local.vue
@@ -285,7 +285,7 @@ export default {
             value: newValue,
           },
         ],
-        addToHistory: false,
+        addToHistory: true,
       });
       this.$store.dispatch('pushNotification', { type: 'success', message: `${StringUtil.getUiPhraseByLang('Linking was successful', this.user.settings.language, this.resources.i18n)}` });
       this.$store.dispatch('setInspectorStatusValue', {

--- a/vue-client/src/store.js
+++ b/vue-client/src/store.js
@@ -719,36 +719,44 @@ const store = createStore({
       commit('flushChangeHistory');
     },
     undoInspectorChange({ dispatch, commit, state }) {
-      const history = state.inspector.changeHistory;
-      const lastNode = history[history.length - 1];
+      const lastChange = state.inspector.changeHistory[state.inspector.changeHistory.length - 1];
 
-      const payload = { addToHistory: false, changeList: [] };
-      each(lastNode, (node) => {
-        if (typeof node.value !== 'undefined' && !node.path.includes(EXTRACT_ON_SAVE)) {
-          // It had a value
-          payload.changeList.push({
-            path: node.path,
-            value: node.value,
-          });
-        } else {
-          if (node.path.includes(EXTRACT_ON_SAVE)) {
-            dispatch('removeExtractItemOnSave', { path: node.path.replace(`.${EXTRACT_ON_SAVE}`, '') });
-          }
-          // It did not have a value (ie key did not exist)
-          const pathParts = node.path.split('.');
-          const key = pathParts[pathParts.length - 1];
-          pathParts.splice(pathParts.length - 1, 1);
-          const path = pathParts.join('.');
-          const data = cloneDeep(get(state.inspector.data, path));
-          delete data[key];
-          payload.changeList.push({
-            path: path,
-            value: data,
-          });
+      const undoChanges = lastChange.reduce((acc, node) => {
+        if (node.path.includes(EXTRACT_ON_SAVE)) {
+          dispatch('removeExtractItemOnSave', { path: node.path.replace(`.${EXTRACT_ON_SAVE}`, '') });
+          return acc;
         }
+
+        if (typeof node.value !== 'undefined') {
+          return [...acc, node];
+        }
+
+        // It did not have a value (ie key did not exist)
+        const pathArray = node.path.split('.')
+        const key = pathArray[pathArray.length - 1];
+        const path = pathArray.slice(0, -1);
+        const data = cloneDeep(get(state.inspector.data, path));
+
+        if (data) {
+          const { [key]: _removedData, ...restData } = data;
+
+          return [
+            ...acc, {
+              path,
+              value: restData,
+            }
+          ]
+        }
+
+        return acc;
+      }, [])
+
+      commit("updateInspectorData", {
+        addToHistory: false,
+        changeList: undoChanges
       });
-      history.splice(history.length - 1, 1);
-      commit('updateInspectorData', payload);
+
+      commit('setChangeHistory', state.inspector.changeHistory.slice(0, -1));
     },
     pushLoadingIndicator({ commit, state }, indicatorString) {
       const loaders = state.status.loadingIndicators;

--- a/vue-client/src/store.js
+++ b/vue-client/src/store.js
@@ -726,6 +726,7 @@ const store = createStore({
           dispatch('removeExtractItemOnSave', { path: node.path.replace(`.${EXTRACT_ON_SAVE}`, '') });
         }
 
+        // It had a value
         if (typeof node.value !== 'undefined') {
           return [...acc, node];
         }
@@ -733,15 +734,15 @@ const store = createStore({
         // It did not have a value (ie key did not exist)
         const pathArray = node.path.split('.')
         const key = pathArray[pathArray.length - 1];
-        const path = pathArray.slice(0, -1);
-        const data = cloneDeep(get(state.inspector.data, path));
+        const parentPath = pathArray.slice(0, -1);
+        const parentData = cloneDeep(get(state.inspector.data, parentPath));
 
-        if (data) {
-          const { [key]: _removedData, ...restData } = data;
+        if (parentData) {
+          const { [key]: _removedData, ...restData } = parentData;
 
           return [
             ...acc, {
-              path,
+              path: parentPath,
               value: restData,
             }
           ]

--- a/vue-client/src/store.js
+++ b/vue-client/src/store.js
@@ -724,7 +724,6 @@ const store = createStore({
       const undoChanges = lastChange.reduce((acc, node) => {
         if (node.path.includes(EXTRACT_ON_SAVE)) {
           dispatch('removeExtractItemOnSave', { path: node.path.replace(`.${EXTRACT_ON_SAVE}`, '') });
-          return acc;
         }
 
         if (typeof node.value !== 'undefined') {


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4297](https://jira.kb.se/browse/LXL-4297), [LXL-4316](https://jira.kb.se/browse/LXL-4316)

### Solves

Allows the user to undo an action replacing an entity with an exisiting work.

### Summary of changes

- Make replace entity with existing work undoable
- Fix issue with stuck tooltip when replacing with existing work
- Rewrite undo functionality.
