### PR TITLE
Fix inactive ShelfMarkSequences showing up in entity adder

### DIFF
--- a/vue-client/src/components/inspector/entity-adder.vue
+++ b/vue-client/src/components/inspector/entity-adder.vue
@@ -198,6 +198,7 @@ export default {
     translatePhrase,
     labelByLang,
     capitalize,
+    // TODO: dead code?
     getSearchParams(searchPhrase) {
       let params;
       if (this.currentSearchParam == null) {
@@ -205,11 +206,6 @@ export default {
       } else {
         params = Object.assign({}, this.currentSearchParam.mappings || {});
         this.currentSearchParam.searchProps.forEach((param) => { params[param] = searchPhrase; });
-      }
-
-      if (this.fieldKey === 'shelfMark') {
-        params['meta.descriptionCreator.@id'] = this.user.getActiveLibraryUri();
-        params.shelfMarkStatus = 'ActiveShelfMark';
       }
 
       return params;

--- a/vue-client/src/components/inspector/search-window.vue
+++ b/vue-client/src/components/inspector/search-window.vue
@@ -95,6 +95,7 @@ export default {
   methods: {
     translatePhrase,
     labelByLang,
+    // TODO: dead code?
     getSearchParams(searchPhrase) {
       if (this.currentSearchParam == null) {
         return { q: searchPhrase };

--- a/vue-client/src/components/mixins/sidesearch-mixin.vue
+++ b/vue-client/src/components/mixins/sidesearch-mixin.vue
@@ -143,6 +143,11 @@ export default {
       Object.keys(this.currentSearchParam?.mappings || {})
         .forEach((key) => urlSearchParams.append(key, this.currentSearchParam.mappings[key]));
 
+      if (this.fieldKey === 'shelfMark') {
+        urlSearchParams.append('meta.descriptionCreator.@id',  this.user.getActiveLibraryUri());
+        urlSearchParams.append('shelfMarkStatus', 'ActiveShelfMark');
+      }
+
       if (this.fieldKey) {
         const field = VocabUtil.getTermObject(this.fieldKey, this.resources.vocab, this.resources.context);
         /**


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

### Tickets involved
[LXL-4404](https://jira.kb.se/browse/LXL-4404)

### Solves
Inactive ShelfMarkSequences and ShelfMarkSequences owned by other libraries showing up when linking shelfMark.

The inactive ones should also have been blocked from linking by the client because they are `replacedBy` the new ones. But  `replacedBy` is not indexed (not in card for `ShelfMarkSequence`).

![bild](https://github.com/libris/lxlviewer/assets/51744858/e438b082-1ac2-4363-a8ba-012ea74f1dce)
 
### Summary of changes
Moved the check to where params are built now.
b9705205 was the breaking change. `getSearchPhrase` is not called anymore

