### PR TITLE
Only fetchMissingLinkedToQuoted for links within system

### DIFF
--- a/vue-client/src/utils/data.js
+++ b/vue-client/src/utils/data.js
@@ -153,7 +153,9 @@ export function getExternalLinks(obj) {
 
 export async function fetchMissingLinkedToQuoted(obj, store) {
   const quoted = store.state.inspector.data.quoted || {};
-  const missingLinks = getExternalLinks(obj).filter((l) => !quoted.hasOwnProperty(l));
+  const missingLinks = getExternalLinks(obj)
+    .filter((l) => !quoted.hasOwnProperty(l))
+    .filter((l) => l.startsWith(settings.apiPath) || translateAliasedUri(l).startsWith(settings.idPath));
   const embellished = false;
   return Promise
     .allSettled(missingLinks.map((l) => HttpUtil.getDocument(l, undefined, embellished)))


### PR DESCRIPTION
## Description
When opening a document we try to lookup all links not in quoted / embellish data.
This is useful when opening a template where we don't have the definitions for the linked things in the template loaded.
However, we shouldn't try to lookup URIs outside libris.kb.se / id.kb.se.
Only `fetchMissingLinkedToQuoted` for links within system.

### Solves
`fetchMissingLinkedToQuoted` trying to lookup things outside libris.kb.se / id.kb.se