### PR TITLE
Fix relinking of work turns instanceOf to an array

### DIFF
--- a/vue-client/src/components/inspector/entity-adder.vue
+++ b/vue-client/src/components/inspector/entity-adder.vue
@@ -330,10 +330,10 @@ export default {
       }
       const linkObj = { '@id': obj['@id'] };
 
-      if (VocabUtil.propIsRepeatable(this.fieldKey, this.resources.context) && !currentValue.length) {
-        currentValue.push(linkObj);
-      } else {
+      if (!VocabUtil.propIsRepeatable(this.fieldKey, this.resources.context) && !currentValue.length) {
         currentValue = linkObj;
+      } else {
+        currentValue.push(linkObj);
       }
       this.$store.dispatch('addToQuoted', obj);
       this.$store.dispatch('setInspectorStatusValue', {

--- a/vue-client/src/components/inspector/entity-adder.vue
+++ b/vue-client/src/components/inspector/entity-adder.vue
@@ -329,7 +329,12 @@ export default {
         }
       }
       const linkObj = { '@id': obj['@id'] };
-      currentValue.push(linkObj);
+
+      if (VocabUtil.propIsRepeatable(this.fieldKey, this.resources.context) && !currentValue.length) {
+        currentValue.push(linkObj);
+      } else {
+        currentValue = linkObj;
+      }
       this.$store.dispatch('addToQuoted', obj);
       this.$store.dispatch('setInspectorStatusValue', {
         property: 'lastAdded',


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`


### Tickets involved
[LXL-4419](https://jira.kb.se/browse/LXL-4419)

### Solves

See commit message.

### Summary of changes

Add check for repeatability of property key when linking things.
