### PR TITLE
LXL-4421: Remove loop causing item-error to dispatch new errors

### DIFF
--- a/vue-client/src/components/inspector/item-error.vue
+++ b/vue-client/src/components/inspector/item-error.vue
@@ -26,19 +26,7 @@ export default {
         delete cleanItem._uid;
       }
       return cleanItem;
-    },
-    failedValidations() {
-      const failedValidations = [];
-      if (this.user.settings.appTech === false) {
-        return failedValidations;
-      }
-      failedValidations.push({
-        text: 'The entity is missing crucial data',
-      });
-
-      this.$store.dispatch('setValidation', { path: this.path, validates: false, reasons: failedValidations });
-      return failedValidations;
-    },
+    }
   },
   components: {
   },
@@ -58,7 +46,7 @@ export default {
 </script>
 
 <template>
-  <div class="ItemError" :id="`formPath-${path}`" :class="{ 'has-failed-validations': failedValidations.length > 0 }">
+  <div class="ItemError" :id="`formPath-${path}`">
     <table>
       <tr v-for="(value, key) in itemAsJson" :key="key">
         <td class="ItemError-key">{{ key }}</td><td class="ItemError-value">{{ value }}</td>


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4421](https://jira.kb.se/browse/LXL-4421)

### Solves
Fixes issue causing Vue to slow down or crash due to `Maximum recursive updates exceeded in component` while in debug mode. The `item-error.vue` component automatically dispatched unwanted `setValidation` actions in debug mode, resulting in a loop as the actions triggered new errors.

The code removed is five years old so the issue shouldn't be related to the Vue3 migration (but maybe Vue2 has a different escape hatch for recursive loops? 🤷)

### Summary of changes

- Remove loop causing item-error to dispatch new errors
