### PR TITLE
Fix LXL-4422 bug

### DIFF
--- a/vue-client/src/components/inspector/field.vue
+++ b/vue-client/src/components/inspector/field.vue
@@ -1050,7 +1050,6 @@ export default {
         <!-- Not linked, local child strings -->
         <item-value
           v-if="getDatatype(item) == 'value'"
-          :is-last-added="isLastAdded"
           :is-removable="!hasSingleValue"
           :is-locked="locked"
           :is-uri-type="isUriType"
@@ -1064,7 +1063,6 @@ export default {
         <!-- shelfControlNumber -->
         <item-shelf-control-number
           v-if="getDatatype(item) == 'shelfControlNumber'"
-          :is-last-added="isLastAdded"
           :is-locked="locked"
           :field-value="item"
           :field-key="fieldKey"
@@ -1076,7 +1074,6 @@ export default {
         <!-- nextShelfControlNumber -->
         <item-next-shelf-control-number
           v-if="getDatatype(item) == 'nextShelfControlNumber'"
-          :is-last-added="isLastAdded"
           :is-locked="locked"
           :field-value="item"
           :field-key="fieldKey"


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4422](https://jira.kb.se/browse/LXL-4422)
### Solves

- Fixes as bug where newly input text was removed (after a short delay) when adding a new field.

### Summary of changes

Remove unspecified parameter/property on initialization of item-value.vue, item-shelf-control-number.vue and item-next-shelf-control-number.vue. The parameter is already specified as a computed in the components, not a property.
