### PR TITLE
Add VS Code workspace for lxl-web with included settings

### DIFF
--- a/lxl-web/.vscode/extensions.json
+++ b/lxl-web/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-	"recommendations": ["svelte.svelte-vscode"]
-}

--- a/lxl-web/.vscode/lxl-web.code-workspace
+++ b/lxl-web/.vscode/lxl-web.code-workspace
@@ -1,0 +1,17 @@
+{
+	"folders": [
+		{
+			"path": "../.."
+		}
+	],
+	"settings": {
+		"[svelte]": {
+			"editor.defaultFormatter": "svelte.svelte-vscode"
+		},
+		"workbench.editor.labelFormat": "short",
+		"explorer.compactFolders": false
+	},
+	"extensions": {
+		"recommendations": ["svelte.svelte-vscode"]
+	}
+}

--- a/lxl-web/.vscode/lxl-web.code-workspace
+++ b/lxl-web/.vscode/lxl-web.code-workspace
@@ -1,7 +1,10 @@
 {
 	"folders": [
 		{
-			"path": "../.."
+			"path": ".."
+		},
+		{
+			"path": "../../lxljs"
 		}
 	],
 	"settings": {

--- a/lxl-web/.vscode/settings.json
+++ b/lxl-web/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-	"[svelte]": {
-		"editor.defaultFormatter": "svelte.svelte-vscode"
-	},
-	"workbench.editor.labelFormat": "short",
-	"explorer.compactFolders": false
-}


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Solves

Add VS Code workspace for lxl-web allowing worskpace specfic settings

### Summary of changes

- Add VS Code workspace for lxl-web 
- Add workspace specific quality-of-life settings