### PR TITLE
Remove redundant page type annotations

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -1,10 +1,9 @@
-import type { PageServerLoad } from './$types';
 import { API_URL } from '$env/static/private';
 
-export const load = (async ({ params, fetch }) => {
+export const load = async ({ params, fetch }) => {
 	const iri = `${API_URL}/${params.fnurgel}`;
 	const response = await fetch(iri, { headers: { Accept: 'application/ld+json' } });
 	const doc = await response.json();
 
 	return { fnurgel: params.fnurgel, iri: iri, lang: params.lang ?? 'sv', doc: doc };
-}) satisfies PageServerLoad;
+};

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-	import type { PageData } from './$types';
-
-	export let data: PageData;
+	export let data;
 </script>
 
 <h1>{data.fnurgel} på {data.lang}</h1>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.server.ts
@@ -1,8 +1,7 @@
-import type { PageServerLoad } from './$types';
 import { API_URL } from '$env/static/private';
 import { redirect } from '@sveltejs/kit';
 
-export const load = (async ({ fetch, url }) => {
+export const load = async ({ fetch, url }) => {
 	if (!url.searchParams.size) {
 		redirect(303, `/`); // redirect to home page if no search params are given
 	}
@@ -17,4 +16,4 @@ export const load = (async ({ fetch, url }) => {
 	return {
 		items
 	};
-}) satisfies PageServerLoad;
+};

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-	import type { PageData } from './$types';
 	import { page } from '$app/stores';
 
-	export let data: PageData;
+	export let data;
 
 	$: q = $page.url.searchParams.get('q');
 </script>


### PR DESCRIPTION
## Description

### Solves

Removes redundant page type annotations (e.g. `PageData` and `PageServerLoad` which no longer are needed. See https://svelte.dev/blog/zero-config-type-safety

### Summary of changes

- Remove redundant page type annotations
