### PR TITLE
Add basic i18n support

### DIFF
--- a/lxl-web/src/app.d.ts
+++ b/lxl-web/src/app.d.ts
@@ -4,7 +4,10 @@ declare global {
 	namespace App {
 		// interface Error {}
 		// interface Locals {}
-		// interface PageData {}
+		interface PageData {
+			locale: import('$lib/i18n/locales').LocaleCode;
+			t: Awaited<ReturnType<typeof import('$lib/i18n').getTranslator>>;
+		}
 		// interface Platform {}
 	}
 }

--- a/lxl-web/src/app.html
+++ b/lxl-web/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="%lang%">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />

--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -1,0 +1,18 @@
+import { defaultLocale, Locales } from '$lib/i18n/locales';
+
+export const handle = async ({ event, resolve }) => {
+	// set HTML lang
+	// https://github.com/sveltejs/kit/issues/3091#issuecomment-1112589090
+	const path = event.url.pathname;
+	let lang = defaultLocale;
+
+	Object.keys(Locales).forEach((locale) => {
+		if (path && path.startsWith(`/${locale}/`)) {
+			lang = locale;
+		}
+	});
+
+	return resolve(event, {
+		transformPageChunk: ({ html }) => html.replace('%lang%', lang)
+	});
+};

--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -7,7 +7,7 @@ export const handle = async ({ event, resolve }) => {
 	let lang = defaultLocale;
 
 	Object.keys(Locales).forEach((locale) => {
-		if (path && path.startsWith(`/${locale}/`)) {
+		if (path && (path.startsWith(`/${locale}/`) || path.endsWith(`/${locale}`))) {
 			lang = locale;
 		}
 	});

--- a/lxl-web/src/lib/components/LangPicker.svelte
+++ b/lxl-web/src/lib/components/LangPicker.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { Locales } from '$lib/i18n/locales';
+	import { browser } from '$app/environment';
+
+	const locales = Object.keys(Locales);
+
+	$: if (browser) {
+		// set HTML lang - should maybe be done earlier, in a server hook?
+		// https://github.com/sveltejs/kit/issues/3091#issuecomment-1112589090
+		document.documentElement.lang = $page.data.locale;
+	}
+</script>
+
+<nav>
+	<ul class="flex">
+		{#each locales as locale}
+			<li class="m-1">
+				{#if locale === $page.data.locale}
+					<span class="font-bold">{locale}</span>
+				{:else}
+					<a href="/{locale}">{locale}</a>
+				{/if}
+			</li>
+		{/each}
+	</ul>
+</nav>

--- a/lxl-web/src/lib/components/LangPicker.svelte
+++ b/lxl-web/src/lib/components/LangPicker.svelte
@@ -1,15 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { Locales } from '$lib/i18n/locales';
-	import { browser } from '$app/environment';
 
 	const locales = Object.keys(Locales);
-
-	$: if (browser) {
-		// set HTML lang - should maybe be done earlier, in a server hook?
-		// https://github.com/sveltejs/kit/issues/3091#issuecomment-1112589090
-		document.documentElement.lang = $page.data.locale;
-	}
 </script>
 
 <nav>
@@ -19,7 +12,7 @@
 				{#if locale === $page.data.locale}
 					<span class="font-bold">{locale}</span>
 				{:else}
-					<a href="/{locale}">{locale}</a>
+					<a href="/{locale}" data-sveltekit-reload>{locale}</a>
 				{/if}
 			</li>
 		{/each}

--- a/lxl-web/src/lib/components/LangPicker.svelte
+++ b/lxl-web/src/lib/components/LangPicker.svelte
@@ -1,18 +1,32 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { Locales } from '$lib/i18n/locales';
+	import { Locales, defaultLocale } from '$lib/i18n/locales';
 
-	const locales = Object.keys(Locales);
+	function mapLocales(currentLocale: string) {
+		return Object.keys(Locales).map((locale) => {
+			// remove any existing lang param and add the new one (if needed)
+			const arr = $page.url.pathname.split('/').filter((p) => !!p && p !== currentLocale);
+			if (locale !== defaultLocale) {
+				arr.unshift(locale);
+			}
+			const url = `/${arr.join('/')}${$page.url.search}`;
+
+			return { value: locale, name: Locales[locale], url };
+		});
+	}
+
+	$: localesObj = mapLocales($page.data.locale);
 </script>
 
 <nav>
 	<ul class="flex">
-		{#each locales as locale}
+		{#each localesObj as locale}
 			<li class="m-1">
-				{#if locale === $page.data.locale}
-					<span class="font-bold">{locale}</span>
+				{#if locale.value === $page.data.locale}
+					<span class="font-bold">{locale.name}</span>
 				{:else}
-					<a href="/{locale}" data-sveltekit-reload>{locale}</a>
+					<!-- server hook (html lang) needs full page reload -->
+					<a href={locale.url} data-sveltekit-reload>{locale.name}</a>
 				{/if}
 			</li>
 		{/each}

--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -26,7 +26,7 @@
 	}
 </script>
 
-<form action="/search" on:submit={handleSubmit}>
+<form action={$page.data.base + '/search'} on:submit={handleSubmit}>
 	<!-- svelte-ignore a11y-autofocus -->
 	<input
 		type="search"

--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -26,7 +26,7 @@
 	}
 </script>
 
-<form action={$page.data.base + '/search'} on:submit={handleSubmit}>
+<form action="search" on:submit={handleSubmit}>
 	<!-- svelte-ignore a11y-autofocus -->
 	<input
 		type="search"

--- a/lxl-web/src/lib/i18n/index.ts
+++ b/lxl-web/src/lib/i18n/index.ts
@@ -1,0 +1,47 @@
+import { dev } from '$app/environment';
+import { interpolate } from './interpolate';
+import { defaultLocale, type LocaleCode } from './locales';
+import sv from './locales/sv.js';
+
+const loadedTranslations: Record<string, typeof sv> = {
+	sv
+};
+
+export async function getTranslator(locale: LocaleCode) {
+	if (!loadedTranslations[locale]) {
+		loadedTranslations[locale] = (await import(`./locales/${locale}.js`)).default;
+		// add error handling?
+	}
+
+	return (key: string, options?: { values?: Record<string, string> }): string => {
+		if (!key.includes('.')) {
+			// do we require nested keys?
+			throw new Error('Incorrect i11n key');
+		}
+		const [section, item] = key.split('.') as [string, string];
+
+		// @ts-expect-error - how to typecheck??
+		const localeResult = loadedTranslations[locale][section]?.[item];
+
+		if (localeResult) {
+			return interpolate(localeResult, options?.values);
+		} else {
+			console.warn(`Missing ${locale} translation for ${key}`);
+		}
+
+		// @ts-expect-error - how to typecheck??
+		const fallbackResult = loadedTranslations[defaultLocale][section][item];
+
+		if (fallbackResult) {
+			return interpolate(fallbackResult, options?.values);
+		}
+
+		const error = `Missing fallback translation for ${key}`;
+		if (dev) {
+			throw new Error(error);
+		}
+
+		console.error(error);
+		return key;
+	};
+}

--- a/lxl-web/src/lib/i18n/index.ts
+++ b/lxl-web/src/lib/i18n/index.ts
@@ -3,6 +3,7 @@ import { interpolate } from './interpolate';
 import { defaultLocale, type LocaleCode } from './locales';
 import sv from './locales/sv.js';
 
+// always import default translation?
 const loadedTranslations: Record<string, typeof sv> = {
 	sv
 };
@@ -13,7 +14,7 @@ export async function getTranslator(locale: LocaleCode) {
 		// add error handling?
 	}
 
-	return (key: string, options?: { values?: Record<string, string> }): string => {
+	return (key: string, values?: { [key: string]: string }): string => {
 		if (!key.includes('.')) {
 			// do we require nested keys?
 			throw new Error('Incorrect i11n key');
@@ -24,7 +25,7 @@ export async function getTranslator(locale: LocaleCode) {
 		const localeResult = loadedTranslations[locale][section]?.[item];
 
 		if (localeResult) {
-			return interpolate(localeResult, options?.values);
+			return interpolate(localeResult, values);
 		} else {
 			console.warn(`Missing ${locale} translation for ${key}`);
 		}
@@ -33,7 +34,7 @@ export async function getTranslator(locale: LocaleCode) {
 		const fallbackResult = loadedTranslations[defaultLocale][section][item];
 
 		if (fallbackResult) {
-			return interpolate(fallbackResult, options?.values);
+			return interpolate(fallbackResult, values);
 		}
 
 		const error = `Missing fallback translation for ${key}`;

--- a/lxl-web/src/lib/i18n/interpolate.test.ts
+++ b/lxl-web/src/lib/i18n/interpolate.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { interpolate } from './interpolate';
+
+describe('iterpolate', () => {
+	it('replaces placeholders with corresponding values', () => {
+		const template = 'Hi {name}, welcome to {site}!';
+		const values = { name: 'Kalle', site: 'Libris' };
+		expect(interpolate(template, values)).toEqual('Hi Kalle, welcome to Libris!');
+	});
+});

--- a/lxl-web/src/lib/i18n/interpolate.ts
+++ b/lxl-web/src/lib/i18n/interpolate.ts
@@ -1,0 +1,8 @@
+const placeholder = /{(.*?)}/g;
+
+export function interpolate(template: string, values?: Record<string, string>) {
+	if (!values) {
+		return template;
+	}
+	return template.replace(placeholder, (match, key) => values[key] || match);
+}

--- a/lxl-web/src/lib/i18n/locales.ts
+++ b/lxl-web/src/lib/i18n/locales.ts
@@ -1,0 +1,14 @@
+export enum Locales {
+	sv = 'Svenska',
+	en = 'English'
+}
+
+export type LocaleCode = keyof typeof Locales;
+export const defaultLocale = 'sv';
+
+export function getSupportedLocale(userLocale: string | undefined): LocaleCode {
+	const locale = Object.keys(Locales).find((supportedLocale) => {
+		return userLocale?.includes(supportedLocale);
+	}) as LocaleCode;
+	return locale || defaultLocale;
+}

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -1,0 +1,11 @@
+/** @type {typeof import('./sv.js').default} */
+export default {
+	home: {
+		welcome_text: 'Welcome to {site}, today is {day}'
+	},
+	search: {
+		result_info: 'Search result for: {q}'
+	},
+	errors: {},
+	general: {}
+};

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -1,0 +1,12 @@
+export default {
+	home: {
+		welcome_text: 'Välkommen till {site}, idag är det {day}'
+	},
+	search: {
+		result_info: 'Sökresultat för: {q}'
+	},
+	errors: {},
+	general: {
+		// shared stuff go here
+	}
+};

--- a/lxl-web/src/routes/(app)/+layout.ts
+++ b/lxl-web/src/routes/(app)/+layout.ts
@@ -4,6 +4,6 @@ import { getSupportedLocale, defaultLocale } from '$lib/i18n/locales';
 export async function load({ params }) {
 	const locale = getSupportedLocale(params?.lang); // will use default locale if no lang param
 	const t = await getTranslator(locale);
-	const base = locale === defaultLocale ? '' : `/${locale}`;
+	const base = locale === defaultLocale ? '/' : `/${locale}/`;
 	return { locale, t, base };
 }

--- a/lxl-web/src/routes/(app)/+layout.ts
+++ b/lxl-web/src/routes/(app)/+layout.ts
@@ -1,8 +1,9 @@
 import { getTranslator } from '$lib/i18n/index.js';
-import { getSupportedLocale } from '$lib/i18n/locales';
+import { getSupportedLocale, defaultLocale } from '$lib/i18n/locales';
 
 export async function load({ params }) {
 	const locale = getSupportedLocale(params?.lang); // will use default locale if no lang param
 	const t = await getTranslator(locale);
-	return { locale, t };
+	const base = locale === defaultLocale ? '' : `/${locale}`;
+	return { locale, t, base };
 }

--- a/lxl-web/src/routes/(app)/+layout.ts
+++ b/lxl-web/src/routes/(app)/+layout.ts
@@ -1,0 +1,8 @@
+import { getTranslator } from '$lib/i18n/index.js';
+import { getSupportedLocale } from '$lib/i18n/locales';
+
+export async function load({ params }) {
+	const locale = getSupportedLocale(params?.lang); // will use default locale if no lang param
+	const t = await getTranslator(locale);
+	return { locale, t };
+}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
@@ -1,10 +1,37 @@
-<script>
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { Locales } from '$lib/i18n/locales';
 	import Search from '$lib/components/Search.svelte';
 	import '../../../app.css';
+
+	export let data;
+
+	$: if (browser) {
+		// set HTML lang - should maybe be done earlier, in a server hook?
+		// https://github.com/sveltejs/kit/issues/3091#issuecomment-1112589090
+		document.documentElement.lang = data.locale;
+	}
+
+	const locales = Object.keys(Locales);
 </script>
 
-<header>
-	<a href="/">Libris</a>
-	<Search />
+<header class="mx-4 flex">
+	<div class="flex-1">
+		<a href="/">Libris</a>
+		<Search />
+	</div>
+	<nav>
+		<ul class="flex">
+			{#each locales as locale}
+				<li class="m-1">
+					{#if locale === data.locale}
+						<span class="font-bold">{locale}</span>
+					{:else}
+						<a href="/{locale}">{locale}</a>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	</nav>
 </header>
 <slot />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
@@ -1,18 +1,7 @@
 <script lang="ts">
-	import { browser } from '$app/environment';
-	import { Locales } from '$lib/i18n/locales';
 	import Search from '$lib/components/Search.svelte';
+	import LangPicker from '$lib/components/LangPicker.svelte';
 	import '../../../app.css';
-
-	export let data;
-
-	$: if (browser) {
-		// set HTML lang - should maybe be done earlier, in a server hook?
-		// https://github.com/sveltejs/kit/issues/3091#issuecomment-1112589090
-		document.documentElement.lang = data.locale;
-	}
-
-	const locales = Object.keys(Locales);
 </script>
 
 <header class="mx-4 flex">
@@ -20,18 +9,6 @@
 		<a href="/">Libris</a>
 		<Search />
 	</div>
-	<nav>
-		<ul class="flex">
-			{#each locales as locale}
-				<li class="m-1">
-					{#if locale === data.locale}
-						<span class="font-bold">{locale}</span>
-					{:else}
-						<a href="/{locale}">{locale}</a>
-					{/if}
-				</li>
-			{/each}
-		</ul>
-	</nav>
+	<LangPicker />
 </header>
 <slot />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
@@ -6,9 +6,12 @@
 	export let data;
 </script>
 
+<svelte:head>
+	<base href={data.base} />
+</svelte:head>
 <header class="mx-4 flex">
 	<div class="flex-1">
-		<a href={data.base || '/'}>Libris</a>
+		<a href={data.base}>Libris</a>
 		<Search />
 	</div>
 	<LangPicker />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
@@ -2,11 +2,13 @@
 	import Search from '$lib/components/Search.svelte';
 	import LangPicker from '$lib/components/LangPicker.svelte';
 	import '../../../app.css';
+
+	export let data;
 </script>
 
 <header class="mx-4 flex">
 	<div class="flex-1">
-		<a href="/">Libris</a>
+		<a href={data.base || '/'}>Libris</a>
 		<Search />
 	</div>
 	<LangPicker />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
@@ -1,1 +1,13 @@
-<h1>Welcome to Libris(?)</h1>
+<script lang="ts">
+	export let data;
+</script>
+
+<h1>
+	{data.t('home.welcome_text', {
+		values: {
+			site: 'Libris',
+			day: `${(() =>
+				new Intl.DateTimeFormat(data.locale, { weekday: 'long' }).format(new Date()))()}`
+		}
+	})}
+</h1>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
@@ -4,10 +4,7 @@
 
 <h1>
 	{data.t('home.welcome_text', {
-		values: {
-			site: 'Libris',
-			day: `${(() =>
-				new Intl.DateTimeFormat(data.locale, { weekday: 'long' }).format(new Date()))()}`
-		}
+		site: 'Libris',
+		day: `${(() => new Intl.DateTimeFormat(data.locale, { weekday: 'long' }).format(new Date()))()}`
 	})}
 </h1>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.server.ts
@@ -11,7 +11,7 @@ export const load = (async ({ fetch, url }) => {
 	const records = await recordsRes.json();
 
 	const items = records.items.map((item) => ({
-		fnurgel: new URL(item['@id']).pathname,
+		fnurgel: new URL(item['@id']).pathname.replace('/', ''),
 		'@id': item['@id']
 	}));
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.server.ts
@@ -11,6 +11,7 @@ export const load = (async ({ fetch, url }) => {
 	const records = await recordsRes.json();
 
 	const items = records.items.map((item) => ({
+		fnurgel: new URL(item['@id']).pathname,
 		'@id': item['@id']
 	}));
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.svelte
@@ -7,7 +7,7 @@
 	$: q = $page.url.searchParams.get('q');
 </script>
 
-<h1>{$page.data.t('search.result_info', { values: { q: `${q}` } })}</h1>
+<h1>{$page.data.t('search.result_info', { q: `${q}` })}</h1>
 <ul>
 	{#each data.items as item (item['@id'])}
 		<li>{item['@id']}</li>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.svelte
@@ -11,7 +11,7 @@
 	<h1>{$page.data.t('search.result_info', { q: `${q}` })}</h1>
 	<ul>
 		{#each data.items as item (item['@id'])}
-			<li><a class="underline" href={data.base + item.fnurgel}>{item.fnurgel}</a></li>
+			<li><a class="underline" href={item.fnurgel}>{item.fnurgel}</a></li>
 		{/each}
 	</ul>
 </div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.svelte
@@ -7,9 +7,11 @@
 	$: q = $page.url.searchParams.get('q');
 </script>
 
-<h1>{$page.data.t('search.result_info', { q: `${q}` })}</h1>
-<ul>
-	{#each data.items as item (item['@id'])}
-		<li>{item['@id']}</li>
-	{/each}
-</ul>
+<div class="m-3">
+	<h1>{$page.data.t('search.result_info', { q: `${q}` })}</h1>
+	<ul>
+		{#each data.items as item (item['@id'])}
+			<li><a class="underline" href={data.base + item.fnurgel}>{item.fnurgel}</a></li>
+		{/each}
+	</ul>
+</div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/search/+page.svelte
@@ -7,7 +7,7 @@
 	$: q = $page.url.searchParams.get('q');
 </script>
 
-<h1>Search results for: {q}</h1>
+<h1>{$page.data.t('search.result_info', { values: { q: `${q}` } })}</h1>
 <ul>
 	{#each data.items as item (item['@id'])}
 		<li>{item['@id']}</li>

--- a/lxl-web/svelte.config.js
+++ b/lxl-web/svelte.config.js
@@ -8,7 +8,10 @@ const config = {
 	preprocess: vitePreprocess(),
 
 	kit: {
-		adapter: adapter()
+		adapter: adapter(),
+		paths: {
+			relative: false
+		}
 	}
 };
 


### PR DESCRIPTION
## Description

### Tickets involved
[LXL-4362](https://jira.kb.se/browse/LXL-4362)

### Summary of changes

A modest proposal on how we could approach the i18n issue. Svelte has [no official solution](https://github.com/sveltejs/kit/issues/553), and after looking at a number of libs, many seem [too large](https://github.com/opral/monorepo/tree/main/inlang), [hacky](https://github.com/kaisermann/svelte-i18n) or [abandoned](https://github.com/ivanhofer/typesafe-i18n). 

I then found [this example](https://poly-i18n.vercel.app/en/kitbook) that felt like a good approach and decided to try it out. It's basically a function that loads the needed translations and returns a translator function from the layout. It supports nested translation files and basic string interpolation (`hello {name} how are you`) and can easily be extended to support our exact needs (unknown to me at this point...)

Some notes:
* Translation files are `.js` at the moment. This allows us to typecheck the `en` using the `sv` one for example, keeping them fully synced. But we could just as well use json files.
* No cookie solution atm. Locales strictly follows the lang param (or lack of). If introduced, we'll have to discuss what should have precedence if both exist.
* Found no way to globally [change the url base path](https://github.com/sveltejs/kit/issues/595) (`/en/` etc) at runtime, which is needed for correct links to be rendered. Current solution exposes a `base` variable that needs to be prepended to all links, which is a bit tedious...