### PR TITLE
Bugfix/user db sometimes not loaded

### DIFF
--- a/vue-client/src/App.vue
+++ b/vue-client/src/App.vue
@@ -366,9 +366,11 @@ export default {
   mounted() {
     this.verifyUser().then(() => {
       this.$nextTick(() => {
-        this.loadUserDatabase();
+        if (this.user.isLoggedIn) {
+          this.loadUserDatabase();
+        }
       });
-    }).catch(() => {});
+    });
     this.initOauth2Client().catch(() => {});
     this.initWarningFunc();
     this.fetchHelpDocs();

--- a/vue-client/src/components/usersettings/user-settings.vue
+++ b/vue-client/src/components/usersettings/user-settings.vue
@@ -101,6 +101,7 @@ export default {
   },
   mounted() {
     this.$nextTick(() => {
+      this.$store.dispatch('loadUserDatabase');
       this.getAvailableChangeCategories();
     });
   },

--- a/vue-client/src/store.js
+++ b/vue-client/src/store.js
@@ -419,7 +419,7 @@ const store = createStore({
       if (state.userDatabase == null || state.userDatabase.notificationCollections == null) {
         return [];
       }
-      return state.userDatabase.notificationCollections.map(c => c['@id']);;
+      return state.userDatabase.notificationCollections.map(c => c['@id']);
     },
     userDatabase: (state) => state.userDatabase,
     status: (state) => state.status,


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description
For a recently logged in user, navigating directly to the user settings view does not necessarily load the user database. Hence, editing the change message subscription section does not work and causes an error. To the user, it seems like the changes take effect, since the boxes still can be checked/unchecked, however these changes are not persistent. This is wrong and causes confusion.

### Tickets involved
--

### Summary of changes

- Load user db when user settings component is mounted
- Don't try to load the user db (and suppress the error) when logged out 

