### PR TITLE
Change path in VS Code workspace file

### DIFF
--- a/lxl-web/lxl-web.code-workspace
+++ b/lxl-web/lxl-web.code-workspace
@@ -1,7 +1,7 @@
 {
 	"folders": [
 		{
-			"path": ".."
+			"path": "."
 		},
 		{
 			"path": "../../lxljs"


### PR DESCRIPTION
## Description

### Solves

After moving the workspace file we also need to change the relative path from parent dir to current
(we vant `lxl-web` and `lxljs`, not `lxlviewer` and `lxljs`).

