### PR TITLE
Trim sibling whitespaces using a preprocessor

### DIFF
--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -22,6 +22,7 @@
 				"husky": "^8.0.3",
 				"lint-staged": "^15.2.0",
 				"lxljs": "file:../lxljs",
+				"magic-string": "^0.30.5",
 				"postcss": "^8.4.32",
 				"prettier": "^3.0.0",
 				"prettier-plugin-svelte": "^3.0.0",

--- a/lxl-web/package.json
+++ b/lxl-web/package.json
@@ -37,6 +37,7 @@
 		"husky": "^8.0.3",
 		"lint-staged": "^15.2.0",
 		"lxljs": "file:../lxljs",
+		"magic-string": "^0.30.5",
 		"postcss": "^8.4.32",
 		"prettier": "^3.0.0",
 		"prettier-plugin-svelte": "^3.0.0",

--- a/lxl-web/src/lib/preprocessors/trimSiblingWhitespaces.js
+++ b/lxl-web/src/lib/preprocessors/trimSiblingWhitespaces.js
@@ -1,0 +1,53 @@
+import { parse, walk } from 'svelte/compiler';
+import MagicString from 'magic-string';
+
+/**
+ * @param {object} options
+ * @param {string[]} options.filenames
+ */
+const trimSiblingWhitespaces = ({ filenames }) => ({
+	name: 'trim-sibling-whitespaces',
+	/**
+	 * @param {object} options
+	 * @param {string} options.content
+	 * @param {string} options.filename
+	 */
+	markup: ({ content, filename }) => {
+		const fileToBePreprocessed = filenames.find((name) => filename.endsWith(name));
+
+		if (fileToBePreprocessed) {
+			const s = new MagicString(content);
+
+			let start;
+			let end;
+
+			const { html } = parse(content, { filename });
+			walk(html, {
+				enter(node) {
+					if (!start) {
+						start = node.start;
+					}
+					if (!end || node.end > end) {
+						end = node.end;
+					}
+				}
+			});
+
+			if (start && end) {
+				s.update(start, end, s.slice(start, end).replace(/^\t*|\n/gm, ''));
+			}
+
+			if (s.hasChanged()) {
+				console.log(
+					`\nTrimmed sibling whitespaces in ${fileToBePreprocessed} using trim-sibling-whitespaces preprocessor\nSee: https://github.com/sveltejs/svelte/issues/189`
+				);
+			}
+			return {
+				code: s.toString(),
+				map: s.generateMap({ source: filename })
+			};
+		}
+	}
+});
+
+export default trimSiblingWhitespaces;

--- a/lxl-web/svelte.config.js
+++ b/lxl-web/svelte.config.js
@@ -1,11 +1,12 @@
 import adapter from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import trimSiblingWhitespaces from './src/lib/preprocessors/trimSiblingWhitespaces.js';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
 	// for more information about preprocessors
-	preprocess: vitePreprocess(),
+	preprocess: [vitePreprocess(), trimSiblingWhitespaces({ filenames: ['DecoratedData.svelte'] })],
 
 	kit: {
 		adapter: adapter(),


### PR DESCRIPTION
## Description

### Solves
Trims sibling whitespaces using a preprocessor which inlines all the template code in specified Svelte files (currently only `DecoratedData.svelte`).

This preprocessor should be seen as an rather blunt work-around until https://github.com/sveltejs/svelte/issues/189 is resolved.
An alternative is to manually inline the relevant code in `DecoratedData.svelte` together with a `prettier-ignore` block.

### Summary of changes

- Trim sibling whitespaces using a preprocessor
