### PR TITLE
Add resource popover/tooltip for previewing linked data

### DIFF
--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -7,6 +7,9 @@
 		"": {
 			"name": "lxl-web",
 			"version": "0.0.1",
+			"dependencies": {
+				"@floating-ui/dom": "^1.6.1"
+			},
 			"devDependencies": {
 				"@playwright/test": "^1.28.1",
 				"@sveltejs/adapter-node": "^2.0.0",
@@ -496,6 +499,28 @@
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+			"integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.1"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.1.tgz",
+			"integrity": "sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==",
+			"dependencies": {
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.1"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+			"integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.13",

--- a/lxl-web/package.json
+++ b/lxl-web/package.json
@@ -50,5 +50,8 @@
 		"typescript": "^5.0.0",
 		"vite": "^5.0.0",
 		"vitest": "^1.0.0"
+	},
+	"dependencies": {
+		"@floating-ui/dom": "^1.6.1"
 	}
 }

--- a/lxl-web/src/lib/actions/resourcePopover/ResourcePopover.svelte
+++ b/lxl-web/src/lib/actions/resourcePopover/ResourcePopover.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import type { ResourceData } from '$lib/types/ResourceData';
+	import { onMount } from 'svelte';
+	import { computePosition, offset, shift, inline, flip, arrow } from '@floating-ui/dom';
+	import DecoratedData from '$lib/components/DecoratedData.svelte';
+
+	export let referenceElement: HTMLElement;
+	export let data: ResourceData;
+	export let onMouseOver: (event: MouseEvent) => void;
+	export let onMouseLeave: (event: MouseEvent) => void;
+	export let onFocus: (event: FocusEvent) => void;
+	export let onBlur: (event: FocusEvent) => void;
+
+	let popoverElement: HTMLElement;
+	let arrowElement: HTMLDivElement;
+
+	const arrowWidth = 14;
+	const arrowHeight = 8;
+
+	function updatePosition() {
+		computePosition(referenceElement, popoverElement, {
+			middleware: [
+				offset(8),
+				shift(),
+				arrow({ element: arrowElement, padding: 6 }),
+				inline(),
+				flip()
+			]
+		}).then(({ strategy, x, y, middlewareData, placement }) => {
+			Object.assign(popoverElement.style, {
+				position: strategy,
+				left: `${x}px`,
+				top: `${y}px`
+			});
+			if (middlewareData.arrow) {
+				const { x: arrowX, y: arrowY } = middlewareData.arrow;
+
+				Object.assign(arrowElement.style, {
+					top:
+						(arrowY != null && `${arrowY}px`) ||
+						(placement === 'bottom' && `-${arrowWidth}px`) ||
+						'',
+					left:
+						(arrowX != null && `${arrowX}px`) ||
+						(placement === 'right' && `-${arrowWidth}px`) ||
+						'',
+					right: (arrowX == null && placement === 'left' && `-${arrowWidth}px`) || '',
+					transform:
+						(placement === 'right' && 'rotate(90deg)') ||
+						(placement === 'bottom' && 'rotate(180deg)') ||
+						(placement === 'left' && 'rotate(270deg)') ||
+						''
+				});
+			}
+		});
+	}
+
+	onMount(() => {
+		updatePosition();
+	});
+</script>
+
+<!-- 
+  @component
+	Renders a popover with decorated data.
+	Note that `ResourcePopover.svelte` isn't intended to be used directly in page templates – use the `use:resourcePopover` action instead (see `$lib/actions/resourcePopover`).
+-->
+<div
+	class="resource-popover"
+	role="complementary"
+	bind:this={popoverElement}
+	on:mouseover={onMouseOver}
+	on:mouseleave={onMouseLeave}
+	on:focus={onFocus}
+	on:blur={onBlur}
+>
+	<div class="content">
+		<DecoratedData {data} />
+	</div>
+	<div class="popover-arrow" bind:this={arrowElement}>
+		<svg
+			aria-hidden="true"
+			width={arrowWidth}
+			height={arrowWidth}
+			viewBox="0 0 {arrowWidth} {arrowWidth}"
+		>
+			<path d="M0 0L{arrowWidth / 2} {arrowHeight}L{arrowWidth} 0" fill="#fff" stroke="#c3c3c3" />
+		</svg>
+	</div>
+</div>
+
+<style>
+	.resource-popover {
+		background: #fff;
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.19);
+		border: 1px solid #c3c3c3;
+		position: absolute;
+		width: max-content;
+		max-width: 360px;
+		top: 0;
+		left: 0;
+		z-index: 100;
+		font-size: 0.875rem;
+		border-radius: 6px;
+	}
+
+	.content {
+		padding: 0.5rem;
+	}
+
+	.popover-arrow {
+		position: absolute;
+	}
+</style>

--- a/lxl-web/src/lib/actions/resourcePopover/index.ts
+++ b/lxl-web/src/lib/actions/resourcePopover/index.ts
@@ -1,0 +1,115 @@
+import type { Action } from 'svelte/action';
+import type { ResourceData } from '$lib/types/ResourceData';
+import ResourcePopover from './ResourcePopover.svelte';
+import { getResourceId, getResourcePropertyStyle } from '$lib/utils/resourceData';
+
+/** Tests to do
+ * - [] Attaches popover when user hovers over trigger node (after delay)
+ * - [] Removes popover when user stops hovering over trigger node (after delay)
+ * - [] Removes popover when user blurs trigger node
+ * - [] Keeps popover open if user hovers over popover (when leaving trigger node)
+ * - [] Removes popover if user stops hovering over popover (without entering trigger node)
+ * - [] Keeps popover if user has focused child element
+ * - [] Doesn't attach popover if fetching of resource data fails
+ */
+
+/* Conditionally add popover action so it's only added when needed */
+const conditionalResourcePopover = (node: HTMLElement, value: ResourceData) => {
+	const style = getResourcePropertyStyle(value);
+	if (style && style.includes('link' || style.includes('definition'))) {
+		const id = getResourceId(value);
+		if (id) {
+			return resourcePopover(node, id);
+		}
+	}
+};
+
+const resourcePopover: Action<HTMLElement, string> = (node: HTMLElement, id: string) => {
+	const FETCH_DELAY = 250;
+	const ATTACH_DELAY = 500;
+	const REMOVE_DELAY = 200;
+	const container = document.getElementById('floating-elements-container') || document.body; // See https://atfzl.com/articles/don-t-attach-tooltips-to-document-body
+
+	let attached = false;
+	let floatingElement: ResourcePopover | null = null;
+	let cancelAttach: (reason?: unknown) => void;
+	let cancelRemove: (reason?: unknown) => void;
+	let cancelFetch: (reason?: unknown) => void;
+
+	node.addEventListener('mouseover', attachPopover);
+	node.addEventListener('mouseout', removePopover);
+
+	async function attachPopover() {
+		try {
+			cancelRemove?.();
+			if (id && !attached) {
+				const [decoratedData] = await Promise.all([
+					getDecoratedData(`/api/${id.split('/').pop()}`),
+					new Promise((resolve, reject) => {
+						cancelAttach = reject; // allows promise rejection from outside the promise constructor scope
+						setTimeout(resolve, ATTACH_DELAY);
+					})
+				]);
+				floatingElement = new ResourcePopover({
+					target: container,
+					props: {
+						referenceElement: node,
+						data: decoratedData,
+						onMouseOver: startFloatingElementInteraction,
+						onFocus: startFloatingElementInteraction,
+						onMouseLeave: endFloatingElementInteraction,
+						onBlur: endFloatingElementInteraction
+					}
+				});
+				attached = true;
+			}
+			// eslint-disable-next-line no-empty
+		} catch {}
+	}
+
+	async function removePopover() {
+		try {
+			cancelAttach?.();
+			cancelFetch?.();
+			await new Promise((resolve, reject) => {
+				cancelRemove = reject;
+				setTimeout(resolve, REMOVE_DELAY);
+			});
+			floatingElement?.$destroy();
+			attached = false;
+			// eslint-disable-next-line no-empty
+		} catch {}
+	}
+
+	function startFloatingElementInteraction() {
+		cancelRemove?.();
+	}
+
+	function endFloatingElementInteraction() {
+		removePopover();
+	}
+
+	async function getDecoratedData(id: string) {
+		await new Promise((resolve, reject) => {
+			cancelFetch = reject;
+			setTimeout(resolve, FETCH_DELAY);
+		});
+		try {
+			const resourceRes = await fetch(`/api/${id.split('/').pop()}`);
+			const resource = await resourceRes.json();
+			return resource;
+		} catch (error) {
+			console.error(error);
+			cancelAttach?.();
+		}
+	}
+
+	return {
+		destroy() {
+			node.removeEventListener('mouseover', attachPopover);
+			node.removeEventListener('mouseout', removePopover);
+		}
+	};
+};
+
+export default conditionalResourcePopover;

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
-	type ResourceData =
-		| null
-		| boolean
-		| string
-		| number
-		| ResourceData[]
-		| undefined
-		| { [key: string]: ResourceData };
+	import type { ResourceData } from '$lib/types/ResourceData';
+	import resourcePopover from '$lib/actions/resourcePopover';
+	import { getResourceId, getResourcePropertyStyle } from '$lib/utils/resourceData';
 
 	export let data: ResourceData;
 
@@ -14,7 +9,7 @@
 		'@context',
 		'@type',
 		'@id',
-		'_hint',
+		'_label',
 		'_style',
 		'_contentBefore',
 		'_contentAfter'
@@ -26,17 +21,12 @@
 		return Object.entries(data).filter(([key]) => !hiddenProperties.includes(key));
 	}
 
-	function getObjectProperty(value: ResourceData, name: string) {
-		if (value && typeof value === 'object' && !Array.isArray(value) && name in value) {
-			return value[name];
-		}
-		return undefined;
-	}
-
 	function getLink(value: ResourceData) {
-		const hints = getObjectProperty(value, '_hint');
-		if (Array.isArray(hints) && hints.includes('link')) {
-			return value?.['@id' as keyof typeof value];
+		if (getResourcePropertyStyle(value)?.includes('link')) {
+			const id = getResourceId(value);
+			if (id) {
+				return id;
+			}
 		}
 		return undefined;
 	}
@@ -71,7 +61,11 @@
 			{#if flattenedProperties.includes(key)}
 				<svelte:self data={value} />
 			{:else}
-				<svelte:element this={getElementType(value)} {...getElementAttributes({ key, value })}>
+				<svelte:element
+					this={getElementType(value)}
+					{...getElementAttributes({ key, value })}
+					use:resourcePopover={value}
+				>
 					<svelte:self data={value} />
 				</svelte:element>
 			{/if}

--- a/lxl-web/src/lib/types/ResourceData.ts
+++ b/lxl-web/src/lib/types/ResourceData.ts
@@ -1,0 +1,8 @@
+export type ResourceData =
+	| null
+	| boolean
+	| string
+	| number
+	| ResourceData[]
+	| undefined
+	| { [key: string]: ResourceData };

--- a/lxl-web/src/lib/utils/resourceData.ts
+++ b/lxl-web/src/lib/utils/resourceData.ts
@@ -1,0 +1,25 @@
+import type { ResourceData } from '$lib/types/ResourceData';
+
+export function getResourceProperty(value: ResourceData, name: string) {
+	if (value && typeof value === 'object' && !Array.isArray(value) && name in value) {
+		return value[name];
+	}
+	return undefined;
+}
+
+export function getResourcePropertyStyle(value: ResourceData) {
+	const style = getResourceProperty(value, '_style');
+	if (style) {
+		return style as string[];
+	}
+
+	return undefined;
+}
+
+export function getResourceId(value: ResourceData) {
+	const id = getResourceProperty(value, '@id');
+	if (typeof id === 'string' && id.length) {
+		return id;
+	}
+	return undefined;
+}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
@@ -17,3 +17,4 @@
 	<LangPicker />
 </header>
 <slot />
+<div id="floating-elements-container" />

--- a/lxl-web/src/routes/api/[[lang=lang]]/[fnurgel=fnurgel]/+server.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/[fnurgel=fnurgel]/+server.ts
@@ -1,0 +1,25 @@
+import { env } from '$env/dynamic/private';
+import { json } from '@sveltejs/kit';
+import { DisplayUtil, type FramedData, LensType } from '$lib/utils/xl';
+import { getSupportedLocale } from '$lib/i18n/locales';
+
+export async function GET({ params, locals }) {
+	const recordRes = await fetch(`${env.API_URL}/${params.fnurgel}?framed=true`, {
+		headers: { Accept: 'application/ld+json' }
+	});
+	const record = await recordRes.json();
+	const mainEntity = record['mainEntity'] as FramedData;
+
+	const displayUtil: DisplayUtil = locals.display;
+
+	const decoratedRecord = displayUtil.format(
+		displayUtil.applyLensOrdered(mainEntity, LensType.Card),
+		getSupportedLocale(params?.lang)
+	);
+
+	return json(decoratedRecord, {
+		headers: {
+			'cache-control': 'public, max-age=300' // Probably best with an short max-age?
+		}
+	});
+}


### PR DESCRIPTION
## Description

### Tickets involved
[LXL-4447](https://jira.kb.se/browse/LXL-4447)

### Solves
Add resource popover/tooltip for previewing linked data (when hovering over links and definitions). [Floating UI](https://floating-ui.com/) is used for placement of the popover.

The popovers are added by using a custom [svelte action](https://svelte.dev/docs/svelte-action) called `resourcePopover` (note that the `ResourcePopover.svelte` component which the action conditionally renders isn't meant to be used directly in the template code).

The action is currently only used in `DecoratedData.svelte` but can be used on any HTML element by simply adding `use:resourcePopover={{'@id': ADD_FNURGEL_HERE}}`

The action adds event listeners on the trigger node and will render a popover if certain conditions are fulfilled. More specifically; when the user hovers over a link or definition two cancellable promises are started at the same time and the popover will only be rendered _if_ and _when_ both promises are resolved.

**The promises / conditions are:**

1. **The user hovers over a trigger element for a set amount of time (currently 500 ms).** This delay is added to prevent obnoxious amounts of popovers when the user moves the cursor around the page. If the user leaves the trigger node the attachment is cancelled.
2. **The fetching of the required data has finished.** The fetch uses a separate timeout (currently set to 250ms) so the fetching starts before the popup appears. This timeout is also added to prevent obnoxious amounts of fetches when the user moves the cursor around the page.

If _any_ of the above is cancelled or fails then no popover will appear. 

The fetch uses a proxy api route to fetch decorated data (`api/[[lang]]/[fnurgel]`). Currently a simple HTTP cache is used but future improvements can be made using localeStorage (or preferably IndexedDB?) to save all linked data locally and  prevent unnecessary refetching. But we then need some way to update the local cache when the data is updated.

### Summary of changes

- Add Floating UI dependency
- Add API route for decorated resource
- Add resource popover action
