### PR TITLE
Search cards

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -45,3 +45,11 @@
 		@apply mx-auto px-4 sm:px-8;
 	}
 }
+
+.decorated-wrapper > span > span:not([data-property='role']) {
+	display: block;
+}
+
+.search-card *[data-property='_style'] {
+	color: red;
+}

--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -45,11 +45,3 @@
 		@apply mx-auto px-4 sm:px-8;
 	}
 }
-
-.decorated-wrapper > span > span:not([data-property='role']) {
-	display: block;
-}
-
-.search-card *[data-property='_style'] {
-	color: red;
-}

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -2,7 +2,11 @@
 	import type { ResourceData } from '$lib/types/ResourceData';
 	import { page } from '$app/stores';
 	import resourcePopover from '$lib/actions/resourcePopover';
-	import { getResourceId, getResourcePropertyStyle } from '$lib/utils/resourceData';
+	import {
+		getResourceId,
+		getResourcePropertyStyle,
+		getFilteredEntries
+	} from '$lib/utils/resourceData';
 	import { relativize } from '$lib/utils/http';
 	import { getSupportedLocale } from '$lib/i18n/locales';
 	export let data: ResourceData;
@@ -12,17 +16,12 @@
 		'@type',
 		'@id',
 		'_label',
-		// '_style',
+		'_style',
 		'_contentBefore',
 		'_contentAfter'
-		// 'inScheme'
 	];
 
 	const flattenedProperties = ['_display', '@value'];
-
-	function getFilteredEntries(data: Record<string, ResourceData>) {
-		return Object.entries(data).filter(([key]) => !hiddenProperties.includes(key));
-	}
 
 	function getLink(value: ResourceData) {
 		if (getResourcePropertyStyle(value)?.includes('link')) {
@@ -42,13 +41,9 @@
 	}
 
 	function getElementAttributes({ key, value }: { key: string; value: ResourceData }) {
-		if (key === 'genreForm') {
-			console.log('genreform', value);
-		}
 		return {
 			'data-property': key,
 			href: getLink(value)
-			// class: getResourcePropertyStyle(value)
 		};
 	}
 
@@ -78,7 +73,7 @@
 		{/each}
 	{:else}
 		{data?._contentBefore || ''}
-		{#each getFilteredEntries(data) as [key, value]}
+		{#each getFilteredEntries(data, hiddenProperties) as [key, value]}
 			{#if flattenedProperties.includes(key)}
 				<svelte:self data={value} />
 			{:else}

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -12,9 +12,10 @@
 		'@type',
 		'@id',
 		'_label',
-		'_style',
+		// '_style',
 		'_contentBefore',
 		'_contentAfter'
+		// 'inScheme'
 	];
 
 	const flattenedProperties = ['_display', '@value'];
@@ -41,9 +42,13 @@
 	}
 
 	function getElementAttributes({ key, value }: { key: string; value: ResourceData }) {
+		if (key === 'genreForm') {
+			console.log('genreform', value);
+		}
 		return {
 			'data-property': key,
 			href: getLink(value)
+			// class: getResourcePropertyStyle(value)
 		};
 	}
 

--- a/lxl-web/src/lib/utils/resourceData.ts
+++ b/lxl-web/src/lib/utils/resourceData.ts
@@ -23,3 +23,7 @@ export function getResourceId(value: ResourceData) {
 	}
 	return undefined;
 }
+
+export function getFilteredEntries(data: Record<string, ResourceData>, hiddenProperties: string[]) {
+	return Object.entries(data).filter(([key]) => !hiddenProperties.includes(key));
+}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -11,7 +11,7 @@
 		<div class="hidden w-80 shrink-0 md:flex">
 			<FacetSidebar facets={data.searchResult.facetGroups} />
 		</div>
-		<main class="max-w-content">
+		<main class="w-full">
 			<ol class="flex flex-col gap-2">
 				{#each data.searchResult.items as item (item['@id'])}
 					<SearchCard {item} />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
 	import SeachMapping from './SeachMapping.svelte';
 	import FacetSidebar from './FacetSidebar.svelte';
-	import DecoratedData from '$lib/components/DecoratedData.svelte';
-	import { LxlLens } from '$lib/utils/display.types';
-	import { relativize } from '$lib/utils/http';
-
+	import SearchCard from './SearchCard.svelte';
 	export let data;
 </script>
 
@@ -15,19 +12,11 @@
 			<FacetSidebar facets={data.searchResult.facetGroups} />
 		</div>
 		<main class="max-w-content">
-			<ul>
+			<ol class="flex flex-col gap-2">
 				{#each data.searchResult.items as item (item['@id'])}
-					<li class="bg-cards">
-						<a href={relativize(item['@id'])}
-							><h2 class="text-4-cond-extrabold">
-								<DecoratedData data={item[LxlLens.CardHeading]} />
-							</h2></a
-						>
-						<DecoratedData data={item[LxlLens.CardBody]} />
-					</li>
-					<br />
+					<SearchCard {item} />
 				{/each}
-			</ul>
+			</ol>
 		</main>
 	</div>
 </div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/FacetGroup.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/FacetGroup.svelte
@@ -19,14 +19,14 @@
 	$: canShowLessFacets = !canShowMoreFacets && filteredFacets.length > defaultFacetsShown;
 </script>
 
-<li class="my-4 border-b-[1px] pb-2 text-2-regular">
+<li class="my-4 border-b-[1px] pb-2">
 	<button
 		id={'toggle-' + group.dimension}
 		type="button"
 		on:click={() => (expanded = !expanded)}
 		aria-expanded={!!expanded}
 		aria-controls={'group-' + group.dimension}
-		class="w-full text-left text-2-cond-bold"
+		class="w-full text-left font-bold"
 	>
 		{expanded ? '⌃' : '⌄'} {group.label}</button
 	>
@@ -46,14 +46,12 @@
 		<ol class="mt-2">
 			{#each shownFacets as facet (facet.view['@id'])}
 				<li>
-					<a class="flex justify-between no-underline text-2-regular" href={facet.view['@id']}>
+					<a class="flex justify-between no-underline" href={facet.view['@id']}>
 						<span class="flex items-baseline">
 							{#if 'selected' in facet}
 								<!-- howto A11y?! -->
 								<span class="sr-only">{facet.selected ? 'Valt filter' : ''}</span>
-								<span class="mr-1 text-3-regular" aria-hidden="true"
-									>{facet.selected ? '☑' : '☐'}</span
-								>
+								<span class="mr-1" aria-hidden="true">{facet.selected ? '☑' : '☐'}</span>
 							{/if}
 							<span>{facet.str}</span>
 						</span>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/FacetSidebar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/FacetSidebar.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <nav class="w-full" aria-labelledby="facet-sidebar-header">
-	<header id="facet-sidebar-header" class="text-3-cond-bold">Filter</header>
+	<header id="facet-sidebar-header" class="font-bold">Filter</header>
 	<ol>
 		{#each facets as group (group.dimension)}
 			<FacetGroup {group} locale={$page.data.locale} />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SeachMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SeachMapping.svelte
@@ -11,10 +11,8 @@
 		{#each filteredMapping as filter}
 			<li class="justify-center rounded-md bg-positive-inv px-4 py-2">
 				<span class="mr-2">
-					<span class="text-secondary-inv text-2-regular">{filter.label}</span>
-					<span class="text-primary-inv text-2-cond-bold"
-						><DecoratedData data={filter.display} /></span
-					>
+					<span class="text-secondary-inv">{filter.label}</span>
+					<span class="font-bold text-primary-inv"><DecoratedData data={filter.display} /></span>
 				</span>
 				{#if 'up' in filter}
 					<a class="text-secondary-inv" href={filter.up?.['@id']}>x</a>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -7,7 +7,7 @@
 
 	export let item: ResourceData;
 
-	const hiddenProperties = ['_label', '_style'];
+	const hiddenProperties = ['_label', '_style', '_contentBefore'];
 	const bodyDisplay = item[LxlLens.CardBody]?._display;
 
 	function getClasses(obj: ResourceData) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { relativize } from '$lib/utils/http';
+	import DecoratedData from '$lib/components/DecoratedData.svelte';
+	import { LxlLens } from '$lib/utils/display.types';
+	import type { FramedData } from '$lib/utils/xl';
+
+	export let item: FramedData;
+	console.log(item[LxlLens.CardBody]._display);
+</script>
+
+<li class="search-card flex flex-col gap-2 rounded-md border-b border-b-primary/16 bg-cards p-6">
+	<a href={relativize(item['@id'])} class="text-primary no-underline text-3-cond-bold"
+		><h2>
+			<DecoratedData data={item[LxlLens.CardHeading]} />
+		</h2></a
+	>
+	<div class="search-card-body flex gap-4 text-2-regular">
+		{#each item[LxlLens.CardBody]._display as property}
+			<span class="flex flex-col gap-2">
+				<span class="text-secondary">{property?._label}</span>
+				<span class="decorated-wrapper">
+					<DecoratedData data={property} />
+				</span>
+			</span>
+		{/each}
+	</div>
+</li>
+
+<style>
+	.search-card-body {
+		@apply grid grid-cols-2 grid-rows-1;
+		grid-template-areas: 'contribution hasInstance';
+	}
+</style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -18,7 +18,7 @@
 
 <li class="search-card flex flex-col gap-2 rounded-md border-b border-b-primary/16 bg-cards p-6">
 	<!-- card heading -->
-	<a href={relativize(item['@id'])} class="text-primary no-underline text-3-cond-bold"
+	<a href={relativize(item['@id'])} class="font-bold text-primary no-underline"
 		><h2>
 			<DecoratedData data={item[LxlLens.CardHeading]} />
 		</h2></a
@@ -27,7 +27,7 @@
 	<div class="search-card-body">
 		{#each bodyDisplay as obj}
 			{#each getFilteredEntries(obj, hiddenProperties) as [key, value]}
-				<div class="search-card-group {getClasses(obj)}" id={key}>
+				<div class="search-card-group {getClasses(obj)}" data-property={key}>
 					<p class="search-card-label mb-1 text-secondary">{obj?._label}</p>
 					{#if Array.isArray(value)}
 						{#each value as v}
@@ -48,33 +48,33 @@
 
 <style>
 	.search-card-body {
-		@apply grid grid-cols-3 gap-4 text-2-regular;
+		@apply grid grid-cols-3 gap-6;
 		grid-template-areas:
 			'contribution hasInstance subject'
 			'genreForm classification contentType';
 	}
 
-	#contribution {
+	[data-property='contribution'] {
 		grid-area: contribution;
 	}
 
-	#hasInstance {
+	[data-property='hasInstance'] {
 		grid-area: hasInstance;
 	}
 
-	#subject {
+	[data-property='subject'] {
 		grid-area: subject;
 	}
 
-	#genreForm {
+	[data-property='genreForm'] {
 		grid-area: genreForm;
 	}
 
-	#classification {
+	[data-property='classification'] {
 		grid-area: classification;
 	}
 
-	#contentType {
+	[data-property='contentType'] {
 		grid-area: contentType;
 	}
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -1,34 +1,63 @@
 <script lang="ts">
 	import { relativize } from '$lib/utils/http';
+	import { getFilteredEntries, getResourcePropertyStyle } from '$lib/utils/resourceData';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import { LxlLens } from '$lib/utils/display.types';
-	import type { FramedData } from '$lib/utils/xl';
+	import type { ResourceData } from '$lib/types/ResourceData';
 
-	export let item: FramedData;
+	export let item: ResourceData;
+	const hiddenProperties = ['_label', '_style'];
+
+	function getClasses(obj: ResourceData) {
+		const style = getResourcePropertyStyle(obj);
+		return style ? style.join(' ') : '';
+	}
+
 	console.log(item[LxlLens.CardBody]._display);
 </script>
 
 <li class="search-card flex flex-col gap-2 rounded-md border-b border-b-primary/16 bg-cards p-6">
+	<!-- card heading -->
 	<a href={relativize(item['@id'])} class="text-primary no-underline text-3-cond-bold"
 		><h2>
 			<DecoratedData data={item[LxlLens.CardHeading]} />
 		</h2></a
 	>
-	<div class="search-card-body flex gap-4 text-2-regular">
-		{#each item[LxlLens.CardBody]._display as property}
-			<span class="flex flex-col gap-2">
-				<span class="text-secondary">{property?._label}</span>
-				<span class="decorated-wrapper">
-					<DecoratedData data={property} />
-				</span>
-			</span>
+	<!-- card body -->
+	<div class="search-card-body">
+		{#each item[LxlLens.CardBody]._display as obj}
+			<div class="search-card-group {getClasses(obj)}">
+				<p class="search-card-label mb-1 text-secondary">{obj?._label}</p>
+				<!-- eslint-disable-next-line no-empty @typescript-eslint/no-unused-vars -->
+				{#each getFilteredEntries(obj, hiddenProperties) as [key, value]}
+					{#if Array.isArray(value)}
+						{#each value as v}
+							<div class="search-card-value">
+								<DecoratedData data={v} />
+							</div>
+						{/each}
+					{:else}
+						<div class="search-card-value">
+							<DecoratedData data={value} />
+						</div>
+					{/if}
+				{/each}
+			</div>
 		{/each}
 	</div>
 </li>
 
 <style>
 	.search-card-body {
-		@apply grid grid-cols-2 grid-rows-1;
-		grid-template-areas: 'contribution hasInstance';
+		@apply grid grid-cols-3 gap-4 text-2-regular;
+		grid-template-areas: 'head nav foot';
+	}
+
+	.search-card-group.nolabel .search-card-label {
+		@apply hidden;
+	}
+
+	.search-card-group.pill .search-card-value {
+		@apply m-1 inline-block rounded-md border border-accent-dark p-1;
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -6,14 +6,14 @@
 	import type { ResourceData } from '$lib/types/ResourceData';
 
 	export let item: ResourceData;
+
 	const hiddenProperties = ['_label', '_style'];
+	const bodyDisplay = item[LxlLens.CardBody]?._display;
 
 	function getClasses(obj: ResourceData) {
 		const style = getResourcePropertyStyle(obj);
 		return style ? style.join(' ') : '';
 	}
-
-	console.log(item[LxlLens.CardBody]._display);
 </script>
 
 <li class="search-card flex flex-col gap-2 rounded-md border-b border-b-primary/16 bg-cards p-6">
@@ -25,11 +25,10 @@
 	>
 	<!-- card body -->
 	<div class="search-card-body">
-		{#each item[LxlLens.CardBody]._display as obj}
-			<div class="search-card-group {getClasses(obj)}">
-				<p class="search-card-label mb-1 text-secondary">{obj?._label}</p>
-				<!-- eslint-disable-next-line no-empty @typescript-eslint/no-unused-vars -->
-				{#each getFilteredEntries(obj, hiddenProperties) as [key, value]}
+		{#each bodyDisplay as obj}
+			{#each getFilteredEntries(obj, hiddenProperties) as [key, value]}
+				<div class="search-card-group {getClasses(obj)}" id={key}>
+					<p class="search-card-label mb-1 text-secondary">{obj?._label}</p>
 					{#if Array.isArray(value)}
 						{#each value as v}
 							<div class="search-card-value">
@@ -41,8 +40,8 @@
 							<DecoratedData data={value} />
 						</div>
 					{/if}
-				{/each}
-			</div>
+				</div>
+			{/each}
 		{/each}
 	</div>
 </li>
@@ -50,14 +49,44 @@
 <style>
 	.search-card-body {
 		@apply grid grid-cols-3 gap-4 text-2-regular;
-		grid-template-areas: 'head nav foot';
+		grid-template-areas:
+			'contribution hasInstance subject'
+			'genreForm classification contentType';
+	}
+
+	#contribution {
+		grid-area: contribution;
+	}
+
+	#hasInstance {
+		grid-area: hasInstance;
+	}
+
+	#subject {
+		grid-area: subject;
+	}
+
+	#genreForm {
+		grid-area: genreForm;
+	}
+
+	#classification {
+		grid-area: classification;
+	}
+
+	#contentType {
+		grid-area: contentType;
 	}
 
 	.search-card-group.nolabel .search-card-label {
 		@apply hidden;
 	}
 
+	.search-card-group.pill {
+		@apply flex flex-wrap items-start gap-1;
+	}
+
 	.search-card-group.pill .search-card-value {
-		@apply m-1 inline-block rounded-md border border-accent-dark p-1;
+		@apply rounded-md border border-accent-dark p-1;
 	}
 </style>


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-23](https://jira.kb.se/browse/LWS-23)

### Solves

* Displays data from the search result somewhat more readable

### Summary of changes

* Each search result `item` is passed to new component `SearchCard` that formats it for this specific use case:
  * prints the top-level `_label`
  * adds top-level `_style` classes (applied to the entire group)
  * adds a wrapper element to each prop entry to keep them grouped
  * property sorting with grid `template-areas`
