### PR TITLE
Result sorting

### DIFF
--- a/lxl-web/src/lib/types/API.ts
+++ b/lxl-web/src/lib/types/API.ts
@@ -1,0 +1,7 @@
+import type { NumericRange } from '@sveltejs/kit';
+
+export type apiError = {
+	message: string;
+	status_code: NumericRange<400, 599>;
+	status: string;
+};

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
@@ -4,13 +4,7 @@ import { DisplayUtil } from '$lib/utils/xl';
 import { getSupportedLocale } from '$lib/i18n/locales';
 import { asResult, type PartialCollectionView } from './search';
 import { getTranslator } from '$lib/i18n';
-import type { NumericRange } from '@sveltejs/kit';
-
-type apiError = {
-	message: string;
-	status_code: NumericRange<400, 599>;
-	status: string;
-};
+import type { apiError } from '$lib/types/API';
 
 export const load = async ({ params, locals, fetch, url }) => {
 	if (!url.searchParams.size) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
@@ -1,15 +1,29 @@
 import { env } from '$env/dynamic/private';
-import { redirect } from '@sveltejs/kit';
+import { redirect, error } from '@sveltejs/kit';
 import { DisplayUtil } from '$lib/utils/xl';
 import { getSupportedLocale } from '$lib/i18n/locales';
 import { asResult, type PartialCollectionView } from './search';
 import { getTranslator } from '$lib/i18n';
+import type { NumericRange } from '@sveltejs/kit';
+
+type apiError = {
+	message: string;
+	status_code: NumericRange<400, 599>;
+	status: string;
+};
 
 export const load = async ({ params, locals, fetch, url }) => {
 	if (!url.searchParams.size) {
 		redirect(303, `/`); // redirect to home page if no search params are given
 	}
+
 	const recordsRes = await fetch(`${env.API_URL}/find.jsonld?${url.searchParams.toString()}`);
+
+	if (!recordsRes.ok) {
+		const err = (await recordsRes.json()) as apiError;
+		throw error(err.status_code, err.status);
+	}
+
 	const result = (await recordsRes.json()) as PartialCollectionView;
 	const displayUtil: DisplayUtil = locals.display;
 	const locale = getSupportedLocale(params?.lang);

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -37,16 +37,16 @@
 					{/if}
 				</p>
 				{#if numHits > 0}
-					<form on:change={handleSortChange}>
+					<div>
 						<label for="search-sort">Sortera efter</label>
-						<select name="search-sort">
+						<select id="search-sort" on:change={handleSortChange}>
 							{#each sortOptions as option}
 								<option value={option.value} selected={option.value === sortOrder}
 									>{option.label}</option
 								>
 							{/each}
 						</select>
-					</form>
+					</div>
 				{/if}
 			</div>
 			<ol class="flex flex-col gap-2">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -32,14 +32,16 @@
 						Inga träffar
 					{/if}
 				</p>
-				<form on:change={handleSortChange}>
-					<label for="search-sort">Sortera efter</label>
-					<select value={sortOrder} name="search-sort">
-						<option value="">Relevans</option>
-						<option value="_sortKeyByLang.{$page.data.locale}">A-Ö</option>
-						<option value="-_sortKeyByLang.{$page.data.locale}">Ö-A</option>
-					</select>
-				</form>
+				{#if numHits > 0}
+					<form on:change={handleSortChange}>
+						<label for="search-sort">Sortera efter</label>
+						<select value={sortOrder} name="search-sort">
+							<option value="">Relevans</option>
+							<option value="_sortKeyByLang.{$page.data.locale}">A-Ö</option>
+							<option value="-_sortKeyByLang.{$page.data.locale}">Ö-A</option>
+						</select>
+					</form>
+				{/if}
 			</div>
 			<ol class="flex flex-col gap-2">
 				{#each $page.data.searchResult.items as item (item['@id'])}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -39,7 +39,7 @@
 				{#if numHits > 0}
 					<div>
 						<label for="search-sort">Sortera efter</label>
-						<select id="search-sort" on:change={handleSortChange}>
+						<select id="search-sort" form="main-search" on:change={handleSortChange}>
 							{#each sortOptions as option}
 								<option value={option.value} selected={option.value === sortOrder}
 									>{option.label}</option

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -7,11 +7,15 @@
 
 	$: numHits = $page.data.searchResult.totalItems;
 	const sortOrder = $page.url.searchParams.get('_sort');
+	const sortOptions = [
+		{ value: '', label: 'Relevans' },
+		{ value: `_sortKeyByLang.${$page.data.locale}`, label: 'A-Ö' },
+		{ value: `-_sortKeyByLang.${$page.data.locale}`, label: 'Ö-A' }
+	];
 
 	function handleSortChange(e: Event) {
 		const value = (e.target as HTMLSelectElement).value;
 		let searchParams = $page.url.searchParams;
-
 		searchParams.set('_sort', value);
 		goto(`find?${searchParams.toString()}`, { invalidateAll: true });
 	}
@@ -36,9 +40,9 @@
 					<form on:change={handleSortChange}>
 						<label for="search-sort">Sortera efter</label>
 						<select value={sortOrder} name="search-sort">
-							<option value="">Relevans</option>
-							<option value="_sortKeyByLang.{$page.data.locale}">A-Ö</option>
-							<option value="-_sortKeyByLang.{$page.data.locale}">Ö-A</option>
+							{#each sortOptions as option}
+								<option value={option.value}>{option.label}</option>
+							{/each}
 						</select>
 					</form>
 				{/if}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -2,18 +2,47 @@
 	import SeachMapping from './SeachMapping.svelte';
 	import FacetSidebar from './FacetSidebar.svelte';
 	import SearchCard from './SearchCard.svelte';
-	export let data;
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+
+	$: numHits = $page.data.searchResult.totalItems;
+	const sortOrder = $page.url.searchParams.get('_sort');
+
+	function handleSortChange(e: Event) {
+		const value = (e.target as HTMLSelectElement).value;
+		let searchParams = $page.url.searchParams;
+
+		searchParams.set('_sort', value);
+		goto(`find?${searchParams.toString()}`, { invalidateAll: true });
+	}
 </script>
 
-<SeachMapping mapping={data.searchResult.mapping} />
+<SeachMapping mapping={$page.data.searchResult.mapping} />
 <div class="container-fluid">
 	<div class="flex gap-16 py-4 sm:py-8">
 		<div class="hidden w-80 shrink-0 md:flex">
-			<FacetSidebar facets={data.searchResult.facetGroups} />
+			<FacetSidebar facets={$page.data.searchResult.facetGroups} />
 		</div>
-		<main class="w-full">
+		<main class="max-w-content">
+			<div class="mb-4 flex justify-between">
+				<p role="status">
+					{#if numHits && numHits > 0}
+						{numHits.toLocaleString($page.data.locale)} träffar
+					{:else}
+						Inga träffar
+					{/if}
+				</p>
+				<form on:change={handleSortChange}>
+					<label for="search-sort">Sortera efter</label>
+					<select value={sortOrder} name="search-sort">
+						<option value="">Relevans</option>
+						<option value="_sortKeyByLang.{$page.data.locale}">A-Ö</option>
+						<option value="-_sortKeyByLang.{$page.data.locale}">Ö-A</option>
+					</select>
+				</form>
+			</div>
 			<ol class="flex flex-col gap-2">
-				{#each data.searchResult.items as item (item['@id'])}
+				{#each $page.data.searchResult.items as item (item['@id'])}
 					<SearchCard {item} />
 				{/each}
 			</ol>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -39,9 +39,11 @@
 				{#if numHits > 0}
 					<form on:change={handleSortChange}>
 						<label for="search-sort">Sortera efter</label>
-						<select value={sortOrder} name="search-sort">
+						<select name="search-sort">
 							{#each sortOptions as option}
-								<option value={option.value}>{option.label}</option>
+								<option value={option.value} selected={option.value === sortOrder}
+									>{option.label}</option
+								>
 							{/each}
 						</select>
 					</form>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/FacetSidebar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/FacetSidebar.svelte
@@ -6,10 +6,12 @@
 </script>
 
 <nav class="w-full" aria-labelledby="facet-sidebar-header">
-	<header id="facet-sidebar-header" class="font-bold">Filter</header>
-	<ol>
-		{#each facets as group (group.dimension)}
-			<FacetGroup {group} locale={$page.data.locale} />
-		{/each}
-	</ol>
+	{#if facets && facets.length > 0}
+		<header id="facet-sidebar-header" class="font-bold">Filter</header>
+		<ol>
+			{#each facets as group (group.dimension)}
+				<FacetGroup {group} locale={$page.data.locale} />
+			{/each}
+		</ol>
+	{/if}
 </nav>


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-56](https://jira.kb.se/browse/LWS-56)

### Summary of changes

* Adds a `select` element with 3 options (for now, more will be added) that sort the current search result
* Display the number of `totalItems` / no hits

Extra:
* Added very basic error handling to `find/page.server` (I noticed that 'hacking' the `_sort` param caused the app to crash since we never check if the fetch was successful before trying to run xl methods on the response)
* Only show the filter panel if there are hits
