### PR TITLE
Don't add an empty change note in adminmetadata

### DIFF
--- a/vue-client/src/views/Inspector.vue
+++ b/vue-client/src/views/Inspector.vue
@@ -468,10 +468,6 @@ export default {
       if (this.recordType === 'Work' && this.inspector.data.record.recordStatus === 'marc:New') {
         this.addCataloguersNote();
       }
-      // Add a change note for the user to input her commit message
-      if (this.recordType === 'Work' || this.recordType === 'Instance') {
-        this.addEmptyChangeNote();
-      }
     },
     checkForMissingHeldBy() {
       const mainEntity = this.inspector.data.mainEntity;
@@ -510,32 +506,6 @@ export default {
           addToHistory: false,
         });
       }
-    },
-    addEmptyChangeNote() {
-      const emptyChangeNote = { '@type': 'ChangeNote', comment: [''] };
-      
-      this.$store.dispatch('updateInspectorData', {
-        changeList: [{
-          path: 'record.hasChangeNote',
-          value: emptyChangeNote,
-        }],
-        addToHistory: false,
-      });
-      this.$store.dispatch('setInspectorStatusValue', {
-        property: 'embellished',
-        value: [{
-          path: 'record.hasChangeNote',
-          value: emptyChangeNote,
-        }],
-      });
-      this.justEmbellished = true;
-      setTimeout(() => {
-        this.$store.dispatch('setInspectorStatusValue', {
-          property: 'embellished',
-          value: [],
-        });
-        this.justEmbellished = false;
-      }, 3000);
     },
     startEditing() {
       this.$store.dispatch('setOriginalData', this.inspector.data);


### PR DESCRIPTION
## Description
It is obsolete as long as we don't enable automatic `ChangeObservation`s

### Tickets involved
[LXL-4454](https://jira.kb.se/browse/LXL-4454)