### PR TITLE
Don't drop query part when navigating within CXZ message view

### DIFF
--- a/vue-client/src/router.js
+++ b/vue-client/src/router.js
@@ -134,4 +134,15 @@ router.beforeEach((to, from, next) => {
   });
 });
 
+router.beforeEach((to, from, next) => {
+  if (to.fullPath === '/directory-care/changes' && from.path.includes('/directory-care/changes')) {
+    next({
+      name: to.name,
+      query: from.query,
+    });
+  } else {
+    next();
+  }
+});
+
 export default router;


### PR DESCRIPTION
Fixes a bug where the CXZ message search results turns empty when clicking Directory Care / Katalogvård. 
See more in [LXL-4444](https://jira.kb.se/browse/LXL-4444).
