### PR TITLE
Search result pagination

### DIFF
--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -9,7 +9,7 @@
 		getResourceId,
 		getPropertyValue
 	} from '$lib/utils/resourceData';
-	import { relativize } from '$lib/utils/http';
+	import { relativizeUrl } from '$lib/utils/http';
 	import { getSupportedLocale } from '$lib/i18n/locales';
 
 	export let data: ResourceData;
@@ -31,7 +31,7 @@
 		if (depth > 1 && hasPropertyStyle(data, 'link')) {
 			const id = getResourceId(value);
 			if (id) {
-				return relativize(id);
+				return relativizeUrl(id);
 			}
 		}
 		return undefined;

--- a/lxl-web/src/lib/utils/addDefaultSearchParams.test.ts
+++ b/lxl-web/src/lib/utils/addDefaultSearchParams.test.ts
@@ -8,7 +8,6 @@ describe('addDefaultSearchParams', () => {
 				['q', '*'],
 				['@type', 'Work'],
 				['_limit', '10'],
-				['_offset', '0'],
 				['_sort', '']
 			])
 		);
@@ -19,7 +18,17 @@ describe('addDefaultSearchParams', () => {
 				['q', 'test'],
 				['@type', 'Work'],
 				['_limit', '10'],
+				['_sort', '']
+			])
+		);
+	});
+	it('resets the offset if set', () => {
+		expect(addDefaultSearchParams(new URLSearchParams([['_offset', '30']]))).toStrictEqual(
+			new URLSearchParams([
 				['_offset', '0'],
+				['q', '*'],
+				['@type', 'Work'],
+				['_limit', '10'],
 				['_sort', '']
 			])
 		);

--- a/lxl-web/src/lib/utils/addDefaultSearchParams.ts
+++ b/lxl-web/src/lib/utils/addDefaultSearchParams.ts
@@ -13,7 +13,7 @@ function addDefaultSearchParams(searchParams: URLSearchParams): URLSearchParams 
 	if (!params.has('_limit')) {
 		params.set('_limit', '10');
 	}
-	if (!params.has('_offset')) {
+	if (params.has('_offset')) {
 		params.set('_offset', '0');
 	}
 	if (!params.has('_sort')) {

--- a/lxl-web/src/lib/utils/http.test.ts
+++ b/lxl-web/src/lib/utils/http.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { relativizeUrl } from './http';
+
+describe('relativize', () => {
+	it('formats an absolute URL to a relative path', () => {
+		expect(relativizeUrl('https://libris.kb.se/grz79wcldbmgz6jr')).toStrictEqual(
+			'grz79wcldbmgz6jr'
+		);
+	});
+	it('removes the opening slash from a relative path', () => {
+		expect(relativizeUrl('/find?q=*&@type=Work&_limit=10')).toStrictEqual(
+			'find?q=*&@type=Work&_limit=10'
+		);
+	});
+});

--- a/lxl-web/src/lib/utils/http.ts
+++ b/lxl-web/src/lib/utils/http.ts
@@ -1,3 +1,14 @@
 export function relativize(uri: string) {
 	return uri.split('/').slice(3).join('');
 }
+
+/**
+ * Turns /find?q=etc into find?q=etc to keep lang support (base href)
+ * @param path A relative path
+ */
+export function removeOpeningSlash(path: string | undefined) {
+	if (path && path.charAt(0) === '/') {
+		return path.replace('/', '');
+	}
+	return path;
+}

--- a/lxl-web/src/lib/utils/http.ts
+++ b/lxl-web/src/lib/utils/http.ts
@@ -1,14 +1,14 @@
-export function relativize(uri: string) {
-	return uri.split('/').slice(3).join('');
-}
-
 /**
- * Turns /find?q=etc into find?q=etc to keep lang support (base href)
- * @param path A relative path
+ * Turns an absolute url into a relative one
+ * & formats it (removes the opening slash for base href)
+ * @param path - absolute or relative url
  */
-export function removeOpeningSlash(path: string | undefined) {
-	if (path && path.charAt(0) === '/') {
-		return path.replace('/', '');
+export function relativizeUrl(url: string | undefined) {
+	if (!url) {
+		return url;
 	}
-	return path;
+	if (url.charAt(0) === '/') {
+		return url.replace('/', '');
+	}
+	return url.split('/').slice(3).join('');
 }

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -2,6 +2,7 @@
 	import SeachMapping from './SeachMapping.svelte';
 	import FacetSidebar from './FacetSidebar.svelte';
 	import SearchCard from './SearchCard.svelte';
+	import Pagination from './Pagination.svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 
@@ -109,13 +110,14 @@
 	}
 	console.log($page.url);
 	console.log($page.data.searchResult);
+	$: searchResult = $page.data.searchResult;
 </script>
 
-<SeachMapping mapping={$page.data.searchResult.mapping} />
+<SeachMapping mapping={searchResult.mapping} />
 <div class="container-fluid">
 	<div class="flex gap-16 py-4 sm:py-8">
 		<div class="hidden w-80 shrink-0 md:flex">
-			<FacetSidebar facets={$page.data.searchResult.facetGroups} />
+			<FacetSidebar facets={searchResult.facetGroups} />
 		</div>
 		<main class="max-w-content">
 			<div class="mb-4 flex justify-between">
@@ -140,29 +142,13 @@
 				{/if}
 			</div>
 			<ol class="flex flex-col gap-2">
-				{#each $page.data.searchResult.items as item (item['@id'])}
+				{#each searchResult.items as item (item['@id'])}
 					<SearchCard {item} />
 				{/each}
 			</ol>
-			{#if $page.data.searchResult.items.length > 0 && totalItems > itemsPerPage}
-				<nav aria-label="paginering" class="my-4 flex justify-center gap-2">
-					{#each Object.entries(pagination) as [key, value]}
-						<svelte:element
-							this={value?.elem}
-							data-property={key}
-							{...value.href && { href: value.href }}
-						>
-							{value.number || value?.label}
-						</svelte:element>
-					{/each}
-				</nav>
+			{#if searchResult.items.length > 0 && searchResult.totalItems > searchResult.itemsPerPage}
+				<Pagination data={searchResult} />
 			{/if}
 		</main>
 	</div>
 </div>
-
-<style>
-	[data-property='currentPage'] {
-		@apply rounded-md border border-primary px-1;
-	}
-</style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -146,9 +146,7 @@
 					<SearchCard {item} />
 				{/each}
 			</ol>
-			{#if searchResult.items.length > 0 && searchResult.totalItems > searchResult.itemsPerPage}
-				<Pagination data={searchResult} />
-			{/if}
+			<Pagination data={searchResult} />
 		</main>
 	</div>
 </div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -6,7 +6,9 @@
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 
-	$: numHits = $page.data.searchResult.totalItems;
+	$: searchResult = $page.data.searchResult;
+	$: numHits = searchResult.totalItems;
+
 	const sortOrder = $page.url.searchParams.get('_sort');
 	const sortOptions = [
 		{ value: '', label: 'Relevans' },
@@ -20,97 +22,6 @@
 		searchParams.set('_sort', value);
 		goto(`find?${searchParams.toString()}`, { invalidateAll: true });
 	}
-
-	$: ({ first, last, next, totalItems, itemsPerPage, itemOffset } = $page.data.searchResult);
-	$: pagination = {
-		get prev() {
-			return {
-				elem: itemOffset > 0 ? 'a' : null,
-				href: setOffsetParam(itemOffset - itemsPerPage > 0 ? itemOffset - itemsPerPage : 0),
-				label: '←',
-				ariaLabel: 'föregående'
-			};
-		},
-		get firstPage() {
-			return {
-				elem: first && this.currentPage.number > 1 ? 'a' : null,
-				href: first?.['@id'],
-				number: 1
-			};
-		},
-		get ellipsisFirst() {
-			return {
-				elem: this.currentPage.number > 2 ? 'span' : null,
-				label: '...'
-			};
-		},
-		get prevPage() {
-			return {
-				...this.prev,
-				elem:
-					this.currentPage.number === this.lastPage.number && this.currentPage.number > 2
-						? 'a'
-						: null,
-				href: setOffsetParam(itemOffset - itemsPerPage),
-				number: this.currentPage.number - 1
-			};
-		},
-		get currentPage() {
-			return {
-				elem: 'span',
-				number: Math.floor(itemOffset / itemsPerPage) + 1
-			};
-		},
-		get nextPage() {
-			return {
-				elem: next ? 'a' : null,
-				href: next?.['@id'],
-				number: this.currentPage.number + 1
-			};
-		},
-		get secondNextPage() {
-			return {
-				elem: this.currentPage.number === 1 && totalItems > itemsPerPage * 2 ? 'a' : null,
-				href: setOffsetParam(itemOffset + itemsPerPage * 2),
-				number: this.nextPage.number + 1
-			};
-		},
-		get ellipsisLast() {
-			return {
-				...this.ellipsisFirst,
-				elem: this.lastPage.number - this.nextPage.number > 1 ? 'span' : null
-			};
-		},
-		get lastPage() {
-			return {
-				elem:
-					last &&
-					this.currentPage.number !== Math.ceil(totalItems / itemsPerPage) &&
-					this.nextPage.number !== Math.ceil(totalItems / itemsPerPage)
-						? 'a'
-						: null,
-				href: last?.['@id'],
-				number: Math.ceil(totalItems / itemsPerPage)
-			};
-		},
-		get next() {
-			return {
-				elem: next ? 'a' : null,
-				href: next?.['@id'],
-				label: '→',
-				ariaLabel: 'Nästa'
-			};
-		}
-	};
-
-	function setOffsetParam(offset: number) {
-		const params = $page.url.searchParams;
-		params.set('_offset', offset.toString());
-		return `find?${params.toString()}`;
-	}
-	console.log($page.url);
-	console.log($page.data.searchResult);
-	$: searchResult = $page.data.searchResult;
 </script>
 
 <SeachMapping mapping={searchResult.mapping} />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -20,6 +20,9 @@
 		const value = (e.target as HTMLSelectElement).value;
 		let searchParams = $page.url.searchParams;
 		searchParams.set('_sort', value);
+		if (searchParams.has('_offset')) {
+			searchParams.set('_offset', '0');
+		}
 		goto(`find?${searchParams.toString()}`, { invalidateAll: true });
 	}
 </script>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -22,12 +22,87 @@
 
 	$: ({ first, last, next, totalItems, itemsPerPage, itemOffset } = $page.data.searchResult);
 	$: pagination = {
-		currentPage: Math.floor(itemOffset / itemsPerPage) + 1,
-		nextPage: Math.floor(itemOffset / itemsPerPage) + 2,
-		lastPage: Math.ceil(totalItems / itemsPerPage)
+		get prev() {
+			return {
+				elem: itemOffset > 0 ? 'a' : null,
+				href: setOffsetParam(itemOffset - itemsPerPage > 0 ? itemOffset - itemsPerPage : 0),
+				label: '←',
+				ariaLabel: 'föregående'
+			};
+		},
+		get firstPage() {
+			return {
+				elem: first && this.currentPage.number > 1 ? 'a' : null,
+				href: first?.['@id'],
+				number: 1
+			};
+		},
+		get ellipsisFirst() {
+			return {
+				elem: this.currentPage.number > 2 ? 'span' : null,
+				label: '...'
+			};
+		},
+		get prevPage() {
+			return {
+				...this.prev,
+				elem:
+					this.currentPage.number === this.lastPage.number && this.currentPage.number > 2
+						? 'a'
+						: null,
+				href: setOffsetParam(itemOffset - itemsPerPage),
+				number: this.currentPage.number - 1
+			};
+		},
+		get currentPage() {
+			return {
+				elem: 'span',
+				number: Math.floor(itemOffset / itemsPerPage) + 1
+			};
+		},
+		get nextPage() {
+			return {
+				elem: next ? 'a' : null,
+				href: next?.['@id'],
+				number: this.currentPage.number + 1
+			};
+		},
+		get secondNextPage() {
+			return {
+				elem: this.currentPage.number === 1 && totalItems > itemsPerPage * 2 ? 'a' : null,
+				href: setOffsetParam(itemOffset + itemsPerPage * 2),
+				number: this.nextPage.number + 1
+			};
+		},
+		get ellipsisLast() {
+			return {
+				...this.ellipsisFirst,
+				elem: this.lastPage.number - this.nextPage.number > 1 ? 'span' : null
+			};
+		},
+		get lastPage() {
+			return {
+				elem:
+					last &&
+					this.currentPage.number !== Math.ceil(totalItems / itemsPerPage) &&
+					this.nextPage.number !== Math.ceil(totalItems / itemsPerPage)
+						? 'a'
+						: null,
+				href: last?.['@id'],
+				number: Math.ceil(totalItems / itemsPerPage)
+			};
+		},
+		get next() {
+			return {
+				elem: next ? 'a' : null,
+				href: next?.['@id'],
+				label: '→',
+				ariaLabel: 'Nästa'
+			};
+		}
 	};
 
-	function setSortParam(offset: number) {
+	function setOffsetParam(offset: number) {
 		const params = $page.url.searchParams;
 		params.set('_offset', offset.toString());
 		return `find?${params.toString()}`;
@@ -71,40 +146,23 @@
 			</ol>
 			{#if $page.data.searchResult.items.length > 0 && totalItems > itemsPerPage}
 				<nav aria-label="paginering" class="my-4 flex justify-center gap-2">
-					<!-- prev -->
-					{#if itemOffset > 0}<a
-							href={setSortParam(itemOffset - itemsPerPage > 0 ? itemOffset - itemsPerPage : 0)}
-							>←</a
-						>{/if}
-					<!-- first -->
-					{#if first && pagination.currentPage !== 1}<a id="first" href={first['@id']}>1</a>{/if}
-					<!-- divider -->
-					{#if pagination.currentPage > 2}<span>...</span>{/if}
-					<!-- prev (if last) -->
-					{#if pagination.currentPage === pagination.lastPage && pagination.currentPage > 2}<a
-							id="prev"
-							href={setSortParam(itemOffset - itemsPerPage)}>{pagination.currentPage - 1}</a
-						>{/if}
-					<!-- current -->
-					<span class="rounded-md border border-primary px-1">{pagination.currentPage}</span>
-					<!-- next -->
-					{#if next}<a id="next" href={next['@id']}>{pagination.nextPage}</a>{/if}
-					<!-- second next (if first) -->
-					{#if pagination.currentPage === 1 && totalItems > itemsPerPage * 2}<a
-							id="second-next"
-							href={setSortParam(itemOffset + itemsPerPage * 2)}>{pagination.nextPage + 1}</a
-						>{/if}
-					<!-- divider -->
-					{#if pagination.lastPage - pagination.nextPage > 1}<span>...</span>{/if}
-					<!-- last -->
-					{#if last && pagination.currentPage !== pagination.lastPage && pagination.nextPage !== pagination.lastPage}<a
-							id="last"
-							href={last['@id']}>{pagination.lastPage}</a
-						>{/if}
-					<!-- next -->
-					{#if next}<a href={next['@id']}>→</a>{/if}
+					{#each Object.entries(pagination) as [key, value]}
+						<svelte:element
+							this={value?.elem}
+							data-property={key}
+							{...value.href && { href: value.href }}
+						>
+							{value.number || value?.label}
+						</svelte:element>
+					{/each}
 				</nav>
 			{/if}
 		</main>
 	</div>
 </div>
+
+<style>
+	[data-property='currentPage'] {
+		@apply rounded-md border border-primary px-1;
+	}
+</style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -19,6 +19,21 @@
 		searchParams.set('_sort', value);
 		goto(`find?${searchParams.toString()}`, { invalidateAll: true });
 	}
+
+	$: ({ first, last, next, totalItems, itemsPerPage, itemOffset } = $page.data.searchResult);
+	$: pagination = {
+		currentPage: Math.floor(itemOffset / itemsPerPage) + 1,
+		nextPage: Math.floor(itemOffset / itemsPerPage) + 2,
+		lastPage: Math.ceil(totalItems / itemsPerPage)
+	};
+
+	function setSortParam(offset: number) {
+		const params = $page.url.searchParams;
+		params.set('_offset', offset.toString());
+		return `find?${params.toString()}`;
+	}
+	console.log($page.url);
+	console.log($page.data.searchResult);
 </script>
 
 <SeachMapping mapping={$page.data.searchResult.mapping} />
@@ -54,6 +69,42 @@
 					<SearchCard {item} />
 				{/each}
 			</ol>
+			{#if $page.data.searchResult.items.length > 0 && totalItems > itemsPerPage}
+				<nav aria-label="paginering" class="my-4 flex justify-center gap-2">
+					<!-- prev -->
+					{#if itemOffset > 0}<a
+							href={setSortParam(itemOffset - itemsPerPage > 0 ? itemOffset - itemsPerPage : 0)}
+							>←</a
+						>{/if}
+					<!-- first -->
+					{#if first && pagination.currentPage !== 1}<a id="first" href={first['@id']}>1</a>{/if}
+					<!-- divider -->
+					{#if pagination.currentPage > 2}<span>...</span>{/if}
+					<!-- prev (if last) -->
+					{#if pagination.currentPage === pagination.lastPage && pagination.currentPage > 2}<a
+							id="prev"
+							href={setSortParam(itemOffset - itemsPerPage)}>{pagination.currentPage - 1}</a
+						>{/if}
+					<!-- current -->
+					<span class="rounded-md border border-primary px-1">{pagination.currentPage}</span>
+					<!-- next -->
+					{#if next}<a id="next" href={next['@id']}>{pagination.nextPage}</a>{/if}
+					<!-- second next (if first) -->
+					{#if pagination.currentPage === 1 && totalItems > itemsPerPage * 2}<a
+							id="second-next"
+							href={setSortParam(itemOffset + itemsPerPage * 2)}>{pagination.nextPage + 1}</a
+						>{/if}
+					<!-- divider -->
+					{#if pagination.lastPage - pagination.nextPage > 1}<span>...</span>{/if}
+					<!-- last -->
+					{#if last && pagination.currentPage !== pagination.lastPage && pagination.nextPage !== pagination.lastPage}<a
+							id="last"
+							href={last['@id']}>{pagination.lastPage}</a
+						>{/if}
+					<!-- next -->
+					{#if next}<a href={next['@id']}>→</a>{/if}
+				</nav>
+			{/if}
 		</main>
 	</div>
 </div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/FacetGroup.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/FacetGroup.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { LocaleCode } from '$lib/i18n/locales';
+	import { removeOpeningSlash } from '$lib/utils/http';
 	import { type FacetGroup } from './search';
 
 	export let group: FacetGroup;
@@ -46,7 +47,7 @@
 		<ol class="mt-2">
 			{#each shownFacets as facet (facet.view['@id'])}
 				<li>
-					<a class="flex justify-between no-underline" href={facet.view['@id']}>
+					<a class="flex justify-between no-underline" href={removeOpeningSlash(facet.view['@id'])}>
 						<span class="flex items-baseline">
 							{#if 'selected' in facet}
 								<!-- howto A11y?! -->

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/FacetGroup.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/FacetGroup.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { LocaleCode } from '$lib/i18n/locales';
-	import { removeOpeningSlash } from '$lib/utils/http';
+	import { relativizeUrl } from '$lib/utils/http';
 	import { type FacetGroup } from './search';
 
 	export let group: FacetGroup;
@@ -47,7 +47,7 @@
 		<ol class="mt-2">
 			{#each shownFacets as facet (facet.view['@id'])}
 				<li>
-					<a class="flex justify-between no-underline" href={removeOpeningSlash(facet.view['@id'])}>
+					<a class="flex justify-between no-underline" href={relativizeUrl(facet.view['@id'])}>
 						<span class="flex items-baseline">
 							{#if 'selected' in facet}
 								<!-- howto A11y?! -->

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/Pagination.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/Pagination.svelte
@@ -19,8 +19,9 @@
 	$: sequenceEnd = pageSequence[pageSequence.length - 1];
 
 	function getOffsetLink(offset: number) {
+		let o = offset < 0 ? 0 : offset;
 		const params = $page.url.searchParams;
-		params.set('_offset', offset.toString());
+		params.set('_offset', o.toString());
 		return `find?${params.toString()}`;
 	}
 </script>
@@ -31,10 +32,7 @@
 			<!-- prev and first -->
 			{#if !isFirstPage || itemOffset > 0}
 				<li>
-					<a
-						href={getOffsetLink(itemOffset - itemsPerPage > 0 ? itemOffset - itemsPerPage : 0)}
-						aria-label="Föregående sida">←</a
-					>
+					<a href={getOffsetLink(itemOffset - itemsPerPage)} aria-label="Föregående sida">←</a>
 				</li>
 				{#if sequenceStart > 1}
 					<li><a href={removeOpeningSlash(first['@id'])}>1</a></li>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/Pagination.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/Pagination.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { removeOpeningSlash } from '$lib/utils/http';
 	import type { SearchResult } from './search';
 	export let data: SearchResult;
 
@@ -36,7 +37,7 @@
 					>
 				</li>
 				{#if sequenceStart > 1}
-					<li><a href={first['@id']}>1</a></li>
+					<li><a href={removeOpeningSlash(first['@id'])}>1</a></li>
 				{/if}
 			{/if}
 			{#if sequenceStart > 2}
@@ -56,9 +57,9 @@
 			<!-- last and next -->
 			{#if !isLastPage}
 				{#if sequenceEnd !== lastPage}
-					<li><a href={last['@id']}>{lastPage}</a></li>
+					<li><a href={removeOpeningSlash(last['@id'])}>{lastPage}</a></li>
 				{/if}
-				<li><a href={next?.['@id']} aria-label="Nästa sida">→</a></li>
+				<li><a href={removeOpeningSlash(next?.['@id'])} aria-label="Nästa sida">→</a></li>
 			{/if}
 		</ul>
 	</nav>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/Pagination.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/Pagination.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import type { SearchResult } from './search';
+	export let data: SearchResult;
+
+	$: ({ first, last, next, totalItems, itemsPerPage, itemOffset } = data);
+	$: currentPage = Math.floor(itemOffset / itemsPerPage) + 1;
+	$: isFirstPage = currentPage === 1;
+	$: lastPage = Math.ceil(totalItems / itemsPerPage);
+	$: isLastPage = currentPage === lastPage;
+
+	const sequenceSize = [...Array(3)];
+	$: sequenceStart = (() => {
+		if (isFirstPage) return currentPage;
+		if (isLastPage) return currentPage - (sequenceSize.length - 1);
+		else return currentPage - 1;
+	})();
+	$: pageSequence = sequenceSize.map((el, i) => sequenceStart + i);
+	$: sequenceEnd = pageSequence[pageSequence.length - 1];
+
+	function getOffsetLink(offset: number) {
+		const params = $page.url.searchParams;
+		params.set('_offset', offset.toString());
+		return `find?${params.toString()}`;
+	}
+</script>
+
+{#if data.items.length > 0 && totalItems > itemsPerPage}
+	<nav aria-label="paginering">
+		<ul class="my-4 flex justify-center gap-2">
+			<!-- prev and first -->
+			{#if !isFirstPage || itemOffset > 0}
+				<li>
+					<a
+						href={getOffsetLink(itemOffset - itemsPerPage > 0 ? itemOffset - itemsPerPage : 0)}
+						aria-label="Föregående sida">←</a
+					>
+				</li>
+				{#if sequenceStart > 1}
+					<li><a href={first['@id']}>1</a></li>
+				{/if}
+			{/if}
+			{#if sequenceStart > 2}
+				<span>...</span>
+			{/if}
+			<!-- page sequence -->
+			{#each pageSequence as p}
+				<a
+					href={getOffsetLink(itemsPerPage * (p - 1))}
+					aria-label="Sida {p}"
+					aria-current={p === currentPage ? 'page' : false}>{p}</a
+				>
+			{/each}
+			{#if lastPage - sequenceEnd > 1}
+				<span>...</span>
+			{/if}
+			<!-- last and next -->
+			{#if !isLastPage}
+				{#if sequenceEnd !== lastPage}
+					<li><a href={last['@id']}>{lastPage}</a></li>
+				{/if}
+				<li><a href={next?.['@id']} aria-label="Nästa sida">→</a></li>
+			{/if}
+		</ul>
+	</nav>
+{/if}
+
+<style>
+	[aria-current='page'] {
+		@apply rounded-md border border-primary px-1 no-underline;
+	}
+</style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/Pagination.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/Pagination.svelte
@@ -9,11 +9,10 @@
 	$: lastPage = Math.ceil(totalItems / itemsPerPage);
 	$: isLastPage = currentPage === lastPage;
 
-	const sequenceSize = [...Array(3)];
+	const sequenceSize = [...Array(2)];
 	$: sequenceStart = (() => {
-		if (isFirstPage) return currentPage;
-		if (isLastPage) return currentPage - (sequenceSize.length - 1);
-		else return currentPage - 1;
+		if (isLastPage) return currentPage - 1;
+		else return currentPage;
 	})();
 	$: pageSequence = sequenceSize.map((el, i) => sequenceStart + i);
 	$: sequenceEnd = pageSequence[pageSequence.length - 1];

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/Pagination.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/Pagination.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { removeOpeningSlash } from '$lib/utils/http';
+	import { relativizeUrl } from '$lib/utils/http';
 	import type { SearchResult } from './search';
 	export let data: SearchResult;
 
@@ -35,7 +35,7 @@
 					<a href={getOffsetLink(itemOffset - itemsPerPage)} aria-label="Föregående sida">←</a>
 				</li>
 				{#if sequenceStart > 1}
-					<li><a href={removeOpeningSlash(first['@id'])}>1</a></li>
+					<li><a href={relativizeUrl(first['@id'])}>1</a></li>
 				{/if}
 			{/if}
 			{#if sequenceStart > 2}
@@ -55,9 +55,9 @@
 			<!-- last and next -->
 			{#if !isLastPage}
 				{#if sequenceEnd !== lastPage}
-					<li><a href={removeOpeningSlash(last['@id'])}>{lastPage}</a></li>
+					<li><a href={relativizeUrl(last['@id'])}>{lastPage}</a></li>
 				{/if}
-				<li><a href={removeOpeningSlash(next?.['@id'])} aria-label="Nästa sida">→</a></li>
+				<li><a href={relativizeUrl(next?.['@id'])} aria-label="Nästa sida">→</a></li>
 			{/if}
 		</ul>
 	</nav>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { relativize } from '$lib/utils/http';
+	import { relativizeUrl } from '$lib/utils/http';
 	import { getFilteredEntries, getPropertyStyle } from '$lib/utils/resourceData';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import { LxlLens } from '$lib/utils/display.types';
@@ -18,7 +18,7 @@
 
 <li class="search-card flex flex-col gap-2 rounded-md border-b border-b-primary/16 bg-cards p-6">
 	<!-- card heading -->
-	<a href={relativize(item['@id'])} class="font-bold text-primary no-underline"
+	<a href={relativizeUrl(item['@id'])} class="font-bold text-primary no-underline"
 		><h2>
 			<DecoratedData data={item[LxlLens.CardHeading]} />
 		</h2></a


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-24](https://jira.kb.se/browse/LWS-24)

### Summary of changes
* Adds a component that allows the user to paginate the search result
* The pagination includes outer (conditionally displayed prev/next, first/last) navigations and an inner sequence of pages (currently 2) in relation to the current page.
* We want to reset the `_offset` on new search (?), so the `addDefaultSearchParam` condition is reversed; reset if it exists, else omit it (defaulting to 0)
* Renamed http util `relativize` -> `relativizeUrl` and extended it to accept relative url:s - removing its opening slash to keep the /lang/ href. Applied to pagination as well as facets.
* Added and updated tests