### PR TITLE
Fix redirect after login

### DIFF
--- a/vue-client/src/store.js
+++ b/vue-client/src/store.js
@@ -687,6 +687,9 @@ const store = createStore({
             headers,
             method: 'GET',
           }).then((response) => response.json()).then((result) => {
+            if (!result.user) {
+              throw new Error(result.message);
+            }
             userObj = User.getUserObject(result.user);
             userObj.token = token;
             userObj.token_expires_at = result.expires_at;
@@ -695,6 +698,8 @@ const store = createStore({
               resolve(userObj);
             });
           }, (error) => {
+            throw new Error(error);
+          }).catch((error) => {
             localStorage.removeItem('at');
             commit('setUser', userObj);
             console.warn(`Authentication failed for existing token: ${error}`);


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`

## Description

### Tickets involved
[LXL-4427](https://jira.kb.se/browse/LXL-4427)

### Solves
* The problem with not properly redirecting after login.

This has to do with the app treating a user as authenticated (by `verifyUser` function resolving the promise) as long as they have a token and the call to the verify endpoint is successful, even if the token is invalid or expired. The app only stores the `lastPath` for unauthenticated users, resulting in the path not updating for users who have an old token stored.

### Summary of changes
* Check if the response from Libris login contains a user or is in fact an error message. If so, throw an error that rejects the promise.