### PR TITLE
Use new decorated functionality on seach cards & mapping

### DIFF
--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -145,6 +145,6 @@
 	}
 
 	.pill {
-		@apply rounded-md border border-accent-dark p-1 no-underline;
+		@apply inline-block rounded-md border border-accent-dark p-1 no-underline;
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -33,7 +33,7 @@
 		<div class="hidden w-80 shrink-0 md:flex">
 			<FacetSidebar facets={searchResult.facetGroups} />
 		</div>
-		<main class="max-w-content">
+		<main class="w-full max-w-content">
 			<div class="mb-4 flex justify-between">
 				<p role="status">
 					{#if numHits && numHits > 0}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SeachMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SeachMapping.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
+	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
 	import type { DisplayMapping } from './search';
 	export let mapping: DisplayMapping[];
 
@@ -12,7 +13,9 @@
 			<li class="justify-center rounded-md bg-positive-inv px-4 py-2">
 				<span class="mr-2">
 					<span class="text-secondary-inv">{filter.label}</span>
-					<span class="font-bold text-primary-inv"><DecoratedData data={filter.display} /></span>
+					<span class="font-bold text-primary-inv"
+						><DecoratedData data={filter.display} showLabels={ShowLabelsOptions['Never']} /></span
+					>
 				</span>
 				{#if 'up' in filter}
 					<a class="text-secondary-inv" href={filter.up?.['@id']}>x</a>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -1,47 +1,24 @@
 <script lang="ts">
 	import { relativizeUrl } from '$lib/utils/http';
-	import { getFilteredEntries, getStyle } from '$lib/utils/resourceData';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import { LxlLens } from '$lib/utils/display.types';
 	import type { ResourceData } from '$lib/types/ResourceData';
+	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
 
 	export let item: ResourceData;
 
-	const hiddenProperties = ['_label', '_style', '_contentBefore'];
 	const bodyDisplay = item[LxlLens.CardBody]?._display;
-
-	function getClasses(obj: ResourceData) {
-		const style = getStyle(obj);
-		return style ? style.join(' ') : '';
-	}
 </script>
 
 <li class="search-card flex flex-col gap-2 rounded-md border-b border-b-primary/16 bg-cards p-6">
-	<!-- card heading -->
 	<a href={relativizeUrl(item['@id'])} class="font-bold text-primary no-underline"
 		><h2>
-			<DecoratedData data={item[LxlLens.CardHeading]} />
+			<DecoratedData data={item[LxlLens.CardHeading]} showLabels={ShowLabelsOptions['Never']} />
 		</h2></a
 	>
-	<!-- card body -->
 	<div class="search-card-body">
-		{#each bodyDisplay as obj}
-			{#each getFilteredEntries(obj, hiddenProperties) as [key, value]}
-				<div class="search-card-group {getClasses(obj)}" data-property={key}>
-					<p class="search-card-label mb-1 text-secondary">{obj?._label}</p>
-					{#if Array.isArray(value)}
-						{#each value as v}
-							<div class="search-card-value">
-								<DecoratedData data={v} />
-							</div>
-						{/each}
-					{:else}
-						<div class="search-card-value">
-							<DecoratedData data={value} />
-						</div>
-					{/if}
-				</div>
-			{/each}
+		{#each bodyDisplay as i}
+			<DecoratedData data={i} showLabels={ShowLabelsOptions['ByPropertyStyle']} block />
 		{/each}
 	</div>
 </li>
@@ -49,44 +26,41 @@
 <style>
 	.search-card-body {
 		@apply grid grid-cols-3 gap-6;
+
 		grid-template-areas:
 			'contribution hasInstance subject'
 			'genreForm classification contentType';
-	}
 
-	[data-property='contribution'] {
-		grid-area: contribution;
-	}
+		& :global(strong) {
+			@apply block font-normal text-secondary;
 
-	[data-property='hasInstance'] {
-		grid-area: hasInstance;
-	}
+			&::first-letter {
+				@apply capitalize;
+			}
+		}
 
-	[data-property='subject'] {
-		grid-area: subject;
-	}
+		& :global([data-property='contribution']) {
+			grid-area: contribution;
+		}
 
-	[data-property='genreForm'] {
-		grid-area: genreForm;
-	}
+		& :global([data-property='hasInstance']) {
+			grid-area: hasInstance;
+		}
 
-	[data-property='classification'] {
-		grid-area: classification;
-	}
+		& :global([data-property='subject']) {
+			grid-area: subject;
+		}
 
-	[data-property='contentType'] {
-		grid-area: contentType;
-	}
+		& :global([data-property='genreForm']) {
+			grid-area: genreForm;
+		}
 
-	.search-card-group.nolabel .search-card-label {
-		@apply hidden;
-	}
+		& :global([data-property='classification']) {
+			grid-area: classification;
+		}
 
-	.search-card-group.pill {
-		@apply flex flex-wrap items-start gap-1;
-	}
-
-	.search-card-group.pill .search-card-value {
-		@apply rounded-md border border-accent-dark p-1;
+		& :global([data-property='contentType']) {
+			grid-area: contentType;
+		}
 	}
 </style>


### PR DESCRIPTION
Use the new `block` and `showLabels` props on searchcards and mappings to reduce code and make everything look normal again.
