### PR TITLE
Break out web stuff from display

### DIFF
--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -3,6 +3,7 @@ import { env } from '$env/dynamic/private';
 import { DisplayUtil, VocabUtil } from '$lib/utils/xl';
 import fs from 'fs';
 import { DERIVED_LENSES } from '$lib/utils/display.types';
+import displayWeb from '$lib/assets/json/display-web.json';
 
 let utilCache;
 
@@ -53,6 +54,11 @@ async function loadUtil() {
 		display = JSON.parse(displayJson);
 		console.warn(`USE_LOCAL_DISPLAY_JSONLD true. Using ${path}`);
 	}
+
+	// Merge display with lxl-web display stuff
+	// TODO later: move content back into definitions display.jsonld
+	display.formatters = { ...display.formatters, ...displayWeb.formatters };
+	display.lensGroups = { ...display.lensGroups, ...displayWeb.lensGroups };
 
 	const vocabUtil = new VocabUtil(vocab, context);
 	const displayUtil = new DisplayUtil(display, vocabUtil);

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -1,0 +1,286 @@
+{
+	"lensGroups": {
+		"web-chips": {
+			"@id": "web-chips",
+			"@type": "fresnel:Group",
+			"lenses": {
+				"Work": {
+					"@id": "Work-web-chips",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "Work",
+					"showProperties": [
+						{
+							"alternateProperties": [
+								{ "subPropertyOf": "hasTitle", "range": "KeyTitle" },
+								{ "subPropertyOf": "hasTitle", "range": "Title" },
+								"hasTitle"
+							]
+						},
+						"legalDate",
+						"version",
+						"marc:arrangedStatementForMusic",
+						"originDate"
+					]
+				},
+				"Concept": {
+					"@id": "Concept-web-chips",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "Concept",
+					"showProperties": [
+						{ "alternateProperties": ["prefLabel", "label", "termComponentList", "code"] }
+					]
+				},
+				"Classification": {
+					"@id": "Classification-web-chips",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "Classification",
+					"showProperties": ["code", "prefLabel"]
+				}
+			}
+		}
+	},
+	"formatters": {
+		"termComponentList-format": {
+			"@id": "termComponentList-format",
+			"@type": "fresnel:Format",
+			"fresnel:propertyFormatDomain": "termComponentList",
+			"fresnel:valueFormat": {
+				"fresnel:contentAfter": "--",
+				"fresnel:contentLast": ""
+			}
+		},
+		"commaBeforeProperty-format": {
+			"TODO": "fullerFormOfName skrivs alltid med parenteser i libris nu, ska det vara så?",
+			"@id": "commaBeforeProperty-format",
+			"@type": "fresnel:Format",
+			"fresnel:propertyFormatDomain": [
+				"lifeSpan",
+				"familyName",
+				"givenName",
+				"name",
+				"marc:numeration",
+				"lifeSpan",
+				"marc:titlesAndOtherWordsAssociatedWithAName",
+				"fullerFormOfName"
+			],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": ", ",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"agent-place-format": {
+			"@id": "agent-place-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Agent"],
+			"fresnel:propertyFormatDomain": ["place"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": " (",
+				"fresnel:contentFirst": "(",
+				"fresnel:contentAfter": ")",
+				"fresnel:contentLast": ")"
+			}
+		},
+		"ProvisionActivity-comma-format": {
+			"@id": "ProvisionActivity-comma-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["ProvisionActivity"],
+			"fresnel:propertyFormatDomain": [
+				"place",
+				"year",
+				"startYear",
+				"date",
+				"marc:publicationStatus"
+			],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": ", ",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"ProvisionActivity-endYear-format": {
+			"TODO": "endYear without startYear? fresnel:contentNoValue on startYear? but we only want it when endYear is present",
+			"@id": "ProvisionActivity-endYear-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["ProvisionActivity"],
+			"fresnel:propertyFormatDomain": ["endYear"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": "-",
+				"fresnel:contentFirst": "-"
+			}
+		},
+		"ProvisionActivity-colon-before-agent-format": {
+			"@id": "ProvisionActivity-colon-before-agent-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["ProvisionActivity"],
+			"fresnel:propertyFormatDomain": ["agent"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": " : ",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"ProvisionActivity-activity-separator-format": {
+			"NOTE": "",
+			"TODO": "this is in between prov activities, what about after other props? valueFormat on publication, manufacture?",
+			"@id": "ProvisionActivity-activity-separator-format",
+			"@type": "fresnel:Format",
+			"fresnel:propertyFormatDomain": ["provisionActivity"],
+			"fresnel:valueFormat": {
+				"fresnel:contentBefore": "; ",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"ProvisionActivity-hasPart-separator-format": {
+			"@id": "ProvisionActivity-hasPart-separator-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["ProvisionActivity"],
+			"fresnel:propertyFormatDomain": ["hasPart", "place"],
+			"fresnel:valueFormat": {
+				"fresnel:contentBefore": "; ",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"subtitle-format": {
+			"@id": "subtitle-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Title"],
+			"fresnel:propertyFormatDomain": ["subtitle", "titleRemainder"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": " : ",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"Contribution-role-format": {
+			"@id": "Contribution-role-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Contribution"],
+			"fresnel:propertyFormatDomain": ["role"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": " (",
+				"fresnel:contentFirst": "(",
+				"fresnel:contentAfter": ")",
+				"fresnel:contentLast": ")"
+			}
+		},
+		"Meeting-format": {
+			"NOTE": "This ia a workaround for old MARC formatting inside the fields",
+			"@id": "Meeting-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Meeting"],
+			"fresnel:propertyFormatDomain": ["name", "date", "place"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": "",
+				"fresnel:contentFirst": "",
+				"fresnel:contentAfter": "",
+				"fresnel:contentLast": ""
+			}
+		},
+		"Family-format": {
+			"NOTE": "This ia a workaround for old MARC formatting inside the fields",
+			"@id": "Meeting-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Family"],
+			"fresnel:propertyFormatDomain": ["lifeSpan"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": "",
+				"fresnel:contentFirst": "",
+				"fresnel:contentAfter": "",
+				"fresnel:contentLast": ""
+			}
+		},
+		"ISNI-digits-format": {
+			"@id": "ISNI-digits-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["ISNI", "ORCID"],
+			"fresnel:propertyFormatDomain": ["value"],
+			"fresnel:valueStyle": ["isniGroupDigits()"]
+		},
+		"Identifier-format": {
+			"@id": "Identifier-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Identifier"],
+			"fresnel:resourceStyle": ["displayType()"]
+		},
+		"genreForm-format": {
+			"@id": "genreForm-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Work"],
+			"fresnel:propertyFormatDomain": ["genreForm"],
+			"fresnel:propertyStyle": ["pill", "nolabel"],
+			"fresnel:valueFormat": {
+				"fresnel:contentBefore": "",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"GenreForm-format": {
+			"@id": "GenreForm-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["GenreForm"],
+			"fresnel:resourceStyle": ["link", "pill"]
+		},
+		"Topic-format": {
+			"@id": "Topic-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Topic"],
+			"fresnel:resourceStyle": ["link"]
+		},
+		"Agent-format": {
+			"@id": "Agent-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Agent"],
+			"fresnel:resourceStyle": ["link"]
+		},
+		"Agent-hasVariant-format": {
+			"@id": "Agent-hasVariant-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Agent"],
+			"fresnel:propertyFormatDomain": ["hasVariant"],
+			"fresnel:valueFormat": {
+				"fresnel:contentBefore": " • ",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"Role-format": {
+			"@id": "Agent-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Role"],
+			"fresnel:resourceStyle": ["definition"]
+		},
+		"Instance-self-x-format": {
+			"@id": "Instance-self-x-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Instance"],
+			"fresnel:propertyFormatDomain": ["hasTitle", "identifiedBy", "summary"],
+			"fresnel:propertyStyle": ["nolabel"]
+		},
+		"Work-self-x-format": {
+			"@id": "Instance-self-x-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Work"],
+			"fresnel:propertyFormatDomain": ["hasTitle", "identifiedBy", "summary"],
+			"fresnel:propertyStyle": ["nolabel"]
+		},
+		"ISBD-area-format": {
+			"@id": "ISBD-area-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Resource"],
+			"fresnel:propertyFormatDomain": ["hasTitle", "editionStatement"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": ". — ",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"default-separators": {
+			"@id": "default-separators",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Resource"],
+			"fresnel:propertyFormatDomain": ["*"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": " • ",
+				"fresnel:contentFirst": ""
+			},
+			"fresnel:valueFormat": {
+				"fresnel:contentBefore": ", ",
+				"fresnel:contentFirst": ""
+			}
+		}
+	}
+}

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -470,7 +470,7 @@ export class DisplayUtil {
 	private _findLens(lenses: LensType | LensType[] | DerivedLensType, className: ClassName) {
 		for (const lens of asArray(lenses)) {
 			for (const cls of [className, ...this.vocabUtil.getBaseClasses(className)]) {
-				if (cls in this.display.lensGroups[lens].lenses) {
+				if (this.display.lensGroups[lens] && cls in this.display.lensGroups[lens].lenses) {
 					return this.display.lensGroups[lens].lenses[cls];
 				}
 			}


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-59](https://jira.kb.se/browse/LWS-59)

### Solves

Breaks out lxl-web lens and formatting into a local file for easier management

To be tested together with https://github.com/libris/definitions/pull/473

### Summary of changes

* Create display-web.json
* Merge contents with display on load
* Fix so that app doesn't break if display-web is empty, for example
