### PR TITLE
Rework search card w. new lens

### DIFF
--- a/lxl-web/src/colors.css
+++ b/lxl-web/src/colors.css
@@ -20,7 +20,7 @@ see https://tailwindcss.com/docs/customizing-colors#using-css-variables */
 	/* Text colors */
 	--text-primary: var(--color-primary);
 	--text-primary-inv: var(--color-white);
-	--text-link: var(--color-accent-dark);
+	--text-link: var(--color-primary);
 
 	/* Bg colors */
 	--bg-main: var(--color-subtle);

--- a/lxl-web/src/colors.css
+++ b/lxl-web/src/colors.css
@@ -5,6 +5,7 @@ see https://tailwindcss.com/docs/customizing-colors#using-css-variables */
 	--color-black: 0 0 0;
 	--color-white: 255 255 255;
 	--color-brown: 82 51 20;
+	--color-brown-light: 103 64 25;
 	--color-dark-green: 66 107 84;
 	--color-light-green: 213 229 220;
 	--color-beige: 248 246 241;
@@ -12,6 +13,7 @@ see https://tailwindcss.com/docs/customizing-colors#using-css-variables */
 
 	/* Fundament */
 	--color-primary: var(--color-brown);
+	--color-primary-light: var(--color-brown-light);
 	--color-accent-dark: var(--color-dark-green);
 	--color-accent-light: var(--color-light-green);
 	--color-subtle: var(--color-beige);
@@ -26,7 +28,7 @@ see https://tailwindcss.com/docs/customizing-colors#using-css-variables */
 	--bg-main: var(--color-subtle);
 	--bg-head: var(--color-accent-light);
 	--bg-positive: var(--color-accent-light);
-	--bg-positive-inv: var(--color-primary);
+	--bg-positive-inv: var(--color-primary-light);
 	--bg-cards: var(--color-white);
 	--bg-pill: var(--color-brown);
 }

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -106,6 +106,29 @@
 					]
 				}
 			}
+		},
+		"web-card": {
+			"@id": "web-card",
+			"@type": "fresnel:Group",
+			"lenses": {
+				"Work": {
+					"@id": "Work-web-card",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "Work",
+					"showProperties": [
+						{
+							"alternateProperties": [
+								{ "subPropertyOf": "hasTitle", "range": "KeyTitle" },
+								{ "subPropertyOf": "hasTitle", "range": "Title" },
+								"hasTitle"
+							]
+						},
+						"contribution",
+						"language",
+						{ "inverseOf": "instanceOf" }
+					]
+				}
+			}
 		}
 	},
 	"formatters": {

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -12,6 +12,15 @@
 	export let showLabels: ShowLabelsOptions = ShowLabelsOptions.DefaultOn;
 	export let allowPopovers = true; // used for preventing nested popovers
 	export let block = false;
+	export let truncate = false;
+
+	let remainder: number | undefined;
+
+	if (truncate && Array.isArray(data) && data?.[0] && '@type' in data[0]) {
+		remainder = data.length - 1;
+		data = data[0];
+		truncate = false;
+	}
 
 	const hiddenProperties = [
 		'@context',
@@ -116,7 +125,14 @@
 	{#if data && typeof data === 'object'}
 		{#if Array.isArray(data)}
 			{#each data as arrayItem}
-				<svelte:self data={arrayItem} depth={depth + 1} {showLabels} {block} {allowPopovers} />
+				<svelte:self
+					data={arrayItem}
+					depth={depth + 1}
+					{showLabels}
+					{block}
+					{allowPopovers}
+					{truncate}
+				/>
 			{/each}
 		{:else}
 			{#if shouldShowContentBefore()}
@@ -138,7 +154,11 @@
 						{showLabels}
 						{block}
 						{allowPopovers}
+						{truncate}
 					/>
+					{#if remainder}
+						<span class="remainder">+ {remainder}</span>
+					{/if}
 				</svelte:element>
 			{:else if data['@value']}
 				<svelte:self data={data['@value']} depth={depth + 1} {showLabels} {block} {allowPopovers} />
@@ -149,6 +169,7 @@
 					{showLabels}
 					{block}
 					{allowPopovers}
+					{truncate}
 				/>
 			{:else}
 				{@const [propertyName, propertyData] = getProperty(data)}
@@ -165,6 +186,7 @@
 							{showLabels}
 							{block}
 							{allowPopovers}
+							{truncate}
 						/>
 					</svelte:element>
 				{/if}
@@ -197,5 +219,9 @@
 	}
 	a.pill {
 		@apply hover:bg-pill/16 focus:bg-pill/16;
+	}
+
+	.remainder {
+		@apply ml-2 rounded-full bg-pill/8 px-2 py-1 text-secondary;
 	}
 </style>

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -14,11 +14,10 @@
 	export let block = false;
 	export let truncate = false;
 
-	let remainder: number | undefined;
-
+	// truncate option; use only first item as data and keep the rest for tooltip
+	let remainder: ResourceData[] | undefined;
 	if (truncate && Array.isArray(data) && data?.[0] && '@type' in data[0]) {
-		remainder = data.length - 1;
-		data = data[0];
+		[data, ...remainder] = data;
 		truncate = false;
 	}
 
@@ -157,7 +156,10 @@
 						{truncate}
 					/>
 					{#if remainder}
-						<span class="remainder">+ {remainder}</span>
+						<span
+							use:resourcePopover={{ data: remainder, lang: getSupportedLocale($page.params.lang) }}
+							class="remainder">+ {remainder.length}</span
+						>
 					{/if}
 				</svelte:element>
 			{:else if data['@value']}

--- a/lxl-web/src/lib/utils/display.types.ts
+++ b/lxl-web/src/lib/utils/display.types.ts
@@ -35,7 +35,7 @@ export const DERIVED_LENSES: DerivedLensTypeDefinition[] = [
 	},
 	{
 		name: LxlLens.CardBody,
-		base: [LensType.Card],
+		base: [LensType.WebCard, LensType.Card],
 		minusFirst: [LensType.WebChip, LensType.Chip],
 		minusAll: []
 	}

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -129,6 +129,7 @@ export enum LensType {
 	SearchChip = 'search-chips',
 	SearchCard = 'search-cards',
 	WebChip = 'web-chips',
+	WebCard = 'web-card',
 	None = null // FIXME
 }
 
@@ -269,6 +270,7 @@ export class DisplayUtil {
 				return LensType.Card;
 			case LensType.Card:
 			case LensType.SearchCard:
+			case LensType.WebCard:
 				return LensType.Chip;
 			case LensType.Chip:
 			case LensType.SearchChip:

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
@@ -21,7 +21,7 @@
 				<img class="h-12 w-12 sm:h-24 sm:w-24" alt="Libris logo" src={logo} />
 				<h1 class="text-3xl font-bold leading-none text-primary sm:text-[5.5rem]">Libris</h1>
 			</div>
-			<label for="main-search" class="text-center text-[1.25rem] text-secondary"
+			<label for="main-search" class="text-center text-secondary text-4-regular"
 				>Hitta och låna i hela Sveriges bibliotekskatalog</label
 			>
 			<div class="w-full max-w-3xl">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
 	import SeachMapping from './SeachMapping.svelte';
 	import SearchCard from './SearchCard.svelte';
 	import Pagination from './Pagination.svelte';
-	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
 	import FacetGroup from './FacetGroup.svelte';
+	import { type SearchResult } from './search';
 
-	$: searchResult = $page.data.searchResult;
+	$: searchResult = $page.data.searchResult as SearchResult;
 	$: numHits = searchResult.totalItems;
 	$: facets = searchResult.facetGroups;
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SeachMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SeachMapping.svelte
@@ -12,13 +12,13 @@
 		{#each filteredMapping as filter}
 			<li class="justify-center rounded-md bg-positive-inv px-4 py-2">
 				<span class="mr-2">
-					<span class="text-secondary-inv">{filter.label}</span>
+					<span class="text-secondary-inv text-2-regular">{filter.label}</span>
 					<span class="font-bold text-primary-inv"
 						><DecoratedData data={filter.display} showLabels={ShowLabelsOptions['Never']} /></span
 					>
 				</span>
 				{#if 'up' in filter}
-					<a class="text-secondary-inv" href={filter.up?.['@id']}>x</a>
+					<a class="text-secondary-inv visited:text-secondary-inv" href={filter.up?.['@id']}>x</a>
 				{/if}
 			</li>
 		{/each}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -11,32 +11,43 @@
 		Image
 	</div>
 	<div class="flex flex-col gap-2">
-		<a href={relativizeUrl(item['@id'])} class="search-card-heading"
+		<a
+			href={relativizeUrl(item['@id'])}
+			class="search-card-heading line-clamp-2 text-ellipsis text-secondary no-underline text-4-regular"
 			><h2>
 				<DecoratedData data={item['card-heading']} showLabels={ShowLabelsOptions.Never} />
 			</h2></a
 		>
-		<div class="search-card-body">
-			<DecoratedData data={item['card-body']} showLabels={ShowLabelsOptions.Never} block />
+		<div class="search-card-body flex gap-2">
+			{#each item['card-body']._display as obj}
+				<div class="rounded-md bg-pill/4 p-2">
+					{#if 'hasInstance' in obj}
+						<span>{obj.hasInstance.length ? `${obj.hasInstance.length} utgåvor` : `1 utgåva`}</span>
+					{:else}
+						<DecoratedData data={obj} showLabels={ShowLabelsOptions.Never} block />
+					{/if}
+				</div>
+			{/each}
+			<!-- <DecoratedData data={item['card-body']} showLabels={ShowLabelsOptions.Never} block /> -->
 		</div>
 	</div>
 </li>
 
 <style>
 	.search-card-heading {
-		@apply line-clamp-2 text-ellipsis text-primary no-underline text-4-regular;
-
 		& :global([data-property='mainTitle']) {
 			@apply text-4-cond-bold;
 		}
-	}
-	.search-card-body {
-		& :global(> div) {
-			@apply grid grid-cols-3 gap-6;
 
-			grid-template-areas: 'contribution language hasInstance';
+		&:not(:visited) {
+			& :global([data-property='mainTitle']) {
+				@apply text-primary;
+			}
 		}
+	}
 
+	.search-card-body {
+		/* grid-template-areas: 'contribution language hasInstance'; */
 		/* hide formatting */
 		& :global([data-property='contribution'] ._contentBefore),
 		:global([data-property='contribution'] ._contentAfter),
@@ -46,11 +57,11 @@
 
 		/* ...except for agents */
 		& :global([data-property='agent'] ._contentBefore),
-		& :global([data-property='agent'] ._contentBefore) {
+		:global([data-property='agent'] ._contentBefore) {
 			@apply inline;
 		}
 
-		& :global([data-property='contribution'] > *) {
+		/* & :global([data-property='contribution'] > *) {
 			@apply block;
 		}
 
@@ -64,6 +75,6 @@
 
 		& :global([data-property='hasInstance']) {
 			grid-area: hasInstance;
-		}
+		} */
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -6,38 +6,48 @@
 	export let item: ResourceData;
 </script>
 
-<li class="search-card flex flex-col gap-2 rounded-md border-b border-b-primary/16 bg-cards p-6">
-	<a href={relativizeUrl(item['@id'])} class="font-bold text-primary no-underline"
-		><h2>
-			<DecoratedData data={item['card-heading']} showLabels={ShowLabelsOptions.Never} />
-		</h2></a
-	>
-	<div class="search-card-body">
-		<DecoratedData data={item['card-body']} block />
+<li class="flex gap-8 rounded-md border-b border-b-primary/16 bg-cards p-6">
+	<div class="flex h-[6.5rem] w-20 shrink-0 items-center justify-center rounded-sm bg-[lightgrey]">
+		Image
+	</div>
+	<div class="flex flex-col gap-2">
+		<a href={relativizeUrl(item['@id'])} class="search-card-heading"
+			><h2>
+				<DecoratedData data={item['card-heading']} showLabels={ShowLabelsOptions.Never} />
+			</h2></a
+		>
+		<div class="search-card-body">
+			<DecoratedData data={item['card-body']} showLabels={ShowLabelsOptions.Never} block />
+		</div>
 	</div>
 </li>
 
 <style>
+	.search-card-heading {
+		@apply line-clamp-2 text-ellipsis text-primary no-underline text-4-regular;
+
+		& :global([data-property='mainTitle']) {
+			@apply text-4-cond-bold;
+		}
+	}
 	.search-card-body {
 		& :global(> div) {
 			@apply grid grid-cols-3 gap-6;
 
-			grid-template-areas:
-				'contribution language subject'
-				'genreForm classification contentType';
+			grid-template-areas: 'contribution language hasInstance';
 		}
 
-		& :global(small) {
-			@apply block font-normal text-secondary;
-
-			&::first-letter {
-				@apply capitalize;
-			}
-		}
-
-		& :global([data-property='contribution'] > ._contentBefore),
-		:global([data-property='contribution'] > ._contentAfter) {
+		/* hide formatting */
+		& :global([data-property='contribution'] ._contentBefore),
+		:global([data-property='contribution'] ._contentAfter),
+		:global([data-property='role']) {
 			@apply hidden;
+		}
+
+		/* ...except for agents */
+		& :global([data-property='agent'] ._contentBefore),
+		& :global([data-property='agent'] ._contentBefore) {
+			@apply inline;
 		}
 
 		& :global([data-property='contribution'] > *) {
@@ -52,20 +62,8 @@
 			grid-area: language;
 		}
 
-		& :global([data-property='subject']) {
-			grid-area: subject;
-		}
-
-		& :global([data-property='genreForm']) {
-			grid-area: genreForm;
-		}
-
-		& :global([data-property='classification']) {
-			grid-area: classification;
-		}
-
-		& :global([data-property='contentType']) {
-			grid-area: contentType;
+		& :global([data-property='hasInstance']) {
+			grid-area: hasInstance;
 		}
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -18,13 +18,13 @@
 				<DecoratedData data={item['card-heading']} showLabels={ShowLabelsOptions.Never} />
 			</h2></a
 		>
-		<div class="search-card-body flex gap-2">
+		<div class="search-card-body flex items-baseline gap-2">
 			{#each item['card-body']._display as obj}
 				<div class="rounded-md bg-pill/4 p-2">
 					{#if 'hasInstance' in obj}
 						<span>{obj.hasInstance.length ? `${obj.hasInstance.length} utgåvor` : `1 utgåva`}</span>
 					{:else}
-						<DecoratedData data={obj} showLabels={ShowLabelsOptions.Never} block />
+						<DecoratedData data={obj} showLabels={ShowLabelsOptions.Never} block truncate />
 					{/if}
 				</div>
 			{/each}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -3,7 +3,7 @@
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import type { ResourceData } from '$lib/types/ResourceData';
 	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
-	export let item: ResourceData;
+	export let item: { '@id': string; 'card-heading': ResourceData; 'card-body': ResourceData };
 </script>
 
 <li class="flex gap-8 rounded-md border-b border-b-primary/16 bg-cards p-6">
@@ -19,7 +19,7 @@
 			</h2></a
 		>
 		<div class="search-card-body flex items-baseline gap-2">
-			{#each item['card-body']._display as obj}
+			{#each item['card-body']?._display as obj}
 				<div class="rounded-md bg-pill/4 p-2">
 					{#if 'hasInstance' in obj}
 						<span>{obj.hasInstance.length ? `${obj.hasInstance.length} utgåvor` : `1 utgåva`}</span>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -28,7 +28,6 @@
 					{/if}
 				</div>
 			{/each}
-			<!-- <DecoratedData data={item['card-body']} showLabels={ShowLabelsOptions.Never} block /> -->
 		</div>
 	</div>
 </li>
@@ -47,7 +46,6 @@
 	}
 
 	.search-card-body {
-		/* grid-template-areas: 'contribution language hasInstance'; */
 		/* hide formatting */
 		& :global([data-property='contribution'] ._contentBefore),
 		:global([data-property='contribution'] ._contentAfter),
@@ -60,21 +58,5 @@
 		:global([data-property='agent'] ._contentBefore) {
 			@apply inline;
 		}
-
-		/* & :global([data-property='contribution'] > *) {
-			@apply block;
-		}
-
-		& :global([data-property='contribution']) {
-			grid-area: contribution;
-		}
-
-		& :global([data-property='language']) {
-			grid-area: language;
-		}
-
-		& :global([data-property='hasInstance']) {
-			grid-area: hasInstance;
-		} */
 	}
 </style>

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -109,28 +109,28 @@ export default {
 			addUtilities({
 				// typography 1-6 variants in design
 				'.text-1-regular': {
-					'@apply text-xs': {}
+					'@apply text-xs font-normal': {}
 				},
 				'.text-1-cond-bold': {
 					'@apply text-xs font-condensed font-bold': {}
 				},
 				'.text-1-cond-caps': {
-					'@apply text-xs font-condensed uppercase tracking-wide': {}
+					'@apply text-xs font-condensed font-normal uppercase tracking-wide': {}
 				},
 				'.text-2-regular': {
-					'@apply text-sm': {}
+					'@apply text-sm font-normal': {}
 				},
 				'.text-2-cond-bold': {
 					'@apply text-sm font-condensed font-bold': {}
 				},
 				'.text-3-regular': {
-					'@apply text-base': {}
+					'@apply text-base font-normal': {}
 				},
 				'.text-3-cond-bold': {
 					'@apply text-base font-condensed font-bold': {}
 				},
 				'.text-4-regular': {
-					'@apply text-lg': {}
+					'@apply text-lg font-normal': {}
 				},
 				'.text-4-cond-bold': {
 					'@apply text-lg font-condensed font-bold': {}

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -42,10 +42,12 @@ export default {
 			xs: ['0.75rem', theme('lineHeight.normal')],
 			sm: ['0.875rem', theme('lineHeight.normal')],
 			base: ['1rem', theme('lineHeight.normal')],
+			lg: ['1.25rem', theme('lineHeight.normal')],
 			xl: ['1.5rem', theme('lineHeight.tight')],
 			'2xl': ['2rem', theme('lineHeight.tight')],
 			'3xl': ['2.5rem', theme('lineHeight.tight')],
-			'4xl': ['4rem', theme('lineHeight.tight')]
+			'4xl': ['3rem', theme('lineHeight.tight')],
+			'5xl': ['4rem', theme('lineHeight.tight')]
 		}),
 		fontFamily: {
 			sans: ['"Roboto Flex"', 'sans-serif'],
@@ -127,14 +129,20 @@ export default {
 				'.text-3-cond-bold': {
 					'@apply text-base font-condensed font-bold': {}
 				},
-				'.text-4-cond-extrabold': {
-					'@apply text-xl font-condensed font-extrabold': {}
+				'.text-4-regular': {
+					'@apply text-lg': {}
+				},
+				'.text-4-cond-bold': {
+					'@apply text-lg font-condensed font-bold': {}
 				},
 				'.text-5-cond-extrabold': {
-					'@apply text-2xl font-condensed font-extrabold': {}
+					'@apply text-xl font-condensed font-extrabold': {}
 				},
 				'.text-6-cond-extrabold': {
-					'@apply text-3xl lg:text-4xl font-condensed font-extrabold': {}
+					'@apply text-2xl md:text-3xl font-condensed font-extrabold': {}
+				},
+				'.text-7-cond-extrabold': {
+					'@apply text-3xl md:text-4xl lg:text-5xl font-condensed font-extrabold': {}
 				},
 				// other utility classes
 				'.gradient-primary': {


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-22](https://jira.kb.se/browse/LWS-22)

### Summary of changes
Iteration of search card given the design:
<img width="528" alt="pippi" src="https://github.com/libris/lxlviewer/assets/22232928/5434a93d-0ff6-4853-bd94-fda3e2d776e6">
(minus year, checkbox, description, right side buttons)

* Created a new `web-card` lens that exclude many of the base card properties
* Rework the `SearchCard` component to support alternate renderings (`hasInstance`)
* New `truncate` option to `DecoratedData` that renders the first item and indicates the remainder (+ x). Not happy to grow it further, other suggestions how to achieve this are welcome :)
* New option to pass `data` directly to popover instead of fetching with id. Used here to show the remainder data (+ x) on hover. 
* Updated styles (typography variants)