### PR TITLE
Publication year on search card

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -124,8 +124,8 @@
 							]
 						},
 						"contribution",
-						"language",
-						{ "inverseOf": "instanceOf" }
+						{ "inverseOf": "instanceOf" },
+						"language"
 					]
 				}
 			}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -1,12 +1,39 @@
 <script lang="ts">
+	import jmespath from 'jmespath';
 	import { relativizeUrl } from '$lib/utils/http';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import type { ResourceData } from '$lib/types/ResourceData';
 	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
 	export let item: { '@id': string; 'card-heading': ResourceData; 'card-body': ResourceData };
+
+	function getInstanceData(instances: ResourceData) {
+		if (typeof instances === 'object') {
+			let count = 1;
+			let query = '_display[].publication[].*[][?year].year[]';
+
+			if (Array.isArray(instances)) {
+				count = instances.length;
+				query = '[]._display[].publication[].*[][?year].year[]';
+			}
+
+			let years = jmespath.search(instances, query);
+			if (years) {
+				years = years
+					.filter((el: string) => !isNaN(parseInt(el)))
+					.sort()
+					.filter((el: string, i: number) => el && (i === 0 || i === years.length - 1))
+					.join('-');
+			}
+			return { count, years };
+		}
+		return null;
+	}
 </script>
 
-<li class="flex gap-8 rounded-md border-b border-b-primary/16 bg-cards p-6" data-testid="search-card">
+<li
+	class="flex gap-8 rounded-md border-b border-b-primary/16 bg-cards p-6"
+	data-testid="search-card"
+>
 	<div class="flex h-[6.5rem] w-20 shrink-0 items-center justify-center rounded-sm bg-[lightgrey]">
 		Image
 	</div>
@@ -23,7 +50,14 @@
 			{#each item['card-body']?._display as obj}
 				<div class="rounded-md bg-pill/4 p-2">
 					{#if 'hasInstance' in obj}
-						<span>{obj.hasInstance.length ? `${obj.hasInstance.length} utgåvor` : `1 utgåva`}</span>
+						{@const instances = getInstanceData(obj.hasInstance)}
+						{#if instances}
+							<span>
+								{instances?.count}
+								{instances.count > 1 ? 'utgåvor' : 'utgåva'}
+								{instances?.years && `(${instances.years})`}
+							</span>
+						{/if}
 					{:else}
 						<DecoratedData data={obj} showLabels={ShowLabelsOptions.Never} block truncate />
 					{/if}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/SearchCard.svelte
@@ -8,6 +8,7 @@
 
 	function getInstanceData(instances: ResourceData) {
 		if (typeof instances === 'object') {
+			let years: string = '';
 			let count = 1;
 			let query = '_display[].publication[].*[][?year].year[]';
 
@@ -16,12 +17,12 @@
 				query = '[]._display[].publication[].*[][?year].year[]';
 			}
 
-			let years = jmespath.search(instances, query);
-			if (years) {
-				years = years
-					.filter((el: string) => !isNaN(parseInt(el)))
+			let res = jmespath.search(instances, query) as string[] | null;
+			if (res) {
+				years = res
+					.filter((el, i, arr) => !isNaN(parseInt(el)) && arr.indexOf(el) === i)
 					.sort()
-					.filter((el: string, i: number) => el && (i === 0 || i === years.length - 1))
+					.filter((el, i, arr) => i === 0 || i === arr.length - 1)
 					.join('-');
 			}
 			return { count, years };


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-58](https://jira.kb.se/browse/LWS-58)

### Summary of changes

Displays instanceOf.publication.year (from-to) on search card (using the `jmespath` package to dig out the years).

Maybe these kinds of operations should be done in the backend, but i'm not entirely sure how to align it with the current data structure there 🤔 

Testing: search for 'sommar' against qa displays a few hits with their publication years indexed.


