### PR TITLE
Use _q parameter

### DIFF
--- a/lxl-web/src/colors.css
+++ b/lxl-web/src/colors.css
@@ -29,6 +29,7 @@ see https://tailwindcss.com/docs/customizing-colors#using-css-variables */
 	--bg-head: var(--color-accent-light);
 	--bg-positive: var(--color-accent-light);
 	--bg-positive-inv: var(--color-primary-light);
+	--bg-negative: var(--color-highlight);
 	--bg-cards: var(--color-white);
 	--bg-pill: var(--color-brown);
 }

--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -7,7 +7,7 @@
 	export let placeholder: string;
 	export let autofocus: boolean = false;
 
-	let q = $page.url.searchParams.get('q')?.trim();
+	let q = $page.url.searchParams.get('_q')?.trim();
 
 	let params = getSortedSearchParams(getDefaultSearchParams($page.url.searchParams));
 	params.set('_offset', '0'); // Always reset offset on new search
@@ -16,7 +16,7 @@
 	afterNavigate(({ to }) => {
 		/** Update input value after navigation */
 		if (to?.url) {
-			q = new URL(to.url).searchParams.get('q')?.trim();
+			q = new URL(to.url).searchParams.get('_q')?.trim();
 		}
 	});
 
@@ -35,7 +35,7 @@
 		id="main-search"
 		class="h-12 w-full rounded-full text-secondary sm:h-14"
 		type="search"
-		name="q"
+		name="_q"
 		{placeholder}
 		aria-label="Sök"
 		spellcheck="false"
@@ -44,7 +44,7 @@
 		data-testid="main-search"
 	/>
 	{#each searchParams as [name, value]}
-		{#if name !== 'q'}
+		{#if name !== '_q'}
 			<input type="hidden" {name} {value} />
 		{/if}
 	{/each}

--- a/lxl-web/src/lib/utils/addDefaultSearchParams.ts
+++ b/lxl-web/src/lib/utils/addDefaultSearchParams.ts
@@ -4,8 +4,8 @@
 function addDefaultSearchParams(searchParams: URLSearchParams): URLSearchParams {
 	const params = new URLSearchParams([...Array.from(searchParams.entries())]);
 
-	if (!params.has('q')) {
-		params.set('q', '*');
+	if (!params.has('_q')) {
+		params.set('_q', '*');
 	}
 	if (!params.has('@type')) {
 		params.set('@type', 'Work');

--- a/lxl-web/src/lib/utils/addDefaultSearchParams.ts
+++ b/lxl-web/src/lib/utils/addDefaultSearchParams.ts
@@ -7,9 +7,9 @@ function addDefaultSearchParams(searchParams: URLSearchParams): URLSearchParams 
 	if (!params.has('_q')) {
 		params.set('_q', '*');
 	}
-	if (!params.has('@type')) {
-		params.set('@type', 'Work');
-	}
+	// if (!params.has('@type')) {
+	// 	params.set('@type', 'Work');
+	// }
 	if (!params.has('_limit')) {
 		params.set('_limit', '10');
 	}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -74,6 +74,11 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 		if (shouldFindRelations && resourceId) {
 			searchParams.set('o', resourceId);
 			searchParams = getSortedSearchParams(addDefaultSearchParams(searchParams));
+
+			// _q and o can not be combined ATM,
+			// TODO: remove when we can use _q for this search
+			searchParams.delete('_q');
+			searchParams.set('@type', 'Work');
 		}
 
 		const recordsRes = await fetch(`${env.API_URL}/find.jsonld?${searchParams.toString()}`);

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -4,6 +4,7 @@
 	import type { DisplayMapping, SearchOperators } from './search';
 	export let mapping: DisplayMapping[];
 	export let parentOperator: keyof typeof SearchOperators | undefined = undefined;
+	export let depth = 0;
 
 	function getRelationSymbol(operator: keyof typeof SearchOperators): string {
 		switch (operator) {
@@ -27,9 +28,12 @@
 
 <ul class="flex flex-wrap items-center gap-2">
 	{#each mapping as m}
-		<li class="mapping-item {m.children ? 'pill-group' : 'pill'} pill-{m.operator}">
+		<li
+			class="mapping-item {m.children ? 'pill-group' : 'pill'} pill-{m.operator}"
+			class:outer={depth === 0}
+		>
 			{#if 'children' in m}
-				<svelte:self mapping={m.children} parentOperator={m.operator} />
+				<svelte:self mapping={m.children} parentOperator={m.operator} depth={depth + 1} />
 			{:else if 'label' in m && 'display' in m}
 				{@const symbol = getRelationSymbol(m.operator)}
 				<div class="pill-label inline-block text-2-regular first-letter:uppercase">{m.label}</div>
@@ -77,7 +81,11 @@
 	}
 
 	.pill-group {
-		@apply flex items-center gap-2 bg-pill/4 p-0 pr-4;
+		@apply flex items-center gap-2 bg-pill/8 p-0 pr-4;
+
+		&.outer {
+			@apply bg-transparent;
+		}
 	}
 
 	.pill-between,

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -1,24 +1,93 @@
 <script lang="ts">
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
-	import type { DisplayMapping } from './search';
+	import type { DisplayMapping, SearchOperators } from './search';
 	export let mapping: DisplayMapping[];
+	export let parentOperator: keyof typeof SearchOperators;
 
-	$: filteredMapping = mapping.filter((m) => m);
+	function getRelationSymbol(operator: keyof typeof SearchOperators): string {
+		switch (operator) {
+			case 'equals':
+				return '';
+			case 'notEquals':
+				return 'not';
+			case 'greaterThan':
+				return '>';
+			case 'greaterThanOrEquals':
+				return '>=';
+			case 'lessThan':
+				return '<';
+			case 'lessThanOrEquals':
+				return '<=';
+			default:
+				return '';
+		}
+	}
 </script>
 
-<ul class="flex flex-wrap gap-2 overflow-hidden">
-	{#each filteredMapping as filter}
-		<li class="flex min-h-9 items-center gap-2 rounded-md bg-positive-inv px-3">
-			<span class="overflow-hidden text-ellipsis">
-				<span class="text-secondary-inv text-2-regular">{filter.label}</span>
-				<span class="font-bold text-primary-inv">
-					<DecoratedData data={filter.display} showLabels={ShowLabelsOptions['Never']} />
+<ul class="flex flex-wrap items-center gap-2">
+	{#each mapping as m}
+		<li class="pill {m.children ? 'pill-group' : ''} pill-{m.operator}">
+			{#if 'children' in m}
+				<svelte:self mapping={m.children} parentOperator={m.operator} />
+			{:else if 'label' in m && 'display' in m}
+				{@const symbol = getRelationSymbol(m.operator)}
+				<span class="pill-label capitalize text-2-regular">{m.label}</span>
+				<span class="pill-relation">{symbol}</span>
+				<span class="pill-value">
+					<DecoratedData data={m.display} showLabels={ShowLabelsOptions['Never']} />
 				</span>
-			</span>
-			{#if 'up' in filter}
-				<a class="text-secondary-inv visited:text-secondary-inv" href={filter.up?.['@id']}>x</a>
+			{/if}
+			{#if 'up' in m}
+				<a class="pill-remove pl-2 no-underline" href={m.up?.['@id']}>x</a>
 			{/if}
 		</li>
+		{#if parentOperator}
+			<li class="pill-between">{parentOperator}</li>
+		{/if}
 	{/each}
 </ul>
+
+<style lang="postcss">
+	.pill {
+		@apply rounded-md px-4 py-2 brightness-100 text-3-cond-bold;
+		transition: filter 0.1s ease;
+	}
+
+	.pill:has(> .pill-remove:hover) {
+		@apply brightness-75;
+	}
+
+	.pill-group {
+		@apply flex items-center gap-2 bg-pill/4 p-0 pr-4;
+	}
+
+	.pill-equals {
+		@apply bg-positive-inv text-primary-inv;
+
+		& .pill-label {
+			@apply text-secondary-inv;
+		}
+	}
+
+	.pill-notEquals {
+		@apply bg-negative text-primary;
+	}
+
+	.pill-between,
+	.pill-relation {
+		@apply uppercase text-primary text-1-regular;
+	}
+
+	.pill-and > ul .pill-between {
+		@apply hidden;
+	}
+
+	ul > .pill-between:last-of-type {
+		@apply hidden;
+	}
+
+	.pill-remove {
+		color: inherit;
+	}
+</style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -3,7 +3,7 @@
 	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
 	import type { DisplayMapping, SearchOperators } from './search';
 	export let mapping: DisplayMapping[];
-	export let parentOperator: keyof typeof SearchOperators;
+	export let parentOperator: keyof typeof SearchOperators | undefined = undefined;
 
 	function getRelationSymbol(operator: keyof typeof SearchOperators): string {
 		switch (operator) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -32,7 +32,7 @@
 				<svelte:self mapping={m.children} parentOperator={m.operator} />
 			{:else if 'label' in m && 'display' in m}
 				{@const symbol = getRelationSymbol(m.operator)}
-				<span class="pill-label capitalize text-2-regular">{m.label}</span>
+				<div class="pill-label inline-block text-2-regular first-letter:uppercase">{m.label}</div>
 				<span class="pill-relation">{symbol}</span>
 				<span class="pill-value">
 					<DecoratedData data={m.display} showLabels={ShowLabelsOptions['Never']} />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -27,7 +27,7 @@
 
 <ul class="flex flex-wrap items-center gap-2">
 	{#each mapping as m}
-		<li class="pill {m.children ? 'pill-group' : ''} pill-{m.operator}">
+		<li class="mapping-item {m.children ? 'pill-group' : 'pill'} pill-{m.operator}">
 			{#if 'children' in m}
 				<svelte:self mapping={m.children} parentOperator={m.operator} />
 			{:else if 'label' in m && 'display' in m}
@@ -43,35 +43,41 @@
 			{/if}
 		</li>
 		{#if parentOperator}
-			<li class="pill-between">{parentOperator}</li>
+			<li class="pill-between pill-between-{parentOperator}">{parentOperator}</li>
 		{/if}
 	{/each}
 </ul>
 
 <style lang="postcss">
-	.pill {
+	.mapping-item {
 		@apply rounded-md px-4 py-2 brightness-100 text-3-cond-bold;
 		transition: filter 0.1s ease;
 	}
 
-	.pill:has(> .pill-remove:hover) {
+	.mapping-item:has(> .pill-remove:hover) {
 		@apply brightness-75;
 	}
 
-	.pill-group {
-		@apply flex items-center gap-2 bg-pill/4 p-0 pr-4;
-	}
-
-	.pill-equals {
+	.pill {
 		@apply bg-positive-inv text-primary-inv;
 
-		& .pill-label {
+		& .pill-label,
+		.pill-relation {
 			@apply text-secondary-inv;
 		}
 	}
 
 	.pill-notEquals {
 		@apply bg-negative text-primary;
+
+		& .pill-label,
+		.pill-relation {
+			@apply text-secondary;
+		}
+	}
+
+	.pill-group {
+		@apply flex items-center gap-2 bg-pill/4 p-0 pr-4;
 	}
 
 	.pill-between,
@@ -79,11 +85,8 @@
 		@apply uppercase text-primary text-1-regular;
 	}
 
-	.pill-and > ul .pill-between {
-		@apply hidden;
-	}
-
-	ul > .pill-between:last-of-type {
+	.pill-between-and,
+	.pill-between:last-of-type {
 		@apply hidden;
 	}
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
@@ -115,7 +115,7 @@ interface Observation {
 	_selected?: boolean;
 }
 
-enum SearchOperators {
+export enum SearchOperators {
 	and = 'and',
 	or = 'or',
 	not = 'not',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
@@ -155,7 +155,7 @@ function displayMappings(
 				const property = m[operator] as FramedData;
 				return {
 					display: displayUtil.lensAndFormat(property, LensType.Chip, locale),
-					label: m.property?.labelByLang?.[locale] || 'no label', // lensandformat?
+					label: m.property?.labelByLang?.[locale] || m.property?.['@id'] || 'no label', // lensandformat?
 					operator,
 					...('up' in m && { up: replacePath(m.up as Link, usePath) }),
 				} as DisplayMapping;

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -4,7 +4,6 @@ export default {
 	content: ['./src/**/*.{html,js,svelte,ts}'],
 	theme: {
 		colors: {
-			transparent: 'transparent',
 			white: 'rgb(var(--color-white) / <alpha-value>)',
 			primary: 'rgb(var(--color-primary) / <alpha-value>)',
 			'accent-light': 'rgb(var(--color-accent-light) / <alpha-value>)',
@@ -20,6 +19,7 @@ export default {
 			disabled: 'rgb(var(--text-primary) / 0.6)'
 		},
 		backgroundColor: {
+			transparent: 'transparent',
 			main: 'rgb(var(--bg-main) / 1)',
 			head: 'rgb(var(--bg-head) / 1)',
 			positive: 'rgb(var(--bg-positive) / 1)',

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -24,6 +24,7 @@ export default {
 			head: 'rgb(var(--bg-head) / 1)',
 			positive: 'rgb(var(--bg-positive) / 1)',
 			'positive-inv': 'rgb(var(--bg-positive-inv) / 1)',
+			negative: 'rgb(var(--bg-negative) / 1)',
 			cards: 'rgb(var(--bg-cards) / 1)',
 			pill: 'rgb(var(--bg-pill) / <alpha-value>)'
 		},


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-40](https://jira.kb.se/browse/LWS-40)

### Solves

Uses the new `_q` parameter allowing advanced search queries.

### Summary of changes

* Use `_q` instead of `q` when searching
* Update `DisplayMappings` (search.ts) and `SearchMappings` (component) to support this.

TODO (maybe not now):
* ~~Build a nicer mapping interface~~
* Search for work by default (atm you need to ask for `type:work`)
* Hide certain params from the input field (you probably don't always want `type:work` there)
* Add labels for all properties in search mapping. Now displaying the `@id` in the absence of `labelByLang`.
* [uri #it ending issue](https://github.com/libris/librisxl/pull/1391) to be solved in FE?