### PR TITLE
LWS-63: Add holdings on resource page

### DIFF
--- a/lxl-web/src/lib/components/Modal.svelte
+++ b/lxl-web/src/lib/components/Modal.svelte
@@ -1,0 +1,92 @@
+<svelte:options accessors />
+
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { fly } from 'svelte/transition';
+	import { cubicInOut } from 'svelte/easing';
+
+	export let dialog: HTMLDialogElement | undefined = undefined;
+	export let close: ((event: Event) => void) | undefined = undefined;
+
+	let prevBodyOverflow: string | undefined = undefined;
+
+	onMount(() => {
+		disableBodyScroll();
+	});
+
+	function handleClose(event: MouseEvent | Event) {
+		// Use close method from prop if available
+		if (close) {
+			event.preventDefault();
+			close(event);
+		} else {
+			dialog?.close();
+		}
+		enableBodyScroll();
+	}
+
+	function handleBackdropClick(event: MouseEvent) {
+		/** Close dialog if backdrop is clicked */
+		if (event.target === event.currentTarget) {
+			dialog?.close();
+		}
+	}
+
+	function disableBodyScroll() {
+		prevBodyOverflow = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+	}
+
+	function enableBodyScroll() {
+		document.body.style.overflow = prevBodyOverflow || '';
+	}
+</script>
+
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+<dialog
+	class="fixed left-0 top-0 flex h-screen max-h-full w-screen max-w-full"
+	tabindex="-1"
+	on:click|self={handleBackdropClick}
+	on:close={handleClose}
+	bind:this={dialog}
+	in:fly={{ x: 24, duration: 300, opacity: 0, easing: cubicInOut }}
+>
+	<div
+		class="absolute right-0 top-0 flex min-h-full w-full flex-col gap-4 bg-main pb-4 md:max-w-[480px]"
+	>
+		<header
+			class="sticky top-0 flex min-h-14 items-center justify-end border-b border-b-primary/8 bg-main py-2 pl-4 pr-2"
+		>
+			<!-- svelte-ignore a11y-autofocus -->
+			<button on:click={handleClose} autofocus class="flex h-11 items-center justify-center">
+				X
+			</button>
+		</header>
+		<slot />
+	</div>
+</dialog>
+
+<style lang="postcss">
+	dialog {
+		background: none;
+	}
+	dialog::backdrop {
+		background-color: rgb(0 0 0 / 0%);
+		transition:
+			display 0.7s allow-discrete,
+			overlay 0.7s allow-discrete,
+			background-color 0.7s;
+		padding: 0;
+	}
+
+	dialog[open]::backdrop {
+		background-color: rgb(0 0 0 / 25%);
+	}
+
+	@starting-style {
+		dialog[open]::backdrop {
+			background-color: rgb(0 0 0 / 0%);
+		}
+	}
+</style>

--- a/lxl-web/src/lib/components/Modal.svelte
+++ b/lxl-web/src/lib/components/Modal.svelte
@@ -59,7 +59,7 @@
 			class="sticky top-0 flex min-h-14 items-center justify-end border-b border-b-primary/8 bg-main py-2 pl-4 pr-2"
 		>
 			<!-- svelte-ignore a11y-autofocus -->
-			<button on:click={handleClose} autofocus class="flex h-11 items-center justify-center">
+			<button on:click={handleClose} autofocus class="flex h-11 w-11 items-center justify-center">
 				X
 			</button>
 		</header>

--- a/lxl-web/src/lib/components/ResourceImage.svelte
+++ b/lxl-web/src/lib/components/ResourceImage.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { getResourceId } from '$lib/utils/resourceData';
+	import type { ResourceData } from '$lib/types/ResourceData';
+	import placeholderBook from '$lib/assets/img/placeholder-book.svg';
+
+	export let resource: ResourceData;
+	export let alt: string | undefined;
+
+	$: src = $page.data.images.find(
+		(uri) => uri.recordId?.replace(/#it/g, '') === getResourceId(resource)
+	)?.imageUri;
+</script>
+
+{#if src}
+	<img {alt} {src} class="object-contain object-center" />
+{:else}
+	<img src={placeholderBook} alt="" class="object-contain object-center" />
+{/if}

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -27,13 +27,13 @@ export default {
 		'concerning.issuanceType': 'Issuance type',
 		'@reverse': 'Relation',
 		'meta.encodingLevel': 'Encoding level',
-		'genreForm': 'Genre/form',
-		'itemHeldBy': 'Library',
-		'contributor': 'Contribution',
-		'language': 'Language',
-		'subject': 'Subject',
-		'yearPublished': 'Year published',
-		'intendedAudience': 'Intended audience'
+		genreForm: 'Genre/form',
+		itemHeldBy: 'Library',
+		contributor: 'Contribution',
+		language: 'Language',
+		subject: 'Subject',
+		yearPublished: 'Year published',
+		intendedAudience: 'Intended audience'
 	},
 	search: {},
 	errors: {},
@@ -41,6 +41,12 @@ export default {
 		collapseAll: 'Collapse all',
 		copyPermalinkToInstance: 'Copy link to edition',
 		latestInstanceCover: 'Cover of latest edition',
-		instanceCover: 'Cover of edition'
+		instanceCover: 'Cover of edition',
+		close: 'Close'
+	},
+	holdings: {
+		availableAt: 'Available at',
+		library: 'library',
+		libraries: 'libraries'
 	}
 };

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -26,13 +26,13 @@ export default {
 		'concerning.issuanceType': 'Utgivningssätt',
 		'@reverse': 'Relation',
 		'meta.encodingLevel': 'Beskrivningsnivå',
-		'genreForm': 'Genre/form',
-		'itemHeldBy': 'Bibliotek',
-		'contributor': 'Medverkan',
-		'language': 'Språk',
-		'subject': 'Ämne',
-		'yearPublished': 'Utgivningsår',
-		'intendedAudience': 'Målgrupp'
+		genreForm: 'Genre/form',
+		itemHeldBy: 'Bibliotek',
+		contributor: 'Medverkan',
+		language: 'Språk',
+		subject: 'Ämne',
+		yearPublished: 'Utgivningsår',
+		intendedAudience: 'Målgrupp'
 	},
 	search: {},
 	errors: {},
@@ -40,6 +40,12 @@ export default {
 		collapseAll: 'Stäng alla',
 		copyPermalinkToInstance: 'Kopiera länk till utgåva',
 		latestInstanceCover: 'Senaste utgåvans omslag',
-		instanceCover: 'Utgåvans omslag'
+		instanceCover: 'Utgåvans omslag',
+		close: 'Stäng'
+	},
+	holdings: {
+		availableAt: 'Finns på',
+		library: 'bibliotek',
+		libraries: 'bibliotek'
 	}
 };

--- a/lxl-web/src/lib/utils/getSortedSearchParams.ts
+++ b/lxl-web/src/lib/utils/getSortedSearchParams.ts
@@ -9,6 +9,10 @@ function getSortedSearchParams(searchParams: URLSearchParams): URLSearchParams {
 		params.delete('expanded');
 	}
 
+	if (params.has('holdings')) {
+		params.delete('holdings');
+	}
+
 	if (params.size) {
 		params.sort();
 	}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -5,12 +5,7 @@ import { getSupportedLocale } from '$lib/i18n/locales.js';
 import { type FramedData, DisplayUtil, pickProperty } from '$lib/utils/xl.js';
 import { LxlLens } from '$lib/utils/display.types.js';
 import { relativizeUrl } from '$lib/utils/http';
-import {
-	calculateExpirationTime,
-	generateAuxdImageUri,
-	getImageLinks,
-	getFirstImageUri
-} from '$lib/utils/auxd';
+import { calculateExpirationTime, generateAuxdImageUri, getImageLinks } from '$lib/utils/auxd';
 import addDefaultSearchParams from '$lib/utils/addDefaultSearchParams.js';
 import getSortedSearchParams from '$lib/utils/getSortedSearchParams.js';
 import { type apiError } from '$lib/types/API.js';
@@ -51,7 +46,7 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 		// set condition to perform search
 		shouldFindRelations = instances.length <= 1;
 
-		const imageUris = getImageUris(getImageLinks(mainEntity));
+		const images = getImageUris(getImageLinks(mainEntity));
 		const holdingsByInstanceId = getHoldingsByInstanceId(mainEntity);
 
 		resourceParts = {
@@ -61,8 +56,7 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 			instances: sortedInstances,
 			holdingsByInstanceId,
 			full: overview,
-			imageUris: imageUris,
-			firstImageUri: getFirstImageUri(imageUris)
+			images
 		};
 	}
 
@@ -147,16 +141,18 @@ function getSortedInstances(instances: Record<string, unknown>[]) {
 }
 
 function getImageUris(imageLinks: { recordId: string; imageLink: string }[]) {
-	return imageLinks.map((idAndLink) => {
-		return {
-			recordId: idAndLink.recordId,
-			imageUri: generateAuxdImageUri(
-				calculateExpirationTime(),
-				idAndLink.imageLink,
-				env.AUXD_SECRET
-			)
-		};
-	});
+	return imageLinks
+		.map((idAndLink) => {
+			return {
+				recordId: idAndLink.recordId,
+				imageUri: generateAuxdImageUri(
+					calculateExpirationTime(),
+					idAndLink.imageLink,
+					env.AUXD_SECRET
+				)
+			};
+		})
+		.filter((image) => image.imageUri !== '');
 }
 
 function getHoldingsByInstanceId(mainEntity) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -9,6 +9,7 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import type { SvelteComponent } from 'svelte';
 	import ResourceImage from '$lib/components/ResourceImage.svelte';
+	import { getHoldingsLink, handleClickHoldings } from './utils';
 
 	export let data;
 
@@ -52,12 +53,6 @@
 			];
 		}, []).length;
 	}
-
-	function getHoldingsLink(url: URL, id: string) {
-		const newSearchParams = new URLSearchParams([...Array.from(url.searchParams.entries())]);
-		newSearchParams.set('holdings', id);
-		return `${url.origin}${url.pathname}?${newSearchParams.toString()}`;
-	}
 </script>
 
 <article class="resource grid">
@@ -73,7 +68,10 @@
 				<ul>
 					{#each Object.keys(instancesByType) as instanceType}
 						<li>
-							<a href={getHoldingsLink($page.url, instancesByType[instanceType]?.[0])}>
+							<a
+								href={getHoldingsLink($page.url, instancesByType[instanceType]?.[0])}
+								on:click={(event) => handleClickHoldings(event, $page.url, $page.state)}
+							>
 								{instanceType}
 								{`(${data.t('holdings.availableAt').toLowerCase()}`}
 								{getAggregatedLibrariesCount(

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -8,6 +8,7 @@
 	import { relativizeUrl } from '$lib/utils/http';
 	import Modal from '$lib/components/Modal.svelte';
 	import type { SvelteComponent } from 'svelte';
+	import ResourceImage from '$lib/components/ResourceImage.svelte';
 
 	export let data;
 
@@ -86,24 +87,20 @@
 					{/each}
 				</ul>
 			</div>
-			{#if data.imageUris.length}
-				<a href={data.firstImageUri} target="_blank">
-					<div class="flex h-full max-h-72 w-full max-w-72 self-center">
-						{#if data.firstImageUri}
-							<img
-								alt={$page.data.t('general.latestInstanceCover')}
-								src={data.firstImageUri}
-								class="h-auto w-full object-contain md:object-right"
-							/>
-						{/if}
-					</div>
-				</a>
+			{#if data.images.length}
+				<div class="flex h-full max-h-72 w-full max-w-72 self-center md:self-start">
+					<ResourceImage
+						resource={data.instances?.find(
+							(instanceItem) => instanceItem['@id'] === data.images[0].recordId.replace('#it', '')
+						)}
+						alt={data.t('general.latestInstanceCover')}
+					/>
+				</div>
 			{/if}
 		</div>
 		{#if data.instances?.length}
 			<InstancesList
 				data={data.instances}
-				imageUris={data.imageUris}
 				columns={[
 					'*[].publication[].*[][?year].year',
 					'*[].publication.*[][?agent].agent',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -1,13 +1,69 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
+	import { afterNavigate } from '$app/navigation';
 	import InstancesList from './InstancesList.svelte';
 	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
+	import { getResourceId } from '$lib/utils/resourceData';
+	import { relativizeUrl } from '$lib/utils/http';
+	import Modal from '$lib/components/Modal.svelte';
+	import type { SvelteComponent } from 'svelte';
+
 	export let data;
+
+	let holdingsModal: SvelteComponent;
+
+	$: instancesByTypeLabel = getInstancesByTypeLabel(data?.instances);
+	$: decoratedInstance =
+		$page.url.searchParams.has('holdings') &&
+		data.instances.find((instanceItem) =>
+			instanceItem['@id'].includes($page.url.searchParams.get('holdings'))
+		);
+
+	afterNavigate(({ from, to }) => {
+		if (
+			to?.url.searchParams.has('holdings') &&
+			from?.url.searchParams.get('holdings') !== to.url.searchParams.get('holdings')
+		) {
+			holdingsModal.dialog.showModal();
+		}
+	});
+
+	function handleCloseHoldings(event: Event) {
+		event.preventDefault();
+		history.back();
+	}
+
+	function getInstancesByTypeLabel(instances) {
+		return instances.reduce((acc, currentInstance) => {
+			const typeLabel = currentInstance['_label'];
+			return {
+				...acc,
+				[typeLabel]: [...(acc[typeLabel] || []), relativizeUrl(getResourceId(currentInstance))]
+			};
+		}, {});
+	}
+
+	function getAggregatedLibrariesCount(instances: string[], holdingsByInstanceId) {
+		return instances.reduce((acc, instanceId) => {
+			return [
+				...new Set([
+					...acc,
+					...holdingsByInstanceId[instanceId].map((holdingItem) => holdingItem?.heldBy?.['@id'])
+				])
+			];
+		}, []).length;
+	}
+
+	function getHoldingsLink(url: URL, id: string) {
+		const newSearchParams = new URLSearchParams([...Array.from(url.searchParams.entries())]);
+		newSearchParams.set('holdings', id);
+		return `${url.origin}${url.pathname}?${newSearchParams.toString()}`;
+	}
 </script>
 
-<article class="resource">
-	<div class="content">
+<article class="resource grid">
+	<div class="content p-4">
 		<header>
 			<h1 class="mb-6 text-6-cond-extrabold">
 				<DecoratedData data={data.heading} showLabels={ShowLabelsOptions.Never} />
@@ -16,6 +72,19 @@
 		<div class="mb-4 flex flex-col-reverse gap-4 md:flex-row">
 			<div class="overview flex-1">
 				<DecoratedData data={data.overview} block />
+				<ul>
+					{#each Object.keys(instancesByTypeLabel) as key}
+						{@const typeInstances = instancesByTypeLabel[key]}
+						<li>
+							<a href={getHoldingsLink($page.url, typeInstances?.[0])}>
+								{key}
+								{`(${data.t('holdings.availableAt').toLowerCase()}`}
+								{getAggregatedLibrariesCount(typeInstances, data.holdingsByInstanceId)}
+								{`${data.t('holdings.libraries')})`}
+							</a>
+						</li>
+					{/each}
+				</ul>
 			</div>
 			{#if data.imageUris.length}
 				<a href={data.firstImageUri} target="_blank">
@@ -38,11 +107,40 @@
 				columns={[
 					'*[].publication[].*[][?year].year',
 					'*[].publication.*[][?agent].agent',
-					'"@type"'
+					'_label'
 				]}
 			/>
 		{/if}
 	</div>
+	{#if $page.url.searchParams.has('holdings') && data.holdingsByInstanceId[$page.url.searchParams.get('holdings')]}
+		{@const holdings = data.holdingsByInstanceId[$page.url.searchParams.get('holdings')]}
+		<Modal close={handleCloseHoldings} bind:this={holdingsModal}>
+			<div class="flex flex-col gap-4 px-4 text-sm">
+				<div class="flex gap-4">
+					<div class="overview">
+						<DecoratedData data={decoratedInstance} block />
+					</div>
+				</div>
+				<div>
+					<h2 class="font-bold">{data.t('holdings.availableAt')}</h2>
+					{#if holdings?.length}
+						<table class="w-full table-auto border-collapse text-sm">
+							{#each holdings as holdingItem}
+								<tr class="h-11 border-b-primary/16 [&:not(:last-child)]:border-b">
+									<td>
+										{holdingItem?.heldBy?.name}
+									</td>
+									<td class="text-right text-secondary">
+										{holdingItem?.heldBy?.sigel ? `(${holdingItem?.heldBy?.sigel})` : ''}
+									</td>
+								</tr>
+							{/each}
+						</table>
+					{/if}
+				</div>
+			</div>
+		</Modal>
+	{/if}
 </article>
 
 <style lang="postcss">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -87,7 +87,7 @@
 				</ul>
 			</div>
 			{#if data.images.length}
-				<div class="flex h-full max-h-72 w-full max-w-72 self-center md:self-start">
+				<div class="flex h-full max-h-72 w-full max-w-72 justify-center self-center md:self-start">
 					<ResourceImage
 						resource={data.instances?.find(
 							(instanceItem) => instanceItem['@id'] === data.images[0].recordId.replace('#it', '')

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/InstancesList.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/InstancesList.svelte
@@ -7,7 +7,7 @@
 	import { getResourceId } from '$lib/utils/resourceData';
 	import { relativizeUrl } from '$lib/utils/http';
 	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
-	import placeholderBook from '$lib/assets/img/placeholder-book.svg';
+	import ResourceImage from '$lib/components/ResourceImage.svelte';
 
 	/**
 	 * TODO:
@@ -19,7 +19,6 @@
 	let expandedInSearchParams = $page.url.searchParams.getAll('expanded') || [];
 
 	export let data: ResourceData;
-	export let imageUris: { recordId: string; imageUri: string }[];
 	export let columns: string[];
 
 	function handleToggleDetails(state: { expandedInstances?: string[] }) {
@@ -109,16 +108,6 @@
 				?.focus();
 		}
 	}
-
-	function getImageUri(item) {
-		return imageUris.find((uri) => {
-			return relativizeUrl(uri.recordId)?.replace(/#it/g, '') === getInstanceId(item);
-		})?.imageUri;
-	}
-
-	function getInstanceId(item: ResourceData) {
-		return relativizeUrl(item?.['@id' as keyof ResourceData]);
-	}
 </script>
 
 <div>
@@ -141,7 +130,6 @@
 		<ul bind:this={instancesList}>
 			{#each data as item (item['@id'])}
 				{@const id = relativizeUrl(getResourceId(item))}
-				{@const cover = getImageUri(item)}
 				<li {id} class="border-t border-t-primary/16">
 					<details
 						{...id && {
@@ -182,21 +170,7 @@
 						<div class="grid gap-2 px-2 pb-8 pt-4 md:grid-cols-3">
 							<div class="flex flex-col gap-4 text-sm">
 								<div class="flex h-full max-h-32 w-full max-w-32">
-									{#if cover}
-										<a href={cover} target="_blank">
-											<div class="flex h-full max-h-32 w-full max-w-32">
-												<img
-													alt={$page.data.t('general.instanceCover')}
-													src={cover}
-													class="object-contain object-left"
-												/>
-											</div>
-										</a>
-									{:else}
-										<div class="flex h-full max-h-32 w-full max-w-32">
-											<img src={placeholderBook} alt="" class="object-contain object-left" />
-										</div>
-									{/if}
+									<ResourceImage resource={item} alt={$page.data.t('general.instanceCover')} />
 								</div>
 								{#if id}
 									<div class="flex flex-col gap-2">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/InstancesList.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/InstancesList.svelte
@@ -8,7 +8,7 @@
 	import { relativizeUrl } from '$lib/utils/http';
 	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
 	import ResourceImage from '$lib/components/ResourceImage.svelte';
-
+	import { getHoldingsLink, handleClickHoldings } from './utils';
 	/**
 	 * TODO:
 	 * - [] Replace jmespath (used for queriyng data for the columns) with something more home-baked (with smaller bundle-size). Another alternative could be querying and preparing the column data server-side?
@@ -46,28 +46,6 @@
 		const newSearchParams = new URLSearchParams([...Array.from(url.searchParams.entries())]);
 		newSearchParams.delete('expanded');
 		return `${url.origin}${url.pathname}${newSearchParams.size ? '?' + newSearchParams.toString() : ''}`;
-	}
-
-	function getHoldingsLink(url: URL, id: string) {
-		const newSearchParams = new URLSearchParams([...Array.from(url.searchParams.entries())]);
-		newSearchParams.set('holdings', id);
-		return `${url.origin}${url.pathname}?${newSearchParams.toString()}`;
-	}
-
-	function handleClickHoldings(
-		event: MouseEvent & { currentTarget: HTMLAnchorElement },
-		url: URL,
-		state: {
-			expandedInstances?: string[];
-		}
-	) {
-		event.preventDefault();
-		if (url.href !== event.currentTarget.href) {
-			goto(event.currentTarget.href, {
-				state,
-				noScroll: true
-			});
-		}
 	}
 
 	function getPermalink(url: URL, id: string) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/InstancesList.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/InstancesList.svelte
@@ -49,6 +49,28 @@
 		return `${url.origin}${url.pathname}${newSearchParams.size ? '?' + newSearchParams.toString() : ''}`;
 	}
 
+	function getHoldingsLink(url: URL, id: string) {
+		const newSearchParams = new URLSearchParams([...Array.from(url.searchParams.entries())]);
+		newSearchParams.set('holdings', id);
+		return `${url.origin}${url.pathname}?${newSearchParams.toString()}`;
+	}
+
+	function handleClickHoldings(
+		event: MouseEvent & { currentTarget: HTMLAnchorElement },
+		url: URL,
+		state: {
+			expandedInstances?: string[];
+		}
+	) {
+		event.preventDefault();
+		if (url.href !== event.currentTarget.href) {
+			goto(event.currentTarget.href, {
+				state,
+				noScroll: true
+			});
+		}
+	}
+
 	function getPermalink(url: URL, id: string) {
 		const newSearchParams = new URLSearchParams({ expanded: id });
 		return `${url.origin}${url.pathname}?${newSearchParams.toString()}#${id}`;
@@ -131,7 +153,7 @@
 						on:toggle={() => handleToggleDetails($page.state)}
 					>
 						<summary
-							class="flex min-h-11 gap-2 px-2 py-4 align-middle hover:bg-pill/16"
+							class="flex min-h-11 gap-2 px-2 align-middle hover:bg-pill/16"
 							on:keydown={handleSummaryKeydown}
 						>
 							{#each columns as columnItem}
@@ -139,9 +161,26 @@
 									<DecoratedData data={jmespath.search(item, columnItem)} />
 								</div>
 							{/each}
+							<div class="text flex flex-1 items-center justify-end text-sm">
+								{#if id && $page.data.holdingsByInstanceId[id]}
+									<a
+										href={getHoldingsLink($page.url, id)}
+										on:click={(event) => handleClickHoldings(event, $page.url, $page.state)}
+									>
+										{$page.data.holdingsByInstanceId[id].length}
+										{$page.data.holdingsByInstanceId[id].length === 1
+											? $page.data.t('holdings.library')
+											: $page.data.t('holdings.libraries')}
+									</a>
+								{:else}
+									<span>
+										{$page.data.t('holdings.availableAt')} 0 {$page.data.t('holdings.libraries')}
+									</span>
+								{/if}
+							</div>
 						</summary>
 						<div class="grid gap-2 px-2 pb-8 pt-4 md:grid-cols-3">
-							<div class="flex flex-col gap-4">
+							<div class="flex flex-col gap-4 text-sm">
 								<div class="flex h-full max-h-32 w-full max-w-32">
 									{#if cover}
 										<a href={cover} target="_blank">
@@ -160,12 +199,24 @@
 									{/if}
 								</div>
 								{#if id}
-									<a
-										href={getPermalink($page.url, id)}
-										on:click={(event) => handleCopyPermalink(event, $page.url, id, $page.state)}
-									>
-										{$page.data.t('general.copyPermalinkToInstance')}
-									</a>
+									<div class="flex flex-col gap-2">
+										<a
+											href={getHoldingsLink($page.url, id)}
+											on:click={(event) => handleClickHoldings(event, $page.url, $page.state)}
+										>
+											{$page.data.t('holdings.availableAt')}
+											{$page.data.holdingsByInstanceId[id].length}
+											{$page.data.holdingsByInstanceId[id].length === 1
+												? $page.data.t('holdings.library')
+												: $page.data.t('holdings.libraries')}
+										</a>
+										<a
+											href={getPermalink($page.url, id)}
+											on:click={(event) => handleCopyPermalink(event, $page.url, id, $page.state)}
+										>
+											{$page.data.t('general.copyPermalinkToInstance')}
+										</a>
+									</div>
 								{/if}
 							</div>
 							<div class="instance-details col-span-2">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/utils.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/utils.ts
@@ -1,0 +1,21 @@
+import { goto } from '$app/navigation';
+
+export function getHoldingsLink(url: URL, value: string) {
+	const newSearchParams = new URLSearchParams([...Array.from(url.searchParams.entries())]);
+	newSearchParams.set('holdings', value);
+	return `${url.origin}${url.pathname}?${newSearchParams.toString()}`;
+}
+
+export function handleClickHoldings(
+	event: MouseEvent & { currentTarget: HTMLAnchorElement },
+	url: URL,
+	state: object
+) {
+	event.preventDefault();
+	if (url.href !== event.currentTarget.href) {
+		goto(event.currentTarget.href, {
+			state,
+			noScroll: true
+		});
+	}
+}


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-63](https://jira.kb.se/browse/LWS-63)

### Solves
- Adds support for a holdings modal (showing where the resource can be found) on the resource page.

### Summary of changes
- Add holdings modal on resource page
- Add ResourceImage component to prevent code duplication
