### PR TITLE
Display _i in search field

### DIFF
--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -7,16 +7,18 @@
 	export let placeholder: string;
 	export let autofocus: boolean = false;
 
-	let q = $page.url.searchParams.get('_q')?.trim();
+	let q = $page.url.searchParams.get('_i')?.trim() || $page.url.searchParams.get('_q')?.trim();
 
 	let params = getSortedSearchParams(getDefaultSearchParams($page.url.searchParams));
 	params.set('_offset', '0'); // Always reset offset on new search
+	params.delete('_i'); // delete possibly old '_i' value on new search
 	const searchParams = Array.from(params);
 
 	afterNavigate(({ to }) => {
 		/** Update input value after navigation */
 		if (to?.url) {
-			q = new URL(to.url).searchParams.get('_q')?.trim();
+			let param = to.url.searchParams.has('_i') ? '_i' : '_q';
+			q = new URL(to.url).searchParams.get(param)?.trim();
 		}
 	});
 


### PR DESCRIPTION
## Description

### Solves

Search field being populated with stuff user never typed (ex * language:"https://id.kb.se/language/swe") when you use filters.

### Summary of changes

Easiest possible solution: display `_i` in search field if it exists, else use `_q`.
My suggestion is we use this as a starting point to investigate the limitations/need for an `_x=advanced` state etc.

Known quirks: 
* search for` yearPublished>2010` 
*  query remains as `_i` is still not present (the search query is not synced back from the api response - maybe is should, but that would result in re-fetching of data)
* use a filter on the side or paginate
* The query now disappears, i.e "becomes mapping pills" because `_i` now exists.