### PR TITLE
Add basic full text links

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -118,6 +118,12 @@
 					"classLensDomain": "Classification",
 					"showProperties": ["code", "prefLabel"]
 				},
+				"MediaObject": {
+					"@id": "MediaObject-chips",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "MediaObject",
+					"showProperties": ["uri", "marc:publicNote"]
+				},
 				"Work": {
 					"@id": "Work-chips",
 					"@type": "fresnel:Lens",
@@ -454,6 +460,18 @@
 			"fresnel:valueFormat": {
 				"fresnel:contentBefore": ", ",
 				"fresnel:contentFirst": ""
+			}
+		},
+		"MediaObject-note-format": {
+			"@id": "MediaObject-note-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["MediaObject"],
+			"fresnel:propertyFormatDomain": ["marc:publicNote"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": " (",
+				"fresnel:contentFirst": "(",
+				"fresnel:contentAfter": ")",
+				"fresnel:contentLast": ")"
 			}
 		},
 		"Instance-self-x-format": {

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -31,6 +31,8 @@
 						"dissertation",
 						"cartographicAttributes",
 						"isPartOf",
+						"associatedMedia",
+						"isPrimaryTopicOf",
 						{ "inverseOf": "instanceOf" }
 					]
 				},
@@ -469,16 +471,30 @@
 				"fresnel:contentFirst": ""
 			}
 		},
-		"marc:publicNote-format": {
-			"@id": "marc:publicNote-format",
+		"MediaObject-format": {
+			"@id": "MediaObject-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Document", "MediaObject"],
+			"fresnel:resourceStyle": ["ext-link", "pill", "uriAsId()"]
+		},
+		"MediaObject-publicNote-format": {
+			"FIXME": "this is just to hide the interpunct before",
+			"@id": "MediaObject-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Document", "MediaObject"],
 			"fresnel:propertyFormatDomain": ["marc:publicNote"],
 			"fresnel:propertyFormat": {
-				"fresnel:contentBefore": " (",
-				"fresnel:contentFirst": "(",
-				"fresnel:contentAfter": ")",
-				"fresnel:contentLast": ")"
+				"fresnel:contentBefore": "",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"isPrimaryTopicOf-associatedMedia-format": {
+			"@id": "isPrimaryTopicOf-associatedMedia-format",
+			"@type": "fresnel:Format",
+			"fresnel:propertyFormatDomain": ["isPrimaryTopicOf", "associatedMedia"],
+			"fresnel:valueFormat": {
+				"fresnel:contentBefore": "",
+				"fresnel:contentFirst": ""
 			}
 		},
 		"Instance-self-x-format": {

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -475,7 +475,7 @@
 			"@id": "MediaObject-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["MediaObject"],
-			"fresnel:resourceStyle": ["ext-link", "uriToId()", "text-large"]
+			"fresnel:resourceStyle": ["ext-link", "uriToId()", "text-large", "block"]
 		},
 		"Document-format": {
 			"@id": "Document-format",
@@ -484,7 +484,7 @@
 			"fresnel:resourceStyle": ["ext-link", "uriToId()"]
 		},
 		"MediaObject-publicNote-format": {
-			"FIXME": "this is just to hide the interpunct before",
+			"FIXME": "this is just to hide the interpunct before caused by uriToId() not fixing contentBefore",
 			"@id": "MediaObject-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Document", "MediaObject"],
@@ -494,10 +494,10 @@
 				"fresnel:contentFirst": ""
 			}
 		},
-		"isPrimaryTopicOf-associatedMedia-format": {
-			"@id": "isPrimaryTopicOf-associatedMedia-format",
+		"associatedMedia-format": {
+			"@id": "associatedMedia-format",
 			"@type": "fresnel:Format",
-			"fresnel:propertyFormatDomain": ["isPrimaryTopicOf", "associatedMedia"],
+			"fresnel:propertyFormatDomain": ["associatedMedia"],
 			"fresnel:valueFormat": {
 				"fresnel:contentBefore": "",
 				"fresnel:contentFirst": ""

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -81,6 +81,7 @@
 						"associatedMedia",
 						"usageAndAccessPolicy",
 						"accessMode",
+						"isPrimaryTopicOf",
 						"isIssueOf",
 						"relatedTo",
 						"issuanceType",
@@ -117,6 +118,12 @@
 					"@type": "fresnel:Lens",
 					"classLensDomain": "Classification",
 					"showProperties": ["code", "prefLabel"]
+				},
+				"Document": {
+					"@id": "Document-chips",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "Document",
+					"showProperties": ["uri", "marc:publicNote"]
 				},
 				"MediaObject": {
 					"@id": "MediaObject-chips",
@@ -462,10 +469,10 @@
 				"fresnel:contentFirst": ""
 			}
 		},
-		"MediaObject-note-format": {
-			"@id": "MediaObject-note-format",
+		"marc:publicNote-format": {
+			"@id": "marc:publicNote-format",
 			"@type": "fresnel:Format",
-			"fresnel:classFormatDomain": ["MediaObject"],
+			"fresnel:classFormatDomain": ["Document", "MediaObject"],
 			"fresnel:propertyFormatDomain": ["marc:publicNote"],
 			"fresnel:propertyFormat": {
 				"fresnel:contentBefore": " (",

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -474,8 +474,14 @@
 		"MediaObject-format": {
 			"@id": "MediaObject-format",
 			"@type": "fresnel:Format",
-			"fresnel:classFormatDomain": ["Document", "MediaObject"],
-			"fresnel:resourceStyle": ["ext-link", "uriAsId()"]
+			"fresnel:classFormatDomain": ["MediaObject"],
+			"fresnel:resourceStyle": ["ext-link", "uriToId()", "text-large"]
+		},
+		"Document-format": {
+			"@id": "Document-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Document"],
+			"fresnel:resourceStyle": ["ext-link", "uriToId()"]
 		},
 		"MediaObject-publicNote-format": {
 			"FIXME": "this is just to hide the interpunct before",

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -475,7 +475,7 @@
 			"@id": "MediaObject-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Document", "MediaObject"],
-			"fresnel:resourceStyle": ["ext-link", "pill", "uriAsId()"]
+			"fresnel:resourceStyle": ["ext-link", "uriAsId()"]
 		},
 		"MediaObject-publicNote-format": {
 			"FIXME": "this is just to hide the interpunct before",

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -229,6 +229,10 @@
 		@apply hover:bg-pill/16 focus:bg-pill/16;
 	}
 
+	.text-large {
+		@apply text-lg;
+	}
+
 	.remainder {
 		@apply ml-2 rounded-full bg-pill/8 px-2 py-1 text-secondary;
 	}

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -237,4 +237,8 @@
 	.remainder {
 		@apply ml-2 rounded-full bg-pill/8 px-2 py-1 text-secondary;
 	}
+
+	.block {
+		display: block;
+	}
 </style>

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -149,6 +149,7 @@
 				<svelte:element
 					this={getElementType(data)}
 					href={getLink(data)}
+					target={hasStyle(data, 'ext-link') ? '_blank' : null}
 					data-type={data['@type']}
 					class={getStyleClasses(data)}
 					use:conditionalResourcePopover={data}

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -38,6 +38,12 @@
 				return relativizeUrl(id);
 			}
 		}
+		if (depth > 1 && hasStyle(data, 'ext-link')) {
+			const id = getResourceId(value);
+			if (id) {
+				return id;
+			}
+		}
 		return undefined;
 	}
 

--- a/lxl-web/src/lib/utils/getAtPath.ts
+++ b/lxl-web/src/lib/utils/getAtPath.ts
@@ -1,0 +1,35 @@
+const isSubMap = (a, b) => {
+	return a instanceof Object && b instanceof Object && Object.keys(a).every((k) => a[k] == b[k]);
+};
+
+function getAtPath(thing, path: Array<string | number | object>, defaultTo = []) {
+	let t = thing;
+	// TODO: handle framed vs unframed
+	for (let i = 0; i < path.length; i++) {
+		const p = path[i];
+		if (p == '*') {
+			if (t instanceof Array) {
+				return t.flatMap((o) => getAtPath(o, path.slice(i + 1), []));
+			} else {
+				return defaultTo;
+			}
+		} else if (typeof p == 'string' || typeof p == 'number') {
+			try {
+				t = t[p];
+			} catch (e) {
+				t = defaultTo;
+			}
+		} else if (p instanceof Object) {
+			if (t instanceof Array) {
+				return t.filter((o) => isSubMap(p, o)).flatMap((o) => getAtPath(o, path.slice(i + 1), []));
+			} else if (isSubMap(p, t)) {
+				continue;
+			} else {
+				return defaultTo;
+			}
+		}
+	}
+	return t;
+}
+
+export default getAtPath;

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -602,16 +602,12 @@ class Formatter {
 		},
 		'uriToId()': (v) => {
 			if (isObject(v) && JsonLd.TYPE in v && Fmt.DISPLAY in v) {
-				// TODO doesn't translate type name
-
 				const display = v[Fmt.DISPLAY] as Array<unknown>;
-				const uriObj = display.find((d) => isObject(d) && 'uri' in d);
-				if (uriObj) {
-					const uri = asArray(uriObj['uri'])[0];
-					v[JsonLd.ID] = uri;
-				}
 				const ix = display.findIndex((d) => isObject(d) && 'uri' in d);
-				if (ix >= 0) {
+
+				if (ix >= 0 && asArray(display[ix]['uri']).length > 0) {
+					const uri = asArray(display[ix]['uri'])[0];
+					v[JsonLd.ID] = uri;
 					display.splice(ix, 1);
 				}
 			}

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -599,6 +599,24 @@ class Formatter {
 				});
 			}
 			return v;
+		},
+		'uriAsId()': (v) => {
+			if (isObject(v) && JsonLd.TYPE in v && Fmt.DISPLAY in v) {
+				// TODO doesn't translate type name
+
+				const display = v[Fmt.DISPLAY] as Array<unknown>;
+				const uriObj = display.find((d) => isObject(d) && 'uri' in d);
+				if (uriObj) {
+					const uri = asArray(uriObj['uri'])[0];
+					v[JsonLd.ID] = uri;
+				}
+				const ix = display.findIndex((d) => isObject(d) && 'uri' in d);
+				if (ix >= 0) {
+					display.splice(ix, 1);
+				}
+			}
+
+			return v;
 		}
 	};
 

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -600,7 +600,7 @@ class Formatter {
 			}
 			return v;
 		},
-		'uriAsId()': (v) => {
+		'uriToId()': (v) => {
 			if (isObject(v) && JsonLd.TYPE in v && Fmt.DISPLAY in v) {
 				// TODO doesn't translate type name
 


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-65](https://jira.kb.se/browse/LWS-65)

### Solves
Basic full text / related content links.
We probably want something nicer but this makes them clickable.
Doesn't handle display of license/copyright etc. (`usageAndAccessPolicy` etc)

Compare https://libris.kb.se/bib/18035875

### Summary of changes
* Display `MediaObject` and `Document` in `associatedMedia` and `isPrimaryTopicOf` as links
* `marc:publicNote` is used as link label
* `associatedMedia` ~= full text/image/etc so is diaplyed in a larger font
* A new style "ext-link" opens links a new tab
* A links from all instances are copied to the detail page overview (Work)

TODO
* "Open in new tab"/"external" icon on links
* Some descriptive text on full links. "Se hela bilden" etc?
* Clicking on image should go to full text/image?  

![bild](https://github.com/libris/lxlviewer/assets/51744858/e74ca55e-56fa-4999-8d2e-caeeb3f2dd4e)

