### PR TITLE
Feature/ i param 2

### DIFF
--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -14,13 +14,7 @@
 	export let block = false;
 	export let truncate = false;
 	export let key: ResourceData | string = data;
-
-	// truncate option; use only first item as data and keep the rest for tooltip
-	let remainder: ResourceData[] | undefined;
-	if (truncate && Array.isArray(data) && data?.[0] && '@type' in data[0]) {
-		[data, ...remainder] = data;
-		truncate = false;
-	}
+	export let remainder: ResourceData | undefined = undefined;
 
 	const hiddenProperties = [
 		'@context',
@@ -130,16 +124,30 @@
 {#key key}
 	{#if data && typeof data === 'object'}
 		{#if Array.isArray(data)}
-			{#each data as arrayItem}
+			{#if truncate && depth === 1 && data.length > 1}
+				<!-- truncate option; use only first item as data and keep the remainder for tooltip -->
+				{@const [first, ...remainder] = data}
 				<svelte:self
-					data={arrayItem}
+					data={first}
 					depth={depth + 1}
 					{showLabels}
 					{block}
 					{allowPopovers}
-					{truncate}
+					truncate={false}
+					{remainder}
 				/>
-			{/each}
+			{:else}
+				{#each data as arrayItem}
+					<svelte:self
+						data={arrayItem}
+						depth={depth + 1}
+						{showLabels}
+						{block}
+						{allowPopovers}
+						{truncate}
+					/>
+				{/each}
+			{/if}
 		{:else}
 			{#if shouldShowContentBefore()}
 				<span class="_contentBefore">
@@ -163,7 +171,7 @@
 						{allowPopovers}
 						{truncate}
 					/>
-					{#if remainder}
+					{#if remainder && Array.isArray(remainder)}
 						<span
 							use:resourcePopover={{ data: remainder, lang: getSupportedLocale($page.params.lang) }}
 							class="remainder">+ {remainder.length}</span

--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -48,6 +48,7 @@
 		{autofocus}
 		data-testid="main-search"
 	/>
+	<input type="hidden" name="_i" value={q} />
 	{#each searchParams as [name, value]}
 		{#if name !== '_q'}
 			<input type="hidden" {name} {value} />

--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -14,7 +14,6 @@
 
 	let params = getSortedSearchParams(getDefaultSearchParams($page.url.searchParams));
 	params.set('_offset', '0'); // Always reset offset on new search
-	params.delete('_i'); // delete possibly old '_i' value on new search
 	const searchParams = Array.from(params);
 
 	afterNavigate(({ to }) => {
@@ -48,10 +47,15 @@
 		{autofocus}
 		data-testid="main-search"
 	/>
-	<input type="hidden" name="_i" value={q} />
 	{#each searchParams as [name, value]}
 		{#if name !== '_q'}
 			<input type="hidden" {name} {value} />
 		{/if}
 	{/each}
+
+	<input type="hidden" name="_i" value={q} />
+	{#if $page.url.searchParams.get('_x') === 'advanced'}
+		<!-- keep 'edit' state on new search -->
+		<input type="hidden" name="_x" value="advanced" />
+	{/if}
 </form>

--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -7,7 +7,10 @@
 	export let placeholder: string;
 	export let autofocus: boolean = false;
 
-	let q = $page.url.searchParams.get('_i')?.trim() || $page.url.searchParams.get('_q')?.trim();
+	$: showAdvanced = $page.url.searchParams.get('_x') === 'advanced';
+	let q = showAdvanced
+		? $page.url.searchParams.get('_q')?.trim()
+		: $page.url.searchParams.get('_i')?.trim();
 
 	let params = getSortedSearchParams(getDefaultSearchParams($page.url.searchParams));
 	params.set('_offset', '0'); // Always reset offset on new search
@@ -17,7 +20,7 @@
 	afterNavigate(({ to }) => {
 		/** Update input value after navigation */
 		if (to?.url) {
-			let param = to.url.searchParams.has('_i') ? '_i' : '_q';
+			let param = showAdvanced ? '_q' : '_i';
 			q = new URL(to.url).searchParams.get(param)?.trim();
 		}
 	});

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -12,10 +12,9 @@ import { type apiError } from '$lib/types/API.js';
 import { asResult, type PartialCollectionView, type SearchResult } from './search.js';
 import getAtPath from '$lib/utils/getAtPath';
 
-let cachedSearchResult: null | PartialCollectionView = null;
+// let cachedSearchResult: null | PartialCollectionView = null;
 
 export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
-	console.log('has cache', !!cachedSearchResult);
 	const displayUtil: DisplayUtil = locals.display;
 	const locale = getSupportedLocale(params?.lang);
 
@@ -71,52 +70,35 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 			redirect(303, `/`); // redirect to home page if no search params are given
 		}
 
-		let result;
+		let searchParams = new URLSearchParams(url.searchParams.toString());
 
-		if (
-			cachedSearchResult &&
-			decodeURIComponent(cachedSearchResult['@id']) === decodeURIComponent(`/find${url.search}`)
-		) {
-			// we have a cached result with matching query
-			console.log('picking up from cache');
-			result = cachedSearchResult;
-			cachedSearchResult = null;
-		} else {
-			let searchParams = new URLSearchParams(url.searchParams.toString());
+		if (shouldFindRelations && resourceId) {
+			searchParams.set('_o', resourceId);
+			searchParams.set('_i', '*');
+			searchParams = getSortedSearchParams(addDefaultSearchParams(searchParams));
+		}
 
-			if (shouldFindRelations && resourceId) {
-				searchParams.set('_o', resourceId);
-				searchParams = getSortedSearchParams(addDefaultSearchParams(searchParams));
-			}
+		console.log('fetching', searchParams.toString());
+		const recordsRes = await fetch(`${env.API_URL}/find.jsonld?${searchParams.toString()}`, {
+			redirect: 'manual'
+		});
 
-			console.log('fetching', searchParams.toString());
-			const recordsRes = await fetch(`${env.API_URL}/find.jsonld?${searchParams.toString()}`);
-
-			if (!recordsRes.ok) {
+		if (!recordsRes.ok) {
+			if (recordsRes.status > 299 && recordsRes.status < 400) {
+				// redirect from api -> redirect in app
+				const location = recordsRes.headers.get('location');
+				const url = location && new URL(location);
+				if (url) {
+					console.log('redirecting to', `${url.pathname}${url.search}`);
+					redirect(recordsRes.status, `${url.pathname}${url.search}`);
+				}
+			} else {
 				const err = (await recordsRes.json()) as apiError;
 				throw error(err.status_code, err.status);
 			}
-
-			result = (await recordsRes.json()) as PartialCollectionView;
 		}
 
-		console.log(
-			'matching',
-			result['@id'],
-			`/find${url.search}`,
-			result['@id'] === `/find${url.search}`
-		);
-
-		if (
-			isFindRoute &&
-			decodeURIComponent(`/find${url.search}`) !== decodeURIComponent(result['@id'])
-		) {
-			// recieved a redirected api response
-			// redirect and cache response for next load
-			cachedSearchResult = result;
-			console.log('redirecting');
-			redirect(308, result['@id']);
-		}
+		const result = (await recordsRes.json()) as PartialCollectionView;
 
 		// Hide zero results from resource page
 		if (result.totalItems > 0 || isFindRoute) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -77,6 +77,7 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 		}
 
 		const recordsRes = await fetch(`${env.API_URL}/find.jsonld?${searchParams.toString()}`, {
+			// intercept 3xx redirects to sync back the correct _i/_q combination provided by api
 			redirect: 'manual'
 		});
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -12,8 +12,6 @@ import { type apiError } from '$lib/types/API.js';
 import { asResult, type PartialCollectionView, type SearchResult } from './search.js';
 import getAtPath from '$lib/utils/getAtPath';
 
-// let cachedSearchResult: null | PartialCollectionView = null;
-
 export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 	const displayUtil: DisplayUtil = locals.display;
 	const locale = getSupportedLocale(params?.lang);
@@ -78,7 +76,6 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 			searchParams = getSortedSearchParams(addDefaultSearchParams(searchParams));
 		}
 
-		console.log('fetching', searchParams.toString());
 		const recordsRes = await fetch(`${env.API_URL}/find.jsonld?${searchParams.toString()}`, {
 			redirect: 'manual'
 		});

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -73,7 +73,10 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 
 		let result;
 
-		if (cachedSearchResult && cachedSearchResult['@id'] === `/find${url.search}`) {
+		if (
+			cachedSearchResult &&
+			decodeURIComponent(cachedSearchResult['@id']) === decodeURIComponent(`/find${url.search}`)
+		) {
 			// we have a cached result with matching query
 			console.log('picking up from cache');
 			result = cachedSearchResult;
@@ -104,7 +107,10 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 			result['@id'] === `/find${url.search}`
 		);
 
-		if (isFindRoute && `/find${url.search}` !== result['@id']) {
+		if (
+			isFindRoute &&
+			decodeURIComponent(`/find${url.search}`) !== decodeURIComponent(result['@id'])
+		) {
 			// recieved a redirected api response
 			// redirect and cache response for next load
 			cachedSearchResult = result;

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -6,12 +6,6 @@
 	import Pagination from './Pagination.svelte';
 	import FacetGroup from './FacetGroup.svelte';
 
-	$: showEditButton = $page.url.searchParams.get('_q') !== $page.url.searchParams.get('_i');
-	$: editActive = $page.url.searchParams.get('_x') === 'advanced';
-	$: toggleEditLink = editActive
-		? $page.url.href.replace('&_x=advanced', '')
-		: `${$page.url.href}&_x=advanced`;
-
 	const sortOrder = $page.url.searchParams.get('_sort');
 	const sortOptions = [
 		{ value: '', label: 'Relevans' },
@@ -41,9 +35,6 @@
 			<div class="find container-fluid">
 				<nav class="mapping flex flex-wrap items-center gap-2" aria-label="Valda filter">
 					<SearchMapping mapping={searchResult.mapping} />
-					{#if showEditButton}
-						<a href={toggleEditLink}>Redigera {editActive ? '(aktiv)' : ''}</a>
-					{/if}
 				</nav>
 				<nav
 					class="lg:facets hidden lg:block"

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -6,6 +6,12 @@
 	import Pagination from './Pagination.svelte';
 	import FacetGroup from './FacetGroup.svelte';
 
+	$: showEditButton = $page.url.searchParams.get('_q') !== $page.url.searchParams.get('_i');
+	$: editActive = $page.url.searchParams.get('_x') === 'advanced';
+	$: toggleEditLink = editActive
+		? $page.url.href.replace('&_x=advanced', '')
+		: `${$page.url.href}&_x=advanced`;
+
 	const sortOrder = $page.url.searchParams.get('_sort');
 	const sortOptions = [
 		{ value: '', label: 'Relevans' },
@@ -33,8 +39,11 @@
 			{@const facets = searchResult.facetGroups}
 			{@const numHits = searchResult.totalItems}
 			<div class="find container-fluid">
-				<nav class="mapping" aria-label="Valda filter">
+				<nav class="mapping flex flex-wrap items-center gap-2" aria-label="Valda filter">
 					<SearchMapping mapping={searchResult.mapping} />
+					{#if showEditButton}
+						<a href={toggleEditLink}>Redigera {editActive ? '(aktiv)' : ''}</a>
+					{/if}
 				</nav>
 				<nav
 					class="lg:facets hidden lg:block"

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -33,7 +33,7 @@
 			{@const facets = searchResult.facetGroups}
 			{@const numHits = searchResult.totalItems}
 			<div class="find container-fluid">
-				<nav class="mapping flex flex-wrap items-center gap-2" aria-label="Valda filter">
+				<nav class="mapping" aria-label="Valda filter">
 					<SearchMapping mapping={searchResult.mapping} />
 				</nav>
 				<nav

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -66,7 +66,7 @@
 		{/if}
 	{/each}
 	{#if showEditButton && depth === 0}
-		<a class="edit-btn" class:active={editActive} href={toggleEditUrl}>
+		<a class="edit-btn" data-sveltekit-replacestate class:active={editActive} href={toggleEditUrl}>
 			<BiPencil class="text-icon-default" />
 			<span>Redigera</span>
 		</a>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -5,6 +5,7 @@
 	import type { DisplayMapping, SearchOperators } from './search';
 	import BiXLg from '~icons/bi/x-lg';
 	import BiPencil from '~icons/bi/pencil';
+	import BiTrash from '~icons/bi/trash';
 	export let mapping: DisplayMapping[];
 	export let parentOperator: keyof typeof SearchOperators | undefined = undefined;
 	export let depth = 0;
@@ -53,10 +54,10 @@
 					<DecoratedData data={m.display} showLabels={ShowLabelsOptions['Never']} />
 				</span>
 			{/if}
-			{#if 'up' in m}
+			{#if 'up' in m && (!m.children || depth > 0)}
 				<span class="pill-remove inline-block align-sub">
-					<a class="float-right pl-2" href={m.up?.['@id']}>
-						<BiXLg class="text-icon-inv-secondary" />
+					<a class="float-right pl-2 text-[inherit] hover:text-[inherit]" href={m.up?.['@id']}>
+						<BiXLg class="" fill="currentColor" fill-opacity="0.8" />
 					</a>
 				</span>
 			{/if}
@@ -64,12 +65,27 @@
 		{#if parentOperator}
 			<li class="pill-between pill-between-{parentOperator}">{parentOperator}</li>
 		{/if}
+		{#if 'up' in m && m.children && depth === 0}
+			<li class="pill-remove">
+				<a class="ghost-btn" href={m.up?.['@id']}>
+					<BiTrash class="text-icon-default" />
+					<span>Rensa</span>
+				</a>
+			</li>
+		{/if}
 	{/each}
 	{#if showEditButton && depth === 0}
-		<a class="edit-btn" data-sveltekit-replacestate class:active={editActive} href={toggleEditUrl}>
-			<BiPencil class="text-icon-default" />
-			<span>Redigera</span>
-		</a>
+		<li>
+			<a
+				class="ghost-btn"
+				data-sveltekit-replacestate
+				class:active={editActive}
+				href={toggleEditUrl}
+			>
+				<BiPencil class="text-icon-default" />
+				<span>Redigera</span>
+			</a>
+		</li>
 	{/if}
 </ul>
 
@@ -80,7 +96,7 @@
 	}
 
 	.mapping-item:has(> .pill-remove:hover) {
-		@apply brightness-75;
+		@apply brightness-[.85];
 	}
 
 	.pill {
@@ -122,7 +138,7 @@
 	}
 
 	/* TODO - move to button component/ghost */
-	.edit-btn {
+	.ghost-btn {
 		@apply flex items-center gap-2 rounded-md bg-main px-4 py-2 text-secondary no-underline outline outline-2 -outline-offset-2 outline-[#52331429] brightness-100 text-3-cond-bold;
 		transition: filter 0.1s ease;
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
+	import { page } from '$app/stores';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
 	import type { DisplayMapping, SearchOperators } from './search';
 	import BiXLg from '~icons/bi/x-lg';
+	import BiPencil from '~icons/bi/pencil';
 	export let mapping: DisplayMapping[];
 	export let parentOperator: keyof typeof SearchOperators | undefined = undefined;
 	export let depth = 0;
+
+	$: showEditButton =
+		$page.url.pathname === `${$page.data.base}find` &&
+		$page.url.searchParams.get('_q') !== $page.url.searchParams.get('_i');
+	$: editActive = $page.url.searchParams.get('_x') === 'advanced';
+	$: toggleEditUrl = editActive
+		? $page.url.href.replace('&_x=advanced', '')
+		: `${$page.url.href}&_x=advanced`;
 
 	function getRelationSymbol(operator: keyof typeof SearchOperators): string {
 		switch (operator) {
@@ -55,11 +65,17 @@
 			<li class="pill-between pill-between-{parentOperator}">{parentOperator}</li>
 		{/if}
 	{/each}
+	{#if showEditButton && depth === 0}
+		<a class="edit-btn" class:active={editActive} href={toggleEditUrl}>
+			<BiPencil class="text-icon-default" />
+			<span>Redigera</span>
+		</a>
+	{/if}
 </ul>
 
 <style lang="postcss">
 	.mapping-item {
-		@apply rounded-md py-2 pl-3 pr-3 brightness-100 text-3-cond-bold;
+		@apply rounded-md px-4 py-2 brightness-100 text-3-cond-bold;
 		transition: filter 0.1s ease;
 	}
 
@@ -103,5 +119,16 @@
 		@apply hidden;
 	}
 	.pill-remove {
+	}
+
+	/* TODO - move to button component/ghost */
+	.edit-btn {
+		@apply flex items-center gap-2 rounded-md bg-main px-4 py-2 text-secondary no-underline outline outline-2 -outline-offset-2 outline-[#52331429] brightness-100 text-3-cond-bold;
+		transition: filter 0.1s ease;
+
+		&:hover,
+		&.active {
+			@apply brightness-95;
+		}
 	}
 </style>

--- a/lxl-web/vite.config.ts
+++ b/lxl-web/vite.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
 		sveltekit(),
 		Icons({
 			compiler: 'svelte',
-			defaultClass: 'text-icon-default'
+			defaultClass: 'text-icon-default',
+			scale: 1
 		})
 	],
 	test: {


### PR DESCRIPTION
## Description

### Solves

* Enables user to see/edit their advanced search query by toggling the `_q` / `_i` params in search field.

### Summary of changes

* Use fetch `reddirect: manual` option to intercept api redirects. Then redirect to the same url in the frontend (in order to get the correct `_i`/`_q` combination).
* Display an edit button next to the search mapping pills _when `_i` and `_q` differ_ (i.e there is an active filter/advanced search query that can be shown in the input field). This felt like a clearer way to express this functionality than to have a 'simple/advanced search' toggle. 

**test with dev api**

~~backend fixes needed for this to work:~~
*  ~~`_x` param accepted and returned from the api (or this state will always be reset in the redirect operation)~~
*  ~~double url encoding fixed (or the url `searchParams` and the response `@id` will never match when using facet links,  resulting in a redirect loop)~~
