### PR TITLE
Add more sort options

### DIFF
--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -36,6 +36,14 @@ export default {
 		intendedAudience: 'Intended audience'
 	},
 	search: {},
+	sort: {
+		relevancy: 'Relevancy',
+		alphaAsc: 'A-Z',
+		alphaDesc: 'Z-A',
+		publicationAsc: 'Publication year (oldest first)',
+		publicationDesc: 'Publication year (newest first)',
+		linksDesc: 'Most linked'
+	},
 	errors: {},
 	general: {
 		collapseAll: 'Collapse all',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -35,6 +35,14 @@ export default {
 		intendedAudience: 'Målgrupp'
 	},
 	search: {},
+	sort: {
+		relevancy: 'Relevans',
+		alphaAsc: 'A-Ö',
+		alphaDesc: 'Ö-A',
+		publicationAsc: 'Utgivningsår (äldst först)',
+		publicationDesc: 'Utgivningsår (nyast först)',
+		linksDesc: 'Mest länkad'
+	},
 	errors: {},
 	general: {
 		collapseAll: 'Stäng alla',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -10,7 +10,10 @@
 	const sortOptions = [
 		{ value: '', label: 'Relevans' },
 		{ value: `_sortKeyByLang.${$page.data.locale}`, label: 'A-Ö' },
-		{ value: `-_sortKeyByLang.${$page.data.locale}`, label: 'Ö-A' }
+		{ value: `-_sortKeyByLang.${$page.data.locale}`, label: 'Ö-A' },
+		{ value: '-@reverse.instanceOf.publication.year', label: 'Utgivningsår (nyast först)' },
+		{ value: '@reverse.instanceOf.publication.year', label: 'Utgivningsår (äldst först)' },
+		{ value: '-reverseLinks.totalItems', label: 'Mest länkad' }
 	];
 
 	function handleSortChange(e: Event) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -8,12 +8,12 @@
 
 	const sortOrder = $page.url.searchParams.get('_sort');
 	const sortOptions = [
-		{ value: '', label: 'Relevans' },
-		{ value: `_sortKeyByLang.${$page.data.locale}`, label: 'A-Ö' },
-		{ value: `-_sortKeyByLang.${$page.data.locale}`, label: 'Ö-A' },
-		{ value: '-@reverse.instanceOf.publication.year', label: 'Utgivningsår (nyast först)' },
-		{ value: '@reverse.instanceOf.publication.year', label: 'Utgivningsår (äldst först)' },
-		{ value: '-reverseLinks.totalItems', label: 'Mest länkad' }
+		{ value: '', label: $page.data.t('sort.relevancy') },
+		{ value: `_sortKeyByLang.${$page.data.locale}`, label: $page.data.t('sort.alphaAsc') },
+		{ value: `-_sortKeyByLang.${$page.data.locale}`, label: $page.data.t('sort.alphaDesc') },
+		{ value: '-@reverse.instanceOf.publication.year', label: $page.data.t('sort.publicationDesc') },
+		{ value: '@reverse.instanceOf.publication.year', label: $page.data.t('sort.publicationAsc') },
+		{ value: '-reverseLinks.totalItems', label: $page.data.t('sort.linksDesc') }
 	];
 
 	function handleSortChange(e: Event) {


### PR DESCRIPTION
## Description
Add more sort options to search component.

### Tickets involved
[LWS-113](https://jira.kb.se/browse/LWS-113)

### Summary of changes
* Add sort options
* Translate sort options

### Not in scope
* Handle sorting of different types correctly. For example the publication year option only works on Works.
* Actual publication year data includes lots of 0000 and 9999. They now come first for oldest and newest, respectively. They should be filtered out by backend.