### PR TITLE
LWS-63: Fix holders by type

### DIFF
--- a/lxl-web/src/lib/utils/isFnurgel.test.ts
+++ b/lxl-web/src/lib/utils/isFnurgel.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import isFnurgel from './isFnurgel';
+
+describe('isFnurgel', () => {
+	it('returns true if fnurgel', () => {
+		expect(isFnurgel('n5ftk39xlxc7vs6g')).toBe(true);
+	});
+	it('returns false if not fnurgel', () => {
+		expect(isFnurgel('test')).toBe(false);
+	});
+});

--- a/lxl-web/src/lib/utils/isFnurgel.ts
+++ b/lxl-web/src/lib/utils/isFnurgel.ts
@@ -1,0 +1,5 @@
+function isFnurgel(value: string) {
+	return /^[a-z0-9]{15,}$/.test(value);
+}
+
+export default isFnurgel;

--- a/lxl-web/src/params/fnurgel.ts
+++ b/lxl-web/src/params/fnurgel.ts
@@ -1,5 +1,6 @@
 import type { ParamMatcher } from '@sveltejs/kit';
+import isFnurgel from '$lib/utils/isFnurgel';
 
 export const match: ParamMatcher = (param: string) => {
-	return /^[a-z0-9]{15,}$/.test(param);
+	return isFnurgel(param);
 };

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -210,7 +210,7 @@ function getHoldingsByType(mainEntity: FramedData) {
 		const type = instanceOfItem['@type'];
 		return {
 			...acc,
-			[type]: [...(acc[type] || []), ...(instanceOfItem?.['@reverse'].itemOf || [])]
+			[type]: [...(acc[type] || []), ...(instanceOfItem?.['@reverse']?.itemOf || [])]
 		};
 	}, {});
 	if (!holdingsByType) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -123,8 +123,8 @@
 				<div>
 					<h2 class="font-bold">
 						{data.t('holdings.availableAt')}
-						{$page.data.holdingsByInstanceId[selectedHolding].length}
-						{$page.data.holdingsByInstanceId[selectedHolding].length === 1
+						{$page.data.holdersByType[holdingUrl].length}
+						{$page.data.holdersByType[holdingUrl].length === 1
 							? $page.data.t('holdings.library')
 							: $page.data.t('holdings.libraries')}
 					</h2>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -123,10 +123,17 @@
 				<div>
 					<h2 class="font-bold">
 						{data.t('holdings.availableAt')}
-						{$page.data.holdersByType[holdingUrl].length}
-						{$page.data.holdersByType[holdingUrl].length === 1
-							? $page.data.t('holdings.library')
-							: $page.data.t('holdings.libraries')}
+						{#if isFnurgel(holdingUrl)}
+							{data.holdingsByInstanceId[selectedHolding].length}
+							{data.holdingsByInstanceId[selectedHolding].length === 1
+								? data.t('holdings.library')
+								: data.t('holdings.libraries')}
+						{:else if data.holdersByType?.[latestHoldingUrl]}
+							{data.holdersByType[latestHoldingUrl].length}
+							{data.holdersByType[latestHoldingUrl].length === 1
+								? data.t('holdings.library')
+								: data.t('holdings.libraries')}
+						{/if}
 					</h2>
 					<table class="w-full table-auto border-collapse text-sm">
 						{#if isFnurgel(latestHoldingUrl)}
@@ -142,7 +149,7 @@
 									</tr>
 								{/each}
 							{/if}
-						{:else if data.holdersByType[latestHoldingUrl]}
+						{:else if data.holdersByType?.[latestHoldingUrl]}
 							{#each data.holdersByType[latestHoldingUrl] as holderItem}
 								<tr class="h-11 border-b-primary/16 [&:not(:last-child)]:border-b">
 									<td>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -121,7 +121,13 @@
 					</div>
 				</div>
 				<div>
-					<h2 class="font-bold">{data.t('holdings.availableAt')}</h2>
+					<h2 class="font-bold">
+						{data.t('holdings.availableAt')}
+						{$page.data.holdingsByInstanceId[selectedHolding].length}
+						{$page.data.holdingsByInstanceId[selectedHolding].length === 1
+							? $page.data.t('holdings.library')
+							: $page.data.t('holdings.libraries')}
+					</h2>
 					<table class="w-full table-auto border-collapse text-sm">
 						{#if isFnurgel(latestHoldingUrl)}
 							{#if data.holdingsByInstanceId[selectedHolding]}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/utils.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/utils.ts
@@ -1,4 +1,5 @@
 import { pushState } from '$app/navigation';
+import isFnurgel from '$lib/utils/isFnurgel';
 
 export function getHoldingsLink(url: URL, value: string) {
 	const newSearchParams = new URLSearchParams([...Array.from(url.searchParams.entries())]);
@@ -13,4 +14,14 @@ export function handleClickHoldings(
 ) {
 	event.preventDefault();
 	pushState(event.currentTarget.href, { ...state, holdings: id });
+}
+
+export function getSelectedHolding(value: string, instanceIdsByType: { [key: string]: string[] }) {
+	if (isFnurgel(value)) {
+		return value;
+	}
+	if (instanceIdsByType[value]?.[0]) {
+		return instanceIdsByType[value][0]; // get first instance if showing holdings by type
+	}
+	return undefined;
 }


### PR DESCRIPTION
### Tickets involved
[LWS-63](https://jira.kb.se/browse/LWS-63)

### Solves

Fixes the list of unique holders (e.g. libraries) by instance type.

### Out of scope
The `+layout.server.ts` file has started growing so it would be preferable to separate it into different `+page.server.ts` files again for the different routes. We also need to fix the missing Typescript types for the resource pages...

### Summary of changes

- Add isFnurgel util method
- Fix unique holders by type
- Add count in holder list title
