### PR TITLE
Add page titles

### DIFF
--- a/lxl-web/src/lib/constants/pageTitle.ts
+++ b/lxl-web/src/lib/constants/pageTitle.ts
@@ -1,0 +1,3 @@
+export const TITLE_SEPARATOR = ' | ';
+export const TITLE_SUFFIX = 'Libris';
+export const TITLE_MAX_LENGTH = 64;

--- a/lxl-web/src/lib/utils/getPageTitle.test.ts
+++ b/lxl-web/src/lib/utils/getPageTitle.test.ts
@@ -1,11 +1,28 @@
 import { describe, it, expect } from 'vitest';
 import getPageTitle from './getPageTitle';
+import { TITLE_SEPARATOR, TITLE_SUFFIX, TITLE_MAX_LENGTH } from '$lib/constants/pageTitle';
 
 describe('getPageTitle', () => {
 	it('adds separator and suffix if page title is given', () => {
-		expect(getPageTitle('test')).toBe('test | Libris');
+		expect(getPageTitle('test')).toBe('test' + TITLE_SEPARATOR + TITLE_SUFFIX);
 	});
 	it('returns only suffix if page title is omitted', () => {
-		expect(getPageTitle()).toBe('Libris');
+		expect(getPageTitle()).toBe(TITLE_SUFFIX);
+	});
+	it('it truncates the title and adds an ellipsis if the total length is greater than the max length', () => {
+		const testString = 'a'.repeat(TITLE_MAX_LENGTH);
+		const truncatedTestString = testString.substring(
+			0,
+			testString.length - TITLE_SEPARATOR.length - TITLE_SUFFIX.length - 1
+		);
+		expect(getPageTitle(testString)).toBe(
+			truncatedTestString + '…' + TITLE_SEPARATOR + TITLE_SUFFIX
+		);
+		expect(getPageTitle(testString).length).toBe(TITLE_MAX_LENGTH);
+	});
+	it('it keeps the title as-is if the total length is equal to the max length', () => {
+		const testString = 'a'.repeat(TITLE_MAX_LENGTH - TITLE_SEPARATOR.length - TITLE_SUFFIX.length);
+		expect(getPageTitle(testString)).toBe(testString + TITLE_SEPARATOR + TITLE_SUFFIX);
+		expect(getPageTitle(testString).length).toBe(TITLE_MAX_LENGTH);
 	});
 });

--- a/lxl-web/src/lib/utils/getPageTitle.test.ts
+++ b/lxl-web/src/lib/utils/getPageTitle.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import getPageTitle from './getPageTitle';
+
+describe('getPageTitle', () => {
+	it('adds separator and suffix if page title is given', () => {
+		expect(getPageTitle('test')).toBe('test | Libris');
+	});
+	it('returns only suffix if page title is omitted', () => {
+		expect(getPageTitle()).toBe('Libris');
+	});
+});

--- a/lxl-web/src/lib/utils/getPageTitle.ts
+++ b/lxl-web/src/lib/utils/getPageTitle.ts
@@ -1,6 +1,9 @@
 /**
  * Adds title separator and suffix to title string
+ *
+ * Future: the suffix should be set in the site config
  */
+
 function getPageTitle(title?: string) {
 	if (title) {
 		return `${title} | Libris`;

--- a/lxl-web/src/lib/utils/getPageTitle.ts
+++ b/lxl-web/src/lib/utils/getPageTitle.ts
@@ -1,14 +1,23 @@
+import { TITLE_SEPARATOR, TITLE_SUFFIX, TITLE_MAX_LENGTH } from '$lib/constants/pageTitle';
+
 /**
  * Adds title separator and suffix to title string
  *
- * Future: the suffix should be set in the site config
+ * Future: the constants should be set in a site config file / environment variables
  */
 
 function getPageTitle(title?: string) {
 	if (title) {
-		return `${title} | Libris`;
+		const separatorAndSuffix = TITLE_SEPARATOR + TITLE_SUFFIX;
+
+		// Truncate the title and add an ellipsis if the total length is greater than the max length
+		if (title.length > TITLE_MAX_LENGTH - separatorAndSuffix.length) {
+			return `${title.substring(0, TITLE_MAX_LENGTH - separatorAndSuffix.length - 1) + '…'}${separatorAndSuffix}`;
+		}
+
+		return `${title}${separatorAndSuffix}`;
 	}
-	return 'Libris';
+	return TITLE_SUFFIX;
 }
 
 export default getPageTitle;

--- a/lxl-web/src/lib/utils/getPageTitle.ts
+++ b/lxl-web/src/lib/utils/getPageTitle.ts
@@ -1,0 +1,11 @@
+/**
+ * Adds title separator and suffix to title string
+ */
+function getPageTitle(title?: string) {
+	if (title) {
+		return `${title} | Libris`;
+	}
+	return 'Libris';
+}
+
+export default getPageTitle;

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -2,7 +2,7 @@ import { redirect, error } from '@sveltejs/kit';
 import jmespath from 'jmespath';
 import { env } from '$env/dynamic/private';
 import { getSupportedLocale } from '$lib/i18n/locales.js';
-import { type FramedData, DisplayUtil, pickProperty } from '$lib/utils/xl.js';
+import { type FramedData, DisplayUtil, pickProperty, toString } from '$lib/utils/xl.js';
 import { LxlLens } from '$lib/utils/display.types.js';
 import { relativizeUrl } from '$lib/utils/http';
 import { calculateExpirationTime, generateAuxdImageUri, getImageLinks } from '$lib/utils/auxd';
@@ -38,6 +38,7 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 		copyMediaLinksToWork(mainEntity);
 
 		resourceId = resource.mainEntity['@id'];
+		const heading = displayUtil.lensAndFormat(mainEntity, LxlLens.PageHeading, locale);
 		const overview = displayUtil.lensAndFormat(mainEntity, LxlLens.PageOverView, locale);
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const [_, overviewWithoutHasInstance] = pickProperty(overview, ['hasInstance']);
@@ -52,7 +53,8 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 		const holdingsByInstanceId = getHoldingsByInstanceId(mainEntity);
 
 		resourceParts = {
-			heading: displayUtil.lensAndFormat(mainEntity, LxlLens.PageHeading, locale),
+			title: toString(heading),
+			heading,
 			overview: overviewWithoutHasInstance,
 			details: displayUtil.lensAndFormat(mainEntity, LxlLens.PageDetails, locale),
 			instances: sortedInstances,

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -5,6 +5,7 @@
 	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
 	import { getResourceId } from '$lib/utils/resourceData';
 	import { relativizeUrl } from '$lib/utils/http';
+	import getPageTitle from '$lib/utils/getPageTitle';
 	import Modal from '$lib/components/Modal.svelte';
 	import ResourceImage from '$lib/components/ResourceImage.svelte';
 	import { getHoldingsLink, handleClickHoldings } from './utils';
@@ -47,6 +48,9 @@
 	}
 </script>
 
+<svelte:head>
+	<title>{getPageTitle(data.title)}</title>
+</svelte:head>
 <article class="resource grid">
 	<div class="content p-4">
 		<header>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/find/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import getPageTitle from '$lib/utils/getPageTitle';
+</script>
+
+<svelte:head>
+	<title>{getPageTitle($page.url.searchParams.get('_q')?.trim())}</title>
+</svelte:head>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import SiteHeader from './SiteHeader.svelte';
 	import '../../../app.css';
+	import getPageTitle from '$lib/utils/getPageTitle';
 	export let data;
 </script>
 
 <svelte:head>
-	<title>Libris</title>
+	<title>{getPageTitle()}</title>
 	<base href={data.base} />
 </svelte:head>
 <SiteHeader />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
@@ -1,1 +1,9 @@
+<script>
+	import getPageTitle from '$lib/utils/getPageTitle';
+</script>
+
+<svelte:head>
+	<title>{getPageTitle()}</title>
+</svelte:head>
+
 <div></div>


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-122](https://jira.kb.se/browse/LWS-122)

### Solves

Adds titles on pages; which are shown in the browsers title bar or a page's tab.
A separator (` | `) and suffix (`Libris`) is added when using the `getPageTitle` helper method.

### Summary of changes

- Add page titles
