### PR TITLE
LWS-125: Hide wildcard pills

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -42,6 +42,7 @@
 	{#each mapping as m}
 		<li
 			class="mapping-item {m.children ? 'pill-group' : 'pill'} pill-{m.operator}"
+			class:wildcard={m.display === '*'}
 			class:outer={depth === 0}
 		>
 			{#if 'children' in m}
@@ -115,6 +116,10 @@
 		.pill-relation {
 			@apply text-secondary;
 		}
+	}
+
+	.pill-equals.wildcard {
+		@apply hidden;
 	}
 
 	.pill-group {


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-125](https://jira.kb.se/browse/LWS-125)

### Solves

Hiding the wildcard pills throughout, which has the desired effect on the resource pages. In the search results, it is now possible to completely clear the pills.
