### PR TITLE
Feature/lws 62 more facets

### DIFF
--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -27,8 +27,12 @@ export default {
 		'concerning.issuanceType': 'Issuance type',
 		'@reverse': 'Relation',
 		'meta.encodingLevel': 'Encoding level',
+		'rdf:type': 'Type',
+		workType: 'Type',
+		instanceType: 'Carrier type',
 		genreForm: 'Genre/form',
 		itemHeldBy: 'Library',
+		bibliography: 'Bibliography',
 		contributor: 'Contribution',
 		language: 'Language',
 		subject: 'Subject',
@@ -37,7 +41,7 @@ export default {
 	},
 	search: {
 		findFilter: 'Find filter'
-  },
+	},
 	sort: {
 		relevancy: 'Relevancy',
 		alphaAsc: 'A-Z',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -26,8 +26,12 @@ export default {
 		'concerning.issuanceType': 'Utgivningssätt',
 		'@reverse': 'Relation',
 		'meta.encodingLevel': 'Beskrivningsnivå',
+		'rdf:type': 'Typ',
+		workType: 'Typ',
+		instanceType: 'Bärartyp',
 		genreForm: 'Genre/form',
 		itemHeldBy: 'Bibliotek',
+		bibliography: 'Bibliografi',
 		contributor: 'Medverkan',
 		language: 'Språk',
 		subject: 'Ämne',
@@ -36,7 +40,7 @@ export default {
 	},
 	search: {
 		findFilter: 'Hitta filter'
-  },
+	},
 	sort: {
 		relevancy: 'Relevans',
 		alphaAsc: 'A-Ö',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
@@ -5,7 +5,6 @@ import {
 	JsonLd,
 	LensType,
 	type Link,
-	type PropertyName,
 	toString
 } from '$lib/utils/xl';
 import { LxlLens } from '$lib/utils/display.types';
@@ -103,8 +102,8 @@ export interface PartialCollectionView {
 }
 
 interface Slice {
+	alias: FacetGroupId;
 	dimension: FacetGroupId;
-	dimensionChain: PropertyName[];
 	observation: Observation[];
 }
 
@@ -157,14 +156,14 @@ function displayMappings(
 					display: displayUtil.lensAndFormat(property, LensType.Chip, locale),
 					label: m.property?.labelByLang?.[locale] || m.property?.['@id'] || 'no label', // lensandformat?
 					operator,
-					...('up' in m && { up: replacePath(m.up as Link, usePath) }),
+					...('up' in m && { up: replacePath(m.up as Link, usePath) })
 				} as DisplayMapping;
 			} else if (operator && operator in m && Array.isArray(m[operator])) {
 				const mappingArr = m[operator] as SearchMapping[];
 				return {
 					children: _iterateMapping(mappingArr),
 					operator,
-					...('up' in m && { up: replacePath(m.up as Link, usePath) }),
+					...('up' in m && { up: replacePath(m.up as Link, usePath) })
 				} as DisplayMapping;
 			} else {
 				return {
@@ -193,7 +192,7 @@ function displayFacetGroups(
 
 	return Object.values(slices).map((g) => {
 		return {
-			label: translate(`facet.${g.dimension}`),
+			label: translate(`facet.${g.alias || g.dimension}`),
 			dimension: g.dimension,
 			facets: g.observation.map((o) => {
 				return {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
@@ -26,7 +26,7 @@ export async function asResult(
 		itemsPerPage: view.itemsPerPage,
 		totalItems: view.totalItems,
 		maxItems: view.maxItems,
-		mapping: displayMappings(view, displayUtil, locale, usePath),
+		mapping: displayMappings(view, displayUtil, locale, translate, usePath),
 		first: replacePath(view.first, usePath),
 		last: replacePath(view.last, usePath),
 		items: view.items.map((i) => ({
@@ -102,7 +102,7 @@ export interface PartialCollectionView {
 }
 
 interface Slice {
-	alias: FacetGroupId;
+	alias: string;
 	dimension: FacetGroupId;
 	observation: Observation[];
 }
@@ -129,6 +129,7 @@ export enum SearchOperators {
 type MappingObj = { [key in SearchOperators]: SearchMapping[] | string | FramedData };
 
 interface SearchMapping extends MappingObj {
+	alias: string;
 	property?: ObjectProperty | DatatypeProperty | PropertyChainAxiom;
 	up: { '@id': string };
 }
@@ -141,6 +142,7 @@ function displayMappings(
 	view: PartialCollectionView,
 	displayUtil: DisplayUtil,
 	locale: LangCode,
+	translate: translateFn,
 	usePath: string
 ): DisplayMapping[] {
 	const mapping = view.search?.mapping || [];
@@ -154,7 +156,9 @@ function displayMappings(
 				const property = m[operator] as FramedData;
 				return {
 					display: displayUtil.lensAndFormat(property, LensType.Chip, locale),
-					label: m.property?.labelByLang?.[locale] || m.property?.['@id'] || 'no label', // lensandformat?
+					label: m.alias
+						? translate(`facet.${m.alias}`)
+						: m.property?.labelByLang?.[locale] || m.property?.['@id'] || 'no label', // lensandformat?
 					operator,
 					...('up' in m && { up: replacePath(m.up as Link, usePath) })
 				} as DisplayMapping;


### PR DESCRIPTION
Some properties (in this case type) need to be displayed with different labels depending on the context. For example the property `rdf:type` (= `@type`) should be displayed as just 'Type' for works whereas for instances it should be 'Carrier type'. For this reason another entry with the key `alias` will now be included in a `Slice` or `SearchMapping` when needed to point out which label should be used (this feature is added in https://github.com/libris/librisxl/pull/1416).

Codewise I'm not completely sure what I'm doing here, just tried to make it work, so feel free to make changes :slightly_smiling_face: The point is that `SearchMapping.alias`/`Slice.alias` should be preferred over `SearchMapping.property`/`Slice.dimension`!