### PR TITLE
LWS-147: Fix instance page sort order

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -46,6 +46,10 @@
 		@apply text-ellipsis rounded-md border-t border-t-primary/16 px-4 py-2 text-3-regular;
 	}
 
+	select {
+		@apply rounded-sm bg-white p-1;
+	}
+
 	.container-fluid {
 		@apply mx-auto px-4 sm:px-8;
 	}

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -43,6 +43,7 @@ export default {
 		findFilter: 'Find filter'
 	},
 	sort: {
+		sortBy: 'Sort by',
 		relevancy: 'Relevancy',
 		alphaAsc: 'A-Z',
 		alphaDesc: 'Z-A',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -42,6 +42,7 @@ export default {
 		findFilter: 'Hitta filter'
 	},
 	sort: {
+		sortBy: 'Sortera efter',
 		relevancy: 'Relevans',
 		alphaAsc: 'A-Ö',
 		alphaDesc: 'Ö-A',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -6,7 +6,7 @@
 	import Pagination from './Pagination.svelte';
 	import FacetGroup from './FacetGroup.svelte';
 
-	const sortOrder = $page.url.searchParams.get('_sort');
+	$: sortOrder = $page.url.searchParams.get('_sort');
 	const sortOptions = [
 		{ value: '', label: $page.data.t('sort.relevancy') },
 		{ value: `_sortKeyByLang.${$page.data.locale}`, label: $page.data.t('sort.alphaAsc') },
@@ -63,7 +63,7 @@
 					{/if}
 				</nav>
 				<section class="results">
-					<div class="mb-4 flex justify-between">
+					<div class="mb-4 flex items-baseline justify-between">
 						<p role="status" data-testid="result-info">
 							{#if numHits && numHits > 0}
 								{numHits.toLocaleString($page.data.locale)} träffar
@@ -72,8 +72,8 @@
 							{/if}
 						</p>
 						{#if numHits > 0}
-							<div data-testid="sort-select">
-								<label for="search-sort">Sortera efter</label>
+							<div class="flex items-baseline gap-2" data-testid="sort-select">
+								<label for="search-sort">{$page.data.t('sort.sortBy')}</label>
 								<select id="search-sort" form="main-search" on:change={handleSortChange}>
 									{#each sortOptions as option}
 										<option value={option.value} selected={option.value === sortOrder}

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -22,6 +22,7 @@ export default {
 			'icon-inv-secondary': 'rgb(var(--icon-inv-secondary) / 0.64)'
 		},
 		backgroundColor: {
+			white: 'rgb(var(--color-white) / <alpha-value>)',
 			transparent: 'transparent',
 			main: 'rgb(var(--bg-main) / 1)',
 			head: 'rgb(var(--bg-head) / 1)',


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-147](https://jira.kb.se/browse/LWS-147)

### Solves

Fixes correct `selected` value for the sort select on instance page

**BUT**... the sorting is still not being done correctly on instance pages despite us sending the correct `_sort` param it seems. Maybe @olovy or @kwahlin can look into it?

### Summary of changes

* make `sortOrder` reactive to changes
* Style `select` somewhat
* add translation
