### PR TITLE
LWS-123: responsive filters

### DIFF
--- a/lxl-web/src/lib/components/Modal.svelte
+++ b/lxl-web/src/lib/components/Modal.svelte
@@ -7,12 +7,15 @@
 	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
 	import IconClose from '~icons/bi/x-lg';
+	import { setModalContext } from '$lib/contexts/modal';
 
 	export let dialog: HTMLDialogElement | undefined = undefined;
 	export let close: ((event: Event) => void) | undefined = undefined;
 	export let position: 'left' | 'right' = 'right';
 
 	let prevBodyOverflow: string | undefined = undefined;
+
+	setModalContext();
 
 	onMount(() => {
 		dialog?.showModal();

--- a/lxl-web/src/lib/components/Modal.svelte
+++ b/lxl-web/src/lib/components/Modal.svelte
@@ -81,7 +81,7 @@
 	>
 		<div class="flex flex-1 flex-col gap-4 overflow-y-auto pb-4">
 			<header
-				class="sticky top-0 z-10 flex min-h-14 items-center justify-between border-b border-b-primary/8 bg-main pl-4 pr-1"
+				class="sticky top-0 z-10 flex min-h-14 items-center justify-between border-b border-b-primary/16 bg-main pl-4 pr-1"
 			>
 				<h1 class="text-3-cond-bold"><slot name="title" /></h1>
 				<!-- svelte-ignore a11y-autofocus -->

--- a/lxl-web/src/lib/components/Modal.svelte
+++ b/lxl-web/src/lib/components/Modal.svelte
@@ -6,10 +6,11 @@
 	import { cubicInOut } from 'svelte/easing';
 	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
-	import BiXLg from '~icons/bi/x-lg';
+	import IconClose from '~icons/bi/x-lg';
 
 	export let dialog: HTMLDialogElement | undefined = undefined;
 	export let close: ((event: Event) => void) | undefined = undefined;
+	export let position: 'left' | 'right' = 'right';
 
 	let prevBodyOverflow: string | undefined = undefined;
 
@@ -63,22 +64,31 @@
 	on:click|self={handleBackdropClick}
 	on:close={handleClose}
 	bind:this={dialog}
-	transition:fly={{ x: 12, duration: 250, opacity: 0, easing: cubicInOut }}
+	transition:fly={{
+		x: position === 'left' ? -12 : 12,
+		duration: 250,
+		opacity: 0,
+		easing: cubicInOut
+	}}
 >
-	<div class="absolute right-0 top-0 flex h-full w-full gap-4 bg-main shadow-2xl md:max-w-[480px]">
+	<div
+		class="absolute right-0 top-0 flex h-full w-full bg-main shadow-2xl md:max-w-[480px]"
+		class:left-0={position === 'left'}
+		class:right-0={position === 'right'}
+	>
 		<div class="flex flex-1 flex-col gap-4 overflow-y-auto pb-4">
 			<header
-				class="sticky top-0 flex min-h-14 items-center justify-between border-b border-b-primary/8 bg-main py-2 pl-4 pr-2"
+				class="sticky top-0 z-10 flex min-h-14 items-center justify-between border-b border-b-primary/8 bg-main pl-4 pr-1"
 			>
 				<h1 class="text-3-cond-bold"><slot name="title" /></h1>
 				<!-- svelte-ignore a11y-autofocus -->
 				<button
 					on:click={handleClose}
 					autofocus
-					class="flex h-11 w-11 items-center justify-center"
+					class="icon-button"
 					aria-label={$page.data.t('general.close')}
 				>
-					<BiXLg />
+					<IconClose />
 				</button>
 			</header>
 			<slot />

--- a/lxl-web/src/lib/contexts/modal.ts
+++ b/lxl-web/src/lib/contexts/modal.ts
@@ -1,0 +1,9 @@
+import { setContext, getContext } from 'svelte';
+
+export function setModalContext() {
+	setContext('modal', true);
+}
+
+export function getModalContext() {
+	return getContext('modal');
+}

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -43,7 +43,16 @@ export default {
 		intendedAudience: 'Intended audience'
 	},
 	search: {
-		findFilter: 'Find filter'
+		loading: 'Loading...',
+		findFilter: 'Find filter',
+		filters: 'Filters',
+		clearFilters: 'Clear',
+		editFilters: 'Edit',
+		noResults: 'No results',
+		hits: 'hits',
+		hitsOne: 'hit',
+		selected: 'selected',
+		selectedOne: 'selected'
 	},
 	sort: {
 		sortBy: 'Sort by',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -42,7 +42,16 @@ export default {
 		intendedAudience: 'Målgrupp'
 	},
 	search: {
-		findFilter: 'Hitta filter'
+		loading: 'Laddar...',
+		findFilter: 'Hitta filter',
+		filters: 'Sökfilter',
+		clearFilters: 'Rensa',
+		editFilters: 'Redigera',
+		noResults: 'Inga resultat',
+		hits: 'träffar',
+		hitsOne: 'träff',
+		selected: 'valda',
+		selectedOne: 'vald'
 	},
 	sort: {
 		sortBy: 'Sortera efter',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -4,7 +4,12 @@
 	import SearchMapping from './SearchMapping.svelte';
 	import SearchCard from './SearchCard.svelte';
 	import Pagination from './Pagination.svelte';
-	import FacetGroup from './FacetGroup.svelte';
+	import Modal from '$lib/components/Modal.svelte';
+	import Filters from './Filters.svelte';
+	import IconSliders from '~icons/bi/sliders';
+	import type { SearchMapping as TypedSearchMapping } from './search';
+
+	let showFiltersModal = false;
 
 	$: sortOrder = $page.url.searchParams.get('_sort');
 	const sortOptions = [
@@ -26,7 +31,16 @@
 		goto(`${$page.url.pathname}?${searchParams.toString()}`, { invalidateAll: true });
 	}
 
-	let searchPhrase = '';
+	function toggleFiltersModal() {
+		showFiltersModal = !showFiltersModal;
+	}
+
+	function getFiltersCount(mapping: TypedSearchMapping) {
+		if (Array.isArray(mapping)) {
+			return mapping.find((mappingItem) => mappingItem?.children)?.children.length || 1;
+		}
+		return 0;
+	}
 </script>
 
 <slot />
@@ -37,45 +51,54 @@
 		{#if searchResult}
 			{@const facets = searchResult.facetGroups}
 			{@const numHits = searchResult.totalItems}
-			<div class="find container-fluid">
-				<nav class="mapping" aria-label="Valda filter">
+			{@const filterCount = getFiltersCount(searchResult.mapping)}
+			<div class="find relative gap-y-4">
+				<nav class="mappings px-4" aria-label="Valda filter">
 					<SearchMapping mapping={searchResult.mapping} />
 				</nav>
-				<nav
-					class="lg:facets hidden lg:block"
-					aria-labelledby="facet-sidebar-header"
-					data-testid="facet-panel"
-				>
-					{#if facets && facets.length > 0}
-						<header id="facet-sidebar-header" class="font-bold">Filter</header>
-						<input
-							bind:value={searchPhrase}
-							class="mt-2"
-							placeholder={$page.data.t('search.findFilter')}
-							title={$page.data.t('search.findFilter')}
-							type="search"
-						/>
-						<ol>
-							{#each facets as group (group.dimension)}
-								<FacetGroup {group} locale={$page.data.locale} {searchPhrase} />
-							{/each}
-						</ol>
-					{/if}
-				</nav>
-				<section class="results">
-					<div class="mb-4 flex items-center justify-between">
-						<p role="status" data-testid="result-info">
+				{#if showFiltersModal}
+					<Modal position="left" close={toggleFiltersModal}>
+						<span slot="title">Sökfilter ({filterCount} valda)</span>
+						<Filters {facets} />
+					</Modal>
+				{/if}
+				<div class="filters" id="filters">
+					<Filters {facets} />
+				</div>
+
+				<div class="results">
+					<div class="toolbar flex min-h-14 items-center justify-between p-4 md:min-h-fit md:pt-0">
+						<a
+							href={`${$page.url.pathname}?${$page.url.searchParams.toString()}#filters`}
+							class="filter-modal-toggle ghost-btn md:hidden"
+							aria-label="Sökfilter"
+							on:click|preventDefault={toggleFiltersModal}
+						>
+							<IconSliders width={20} height={20} />
+							<span>Sökfilter</span>
+							{#if filterCount}
+								<span
+									class="flex h-5 w-5 items-center justify-center rounded-full bg-pill text-xs font-bold leading-none text-primary-inv"
+								>
+									{filterCount}
+								</span>
+							{/if}
+						</a>
+						<div class="hits pt-4 text-secondary md:pt-0" role="status" data-testid="result-info">
 							{#if numHits && numHits > 0}
 								{numHits.toLocaleString($page.data.locale)} träffar
 							{:else}
 								Inga träffar
 							{/if}
-						</p>
+						</div>
 						{#if numHits > 0}
-							<div class="flex flex-col items-baseline" data-testid="sort-select">
-								<label class="pl-1 text-secondary text-2-regular" for="search-sort"
-									>{$page.data.t('sort.sortBy')}</label
-								>
+							<div
+								class="sort-select flex flex-col items-baseline justify-self-end"
+								data-testid="sort-select"
+							>
+								<label class="pl-1 text-secondary text-2-regular" for="search-sort">
+									{$page.data.t('sort.sortBy')}
+								</label>
 								<select id="search-sort" form="main-search" on:change={handleSortChange}>
 									{#each sortOptions as option}
 										<option value={option.value} selected={option.value === sortOrder}
@@ -86,13 +109,13 @@
 							</div>
 						{/if}
 					</div>
-					<ol class="flex flex-col gap-2">
+					<ol class="flex flex-col gap-2 px-4">
 						{#each searchResult.items as item (item['@id'])}
 							<SearchCard {item} />
 						{/each}
 					</ol>
 					<Pagination data={searchResult} />
-				</section>
+				</div>
 			</div>
 		{/if}
 	{:catch error}
@@ -101,29 +124,70 @@
 {/if}
 
 <style lang="postcss">
-	.find {
-		@apply grid gap-4 py-4;
+	.toolbar {
+		grid-area: toolbar;
+		display: grid;
 		grid-template-areas:
-			'mapping'
-			'results';
+			'filter-modal-toggle sort-select'
+			'hits hits';
+	}
 
-		@media screen and (min-width: theme('screens.lg')) {
-			grid-template-areas:
-				'mapping mapping'
-				'facets results';
-			grid-template-columns: 320px 1fr;
+	.filters {
+		grid-area: filters;
+		display: none;
+	}
+
+	#filters {
+		&:target {
+			display: block; /* TODO: fix better no-JS fallback styling */
 		}
 	}
 
-	.mapping {
-		grid-area: mapping;
-	}
-
-	.facets {
-		grid-area: facets;
+	.mappings {
+		grid-area: mappings;
+		display: none;
 	}
 
 	.results {
 		grid-area: results;
+	}
+
+	.filter-toggle {
+		grid-area: filter-toggle;
+	}
+
+	.sort-select {
+		grid-area: sort-select;
+	}
+
+	.hits {
+		grid-area: hits;
+	}
+
+	@media screen and (min-width: theme('screens.md')) {
+		.find {
+			display: grid;
+			grid-template-columns: 320px 1fr;
+			grid-template-areas:
+				'toolbar toolbar'
+				'mappings mappings'
+				'filters results';
+		}
+
+		.filters {
+			display: block;
+		}
+
+		.mappings {
+			display: block;
+		}
+
+		.filter-modal-toggle {
+			display: none;
+		}
+
+		.toolbar {
+			grid-template-areas: 'hits sort-select';
+		}
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -46,7 +46,7 @@
 <slot />
 {#if $page.data.searchResult}
 	{#await $page.data.searchResult}
-		<p class="px-8">Laddar...</p>
+		<p class="px-8">{$page.data.t('search.loading')}</p>
 	{:then searchResult}
 		{#if searchResult}
 			{@const facets = searchResult.facetGroups}
@@ -58,7 +58,10 @@
 				</nav>
 				{#if showFiltersModal}
 					<Modal position="left" close={toggleFiltersModal}>
-						<span slot="title">Sökfilter ({filterCount} valda)</span>
+						<span slot="title">
+							{$page.data.t('search.filters')} ({numHits.toLocaleString($page.data.locale)}
+							{numHits == 1 ? $page.data.t('search.hitsOne') : $page.data.t('search.hits')})
+						</span>
 						<Filters {facets} />
 					</Modal>
 				{/if}
@@ -75,7 +78,7 @@
 							on:click|preventDefault={toggleFiltersModal}
 						>
 							<IconSliders width={20} height={20} />
-							<span>Sökfilter</span>
+							{$page.data.t('search.filters')}
 							{#if filterCount}
 								<span
 									class="flex h-5 w-5 items-center justify-center rounded-full bg-pill text-xs font-bold leading-none text-primary-inv"
@@ -88,7 +91,7 @@
 							{#if numHits && numHits > 0}
 								{numHits.toLocaleString($page.data.locale)} träffar
 							{:else}
-								Inga träffar
+								{$page.data.t('search.noResults')}
 							{/if}
 						</div>
 						{#if numHits > 0}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -38,10 +38,9 @@
 	}
 
 	function getFiltersCount(mapping: DisplayMapping[]) {
-		if (Array.isArray(mapping)) {
-			return mapping.find((mappingItem) => mappingItem?.children)?.children.length || 1;
-		}
-		return 0;
+		return (mapping[0].children || mapping).filter(
+			(filterItem) => !(filterItem.display === '*' && filterItem.operator === 'equals') // TODO: probably best to do wildcard-filtering in an earlier step (in search.ts)?
+		).length;
 	}
 </script>
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -62,11 +62,11 @@
 							{$page.data.t('search.filters')} ({numHits.toLocaleString($page.data.locale)}
 							{numHits == 1 ? $page.data.t('search.hitsOne') : $page.data.t('search.hits')})
 						</span>
-						<Filters {facets} />
+						<Filters {facets} mapping={searchResult.mapping} />
 					</Modal>
 				{/if}
 				<div class="filters" id="filters">
-					<Filters {facets} />
+					<Filters {facets} mapping={searchResult.mapping} />
 				</div>
 
 				<div class="results">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
@@ -4,6 +4,7 @@
 	import { type FacetGroup } from './search';
 	import BiChevronRight from '~icons/bi/chevron-right';
 	import BiChevronDown from '~icons/bi/chevron-down';
+	import { page } from '$app/stores';
 
 	export let group: FacetGroup;
 	export let locale: LocaleCode;
@@ -91,7 +92,7 @@
 			>
 		{/if}
 		{#if searchPhrase && filteredFacets.length === 0}
-			<span role="status" aria-atomic="true">Inget resultat</span>
+			<span role="status" aria-atomic="true">{$page.data.t('search.noResults')}</span>
 		{/if}
 	</div>
 </li>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
@@ -67,7 +67,7 @@
 			<!-- facet range inputs; hide in filter search results -->
 			<FacetRange search={group.search} />
 		{/if}
-		<ol class="max-h-437px mt-2 overflow-scroll" data-testid="facet-list">
+		<ol class="max-h-437px mt-2 overflow-auto" data-testid="facet-list">
 			{#each shownFacets as facet (facet.view['@id'])}
 				<li class="pl-6">
 					<a

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
@@ -27,7 +27,7 @@
 	$: canShowLessFacets = !canShowMoreFacets && filteredFacets.length > defaultFacetsShown;
 </script>
 
-<li class="my-4 border-b-[2px] border-primary pb-2" class:hidden={searchPhrase && !hasHits}>
+<li class="border-b border-primary first:border-t" class:hidden={searchPhrase && !hasHits}>
 	<button
 		id={'toggle-' + group.dimension}
 		type="button"
@@ -36,7 +36,7 @@
 		}}
 		aria-expanded={!!expanded}
 		aria-controls={'group-' + group.dimension}
-		class="w-full text-left font-bold"
+		class="min-h-11 w-full text-left font-bold"
 		data-testid="facet-toggle"
 	>
 		<span class="flex items-center gap-2">
@@ -59,11 +59,15 @@
 		id={'group-' + group.dimension}
 		aria-labelledby={'toggle-' + group.dimension}
 		class:hidden={!expanded}
+		class="mb-4"
 	>
 		<ol class="max-h-437px mt-2 overflow-scroll" data-testid="facet-list">
 			{#each shownFacets as facet (facet.view['@id'])}
-				<li>
-					<a class="flex justify-between no-underline" href={relativizeUrl(facet.view['@id'])}>
+				<li class="pl-6">
+					<a
+						class="flex items-center justify-between no-underline"
+						href={relativizeUrl(facet.view['@id'])}
+					>
 						<span class="flex items-baseline">
 							{#if 'selected' in facet}
 								<!-- howto A11y?! -->
@@ -72,14 +76,14 @@
 							{/if}
 							<span>{facet.str}</span>
 						</span>
-						<span>({facet.totalItems.toLocaleString(locale)})</span>
+						<span class="text-sm text-secondary">({facet.totalItems.toLocaleString(locale)})</span>
 					</a>
 				</li>
 			{/each}
 		</ol>
 		{#if canShowMoreFacets || canShowLessFacets}
 			<button
-				class="my-2"
+				class="mt-4 pl-6"
 				on:click={() =>
 					canShowMoreFacets ? (facetsShown = numfacets) : (facetsShown = defaultFacetsShown)}
 			>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/Filters.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/Filters.svelte
@@ -2,10 +2,11 @@
 	import { page } from '$app/stores';
 	import { getModalContext } from '$lib/contexts/modal';
 	import FacetGroup from './FacetGroup.svelte';
-	import type { FacetGroup as TypedFacetGroup } from './search';
+	import type { DisplayMapping, FacetGroup as TypedFacetGroup } from './search';
 	import SearchMapping from './SearchMapping.svelte';
 
 	export let facets: TypedFacetGroup[];
+	export let mapping: DisplayMapping[];
 
 	const inModal = getModalContext();
 
@@ -16,7 +17,7 @@
 	{#if facets?.length}
 		{#if inModal}
 			<nav class="px-4" aria-label="Valda filter">
-				<SearchMapping mapping={$page.data.searchResult.mapping} />
+				<SearchMapping {mapping} />
 			</nav>
 		{/if}
 		{#if facets?.length}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/Filters.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/Filters.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { getModalContext } from '$lib/contexts/modal';
+	import FacetGroup from './FacetGroup.svelte';
+	import type { FacetGroup as TypedFacetGroup } from './search';
+	import SearchMapping from './SearchMapping.svelte';
+
+	export let facets: TypedFacetGroup[];
+
+	const inModal = getModalContext();
+
+	let searchPhrase = '';
+</script>
+
+<div class="flex flex-col gap-4">
+	{#if facets?.length}
+		{#if inModal}
+			<nav class="px-4" aria-label="Valda filter">
+				<SearchMapping mapping={$page.data.searchResult.mapping} />
+			</nav>
+		{/if}
+		{#if facets?.length}
+			<nav class="flex flex-col gap-4 px-4">
+				<input
+					bind:value={searchPhrase}
+					placeholder={$page.data.t('search.findFilter')}
+					title={$page.data.t('search.findFilter')}
+					class="w-full"
+					type="search"
+				/>
+				<ol>
+					{#each facets as group (group.dimension)}
+						<FacetGroup {group} locale={$page.data.locale} {searchPhrase} />
+					{/each}
+				</ol>
+			</nav>
+		{/if}
+	{/if}
+</div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/stores';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
+	import { getModalContext } from '$lib/contexts/modal';
 	import type { DisplayMapping, SearchOperators } from './search';
 	import BiXLg from '~icons/bi/x-lg';
 	import BiPencil from '~icons/bi/pencil';
@@ -9,6 +10,8 @@
 	export let mapping: DisplayMapping[];
 	export let parentOperator: keyof typeof SearchOperators | undefined = undefined;
 	export let depth = 0;
+
+	const inModal = getModalContext();
 
 	$: showEditButton =
 		$page.url.pathname === `${$page.data.base}find` &&
@@ -83,7 +86,7 @@
 			</li>
 		{/if}
 	{/each}
-	{#if showEditButton && depth === 0}
+	{#if !inModal && showEditButton && depth === 0}
 		<li>
 			<a
 				class="ghost-btn"

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -135,7 +135,7 @@
 	}
 
 	.pill-group {
-		@apply flex items-center gap-2 bg-pill/8 p-0 pr-4;
+		@apply flex items-center gap-2 bg-pill/8 p-0;
 
 		&.outer {
 			@apply bg-transparent;

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -81,7 +81,7 @@
 			<li class="pill-remove">
 				<a class="ghost-btn" href={m.up?.['@id']}>
 					<BiTrash class="text-icon" />
-					<span>Rensa</span>
+					{$page.data.t('search.clearFilters')}
 				</a>
 			</li>
 		{/if}
@@ -95,7 +95,7 @@
 				href={toggleEditUrl}
 			>
 				<BiPencil class="text-icon" />
-				<span>Redigera</span>
+				{$page.data.t('search.editFilters')}
 			</a>
 		</li>
 	{/if}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -151,17 +151,4 @@
 	.pill-between:last-of-type {
 		@apply hidden;
 	}
-	.pill-remove {
-	}
-
-	/* TODO - move to button component/ghost */
-	.ghost-btn {
-		@apply flex items-center gap-2 rounded-md bg-main px-4 py-2 text-secondary no-underline outline outline-2 -outline-offset-2 outline-[#52331429] brightness-100 text-3-cond-bold;
-		transition: filter 0.1s ease;
-
-		&:hover,
-		&.active {
-			@apply brightness-95;
-		}
-	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
@@ -63,7 +63,7 @@ export interface FacetGroup {
 	facets: (Facet | MultiSelectFacet)[];
 }
 
-interface Facet {
+export interface Facet {
 	totalItems: number;
 	view: Link;
 	object: DisplayDecorated;
@@ -132,7 +132,7 @@ export enum SearchOperators {
 
 type MappingObj = { [key in SearchOperators]: SearchMapping[] | string | FramedData };
 
-interface SearchMapping extends MappingObj {
+export interface SearchMapping extends MappingObj {
 	alias: string;
 	property?: ObjectProperty | DatatypeProperty | PropertyChainAxiom;
 	up: { '@id': string };

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -158,6 +158,14 @@ export default {
 				// other utility classes
 				'.gradient-primary': {
 					'@apply bg-gradient-to-b from-[#7B4C1E] to-[#674019]': {}
+				},
+				'.icon-button': {
+					'@apply w-11 h-11 flex items-center justify-center rounded-full hover:bg-cards focus:bg-cards transition-colors relative':
+						{}
+				},
+				'.ghost-btn': {
+					'@apply flex items-center gap-2 rounded-md bg-main px-4 py-2 text-secondary no-underline outline outline-2 -outline-offset-2 outline-[#52331429] brightness-100 text-3-cond-bold hover:brightness-95 active:brightness-95':
+						{}
 				}
 			});
 		}


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-123](https://jira.kb.se/browse/LWS-123)

### Solves

Adds support for showing and selecting filters on smaller screens.

TODO:
- Shallow routing / usage of `pushState` so back navigation closes the modal after opening it. This however opens a can of worms regarding what should happen when multiple filters are applied before closing the modal. We need to discuss this before implementing it.
- Horizontal scrolling of selected filters? The selected filters should probably not be wrapped as the screen real estate is really limited on mobiles. Figma sketches to discuss around would be good here.
- A _"Show X results"_ button (placed at the bottom of the modal?)
- Better no-js fallback styling (with added close button using an anchor link).
- The `+layout.svelte` has grown quite alot lately so we should probably separate the search functionality into a component, which can be reused instead. The same also applies to `+layout.server.ts` which has become a little bit unwieldy.
 
### Summary of changes

- Add support for choosing modal position
- Localize strings
- Add utility class for `ghost-btn`
