### PR TITLE
LWS-119: Responsive search card

### DIFF
--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -241,7 +241,7 @@
 	}
 
 	.remainder {
-		@apply ml-2 rounded-full bg-pill/8 px-2 py-1 text-secondary;
+		@apply ml-2 whitespace-nowrap rounded-full bg-pill/8 px-2 py-0.5 text-secondary;
 	}
 
 	.block {

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -52,7 +52,8 @@ export default {
 		hits: 'hits',
 		hitsOne: 'hit',
 		selected: 'selected',
-		selectedOne: 'selected'
+		selectedOne: 'selected',
+		editions: 'editions'
 	},
 	sort: {
 		sortBy: 'Sort by',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -51,7 +51,8 @@ export default {
 		hits: 'träffar',
 		hitsOne: 'träff',
 		selected: 'valda',
-		selectedOne: 'vald'
+		selectedOne: 'vald',
+		editions: 'utgåvor'
 	},
 	sort: {
 		sortBy: 'Sortera efter',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -113,7 +113,7 @@
 							</div>
 						{/if}
 					</div>
-					<ol class="flex flex-col gap-2 px-4">
+					<ol class="flex flex-col gap-2 md:px-4">
 						{#each searchResult.items as item (item['@id'])}
 							<SearchCard {item} />
 						{/each}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -42,7 +42,7 @@
 </script>
 
 <li
-	class="flex gap-4 rounded-md border-b border-b-primary/16 bg-cards p-4 sm:gap-8 sm:p-6"
+	class="flex gap-4 border-b border-b-primary/16 bg-cards p-4 sm:gap-8 md:rounded-md md:p-6"
 	data-testid="search-card"
 >
 	<a href={relativizeUrl(item['@id'])}>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -42,11 +42,11 @@
 </script>
 
 <li
-	class="flex gap-8 rounded-md border-b border-b-primary/16 bg-cards p-6"
+	class="flex gap-4 rounded-md border-b border-b-primary/16 bg-cards p-4 sm:gap-8 sm:p-6"
 	data-testid="search-card"
 >
 	<a href={relativizeUrl(item['@id'])}>
-		<div class="relative flex h-full max-h-28 w-full max-w-20">
+		<div class="relative flex h-full max-h-32 w-full max-w-20">
 			{#if item.imageUri}
 				<img
 					src={item.imageUri}
@@ -66,7 +66,6 @@
 			{:else}
 				<div class="flex items-center justify-center">
 					<img src={placeholder} alt="" class="h-20 w-20 rounded-sm object-cover" />
-
 					{#if getTypeIcon(item['@type'])}
 						<svelte:component
 							this={getTypeIcon(item['@type'])}
@@ -78,35 +77,41 @@
 		</div>
 	</a>
 
-	<div class="flex flex-1 flex-col gap-2">
+	<div class="flex flex-1 flex-col gap-1 sm:gap-2">
 		<a
 			href={relativizeUrl(item['@id'])}
-			class="search-card-heading line-clamp-2 text-ellipsis no-underline text-4-regular"
+			class="search-card-heading line-clamp-1 text-ellipsis no-underline text-4-regular sm:line-clamp-2"
 			data-testid="search-card-heading"
 			><h2>
 				<DecoratedData data={item['card-heading']} showLabels={ShowLabelsOptions.Never} />
 			</h2></a
 		>
-		<div class="search-card-body flex items-baseline gap-2">
+		<div class="search-card-body flex flex-col items-baseline gap-1 sm:flex-row sm:gap-2">
 			{#each item['card-body']?._display as obj}
-				<div class="rounded-md bg-pill/4 p-2">
-					{#if 'hasInstance' in obj}
-						{@const instances = getInstanceData(obj.hasInstance)}
-						{#if instances}
+				{#if 'hasInstance' in obj}
+					{@const instances = getInstanceData(obj.hasInstance)}
+					{#if instances?.years}
+						<div
+							class="search-card-prop line-clamp-1 sm:line-clamp-2 sm:rounded-md sm:bg-pill/4 sm:p-2"
+						>
 							<span>
 								{#if instances.count > 1}
 									{instances?.count}
-									{instances.count > 1 ? 'utgåvor' : 'utgåva'}
-									{instances?.years && `(${instances.years})`}
+									{$page.data.t('search.editions')}
+									{`(${instances.years})`}
 								{:else}
-									{instances?.years && `${instances.years}`}
+									{instances.years}
 								{/if}
 							</span>
-						{/if}
-					{:else}
-						<DecoratedData data={obj} showLabels={ShowLabelsOptions.Never} block truncate />
+						</div>
 					{/if}
-				</div>
+				{:else}
+					<div
+						class="search-card-prop line-clamp-1 sm:line-clamp-2 sm:rounded-md sm:bg-pill/4 sm:p-2"
+					>
+						<DecoratedData data={obj} showLabels={ShowLabelsOptions.Never} block truncate />
+					</div>
+				{/if}
 			{/each}
 		</div>
 	</div>
@@ -132,5 +137,10 @@
 		:global([data-property='agent'] ._contentBefore) {
 			@apply inline;
 		}
+	}
+
+	/* Hide lang on small screens */
+	.search-card-prop:has([data-property='language']) {
+		@apply hidden sm:inline;
 	}
 </style>


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-154](https://kbse.atlassian.net/browse/LWS-154)

### Solves

Search cards for smaller screens

### Summary of changes

Did not exhaust myself in reworking this, since I have a feeling search cards will be redesigned again sometime soon. But at least it looks ok now in mobile imo. 

* Under `sm`: Removed 'language' field, no 'pill' styling, tighter gaps; as in design
* I am however allowing contributor & years to have one row each (then line-clamped), I don't think it's possible to fit the card body into one single row.


* Fixed the empty 'ghost' bubbles that appear on cards (instances but no years)
* Added translations
