### PR TITLE
Use thumbnails

### DIFF
--- a/lxl-web/src/lib/components/ResourceImage.svelte
+++ b/lxl-web/src/lib/components/ResourceImage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { type Image, Widths } from '$lib/utils/auxd.types';
+	import { type Image, Width } from '$lib/utils/auxd.types';
 	import placeholder from '$lib/assets/img/placeholder.svg';
 	import getTypeIcon from '$lib/utils/getTypeIcon';
 	import { bestSize } from '$lib/utils/auxd';
@@ -9,14 +9,14 @@
 	export let alt: string | undefined;
 	export let linkToFull = false;
 	export let type = '';
-	export let thumbnailTargetWidth: number = Widths.SMALL;
+	export let thumbnailTargetWidth: number = Width.SMALL;
 	export let showPlaceholder = true;
 	export let loading: 'eager' | 'lazy' = 'eager';
 
 	$: image = first(images);
 
 	$: thumb = bestSize(image, thumbnailTargetWidth);
-	$: full = bestSize(image, Widths.FULL);
+	$: full = bestSize(image, Width.FULL);
 </script>
 
 {#if image}

--- a/lxl-web/src/lib/components/ResourceImage.svelte
+++ b/lxl-web/src/lib/components/ResourceImage.svelte
@@ -1,29 +1,47 @@
 <script lang="ts">
-	import { page } from '$app/stores';
-	import { getResourceId } from '$lib/utils/resourceData';
-	import type { ResourceData } from '$lib/types/ResourceData';
+	import { type Image, Widths } from '$lib/utils/auxd.types';
 	import placeholder from '$lib/assets/img/placeholder.svg';
 	import getTypeIcon from '$lib/utils/getTypeIcon';
+	import { bestSize } from '$lib/utils/auxd';
+	import { first } from '$lib/utils/xl';
 
-	export let resource: ResourceData;
+	export let images: Image[];
 	export let alt: string | undefined;
 	export let linkToFull = false;
 	export let type = '';
+	export let thumbnailTargetWidth: number = Widths.SMALL;
+	export let showPlaceholder = true;
+	export let loading: 'eager' | 'lazy' = 'eager';
 
-	$: src = $page.data.images.find(
-		(uri) => uri.recordId?.replace(/#it/g, '') === getResourceId(resource)
-	)?.imageUri;
+	$: image = first(images);
+
+	$: thumb = bestSize(image, thumbnailTargetWidth);
+	$: full = bestSize(image, Widths.FULL);
 </script>
 
-{#if src}
+{#if image}
 	{#if linkToFull}
-		<a href={src} target="_blank" class="contents">
-			<img {alt} {src} class="object-contain object-center" />
+		<a href={full.url} target="_blank" class="contents">
+			<img
+				{alt}
+				{loading}
+				src={thumb.url}
+				width={thumb.widthṔx}
+				height={thumb.heightPx}
+				class="object-contain object-center"
+			/>
 		</a>
 	{:else}
-		<img {alt} {src} class="object-contain object-center" />
+		<img
+			{alt}
+			{loading}
+			src={thumb.url}
+			width={thumb.widthṔx}
+			height={thumb.heightPx}
+			class="object-contain object-center"
+		/>
 	{/if}
-{:else}
+{:else if showPlaceholder}
 	<div class="flex items-center justify-center">
 		<img src={placeholder} alt="" class="h-20 w-20 rounded-sm object-cover" />
 		{#if getTypeIcon(type)}

--- a/lxl-web/src/lib/utils/auxd.types.ts
+++ b/lxl-web/src/lib/utils/auxd.types.ts
@@ -1,0 +1,46 @@
+import { isObject, JsonLd, type Link, Owl } from '$lib/utils/xl';
+
+type SizePx = `${number}px`;
+
+type AuxdUrl = string;
+
+export interface KbvImageObject {
+	[JsonLd.ID]?: string;
+	[Owl.SAME_AS]?: Link[];
+	width?: SizePx;
+	height?: SizePx;
+	thumbnail?: KbvImageObject[];
+}
+
+export enum Widths {
+	SMALL = 128,
+	MEDIUM = 256,
+	FULL = 99999
+}
+
+export interface ImageResolution {
+	url: string;
+	widthṔx: number;
+	heightPx: number;
+}
+
+export interface AuthImageResolution extends ImageResolution {
+	url: AuxdUrl;
+}
+
+export interface Image {
+	sizes: ImageResolution[]; // always ordered smallest to largest
+	recordId: string;
+}
+
+export interface AuthImage extends Image {
+	sizes: AuthImageResolution[];
+}
+
+export function isImage(v: unknown): v is Image {
+	return isObject(v) && 'sizes' in v && 'recordId' in v;
+}
+
+export function isImageResolution(v: unknown): v is ImageResolution {
+	return isObject(v) && 'url' in v && 'widthṔx' in v && 'heightPx' in v;
+}

--- a/lxl-web/src/lib/utils/auxd.types.ts
+++ b/lxl-web/src/lib/utils/auxd.types.ts
@@ -12,7 +12,7 @@ export interface KbvImageObject {
 	thumbnail?: KbvImageObject[];
 }
 
-export enum Widths {
+export enum Width {
 	SMALL = 128,
 	MEDIUM = 256,
 	FULL = 99999

--- a/lxl-web/src/lib/utils/auxd.types.ts
+++ b/lxl-web/src/lib/utils/auxd.types.ts
@@ -2,7 +2,7 @@ import { isObject, JsonLd, type Link, Owl } from '$lib/utils/xl';
 
 type SizePx = `${number}px`;
 
-type AuxdUrl = string;
+type SecureLink = string;
 
 export interface KbvImageObject {
 	[JsonLd.ID]?: string;
@@ -24,8 +24,8 @@ export interface ImageResolution {
 	heightPx: number;
 }
 
-export interface AuthImageResolution extends ImageResolution {
-	url: AuxdUrl;
+export interface SecureImageResolution extends ImageResolution {
+	url: SecureLink;
 }
 
 export interface Image {
@@ -33,8 +33,8 @@ export interface Image {
 	recordId: string;
 }
 
-export interface AuthImage extends Image {
-	sizes: AuthImageResolution[];
+export interface SecureImage extends Image {
+	sizes: SecureImageResolution[];
 }
 
 export function isImage(v: unknown): v is Image {

--- a/lxl-web/src/lib/utils/http.ts
+++ b/lxl-web/src/lib/utils/http.ts
@@ -12,3 +12,10 @@ export function relativizeUrl(url: string | undefined) {
 	}
 	return url.split('/').slice(3).join('');
 }
+
+export function stripAnchor(url: string | undefined) {
+	if (!url) {
+		return url;
+	}
+	return url.split('#')[0];
+}

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -19,6 +19,10 @@ export enum JsonLd {
 	VOCAB = '@vocab'
 }
 
+export enum Owl {
+	SAME_AS = 'sameAs'
+}
+
 enum Fmt {
 	DISPLAY = '_display',
 	PROPS = '_props',
@@ -1014,6 +1018,10 @@ function asArray<V>(v: V | Array<V>): Array<V> | [] {
 
 function unwrapSingle(v: unknown) {
 	return Array.isArray(v) ? (v.length == 1 ? v[0] : v) : v;
+}
+
+export function first<V>(v: Array<V>): V | undefined {
+	return Array.isArray(v) ? (v.length > 0 ? v[0] : undefined) : undefined;
 }
 
 function mapMaybeArray(v, fn) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -6,7 +6,7 @@ import { getSupportedLocale } from '$lib/i18n/locales.js';
 import { type FramedData, DisplayUtil, pickProperty, toString, JsonLd } from '$lib/utils/xl.js';
 import { LxlLens } from '$lib/utils/display.types.js';
 import { relativizeUrl } from '$lib/utils/http';
-import { calculateExpirationTime, generateAuxdImageUri, getImageLinks } from '$lib/utils/auxd';
+import { getImages, auxdAuth } from '$lib/utils/auxd';
 import addDefaultSearchParams from '$lib/utils/addDefaultSearchParams.js';
 import getSortedSearchParams from '$lib/utils/getSortedSearchParams.js';
 import { type apiError } from '$lib/types/API.js';
@@ -50,7 +50,7 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 
 		shouldFindRelations = instances.length <= 1;
 
-		const images = getImageUris(getImageLinks(mainEntity));
+		const images = getImages(mainEntity).map((i) => auxdAuth(i, env.AUXD_SECRET));
 		const holdingsByInstanceId = getHoldingsByInstanceId(mainEntity);
 		const holdingsByType = getHoldingsByType(mainEntity);
 		const holdersByType = Object.entries(holdingsByType).reduce((acc, [type, holdings]) => {
@@ -167,21 +167,6 @@ function getSortedInstances(instances: Record<string, unknown>[]) {
 		}
 		return yearB - yearA;
 	});
-}
-
-function getImageUris(imageLinks: { recordId: string; imageLink: string }[]) {
-	return imageLinks
-		.map((idAndLink) => {
-			return {
-				recordId: idAndLink.recordId,
-				imageUri: generateAuxdImageUri(
-					calculateExpirationTime(),
-					idAndLink.imageLink,
-					env.AUXD_SECRET
-				)
-			};
-		})
-		.filter((image) => image.imageUri !== '');
 }
 
 function sortHoldings(holdings) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -6,7 +6,7 @@ import { getSupportedLocale } from '$lib/i18n/locales.js';
 import { type FramedData, DisplayUtil, pickProperty, toString, JsonLd } from '$lib/utils/xl.js';
 import { LxlLens } from '$lib/utils/display.types.js';
 import { relativizeUrl } from '$lib/utils/http';
-import { getImages, auxdAuth } from '$lib/utils/auxd';
+import { getImages, toSecure } from '$lib/utils/auxd';
 import addDefaultSearchParams from '$lib/utils/addDefaultSearchParams.js';
 import getSortedSearchParams from '$lib/utils/getSortedSearchParams.js';
 import { type apiError } from '$lib/types/API.js';
@@ -50,7 +50,7 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 
 		shouldFindRelations = instances.length <= 1;
 
-		const images = getImages(mainEntity).map((i) => auxdAuth(i, env.AUXD_SECRET));
+		const images = getImages(mainEntity).map((i) => toSecure(i, env.AUXD_SECRET));
 		const holdingsByInstanceId = getHoldingsByInstanceId(mainEntity);
 		const holdingsByType = getHoldingsByType(mainEntity);
 		const holdersByType = Object.entries(holdingsByType).reduce((acc, [type, holdings]) => {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -7,15 +7,9 @@
 	import { page } from '$app/stores';
 	import placeholder from '$lib/assets/img/placeholder.svg';
 	import getTypeIcon from '$lib/utils/getTypeIcon';
-	import type { AuthImageResolution } from '$lib/utils/auxd.types';
+	import type { SearchResultItem } from './search';
 
-	export let item: {
-		'@id': string;
-		'@type': string;
-		'card-heading': ResourceData;
-		'card-body': ResourceData;
-		image: AuthImageResolution | undefined;
-	};
+	export let item: SearchResultItem;
 
 	function getInstanceData(instances: ResourceData) {
 		if (typeof instances === 'object') {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -7,14 +7,16 @@
 	import { page } from '$app/stores';
 	import placeholder from '$lib/assets/img/placeholder.svg';
 	import getTypeIcon from '$lib/utils/getTypeIcon';
+	import type { AuthImageResolution } from '$lib/utils/auxd';
 
 	export let item: {
 		'@id': string;
 		'@type': string;
 		'card-heading': ResourceData;
 		'card-body': ResourceData;
-		imageUri: string;
+		image: AuthImageResolution | undefined;
 	};
+
 	function getInstanceData(instances: ResourceData) {
 		if (typeof instances === 'object') {
 			let years: string = '';
@@ -47,9 +49,11 @@
 >
 	<a href={relativizeUrl(item['@id'])}>
 		<div class="relative flex h-full max-h-32 w-full max-w-20">
-			{#if item.imageUri}
+			{#if item.image}
 				<img
-					src={item.imageUri}
+					src={item.image.url}
+					width={item.image.widthṔx}
+					height={item.image.heightPx}
 					alt={$page.data.t('general.latestInstanceCover')}
 					class="h-auto w-full rounded-sm object-cover object-top"
 				/>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -7,7 +7,7 @@
 	import { page } from '$app/stores';
 	import placeholder from '$lib/assets/img/placeholder.svg';
 	import getTypeIcon from '$lib/utils/getTypeIcon';
-	import type { AuthImageResolution } from '$lib/utils/auxd';
+	import type { AuthImageResolution } from '$lib/utils/auxd.types';
 
 	export let item: {
 		'@id': string;

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -11,7 +11,7 @@
 	import ResourceImage from '$lib/components/ResourceImage.svelte';
 	import { getHoldingsLink, handleClickHoldings } from './utils';
 	import { getSelectedHolding } from './utils';
-	import { Widths } from '$lib/utils/auxd.types';
+	import { Width } from '$lib/utils/auxd.types';
 
 	export let data;
 
@@ -89,7 +89,7 @@
 					<ResourceImage
 						images={data.images}
 						alt={data.t('general.latestInstanceCover')}
-						thumbnailTargetWidth={Widths.MEDIUM}
+						thumbnailTargetWidth={Width.MEDIUM}
 						linkToFull
 					/>
 				</div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -11,6 +11,7 @@
 	import ResourceImage from '$lib/components/ResourceImage.svelte';
 	import { getHoldingsLink, handleClickHoldings } from './utils';
 	import { getSelectedHolding } from './utils';
+	import { Widths } from '$lib/utils/auxd.types';
 
 	export let data;
 
@@ -86,10 +87,9 @@
 			{#if data.images.length}
 				<div class="flex h-full max-h-72 w-full max-w-72 justify-center self-center md:self-start">
 					<ResourceImage
-						resource={data.instances.find((instanceItem) =>
-							data.images.find((imageItem) => imageItem.recordId.includes(instanceItem['@id']))
-						)}
+						images={data.images}
 						alt={data.t('general.latestInstanceCover')}
+						thumbnailTargetWidth={Widths.MEDIUM}
 						linkToFull
 					/>
 				</div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/InstancesList.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/InstancesList.svelte
@@ -153,9 +153,10 @@
 							<div class="flex flex-col gap-4 text-sm">
 								<div class="flex h-full max-h-32 w-full max-w-32">
 									<ResourceImage
-										resource={item}
+										images={$page.data.images.filter((i) => i.recordId === id)}
 										alt={$page.data.t('general.instanceCover')}
 										type={$page.data.type}
+										loading="lazy"
 										linkToFull
 									/>
 								</div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
@@ -11,7 +11,8 @@ import {
 import { LxlLens } from '$lib/utils/display.types';
 import { type translateFn, getTranslator } from '$lib/i18n';
 import { type LocaleCode as LangCode } from '$lib/i18n/locales';
-import { calculateExpirationTime, generateAuxdImageUri, getFirstImageLink } from '$lib/utils/auxd';
+import { bestImage, bestSize, auxdAuth } from '$lib/utils/auxd';
+import { Widths } from '$lib/utils/auxd.types';
 
 export async function asResult(
 	view: PartialCollectionView,
@@ -31,11 +32,11 @@ export async function asResult(
 		first: replacePath(view.first, usePath),
 		last: replacePath(view.last, usePath),
 		items: view.items.map((i) => ({
-			[JsonLd.ID]: i.meta[JsonLd.ID],
-			[JsonLd.TYPE]: i[JsonLd.TYPE],
+			[JsonLd.ID]: i.meta[JsonLd.ID] as string,
+			[JsonLd.TYPE]: i[JsonLd.TYPE] as string,
 			[LxlLens.CardHeading]: displayUtil.lensAndFormat(i, LxlLens.CardHeading, locale),
 			[LxlLens.CardBody]: displayUtil.lensAndFormat(i, LxlLens.CardBody, locale),
-			imageUri: generateAuxdImageUri(calculateExpirationTime(), getFirstImageLink(i), auxdSecret)
+			image: auxdAuth(bestSize(bestImage(i), Widths.SMALL), auxdSecret)
 		})),
 		facetGroups: displayFacetGroups(view, displayUtil, locale, translate, usePath)
 	};
@@ -50,8 +51,16 @@ export interface SearchResult {
 	first: Link;
 	last: Link;
 	next?: Link;
-	items: DisplayDecorated[];
+	items: SearchResultItem[];
 	facetGroups: FacetGroup[];
+}
+
+export interface SearchResultItem {
+	[JsonLd.ID]: string;
+	[JsonLd.TYPE]: string;
+	[LxlLens.CardHeading]: DisplayDecorated;
+	[LxlLens.CardBody]: DisplayDecorated;
+	image: AuthImageResolution | undefined;
 }
 
 type FacetGroupId = string;

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
@@ -12,7 +12,7 @@ import { LxlLens } from '$lib/utils/display.types';
 import { type translateFn, getTranslator } from '$lib/i18n';
 import { type LocaleCode as LangCode } from '$lib/i18n/locales';
 import { bestImage, bestSize, auxdAuth } from '$lib/utils/auxd';
-import { Widths } from '$lib/utils/auxd.types';
+import { Width } from '$lib/utils/auxd.types';
 
 export async function asResult(
 	view: PartialCollectionView,
@@ -36,7 +36,7 @@ export async function asResult(
 			[JsonLd.TYPE]: i[JsonLd.TYPE] as string,
 			[LxlLens.CardHeading]: displayUtil.lensAndFormat(i, LxlLens.CardHeading, locale),
 			[LxlLens.CardBody]: displayUtil.lensAndFormat(i, LxlLens.CardBody, locale),
-			image: auxdAuth(bestSize(bestImage(i), Widths.SMALL), auxdSecret)
+			image: auxdAuth(bestSize(bestImage(i), Width.SMALL), auxdSecret)
 		})),
 		facetGroups: displayFacetGroups(view, displayUtil, locale, translate, usePath)
 	};

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
@@ -11,7 +11,7 @@ import {
 import { LxlLens } from '$lib/utils/display.types';
 import { type translateFn, getTranslator } from '$lib/i18n';
 import { type LocaleCode as LangCode } from '$lib/i18n/locales';
-import { bestImage, bestSize, auxdAuth } from '$lib/utils/auxd';
+import { bestImage, bestSize, toSecure } from '$lib/utils/auxd';
 import { Width } from '$lib/utils/auxd.types';
 
 export async function asResult(
@@ -36,7 +36,7 @@ export async function asResult(
 			[JsonLd.TYPE]: i[JsonLd.TYPE] as string,
 			[LxlLens.CardHeading]: displayUtil.lensAndFormat(i, LxlLens.CardHeading, locale),
 			[LxlLens.CardBody]: displayUtil.lensAndFormat(i, LxlLens.CardBody, locale),
-			image: auxdAuth(bestSize(bestImage(i), Width.SMALL), auxdSecret)
+			image: toSecure(bestSize(bestImage(i), Width.SMALL), auxdSecret)
 		})),
 		facetGroups: displayFacetGroups(view, displayUtil, locale, translate, usePath)
 	};


### PR DESCRIPTION
## Description
Use thumbnails (128, 256px wide) in search results and on resource page.

### Tickets involved
[LWS-72](https://jira.kb.se/browse/LWS-72)

### Summary of changes
* Use thumbnail images
* Data structure `Image` for passing around image information (can be extended with license information etc.)
* Pass image to use to `ResourceImage` instead of it digging it out from the page data.
* Let `ResourceImage` take multiple images but only display one so far.
* lazy load instance thumbnails

TODO
* Use `ResourceImage` in `SearchCard`?