### PR TITLE
Fix filter pill space in Firefox

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchMapping.svelte
@@ -57,10 +57,10 @@
 			{:else if m.operator === 'existence' || m.operator === 'notExistence'}
 				{@const symbol = getRelationSymbol(m.operator)}
 				<span class="pill-relation">{symbol}</span>
-				<div class="pill-label inline-block text-2-regular first-letter:uppercase">{m.label}</div>
+				<div class="pill-label inline text-2-regular first-letter:uppercase">{m.label}</div>
 			{:else if 'label' in m && 'display' in m}
 				{@const symbol = getRelationSymbol(m.operator)}
-				<div class="pill-label inline-block text-2-regular first-letter:uppercase">{m.label}</div>
+				<div class="pill-label inline text-2-regular first-letter:uppercase">{m.label}</div>
 				<span class="pill-relation">{symbol}</span>
 				<span class="pill-value">
 					<DecoratedData data={m.display} showLabels={ShowLabelsOptions['Never']} />


### PR DESCRIPTION
### Solves

Using `inline` instead of `inline-block` for the labels seems to remove the weird filter pill space in Firefox. Can anyone confirm?