### PR TITLE
LWS-171: Fix label visibility

### DIFF
--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -14,6 +14,9 @@
 	export let block = false;
 	export let truncate = false;
 	export let remainder: ResourceData | undefined = undefined;
+	export let keyed = true;
+
+	$: key = keyed && data; // an ugly work-around to fix duplicate content on out transitions when closing modals (not entirely sure what is the root cause...)
 
 	const hiddenProperties = [
 		'@context',
@@ -120,7 +123,7 @@
   @component
 	Component used for rendering decorated data.
 -->
-{#key data}
+{#key key}
 	{#if data && typeof data === 'object'}
 		{#if Array.isArray(data)}
 			{#if truncate && depth === 1 && data.length > 1}
@@ -134,6 +137,7 @@
 					{allowPopovers}
 					truncate={false}
 					{remainder}
+					{keyed}
 				/>
 			{:else}
 				{#each data as arrayItem}
@@ -144,6 +148,7 @@
 						{block}
 						{allowPopovers}
 						{truncate}
+						{keyed}
 					/>
 				{/each}
 			{/if}
@@ -169,6 +174,7 @@
 						{block}
 						{allowPopovers}
 						{truncate}
+						{keyed}
 					/>
 					{#if remainder && Array.isArray(remainder)}
 						<span
@@ -178,7 +184,14 @@
 					{/if}
 				</svelte:element>
 			{:else if data['@value']}
-				<svelte:self data={data['@value']} depth={depth + 1} {showLabels} {block} {allowPopovers} />
+				<svelte:self
+					data={data['@value']}
+					depth={depth + 1}
+					{showLabels}
+					{block}
+					{allowPopovers}
+					{keyed}
+				/>
 			{:else if data['_display']}
 				<svelte:self
 					data={data['_display']}
@@ -187,6 +200,7 @@
 					{block}
 					{allowPopovers}
 					{truncate}
+					{keyed}
 				/>
 			{:else}
 				{@const [propertyName, propertyData] = getProperty(data)}
@@ -204,6 +218,7 @@
 							{block}
 							{allowPopovers}
 							{truncate}
+							{keyed}
 						/>
 					</svelte:element>
 				{/if}

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -13,7 +13,6 @@
 	export let allowPopovers = true; // used for preventing nested popovers
 	export let block = false;
 	export let truncate = false;
-	export let key: ResourceData | string = data;
 	export let remainder: ResourceData | undefined = undefined;
 
 	const hiddenProperties = [
@@ -121,7 +120,7 @@
   @component
 	Component used for rendering decorated data.
 -->
-{#key key}
+{#key data}
 	{#if data && typeof data === 'object'}
 		{#if Array.isArray(data)}
 			{#if truncate && depth === 1 && data.length > 1}

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -16,7 +16,7 @@
 	export let remainder: ResourceData | undefined = undefined;
 	export let keyed = true;
 
-	$: key = keyed && data; // an ugly work-around to fix duplicate content on out transitions when closing modals (not entirely sure what is the root cause...)
+	$: key = keyed && data; // an ugly work-around to fix duplicate content on out transitions when closing modals (not entirely sure what the root cause is...) – we should try to remove the need for this when updating to Svelte 5.
 
 	const hiddenProperties = [
 		'@context',

--- a/lxl-web/src/lib/components/Modal.svelte
+++ b/lxl-web/src/lib/components/Modal.svelte
@@ -67,6 +67,7 @@
 	on:click|self={handleBackdropClick}
 	on:close={handleClose}
 	bind:this={dialog}
+	data-testid="modal"
 	transition:fly={{
 		x: position === 'left' ? -12 : 12,
 		duration: 250,

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -73,6 +73,7 @@
 							<a
 								href={getHoldingsLink($page.url, type)}
 								data-sveltekit-preload-data="false"
+								data-testid="holding-link"
 								on:click={(event) => handleClickHoldings(event, $page.state, type)}
 							>
 								{localizedInstanceTypes[type]}
@@ -121,7 +122,7 @@
 						</div>
 					{/if}
 					<div class="overview">
-						<DecoratedData data={selectedHoldingInstance} block />
+						<DecoratedData data={selectedHoldingInstance} block keyed={false} />
 					</div>
 				</div>
 				<div>

--- a/lxl-web/tests/resource.spec.ts
+++ b/lxl-web/tests/resource.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@playwright/test';
+
+test('decorated data label visibilty is correct after page navigations', async ({ page }) => {
+	// TODO: We should probably mock the required requests but something similar to https://github.com/markjaquith/sveltekit-playwright-fetch-mock would be needed to mock the server-side fetches.
+	await page.goto('/6hzmwhl84lm2v7ks');
+	await expect(page.getByText('Medverkan och funktion')).toBeHidden();
+	await page.getByText('Cyrén, Karin, 1984-').first().click();
+	await expect(page.getByText('Beskrivning')).toBeVisible();
+});

--- a/lxl-web/tests/resource.spec.ts
+++ b/lxl-web/tests/resource.spec.ts
@@ -7,3 +7,14 @@ test('decorated data label visibilty is correct after page navigations', async (
 	await page.getByText('Cyrén, Karin, 1984-').first().click();
 	await expect(page.getByText('Beskrivning')).toBeVisible();
 });
+
+test('decorated data in holdings modal is not duplicated while closing modal', async ({ page }) => {
+	await page.goto('/6hzmwhl84lm2v7ks');
+	await page.getByTestId('holding-link').first().click();
+	await expect(page.locator('dialog [data-type="Instance"]')).toHaveCount(1);
+	await page.keyboard.press('Escape');
+	await page.waitForTimeout(10);
+	expect(page.locator('dialog [data-type="Instance"]')).toHaveCount(1);
+	await page.getByTestId('modal').waitFor({ state: 'hidden' });
+	await expect(page.getByTestId('modal')).toBeHidden();
+});


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-171](https://kbse.atlassian.net/browse/LWS-171)

### Solves

Fixes the visiblity of decorated data labels when navigating (I accidentally introduced the bug in https://github.com/libris/lxlviewer/commit/999dc779c859fe99a9712d108d5f531cfed707d1 when fixing duplicate content when closing modals). 

I have now added tests for both cases to catch eventual similar regressions in the future.

### Summary of changes

- Use data as value in key block
- Add tests
- Add workaround to remove duplicate content when closing modals
