### PR TITLE
LWS-131: Pagination bugfix/improvements

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -118,13 +118,12 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 
 		// Hide zero results from resource page
 		if (result.totalItems > 0 || isFindRoute) {
-			const pathname = params.lang ? url.pathname.replace(`/${params.lang}`, '') : url.pathname;
 			return (await asResult(
 				result,
 				displayUtil,
 				locale,
 				env.AUXD_SECRET,
-				pathname
+				url.pathname
 			)) as SearchResult;
 		}
 		return null;

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import type { LocaleCode } from '$lib/i18n/locales';
-	import { relativizeUrl } from '$lib/utils/http';
 	import { page } from '$app/stores';
 	import { type FacetGroup } from './search';
 	import BiChevronRight from '~icons/bi/chevron-right';
@@ -70,10 +69,7 @@
 		<ol class="max-h-437px mt-2 overflow-y-auto" data-testid="facet-list">
 			{#each shownFacets as facet (facet.view['@id'])}
 				<li class="pl-6">
-					<a
-						class="flex items-center justify-between no-underline"
-						href={relativizeUrl(facet.view['@id'])}
-					>
+					<a class="flex items-center justify-between no-underline" href={facet.view['@id']}>
 						<span class="flex items-baseline">
 							{#if 'selected' in facet}
 								<!-- howto A11y?! -->

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/Pagination.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/Pagination.svelte
@@ -1,28 +1,30 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { relativizeUrl } from '$lib/utils/http';
 	import type { SearchResult } from './search';
 	import BiChevronRight from '~icons/bi/chevron-right';
 	import BiChevronLeft from '~icons/bi/chevron-left';
 	export let data: SearchResult;
 
-	$: ({ first, last, next, totalItems, itemsPerPage, itemOffset } = data);
+	$: ({ first, last, next, totalItems, itemsPerPage, itemOffset, maxItems } = data);
 	$: currentPage = Math.floor(itemOffset / itemsPerPage) + 1;
 	$: isFirstPage = currentPage === 1;
-	$: lastPage = Math.ceil(totalItems / itemsPerPage);
+	$: lastItem = totalItems > maxItems ? maxItems : totalItems;
+	$: lastPage = Math.ceil(lastItem / itemsPerPage);
 	$: isLastPage = currentPage === lastPage;
 
-	const sequenceSize = [...Array(2)];
+	// How many pages to display in a sequence (excl first & last)
+	const sequenceSize = 3;
+	const sequenceArr = [...Array(sequenceSize)];
 	$: sequenceStart = (() => {
-		if (isLastPage) return currentPage - 1;
+		if (currentPage + (sequenceSize - 1) >= lastPage) return lastPage - (sequenceSize - 1);
 		else return currentPage;
 	})();
-	$: pageSequence = sequenceSize.map((el, i) => sequenceStart + i);
+	$: pageSequence = sequenceArr.map((el, i) => sequenceStart + i);
 	$: sequenceEnd = pageSequence[pageSequence.length - 1];
 
 	function getOffsetLink(offset: number) {
 		let o = offset < 0 ? 0 : offset;
-		const params = $page.url.searchParams;
+		const params = new URLSearchParams($page.url.searchParams.toString());
 		params.set('_offset', o.toString());
 		return `${$page.url.pathname}?${params.toString()}`;
 	}
@@ -43,10 +45,8 @@
 				</li>
 				{#if sequenceStart > 1}
 					<li>
-						<a
-							aria-label="{$page.data.t('search.page')} 1"
-							class="button-ghost"
-							href={relativizeUrl(first['@id'])}>1</a
+						<a aria-label="{$page.data.t('search.page')} 1" class="button-ghost" href={first['@id']}
+							>1</a
 						>
 					</li>
 				{/if}
@@ -58,10 +58,11 @@
 			{#each pageSequence as p}
 				<li>
 					<a
-						class={p === currentPage ? 'button-primary' : 'button-ghost'}
+						class={p === currentPage ? 'button-primary' : 'button-ghost hidden sm:flex'}
 						href={getOffsetLink(itemsPerPage * (p - 1))}
 						aria-label="{$page.data.t('search.page')} {p}"
-						aria-current={p === currentPage ? 'page' : false}>{p}</a
+						aria-current={p === currentPage ? 'page' : null}
+						>{p.toLocaleString($page.data.locale)}</a
 					>
 				</li>
 			{/each}
@@ -75,15 +76,12 @@
 						<a
 							aria-label="{$page.data.t('search.page')} {lastPage}"
 							class="button-ghost"
-							href={relativizeUrl(last['@id'])}>{lastPage}</a
+							href={last['@id']}>{lastPage.toLocaleString($page.data.locale)}</a
 						>
 					</li>
 				{/if}
 				<li>
-					<a
-						class="button-ghost"
-						href={relativizeUrl(next?.['@id'])}
-						aria-label={$page.data.t('search.next')}
+					<a class="button-ghost" href={next?.['@id']} aria-label={$page.data.t('search.next')}
 						><BiChevronRight aria-hidden="true" class="text-icon" /></a
 					>
 				</li>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/Pagination.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/Pagination.svelte
@@ -13,13 +13,19 @@
 	$: isLastPage = currentPage === lastPage;
 
 	// How many pages to display in a sequence (excl first & last)
-	const sequenceSize = 3;
-	const sequenceArr = [...Array(sequenceSize)];
+	let sequenceSize = 3;
+
+	$: if (sequenceSize > lastPage) {
+		sequenceSize = lastPage;
+	}
 	$: sequenceStart = (() => {
-		if (currentPage + (sequenceSize - 1) >= lastPage) return lastPage - (sequenceSize - 1);
-		else return currentPage;
+		if (currentPage + (sequenceSize - 1) >= lastPage) {
+			return lastPage - (sequenceSize - 1);
+		} else {
+			return currentPage;
+		}
 	})();
-	$: pageSequence = sequenceArr.map((el, i) => sequenceStart + i);
+	$: pageSequence = [...Array(sequenceSize)].map((el, i) => sequenceStart + i);
 	$: sequenceEnd = pageSequence[pageSequence.length - 1];
 
 	function getOffsetLink(offset: number) {


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-131](https://kbse.atlassian.net/browse/LWS-131)

### Solves

Bugs:
* Fix 'page 2'-bug (description of how to reproduce in comment in ticket). Caused by mutation of `$page.url.searchParams` 😱 
* Take `maxItems` into consideration (limit pagination at 10 000 when `totalItems` exceeds it).

Improvements:
* Rewrite links in search.ts _with_ lang param (no need to make extra call `relativizeUrl`).
* `sequenceSize` now more accurately decides now many pages should be displayed in pagination (aside from prev, first, last, next). Increasing from 2 to 3 because why not?
* Localizing the page numbers for readability.
