### PR TITLE
Add external link icon and make text smaller

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -510,7 +510,7 @@
 			"@id": "MediaObject-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["MediaObject"],
-			"fresnel:resourceStyle": ["ext-link", "uriToId()", "text-large", "block"]
+			"fresnel:resourceStyle": ["ext-link", "uriToId()"]
 		},
 		"Document-format": {
 			"@id": "Document-format",

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -510,7 +510,7 @@
 			"@id": "MediaObject-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["MediaObject"],
-			"fresnel:resourceStyle": ["ext-link", "uriToId()"]
+			"fresnel:resourceStyle": ["ext-link", "uriToId()", "text-3-cond-bold"]
 		},
 		"Document-format": {
 			"@id": "Document-format",

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -230,10 +230,13 @@
 				</span>
 			{/if}
 			{#if hasStyle(data, 'ext-link')}
-				<a href={getLink(data)}>
+				<a href={getLink(data)} target="_blank">
 					<span class="ext-link inline-block pl-1">
 						<BiBoxArrowUpRight />
 					</span>
+					{#if data['@type'] === 'MediaObject'}
+						<span class="whitespace-pre after:content-['\a']"></span>
+					{/if}
 				</a>
 			{/if}
 		{/if}

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -6,6 +6,7 @@
 	import { hasStyle, getStyle, getResourceId, getPropertyValue } from '$lib/utils/resourceData';
 	import { relativizeUrl } from '$lib/utils/http';
 	import { getSupportedLocale } from '$lib/i18n/locales';
+	import BiBoxArrowUpRight from '~icons/bi/box-arrow-up-right';
 
 	export let data: ResourceData;
 	export let depth = 0;
@@ -227,6 +228,13 @@
 				<span class="_contentAfter">
 					{data._contentAfter}
 				</span>
+			{/if}
+			{#if hasStyle(data, 'ext-link')}
+				<a href={getLink(data)}>
+					<span class="ext-link inline-block pl-1">
+						<BiBoxArrowUpRight />
+					</span>
+				</a>
 			{/if}
 		{/if}
 	{:else}

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -234,6 +234,7 @@
 					<span class="ext-link inline-block pl-1">
 						<BiBoxArrowUpRight />
 					</span>
+					<!-- FIXME don't hardcode MediaObject -->
 					{#if data['@type'] === 'MediaObject'}
 						<span class="whitespace-pre after:content-['\a']"></span>
 					{/if}


### PR DESCRIPTION
### Tickets involved
[LWS-141](https://kbse.atlassian.net/browse/LWS-141)

### Solves

Add icon to external links. Suggested form:

![Screenshot from 2024-05-16 11-00-09](https://github.com/libris/lxlviewer/assets/48950665/ef7d21dc-c396-4b77-8c64-da76c7269ebe)

We could do this in a more general way by e.g. supporting icons in `fresnel:contentLast` etc, by mapping an icon name to a general Svelte component (icon) in a similar way as in` getTypeIcon.ts`  but not sure if it is worth it? 

### TODO:
* Popover: "Opens in new tab" ???