### PR TITLE
LWS-138: styling tweaks to filters

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
@@ -59,11 +59,11 @@
 			<!-- facet range inputs; hide in filter search results -->
 			<FacetRange search={group.search} />
 		{/if}
-		<ol class="mt-2 max-h-[437px] overflow-y-auto" data-testid="facet-list">
+		<ol class="mt-2 max-h-[437px] overflow-y-auto overflow-x-clip" data-testid="facet-list">
 			{#each shownFacets as facet (facet.view['@id'])}
-				<li class="pl-6">
+				<li class="mb-[0.3rem]">
 					<a
-						class="facet-link flex items-end justify-between gap-2 no-underline"
+						class="facet-link flex items-end justify-between gap-2 pl-6 no-underline"
 						href={facet.view['@id']}
 					>
 						<span class="flex items-baseline">
@@ -87,17 +87,10 @@
 		</ol>
 		{#if canShowMoreFacets || canShowLessFacets}
 			<button
-				class="mt-2 flex w-full items-center gap-4 rounded-md bg-pill/4 p-2 text-3-regular"
+				class="mt-4 pl-6"
 				on:click={() =>
 					canShowMoreFacets ? (facetsShown = numfacets) : (facetsShown = defaultFacetsShown)}
 			>
-				<span
-					class="button-ghost h-9 w-9 p-0"
-					class:rotate-90={canShowMoreFacets}
-					class:-rotate-90={canShowLessFacets}
-				>
-					<BiChevronRight class="text-icon" />
-				</span>
 				{canShowMoreFacets ? $page.data.t('search.showMore') : $page.data.t('search.showFewer')}
 			</button>
 		{/if}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
@@ -63,7 +63,7 @@
 			{#each shownFacets as facet (facet.view['@id'])}
 				<li class="pl-6">
 					<a
-						class="facet-link flex items-end justify-between gap-2 py-px no-underline"
+						class="facet-link flex items-end justify-between gap-2 no-underline"
 						href={facet.view['@id']}
 					>
 						<span class="flex items-baseline">
@@ -76,7 +76,8 @@
 							{/if}
 							<span>{facet.str}</span>
 						</span>
-						<span class="facet-total text-sm text-secondary md:text-xs lg:text-sm rounded-sm bg-pill/4 px-1 mb-px"
+						<span
+							class="facet-total mb-px rounded-sm bg-pill/4 px-1 text-sm text-secondary md:text-xs lg:text-sm"
 							aria-label="{facet.totalItems} {$page.data.t('search.hits')}"
 							>{facet.totalItems.toLocaleString(locale)}</span
 						>
@@ -86,7 +87,7 @@
 		</ol>
 		{#if canShowMoreFacets || canShowLessFacets}
 			<button
-				class="mt-2 flex text-3-regular w-full items-center gap-4 rounded-md bg-pill/4 p-2"
+				class="mt-2 flex w-full items-center gap-4 rounded-md bg-pill/4 p-2 text-3-regular"
 				on:click={() =>
 					canShowMoreFacets ? (facetsShown = numfacets) : (facetsShown = defaultFacetsShown)}
 			>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
@@ -3,7 +3,6 @@
 	import { page } from '$app/stores';
 	import { type FacetGroup } from './search';
 	import BiChevronRight from '~icons/bi/chevron-right';
-	import BiChevronDown from '~icons/bi/chevron-down';
 	import FacetRange from './FacetRange.svelte';
 
 	export let group: FacetGroup;
@@ -41,15 +40,9 @@
 		data-testid="facet-toggle"
 	>
 		<span class="flex items-center gap-2">
-			<span>
-				{#if searchPhrase}
-					<!-- Currently groups can't be minimized while searching -->
-					<BiChevronDown class="text-icon" />
-				{:else if expanded}
-					<BiChevronDown class="text-icon" />
-				{:else}
-					<BiChevronRight class="text-icon" />
-				{/if}
+			<!-- Currently groups can't be minimized while searching -->
+			<span class:rotate-90={searchPhrase || expanded} class="transition-transform">
+				<BiChevronRight class="text-icon" />
 			</span>
 			<span>
 				{group.label}
@@ -66,10 +59,13 @@
 			<!-- facet range inputs; hide in filter search results -->
 			<FacetRange search={group.search} />
 		{/if}
-		<ol class="max-h-437px mt-2 overflow-y-auto" data-testid="facet-list">
+		<ol class="mt-2 max-h-[437px] overflow-y-auto" data-testid="facet-list">
 			{#each shownFacets as facet (facet.view['@id'])}
 				<li class="pl-6">
-					<a class="flex items-center justify-between no-underline" href={facet.view['@id']}>
+					<a
+						class="facet-link flex items-end justify-between gap-2 py-px no-underline"
+						href={facet.view['@id']}
+					>
 						<span class="flex items-baseline">
 							{#if 'selected' in facet}
 								<!-- howto A11y?! -->
@@ -80,8 +76,9 @@
 							{/if}
 							<span>{facet.str}</span>
 						</span>
-						<span class="text-sm text-secondary md:text-xs lg:text-sm"
-							>({facet.totalItems.toLocaleString(locale)})</span
+						<span class="facet-total text-sm text-secondary md:text-xs lg:text-sm rounded-sm bg-pill/4 px-1 mb-px"
+							aria-label="{facet.totalItems} {$page.data.t('search.hits')}"
+							>{facet.totalItems.toLocaleString(locale)}</span
 						>
 					</a>
 				</li>
@@ -89,14 +86,19 @@
 		</ol>
 		{#if canShowMoreFacets || canShowLessFacets}
 			<button
-				class="mt-4 pl-6"
+				class="mt-2 flex text-3-regular w-full items-center gap-4 rounded-md bg-pill/4 p-2"
 				on:click={() =>
 					canShowMoreFacets ? (facetsShown = numfacets) : (facetsShown = defaultFacetsShown)}
 			>
-				{canShowMoreFacets
-					? $page.data.t('search.showMore')
-					: $page.data.t('search.showFewer')}</button
-			>
+				<span
+					class="button-ghost h-9 w-9 p-0"
+					class:rotate-90={canShowMoreFacets}
+					class:-rotate-90={canShowLessFacets}
+				>
+					<BiChevronRight class="text-icon" />
+				</span>
+				{canShowMoreFacets ? $page.data.t('search.showMore') : $page.data.t('search.showFewer')}
+			</button>
 		{/if}
 		{#if searchPhrase && filteredFacets.length === 0}
 			<span role="status" aria-atomic="true">{$page.data.t('search.noResults')}</span>
@@ -105,7 +107,10 @@
 </li>
 
 <style lang="postcss">
-	.max-h-437px {
-		max-height: 437px;
+	.facet-link:hover,
+	.facet-link:focus {
+		& .facet-total {
+			@apply bg-pill/8;
+		}
 	}
 </style>


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-138](https://kbse.atlassian.net/browse/LWS-138)

### Summary of changes

Applied some additional styling to the content in the filter panel.
* Slightly more highlighted and repositioned totalItems for better readability (?)
* More visible toggle btn

Still doesn't look at all readable some cases, but if truncation isn't an option, we really should give the panel (back) some more width. 

<img width="307" alt="Skärmavbild 2024-05-16 kl  16 26 56" src="https://github.com/libris/lxlviewer/assets/22232928/44b9f4be-74db-4aa4-a39f-76cd17071c57">


