### PR TITLE
Fix/LWS-177-holdings-type

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -110,3 +110,9 @@
 		@apply hover:bg-negative hover:text-secondary focus:bg-negative focus:text-secondary;
 	}
 }
+
+@layer utilities {
+	.search-card {
+		@apply flex gap-4 overflow-hidden border-b border-b-primary/16 bg-cards p-4 sm:gap-8 md:rounded-md md:p-6;
+	}
+}

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -11,6 +11,7 @@
 	export let depth = 0;
 	export let showLabels: ShowLabelsOptions = ShowLabelsOptions.DefaultOn;
 	export let allowPopovers = true; // used for preventing nested popovers
+	export let allowLinks = true;
 	export let block = false;
 	export let truncate = false;
 	export let remainder: ResourceData | undefined = undefined;
@@ -29,23 +30,25 @@
 	];
 
 	function getLink(value: ResourceData) {
-		if (depth > 1 && hasStyle(data, 'link')) {
-			const id = getResourceId(value);
-			if (id) {
-				return relativizeUrl(id);
+		if (allowLinks) {
+			if (depth > 1 && hasStyle(data, 'link')) {
+				const id = getResourceId(value);
+				if (id) {
+					return relativizeUrl(id);
+				}
 			}
-		}
-		if (depth > 1 && hasStyle(data, 'ext-link')) {
-			const id = getResourceId(value);
-			if (id) {
-				return id;
+			if (depth > 1 && hasStyle(data, 'ext-link')) {
+				const id = getResourceId(value);
+				if (id) {
+					return id;
+				}
 			}
 		}
 		return undefined;
 	}
 
 	function getElementType(value: ResourceData) {
-		if (getLink(value)) {
+		if (allowLinks && getLink(value)) {
 			return 'a';
 		}
 		if (block && isTopLevel()) {
@@ -134,6 +137,7 @@
 					depth={depth + 1}
 					{showLabels}
 					{block}
+					{allowLinks}
 					{allowPopovers}
 					truncate={false}
 					{remainder}
@@ -146,6 +150,7 @@
 						depth={depth + 1}
 						{showLabels}
 						{block}
+						{allowLinks}
 						{allowPopovers}
 						{truncate}
 						{keyed}
@@ -172,6 +177,7 @@
 						depth={depth + 1}
 						{showLabels}
 						{block}
+						{allowLinks}
 						{allowPopovers}
 						{truncate}
 						{keyed}
@@ -189,6 +195,7 @@
 					depth={depth + 1}
 					{showLabels}
 					{block}
+					{allowLinks}
 					{allowPopovers}
 					{keyed}
 				/>
@@ -198,6 +205,7 @@
 					depth={depth + 1}
 					{showLabels}
 					{block}
+					{allowLinks}
 					{allowPopovers}
 					{truncate}
 					{keyed}
@@ -216,6 +224,7 @@
 							depth={depth + 1}
 							{showLabels}
 							{block}
+							{allowLinks}
 							{allowPopovers}
 							{truncate}
 							{keyed}

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -72,7 +72,9 @@ export default {
 		page: 'Page',
 		next: 'Next page',
 		showMore: 'Show more',
-		showFewer: 'Show fewer'
+		showFewer: 'Show fewer',
+		showDetails: 'Show more',
+		hideDetails: 'Show less'
 	},
 	sort: {
 		sortBy: 'Sort by',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -71,7 +71,9 @@ export default {
 		page: 'Sida',
 		next: 'Nästa sida',
 		showMore: 'Visa fler',
-		showFewer: 'Visa färre'
+		showFewer: 'Visa färre',
+		showDetails: 'Visa mer',
+		hideDetails: 'Visa mindre'
 	},
 	sort: {
 		sortBy: 'Sortera efter',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -42,6 +42,9 @@
 
 	$: shouldShowHeaderBackground = !data.instances?.length;
 
+	$: expandableAsideSearchCard =
+		asideSearchCardElement?.scrollHeight > ASIDE_SEARCH_CARD_MAX_HEIGHT;
+
 	function handleCloseHoldings() {
 		history.back();
 	}
@@ -130,6 +133,7 @@
 				<div class="search-card mb-4 flex flex-col !gap-4 !p-4 text-sm">
 					<div
 						class="overview relative"
+						class:expandable={expandableAsideSearchCard}
 						class:expanded={expandedAsideSearchCard}
 						style="--max-height:{ASIDE_SEARCH_CARD_MAX_HEIGHT}px"
 						bind:this={asideSearchCardElement}
@@ -258,24 +262,23 @@
 			white-space: nowrap;
 		}
 	}
-	:global(dialog) {
-		.overview {
-			max-height: var(--max-height);
-			overflow: hidden;
-		}
 
-		.overview:not(.expanded)::after {
-			@apply pointer-events-none absolute h-12 w-full overflow-hidden;
-			content: '';
-			bottom: 0;
-			left: 0;
-			pointer-events: none;
-			background: linear-gradient(to bottom, rgb(var(--bg-cards) / 0), rgb(var(--bg-cards) / 1));
-			overflow: hidden;
-		}
+	.expandable {
+		max-height: var(--max-height);
+		overflow: hidden;
+	}
 
-		.expanded {
-			max-height: initial;
-		}
+	.expandable:not(.expanded)::after {
+		@apply pointer-events-none absolute h-12 w-full overflow-hidden;
+		content: '';
+		bottom: 0;
+		left: 0;
+		pointer-events: none;
+		background: linear-gradient(to bottom, rgb(var(--bg-cards) / 0), rgb(var(--bg-cards) / 1));
+		overflow: hidden;
+	}
+
+	.expanded {
+		max-height: initial;
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -148,7 +148,7 @@
 									allowLinks={false}
 								/>
 							</span>
-							{#if selectedHolding}
+							{#if selectedHolding && data.instances?.length !== 1}
 								<span> • </span>
 								{#if isFnurgel(selectedHolding)}
 									{selectedHoldingInstance['_label']}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -16,8 +16,8 @@
 
 	let selectedHolding: string | undefined;
 	let latestHoldingUrl: string | undefined;
-	let asideSearchCardElement: HTMLElement | null;
-	let expandedAsideSearchCard = false;
+	let holdingsInstanceElement: HTMLElement | null;
+	let expandedHoldingsInstance = false;
 
 	$: selectedHoldingInstance = selectedHolding
 		? data.instances?.find((instanceItem) => instanceItem['@id'].includes(selectedHolding)) ||
@@ -42,8 +42,8 @@
 
 	$: shouldShowHeaderBackground = !data.instances?.length;
 
-	$: expandableAsideSearchCard =
-		asideSearchCardElement?.scrollHeight > ASIDE_SEARCH_CARD_MAX_HEIGHT;
+	$: expandableHoldingsInstance =
+		holdingsInstanceElement?.scrollHeight > ASIDE_SEARCH_CARD_MAX_HEIGHT;
 
 	function handleCloseHoldings() {
 		history.back();
@@ -132,11 +132,12 @@
 			<div class="flex flex-col">
 				<div class="search-card mb-4 flex flex-col !gap-4 !p-4 text-sm">
 					<div
+						id="instance-details"
 						class="overview relative"
-						class:expandable={expandableAsideSearchCard}
-						class:expanded={expandedAsideSearchCard}
+						class:expandable={expandableHoldingsInstance}
+						class:expanded={expandedHoldingsInstance}
 						style="--max-height:{ASIDE_SEARCH_CARD_MAX_HEIGHT}px"
-						bind:this={asideSearchCardElement}
+						bind:this={holdingsInstanceElement}
 					>
 						<h2 class="mb-2">
 							<span class="font-bold">
@@ -167,9 +168,11 @@
 					</div>
 					<button
 						class="text-left underline"
-						on:click={() => (expandedAsideSearchCard = !expandedAsideSearchCard)}
+						on:click={() => (expandedHoldingsInstance = !expandedHoldingsInstance)}
+						aria-expanded={expandedHoldingsInstance}
+						aria-controls="instance-details"
 					>
-						{expandedAsideSearchCard
+						{expandedHoldingsInstance
 							? $page.data.t('search.hideDetails')
 							: $page.data.t('search.showDetails')}</button
 					>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -140,7 +140,13 @@
 					>
 						<h2 class="mb-2">
 							<span class="font-bold">
-								<DecoratedData data={data.title} block keyed={false} allowPopovers={false} />
+								<DecoratedData
+									data={data.title}
+									block
+									keyed={false}
+									allowPopovers={false}
+									allowLinks={false}
+								/>
 							</span>
 							{#if selectedHolding}
 								<span> • </span>
@@ -156,6 +162,7 @@
 							block
 							keyed={false}
 							allowPopovers={false}
+							allowLinks={false}
 						/>
 					</div>
 					<button


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-177](https://kbse.atlassian.net/browse/LWS-177)

### Solves

Quick and dirty fix for selected instance details/work shown in the holdings  modal.

It now shows the work details (and type) for aggregated holdings and instance details (and type) for selected instances. Support for expanding/minimizing the content is added as it can often be quite long.

It would be preferable to instead add new lenses for instances so we should revist this issue soon.

### Summary of changes

- Fix selected instance details and add card styling
 
<img width="1624" alt="Skärmavbild 2024-05-20 kl  14 44 55" src="https://github.com/libris/lxlviewer/assets/10220360/9371e1fb-8738-4a75-9ad0-0eeb8abd2dfb">

