### PR TITLE
Don't check holdings for sigel if there's no active sigel

### DIFF
--- a/vue-client/src/components/inspector/reverse-relations.vue
+++ b/vue-client/src/components/inspector/reverse-relations.vue
@@ -71,19 +71,22 @@ export default {
           query['itemOf.@id'] = this.mainEntity['@id'];
           query['@type'] = 'Item';
 
-          // Check if my sigel has holding
-          const myHoldingQuery = Object.assign({}, query);
-          myHoldingQuery._limit = 1;
-          myHoldingQuery['heldBy.@id'] = this.user.getActiveLibraryUri();
-          HttpUtil.getRelatedRecords(myHoldingQuery, this.settings.apiPath)
-            .then((response) => {
-              if (response.totalItems > 0) {
-                this.myHolding = response.items[0]['@id'];
-              } else this.myHolding = null;
-            })
-            .catch((error) => {
-              console.log(error);
-            });
+          if (this.user.isLoggedIn) {
+            // Check if my sigel has holding
+            const myHoldingQuery = Object.assign({}, query);
+            myHoldingQuery._limit = 1;
+            myHoldingQuery['heldBy.@id'] = this.user.getActiveLibraryUri();
+
+            HttpUtil.getRelatedRecords(myHoldingQuery, this.settings.apiPath)
+              .then((response) => {
+                if (response.totalItems > 0) {
+                  this.myHolding = response.items[0]['@id'];
+                } else this.myHolding = null;
+              })
+              .catch((error) => {
+                console.log(error);
+              });
+          }
         } else {
           query.o = this.mainEntity['@id'];
         }

--- a/vue-client/src/components/inspector/reverse-relations.vue
+++ b/vue-client/src/components/inspector/reverse-relations.vue
@@ -76,7 +76,6 @@ export default {
             const myHoldingQuery = Object.assign({}, query);
             myHoldingQuery._limit = 1;
             myHoldingQuery['heldBy.@id'] = this.user.getActiveLibraryUri();
-
             HttpUtil.getRelatedRecords(myHoldingQuery, this.settings.apiPath)
               .then((response) => {
                 if (response.totalItems > 0) {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

Currently if you visit e.g. https://libris.kb.se/katalogisering/search/libris?q=*&_limit=20&%40type=Instance&_sort= the cat client will do 41 `/find` searches. 20 of them are of the type "does my current sigel have holdings for this instance?". These are performed even if you're not logged in, i.e., even if there is no active sigel (`myHoldingQuery['heldBy.@id']` will then be `https://libris.kb.se/library/`). Which is just meaningless and wasteful. So let's only do that search if logged in :)

(So this reduces the number of searches from 41 to 20; additionally, if https://github.com/libris/librisxl/pull/1439 is merged, we can do some furter adjustments and go from 20 to 1)