### PR TITLE
LWS-178: Remove padding around search cards on mobile breakpoints

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -62,7 +62,7 @@
 					<SearchMapping mapping={searchResult.mapping} />
 				</nav>
 			{/if}
-			<div class="relative gap-y-4 find-layout">
+			<div class="relative gap-y-4 find-layout md:find-padding">
 				{#if showFiltersModal}
 					<Modal position="left" close={toggleFiltersModal}>
 						<span slot="title">
@@ -77,7 +77,9 @@
 				</div>
 
 				<div class="results max-w-content">
-					<div class="toolbar flex min-h-14 items-center justify-between pb-4 md:min-h-fit">
+					<div
+						class="toolbar flex min-h-14 items-center justify-between pb-4 find-padding md:min-h-fit"
+					>
 						<a
 							href={`${$page.url.pathname}?${$page.url.searchParams.toString()}#filters`}
 							class="filter-modal-toggle button-ghost md:hidden"

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -62,7 +62,7 @@
 					<SearchMapping mapping={searchResult.mapping} />
 				</nav>
 			{/if}
-			<div class="relative gap-y-4 find-layout md:find-padding">
+			<div class="relative gap-y-4 find-layout md:page-padding">
 				{#if showFiltersModal}
 					<Modal position="left" close={toggleFiltersModal}>
 						<span slot="title">
@@ -78,7 +78,7 @@
 
 				<div class="results max-w-content">
 					<div
-						class="toolbar flex min-h-14 items-center justify-between pb-4 find-padding md:min-h-fit"
+						class="toolbar flex min-h-14 items-center justify-between pb-4 page-padding md:min-h-fit"
 					>
 						<a
 							href={`${$page.url.pathname}?${$page.url.searchParams.toString()}#filters`}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -38,7 +38,7 @@
 </script>
 
 <li
-	class="flex gap-4 border-b border-b-primary/16 bg-cards p-4 sm:gap-8 md:rounded-md md:p-6"
+	class="flex gap-4 border-b border-b-primary/16 bg-cards p-4 sm:gap-8 sm:p-6 md:rounded-md"
 	data-testid="search-card"
 >
 	<a href={relativizeUrl(item['@id'])}>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -54,7 +54,7 @@
 	<title>{getPageTitle(data.title)}</title>
 </svelte:head>
 <article>
-	<div class="resource gap-8 find-layout" class:bg-header={shouldShowHeaderBackground}>
+	<div class="resource gap-8 find-layout find-padding" class:bg-header={shouldShowHeaderBackground}>
 		<div
 			class="mb-2 mt-4 flex max-h-64 max-w-64 justify-center self-center md:mx-auto md:justify-start md:self-start md:px-2 xl:px-0"
 			class:hidden={!$page.data.images?.length}
@@ -113,7 +113,7 @@
 		</div>
 	</div>
 	{#if data.instances?.length}
-		<div class="instances !pt-2 find-layout">
+		<div class="instances !pt-2 find-layout find-padding">
 			<div class="instances-list max-w-content border-t border-t-primary/16 pt-6">
 				<InstancesList
 					data={data.instances}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -54,7 +54,7 @@
 	<title>{getPageTitle(data.title)}</title>
 </svelte:head>
 <article>
-	<div class="resource gap-8 find-layout find-padding" class:bg-header={shouldShowHeaderBackground}>
+	<div class="resource gap-8 find-layout page-padding" class:bg-header={shouldShowHeaderBackground}>
 		<div
 			class="mb-2 mt-4 flex max-h-64 max-w-64 justify-center self-center md:mx-auto md:justify-start md:self-start md:px-2 xl:px-0"
 			class:hidden={!$page.data.images?.length}
@@ -113,7 +113,7 @@
 		</div>
 	</div>
 	{#if data.instances?.length}
-		<div class="instances !pt-2 find-layout find-padding">
+		<div class="instances !pt-2 find-layout page-padding">
 			<div class="instances-list max-w-content border-t border-t-primary/16 pt-6">
 				<InstancesList
 					data={data.instances}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <header
-	class="flex gap-4 bg-site-header find-padding sm:px-6 md:grid"
+	class="flex gap-4 bg-site-header find-padding md:grid"
 	class:md:find-layout={!isLandingPage}
 	class:md:grid-cols-find={!isLandingPage}
 >

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <header
-	class="flex gap-4 bg-site-header p-4 sm:px-6 md:grid"
+	class="flex gap-4 bg-site-header find-padding sm:px-6 md:grid"
 	class:md:find-layout={!isLandingPage}
 	class:md:grid-cols-find={!isLandingPage}
 >

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <header
-	class="flex gap-4 bg-site-header find-padding md:grid"
+	class="flex gap-4 bg-site-header page-padding md:grid"
 	class:md:find-layout={!isLandingPage}
 	class:md:grid-cols-find={!isLandingPage}
 >

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -181,7 +181,7 @@ export default {
 				'.find-layout': {
 					'@apply flex flex-col gap-4 md:grid md:grid-cols-find md:gap-8': {}
 				},
-				'.find-padding': {
+				'.page-padding': {
 					'@apply p-4 sm:px-6': {}
 				}
 			});

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -179,7 +179,10 @@ export default {
 						{}
 				},
 				'.find-layout': {
-					'@apply flex flex-col gap-4 p-4 sm:px-6 md:grid md:grid-cols-find md:gap-8': {}
+					'@apply flex flex-col gap-4 md:grid md:grid-cols-find md:gap-8': {}
+				},
+				'.find-padding': {
+					'@apply p-4 sm:px-6': {}
 				}
 			});
 		}


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-178](https://kbse.atlassian.net/browse/LWS-178)

### Solves
Removes padding around search cards on mobile breakpoints (so they stretch to the edges of the screen)

### Summary of changes

- Remove padding around search cards on mobile breakpoints
