### PR TITLE
LWS-180: Responsive instance list img

### DIFF
--- a/lxl-web/src/lib/components/ResourceImage.svelte
+++ b/lxl-web/src/lib/components/ResourceImage.svelte
@@ -21,14 +21,14 @@
 
 {#if image}
 	{#if linkToFull}
-		<a href={full.url} target="_blank" class="contents">
+		<a href={full.url} target="_blank" class="contents object-[inherit]">
 			<img
 				{alt}
 				{loading}
 				src={thumb.url}
 				width={thumb.widthṔx}
 				height={thumb.heightPx}
-				class="object-contain object-center"
+				class="object-contain object-[inherit]"
 			/>
 		</a>
 	{:else}
@@ -38,7 +38,7 @@
 			src={thumb.url}
 			width={thumb.widthṔx}
 			height={thumb.heightPx}
-			class="object-contain object-center"
+			class="object-contain object-[inherit]"
 		/>
 	{/if}
 {:else if showPlaceholder}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -56,7 +56,7 @@
 <article>
 	<div class="resource gap-8 find-layout" class:bg-header={shouldShowHeaderBackground}>
 		<div
-			class="mb-2 mt-4 flex max-h-64 max-w-64 justify-center self-center md:mx-auto md:justify-start md:self-start md:px-2 xl:px-0"
+			class="mb-2 mt-4 flex max-h-64 max-w-64 justify-center self-center object-center md:mx-auto md:justify-start md:self-start md:px-2 xl:px-0"
 			class:hidden={!$page.data.images?.length}
 		>
 			{#if data.images.length}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/InstancesList.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/InstancesList.svelte
@@ -147,8 +147,7 @@
 <style lang="postcss">
 	.column-headers,
 	summary {
-		@apply gap-2;
-		grid-template-columns: 16px 1fr 2fr 1fr 1fr;
+		@apply grid-cols-instance-list gap-2;
 
 		& > :last-child {
 			@apply pr-1;

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/InstancesListContent.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/InstancesListContent.svelte
@@ -39,7 +39,7 @@
 <div class:oneOfMany>
 	{#if oneOfMany}
 		<div class="col-span-2 flex flex-col gap-2 text-sm">
-			<div class="flex h-full max-h-32 w-full max-w-32">
+			<div class="flex h-full max-h-32 w-full max-w-32 object-left">
 				<ResourceImage
 					images={$page.data.images.filter((i) => i.recordId === id)}
 					alt={$page.data.t('general.instanceCover')}
@@ -49,7 +49,7 @@
 				/>
 			</div>
 			{#if id && $page.data.holdingsByInstanceId[id]}
-				<div class="flex flex-col gap-2">
+				<div class="flex flex-col gap-1">
 					<a
 						href={getHoldingsLink($page.url, id)}
 						data-sveltekit-preload-data="false"
@@ -90,7 +90,6 @@
 	}
 
 	.oneOfMany {
-		@apply grid gap-2 py-8 md:grid-cols-5;
-		grid-template-columns: 16px 1fr 2fr 1fr 1fr;
+		@apply grid grid-cols-1 gap-4 py-8 sm:grid-cols-instance-list sm:gap-2;
 	}
 </style>

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -116,7 +116,8 @@ export default {
 				content: '78rem'
 			},
 			gridTemplateColumns: {
-				find: 'minmax(240px, 1fr) 5fr'
+				find: 'minmax(240px, 1fr) 5fr',
+				'instance-list': '16px 1fr 2fr 1fr 1fr'
 			},
 			boxShadow: {
 				input: 'inset 0px 1px 0px 0px rgb(var(--color-primary) / 0.16)',


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-180](https://kbse.atlassian.net/browse/LWS-180)

### Solves

Improve responsiveness of instance list images.

### Summary of changes

* Extracted the template columns of the instance list into a tailwind class used on both header & content. On small screens the content gets a single column.
* Make the image inherit the value of `object-position` instead of always centering it. Allowing us to set it left for the instance list & center for the resource img.