### PR TITLE
Display related resources in tabs on resource page

### DIFF
--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -82,7 +82,8 @@ export default {
 		showMore: 'Show more',
 		showFewer: 'Show fewer',
 		showDetails: 'Show more',
-		hideDetails: 'Show less'
+		hideDetails: 'Show less',
+		occursAs: 'as'
 	},
 	sort: {
 		sortBy: 'Sort by',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -81,7 +81,8 @@ export default {
 		showMore: 'Visa fler',
 		showFewer: 'Visa färre',
 		showDetails: 'Visa mer',
-		hideDetails: 'Visa mindre'
+		hideDetails: 'Visa mindre',
+		occursAs: 'förekommer som'
 	},
 	sort: {
 		sortBy: 'Sortera efter',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -184,8 +184,12 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 		...resourceParts,
 		searchResult: isFindRoute
 			? await getSearchResult()
-			: isDataRequest && isResourceRoute && shouldFindRelations && resourceId
-				? getRelated() // stream results on resource page
+			: isResourceRoute && shouldFindRelations && resourceId
+				? // stream results on resource page when doing client side navigation
+					// TODO: fix waterfall. fetch in parallel with rest of page data when SSR
+					isDataRequest
+					? getRelated()
+					: await getRelated()
 				: null
 	};
 };

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.server.ts
@@ -25,7 +25,7 @@ import {
 } from './search.js';
 import getAtPath from '$lib/utils/getAtPath';
 
-export const load = async ({ params, url, locals, fetch }) => {
+export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 	const displayUtil: DisplayUtil = locals.display;
 	const vocabUtil: VocabUtil = locals.vocab;
 	const locale = getSupportedLocale(params?.lang);
@@ -92,20 +92,12 @@ export const load = async ({ params, url, locals, fetch }) => {
 		};
 	}
 
-	const searchResult = isFindRoute || shouldFindRelations ? getSearchResult() : null;
-
 	async function getSearchResult() {
 		if (isFindRoute && !url.searchParams.size) {
 			redirect(303, `/`); // redirect to home page if no search params are given
 		}
 
-		let searchParams = new URLSearchParams(url.searchParams.toString());
-
-		if (shouldFindRelations && resourceId) {
-			searchParams.set('_o', resourceId);
-			searchParams.set('_i', '*');
-			searchParams = getSortedSearchParams(addDefaultSearchParams(searchParams));
-		}
+		const searchParams = new URLSearchParams(url.searchParams.toString());
 
 		const recordsRes = await fetch(`${env.API_URL}/find.jsonld?${searchParams.toString()}`, {
 			// intercept 3xx redirects to sync back the correct _i/_q combination provided by api
@@ -130,19 +122,52 @@ export const load = async ({ params, url, locals, fetch }) => {
 
 		const result = (await recordsRes.json()) as PartialCollectionView;
 
+		return (await asResult(
+			result,
+			displayUtil,
+			vocabUtil,
+			locale,
+			env.AUXD_SECRET,
+			url.pathname
+		)) as SearchResult;
+	}
+
+	async function fetchRelated(fetchUri: string) {
+		const recordsRes = await fetch(fetchUri);
+
+		if (!recordsRes.ok) {
+			const err = (await recordsRes.json()) as apiError;
+			throw error(err.status_code, { message: err.message, status: err.status });
+		}
+
+		return (await recordsRes.json()) as PartialCollectionView;
+	}
+
+	async function getRelated() {
+		let searchParams = new URLSearchParams(url.searchParams.toString());
+
+		if (resourceId) {
+			searchParams.set('_o', resourceId);
+			searchParams.set('_i', '*');
+			searchParams = getSortedSearchParams(addDefaultSearchParams(searchParams));
+		}
+
+		let result = await fetchRelated(`${env.API_URL}/find.jsonld?${searchParams.toString()}`);
+
+		// Go to first tab (predicate) if none selected
 		if (searchParams.has('_o') && !searchParams.has('_p')) {
 			const predicates = displayPredicates(result, displayUtil, locale, url.pathname);
 			if (predicates.length > 0) {
-				const apiSearch = new URL(predicates[0].view['@id'], url).search;
-				console.log('redirecting to', `${url.pathname}${apiSearch}`);
-				redirect(302, `${url.pathname}${apiSearch}`);
+				const queryParams = new URL(predicates[0].view['@id'], url).search;
+				const fetchUrl = `${env.API_URL}/find.jsonld${queryParams}`;
+				result = await fetchRelated(fetchUrl);
 			} else {
 				return null;
 			}
 		}
 
 		// Hide zero results from resource page
-		if (result.totalItems > 0 || isFindRoute) {
+		if (result.totalItems > 0) {
 			return (await asResult(
 				result,
 				displayUtil,
@@ -157,9 +182,11 @@ export const load = async ({ params, url, locals, fetch }) => {
 
 	return {
 		...resourceParts,
-		// waits for data on initial page load, streams in on client side navigation
-		// searchResult: isDataRequest && isResourceRoute ? searchResult : await searchResult
-		searchResult: await searchResult
+		searchResult: isFindRoute
+			? await getSearchResult()
+			: isDataRequest && isResourceRoute && shouldFindRelations && resourceId
+				? getRelated() // stream results on resource page
+				: null
 	};
 };
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -60,7 +60,7 @@
 					aria-label={$page.data.t('search.selectedFilters')}
 				>
 					<ul class="flex flex-wrap items-center gap-2">
-						<li class="font-bold">{$page.data.title}</li>
+						<li class="max-w-80 truncate font-bold">{$page.data.title}</li>
 						{$page.data.t('search.occursAs')}
 
 						{#each searchResult.predicates as p}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -54,6 +54,29 @@
 			{@const facets = searchResult.facetGroups}
 			{@const numHits = searchResult.totalItems}
 			{@const filterCount = getFiltersCount(searchResult.mapping)}
+			{#if searchResult.predicates.length > 0}
+				<nav
+					class="border-b border-primary/16 px-4 md:flex lg:px-6"
+					aria-label={$page.data.t('search.selectedFilters')}
+				>
+					<ul class="flex flex-wrap items-center gap-2">
+						<li class="font-bold">{$page.data.title}</li>
+						{$page.data.t('search.occursAs')}
+
+						{#each searchResult.predicates as p}
+							<li>
+								<a
+									class="tab"
+									class:active={true}
+									class:tab-selected={p.selected}
+									data-sveltekit-replacestate
+									href={p.view['@id']}>{p.str}</a
+								>
+							</li>
+						{/each}
+					</ul>
+				</nav>
+			{/if}
 			{#if shouldShowMapping(searchResult.mapping)}
 				<nav
 					class="hidden md:flex md:px-6 md:pb-0 md:pt-4"
@@ -201,5 +224,14 @@
 		.toolbar {
 			grid-template-areas: 'hits sort-select';
 		}
+	}
+
+	.tab {
+		@apply block px-4 py-4 lowercase no-underline;
+		transition: filter 0.1s ease;
+	}
+
+	.tab-selected {
+		@apply border-b border-b-2 border-primary;
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -70,8 +70,14 @@
 									class:active={true}
 									class:tab-selected={p.selected}
 									data-sveltekit-replacestate
-									href={p.view['@id']}>{p.str}</a
+									href={p.view['@id']}
 								>
+									{p.str}
+									<span
+										class="mb-px rounded-sm bg-pill/4 px-1 text-sm text-secondary md:text-xs lg:text-sm"
+										aria-label="{p.totalItems} {$page.data.t('search.hits')}">{p.totalItems}</span
+									>
+								</a>
 							</li>
 						{/each}
 					</ul>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -237,7 +237,7 @@
 	}
 
 	.tab {
-		@apply block px-4 py-4 lowercase no-underline;
+		@apply block py-4 pl-4 pr-3.5 lowercase no-underline;
 		transition: filter 0.1s ease;
 	}
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -56,12 +56,12 @@
 			{@const filterCount = getFiltersCount(searchResult.mapping)}
 			{#if searchResult.predicates.length > 0}
 				<nav
-					class="border-b border-primary/16 px-4 pt-4 md:flex lg:px-6"
+					class="border-b border-primary/16 px-4 md:flex lg:px-6"
 					aria-label={$page.data.t('search.selectedFilters')}
 				>
 					<ul class="flex flex-wrap items-center gap-2">
-						<li class="max-w-80 truncate pb-4 font-bold">{$page.data.title}</li>
-						<span class="pb-4">{$page.data.t('search.occursAs')}</span>
+						<li class="tab-header max-w-80 truncate font-bold">{$page.data.title}</li>
+						<span class="tab-header">{$page.data.t('search.occursAs')}</span>
 
 						{#each searchResult.predicates as p}
 							<li>
@@ -226,12 +226,17 @@
 		}
 	}
 
+	.tab-header {
+		@apply block py-4;
+	}
+
 	.tab {
-		@apply block px-4 pb-4 lowercase no-underline;
+		@apply block px-4 py-4 lowercase no-underline;
 		transition: filter 0.1s ease;
 	}
 
 	.tab-selected {
-		@apply border-b border-b-2 border-primary;
+		@apply border-primary pb-3.5;
+		border-bottom-width: 0.125rem;
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -56,12 +56,12 @@
 			{@const filterCount = getFiltersCount(searchResult.mapping)}
 			{#if searchResult.predicates.length > 0}
 				<nav
-					class="border-b border-primary/16 px-4 md:flex lg:px-6"
+					class="border-b border-primary/16 px-4 pt-4 md:flex lg:px-6"
 					aria-label={$page.data.t('search.selectedFilters')}
 				>
 					<ul class="flex flex-wrap items-center gap-2">
-						<li class="max-w-80 truncate font-bold">{$page.data.title}</li>
-						{$page.data.t('search.occursAs')}
+						<li class="max-w-80 truncate pb-4 font-bold">{$page.data.title}</li>
+						<span class="pb-4">{$page.data.t('search.occursAs')}</span>
 
 						{#each searchResult.predicates as p}
 							<li>
@@ -227,7 +227,7 @@
 	}
 
 	.tab {
-		@apply block px-4 py-4 lowercase no-underline;
+		@apply block px-4 pb-4 lowercase no-underline;
 		transition: filter 0.1s ease;
 	}
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
@@ -43,7 +43,8 @@ export async function asResult(
 				displayUtil.lensAndFormat(vocabUtil.getDefinition(i[JsonLd.TYPE]), LensType.Chip, locale)
 			)
 		})),
-		facetGroups: displayFacetGroups(view, displayUtil, locale, translate, usePath)
+		facetGroups: displayFacetGroups(view, displayUtil, locale, translate, usePath),
+		predicates: displayPredicates(view, displayUtil, locale, usePath)
 	};
 }
 
@@ -58,6 +59,7 @@ export interface SearchResult {
 	next?: Link;
 	items: SearchResultItem[];
 	facetGroups: FacetGroup[];
+	predicates: MultiSelectFacet[];
 }
 
 export interface SearchResultItem {
@@ -125,6 +127,7 @@ export interface PartialCollectionView {
 	stats?: {
 		[JsonLd.ID]: '#stats';
 		sliceByDimension: Record<FacetGroupId, Slice>;
+		_predicates: Observation[];
 	};
 }
 
@@ -260,6 +263,25 @@ function displayFacetGroups(
 					str: toString(displayUtil.lensAndFormat(o.object, LensType.Chip, locale)) || ''
 				};
 			})
+		};
+	});
+}
+
+function displayPredicates(
+	view: PartialCollectionView,
+	displayUtil: DisplayUtil,
+	locale: LangCode,
+	usePath: string
+): MultiSelectFacet[] {
+	const predicates = view.stats?._predicates || [];
+
+	return predicates.map((o) => {
+		return {
+			...('_selected' in o && { selected: o._selected }),
+			totalItems: o.totalItems,
+			view: replacePath(o.view, usePath),
+			object: displayUtil.lensAndFormat(o.object, LensType.Chip, locale),
+			str: toString(displayUtil.lensAndFormat(o.object, LensType.WebChip, locale)) || ''
 		};
 	});
 }

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
@@ -267,7 +267,7 @@ function displayFacetGroups(
 	});
 }
 
-function displayPredicates(
+export function displayPredicates(
 	view: PartialCollectionView,
 	displayUtil: DisplayUtil,
 	locale: LangCode,


### PR DESCRIPTION
## Description
Separate related resource on relation type (predicate) on the resource page.
Display each relation type as a tab.

Not super happy with the wording
`<resource>` förekommer som `<predicate label>`

Depends on https://github.com/libris/librisxl/pull/1438

### Tickets involved
[LWS-164](https://jira.kb.se/browse/LWS-164)

### Summary of changes
* Split `getSearchResult()` into `getSearchResult()` and  `getRelated()` because it was getting super gnarly. Svelte Redirects cannot be used inside streaming responses. Might have to redo this when we add free text filtering to that list.
* Getting related resources requires two search API round trips when entering a resource page. One to get the list of predicates and one for selecting the first one. The API could be extended to allow e.g. `_p=0` to automatically select the first available `_p`
* Mobile layout is so-so

![Skärmbild från 2024-05-22 16-54-11](https://github.com/libris/lxlviewer/assets/51744858/9ba099d0-6944-4073-9474-38761ce6097e)

![bild](https://github.com/libris/lxlviewer/assets/51744858/9eebc660-955a-49f7-bebf-4e4018f7f183)


![Skärmbild från 2024-05-22 17-07-03](https://github.com/libris/lxlviewer/assets/51744858/632e06ec-3f5b-4965-acf4-6a9d01c1b642)
![Skärmbild från 2024-05-22 17-06-47](https://github.com/libris/lxlviewer/assets/51744858/a96b7edc-efc1-4229-a24f-72470c15088c)
