### PR TITLE
Bugfix lingering _o param on new search

### DIFF
--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -18,6 +18,7 @@
 	params.set('_offset', '0');
 	params.delete('_i');
 	params.delete('_o');
+	params.delete('_p');
 	const searchParams = Array.from(params);
 
 	afterNavigate(({ to }) => {

--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -14,8 +14,10 @@
 		: $page.url.searchParams.get('_i')?.trim();
 
 	let params = getSortedSearchParams(getDefaultSearchParams($page.url.searchParams));
-	params.set('_offset', '0'); // Always reset offset on new search
-	params.delete('_i'); // reset '_i' param on new search
+	// Always reset these params on new search
+	params.set('_offset', '0');
+	params.delete('_i');
+	params.delete('_o');
 	const searchParams = Array.from(params);
 
 	afterNavigate(({ to }) => {


### PR DESCRIPTION
## Description

### Tickets involved
Unreported

### Solves

Recreate in QA:
* Visit a resource page with related items: https://beta.libris-qa.kb.se/42gkn33n1g72f46
* Navigate to page 2 (`_o` now appears in url)
* Reload the page
* Perform a new search using the top search bar
* The new search result still (secretly) uses the `_o` param, heavily impacting the results.

### Summary of changes

delete _o from params to be included on new search.
