### PR TITLE
Use totalItemsByRelation when possible

### DIFF
--- a/vue-client/src/components/inspector/reverse-relations.vue
+++ b/vue-client/src/components/inspector/reverse-relations.vue
@@ -64,6 +64,16 @@ export default {
         return;
       }
 
+      if (this.mode == 'items' && this.mainEntity.reverseLinks && this.mainEntity.reverseLinks.totalItemsByRelation) {
+        this.numberOfRelations = this.mainEntity.reverseLinks.totalItemsByRelation.itemOf;
+        this.checkingRelations = false;
+        query['itemOf.@id'] = this.mainEntity['@id'];
+        query['@type'] = 'Item';
+        this.panelQuery = Object.assign({}, query);
+        this.$emit('numberOfRelations', this.numberOfRelations);
+        return;
+      }
+
       this.checkingRelations = true;
       const timeoutLength = 1100; // Needed so that the index has time to update
       setTimeout(() => { //

--- a/vue-client/src/components/inspector/reverse-relations.vue
+++ b/vue-client/src/components/inspector/reverse-relations.vue
@@ -65,7 +65,7 @@ export default {
       }
 
       if (this.mode == 'items' && this.mainEntity.reverseLinks && this.mainEntity.reverseLinks.totalItemsByRelation) {
-        this.numberOfRelations = this.mainEntity.reverseLinks.totalItemsByRelation.itemOf;
+        this.numberOfRelations = this.mainEntity.reverseLinks.totalItemsByRelation.itemOf || 0;
         this.checkingRelations = false;
         query['itemOf.@id'] = this.mainEntity['@id'];
         query['@type'] = 'Item';


### PR DESCRIPTION
Since https://github.com/libris/librisxl/pull/1439 we store the total number of incoming links per type in each ES document. This vue-client change uses that data (if present), avoiding unnecessary requests. Backwards-compatible with older indices.

For a typical cataloguing client search result page this reduces the number of `/find` requests by 20.