### PR TITLE
Frontpage content as .md

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
@@ -1,6 +1,8 @@
 <script>
 	import getPageTitle from '$lib/utils/getPageTitle';
 	import { page } from '$app/stores';
+	import EnContent from './frontpage.en.md';
+	import SvContent from './frontpage.sv.md';
 </script>
 
 <svelte:head>
@@ -9,43 +11,8 @@
 
 <article class="container-fluid my-8 max-w-3xl">
 	{#if $page.data.locale === 'en'}
-		<h2 class="mb-2 text-5-cond-extrabold">
-			Welcome to the first beta version of Libris' new search service
-		</h2>
-		<p class="mb-2">This beta version currently includes functionality for</p>
-		<ul class="mb-2 list-inside list-disc">
-			<li>Simple search</li>
-			<li>Search results with the option to refine</li>
-			<li>Detailed information about search results</li>
-		</ul>
-		<p class="mb-2">
-			More features will be added continuosly. Please note that the beta version contains test data
-			that may be incomplete or inaccurate.
-		</p>
-		<p class="mb-2">
-			Your feedback is important to us; please leave it via <a
-				href="https://survey.kb.se/librisbeta/en">this form</a
-			>. Here you can find answers to
-			<a href="http://kb.se/libris">frequently asked questions</a>.
-		</p>
+		<EnContent />
 	{:else}
-		<h2 class="mb-2 text-5-cond-extrabold">
-			Välkommen till den första betaversionen av Libris nya söktjänst
-		</h2>
-		<p class="mb-2">Denna betaversion innehåller än så länge möjligheter till</p>
-		<ul class="mb-2 list-inside list-disc">
-			<li>Enkel sökning</li>
-			<li>Träfflista med möjlighet till avgränsning</li>
-			<li>Detaljerad information om träffarna</li>
-		</ul>
-		<p class="mb-2">
-			Flera funktioner kommer att läggas till allt eftersom de blir färdiga. Observera att
-			betaversionen innehåller testdata som kan innehålla ofullständigheter och felaktigheter.
-		</p>
-		<p class="mb-2">
-			Dina synpunkter är viktiga för oss, lämna dem gärna via <a
-				href="https://survey.kb.se/librisbeta">detta formulär</a
-			>. Här hittar du svar på <a href="http://kb.se/libris">vanligt förekommande frågor</a>.
-		</p>
+		<SvContent />
 	{/if}
 </article>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteFooter.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteFooter.svelte
@@ -13,7 +13,10 @@
 			</p>
 			<ul>
 				<li>
-					<a href="http://kb.se/libris">{$page.data.t('footer.faq')}</a>
+					<a
+						href="https://www.kb.se/samverkan-och-utveckling/libris/fragor-och-svar-om-libris-sok.html"
+						>{$page.data.t('footer.faq')}</a
+					>
 				</li>
 			</ul>
 		</nav>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/frontpage.en.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/frontpage.en.md
@@ -1,0 +1,13 @@
+## Welcome to the first beta version of Libris' new search service
+
+This beta version currently includes functionality for
+
+- Simple search
+- Search results with the option to refine
+- Detailed information about search results
+
+More features will be added continuosly. Please note that the beta version contains test data
+that may be incomplete or inaccurate.
+
+Your feedback is important to us; please leave it via [this form](https://survey.kb.se/librisbeta/en).
+Here you can find answers to [frequently asked questions](https://www.kb.se/samverkan-och-utveckling/libris/fragor-och-svar-om-libris-sok.html).

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/frontpage.sv.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/frontpage.sv.md
@@ -1,0 +1,13 @@
+## Välkommen till den första betaversionen av Libris nya söktjänst
+
+Denna betaversion innehåller än så länge möjligheter till
+
+- Enkel sökning
+- Träfflista med möjlighet till avgränsning
+- Detaljerad information om träffarna
+
+Flera funktioner kommer att läggas till allt eftersom de blir färdiga.
+Observera att betaversionen innehåller testdata som kan innehålla ofullständigheter och felaktigheter.
+
+Dina synpunkter är viktiga för oss, lämna dem gärna via [detta formulär](https://survey.kb.se/librisbeta).
+Här hittar du svar på [vanligt förekommande frågor](https://www.kb.se/samverkan-och-utveckling/libris/fragor-och-svar-om-libris-sok.html).


### PR DESCRIPTION
### Summary of changes

* Frontpage content as frontpage.[lang].md.
* Correct link to FAQ on frontpage and in footer. 