### PR TITLE
Feature/lws 165 add subject codes

### DIFF
--- a/lxl-web/src/lib/utils/http.ts
+++ b/lxl-web/src/lib/utils/http.ts
@@ -24,5 +24,8 @@ export function getUriSlug(url: string | undefined) {
 	if (!url) {
 		return '';
 	}
-	return new URL(url).pathname.split('/').pop();
+	const urlArray = new URL(url).pathname.split('/');
+	return urlArray.includes('term')
+		? urlArray.slice(urlArray.indexOf('term') + 1).join('/')
+		: urlArray.pop();
 }

--- a/lxl-web/src/lib/utils/http.ts
+++ b/lxl-web/src/lib/utils/http.ts
@@ -19,3 +19,10 @@ export function stripAnchor(url: string | undefined) {
 	}
 	return url.split('#')[0];
 }
+
+export function getUriSlug(url: string | undefined) {
+	if (!url) {
+		return '';
+	}
+	return new URL(url).pathname.split('/').pop();
+}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/FacetGroup.svelte
@@ -74,7 +74,10 @@
 								>
 								<span class="mr-1" aria-hidden="true">{facet.selected ? '☑' : '☐'}</span>
 							{/if}
-							<span>{facet.str}</span>
+							<span
+								>{facet.str}
+								<span class="ml-0.5 text-xs text-primary/40">{facet.discriminator}</span>
+							</span>
 						</span>
 						<span
 							class="facet-total mb-px rounded-sm bg-pill/4 px-1 text-sm text-secondary md:text-xs lg:text-sm"

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/search.ts
@@ -14,6 +14,8 @@ import { getTranslator, type translateFn } from '$lib/i18n';
 import { type LocaleCode as LangCode } from '$lib/i18n/locales';
 import { bestImage, bestSize, toSecure } from '$lib/utils/auxd';
 import { type SecureImageResolution, Width } from '$lib/utils/auxd.types';
+import getAtPath from '$lib/utils/getAtPath';
+import { getUriSlug } from '$lib/utils/http';
 
 export async function asResult(
 	view: PartialCollectionView,
@@ -95,6 +97,7 @@ export interface Facet {
 	view: Link;
 	object: DisplayDecorated;
 	str: string;
+	discriminator: string;
 }
 
 interface MultiSelectFacet extends Facet {
@@ -260,7 +263,8 @@ function displayFacetGroups(
 					totalItems: o.totalItems,
 					view: replacePath(o.view, usePath),
 					object: displayUtil.lensAndFormat(o.object, LensType.Chip, locale),
-					str: toString(displayUtil.lensAndFormat(o.object, LensType.Chip, locale)) || ''
+					str: toString(displayUtil.lensAndFormat(o.object, LensType.Chip, locale)) || '',
+					discriminator: getUriSlug(getAtPath(o.object, ['inScheme', JsonLd.ID], '')) || ''
 				};
 			})
 		};


### PR DESCRIPTION
Show `inScheme` `code` for facets (sao, saogf, gmgpc/swe etc). The background is that `code` is not included in the response from the backend, hence this special handling. Also, there is currently no way in the Fresnel/`display-web.json`-logic to present something differently _only in the facets_. This may be fixed with sublenses in the future.

### TODO: 
* Some marc terms render an empty string (when missing` @type`?) 