### PR TITLE
Feature/lws 152 redesigned search cards

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -110,9 +110,3 @@
 		@apply hover:bg-negative hover:text-secondary focus:bg-negative focus:text-secondary;
 	}
 }
-
-@layer utilities {
-	.search-card {
-		@apply flex  border-b border-b-primary/16 bg-cards p-4 md:rounded-md md:p-6;
-	}
-}

--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -113,6 +113,6 @@
 
 @layer utilities {
 	.search-card {
-		@apply flex gap-4 overflow-hidden border-b border-b-primary/16 bg-cards p-4 sm:gap-8 md:rounded-md md:p-6;
+		@apply flex  border-b border-b-primary/16 bg-cards p-4 md:rounded-md md:p-6;
 	}
 }

--- a/lxl-web/src/lib/assets/img/placeholder.svg
+++ b/lxl-web/src/lib/assets/img/placeholder.svg
@@ -1,3 +1,3 @@
-<svg width="100" height="150" viewBox="0 0 100 150" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="100" height="150" fill="rgba(82, 51, 20, 0.04)"/>
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="100" height="100" fill="rgba(82, 51, 20, 0.04)"/>
 </svg>

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -279,10 +279,16 @@
 					"showProperties": ["language", { "inverseOf": "instanceOf" }]
 				},
 				"Instance": {
-					"@id": "Instance-web-card",
+					"@id": "Instance-web-card-footer",
 					"@type": "fresnel:Lens",
 					"classLensDomain": "Instance",
 					"showProperties": ["hasTitle", "responsibilityStatement", "identifier", "publication"]
+				},
+				"Person": {
+					"@id": "Person-web-card-footer",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "Instance",
+					"showProperties": ["nationality"]
 				}
 			}
 		}

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -265,7 +265,7 @@
 
 <style lang="postcss">
 	.definition {
-		@apply text-sm italic text-secondary underline decoration-dotted;
+		@apply text-sm text-secondary underline decoration-dotted;
 	}
 
 	.pill {

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -216,9 +216,17 @@
 				{#if propertyName && propertyData}
 					<svelte:element this={getElementType(propertyData)} data-property={propertyName}>
 						{#if shouldShowLabels()}
-							<div class="label">
-								{data._label}
-							</div>
+							<svelte:element this={block ? 'div' : 'span'}>
+								<!-- Add inner span with inline-block to achieve first letter capitalization while still supporting inline whitespaces -->
+								<span
+									class="inline-block first-letter:capitalize"
+									class:text-sm={block}
+									class:text-secondary={block}
+								>
+									{data._label}
+								</span>
+								{' '}
+							</svelte:element>
 						{/if}
 						<svelte:self
 							data={propertyData}
@@ -258,10 +266,6 @@
 <style lang="postcss">
 	.definition {
 		@apply text-sm italic text-secondary underline decoration-dotted;
-	}
-
-	.label {
-		@apply text-sm text-secondary first-letter:uppercase;
 	}
 
 	.pill {

--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -14,8 +14,11 @@
 		: $page.url.searchParams.get('_i')?.trim();
 
 	let params = getSortedSearchParams(getDefaultSearchParams($page.url.searchParams));
-	params.set('_offset', '0'); // Always reset offset on new search
-	params.delete('_i'); // reset '_i' param on new search
+	// Always reset these params on new search
+	params.set('_offset', '0');
+	params.delete('_i');
+	params.delete('_o');
+	params.delete('_p');
 	const searchParams = Array.from(params);
 
 	afterNavigate(({ to }) => {

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -54,7 +54,10 @@ export default {
 		language: 'Language',
 		subject: 'Subject',
 		yearPublished: 'Year published',
-		intendedAudience: 'Intended audience'
+		intendedAudience: 'Intended audience',
+		nationality: 'Nationality',
+		hasOccupation: 'Has Occupation',
+		fieldOfActivity: 'Field of Activity'
 	},
 	search: {
 		search: 'Search',

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -69,6 +69,7 @@ export default {
 		clearFilters: 'Clear',
 		editFilters: 'Edit',
 		noResults: 'No results',
+		hitsOf: 'of',
 		hits: 'hits',
 		hitsOne: 'hit',
 		selected: 'selected',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -53,7 +53,10 @@ export default {
 		language: 'Språk',
 		subject: 'Ämne',
 		yearPublished: 'Utgivningsår',
-		intendedAudience: 'Målgrupp'
+		intendedAudience: 'Målgrupp',
+		nationality: 'Nationalitet/verksamhetsland',
+		hasOccupation: 'Har yrke eller sysselsättning',
+		fieldOfActivity: 'Verksamhetsområde'
 	},
 	search: {
 		search: 'Sök',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -68,6 +68,7 @@ export default {
 		clearFilters: 'Rensa',
 		editFilters: 'Redigera',
 		noResults: 'Inga resultat',
+		hitsOf: 'av',
 		hits: 'träffar',
 		hitsOne: 'träff',
 		selected: 'valda',

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -663,11 +663,15 @@ export class DisplayUtil {
 	}
 
 	private orderScripts(scripts: LangCode[]): LangCode[] {
-		return scripts.sort((a, b) => {
-			const aa = isTransliteratedLatin(a) ? a : '_' + a;
-			const bb = isTransliteratedLatin(a) ? b : '_' + b;
-			return bb.localeCompare(aa);
-		});
+		return [
+			...new Set(
+				scripts.sort((a, b) => {
+					const aa = isTransliteratedLatin(a) ? a : '_' + a;
+					const bb = isTransliteratedLatin(a) ? b : '_' + b;
+					return bb.localeCompare(aa);
+				})
+			)
+		];
 	}
 }
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -169,7 +169,7 @@
 							</div>
 						{/if}
 					</div>
-					<ol class="flex flex-col gap-2 md:px-0">
+					<ol class="flex flex-col gap-0.5 md:px-0">
 						{#each searchResult.items as item (item['@id'])}
 							<li>
 								<SearchCard {item} />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -142,7 +142,9 @@
 					</div>
 					<ol class="flex flex-col gap-2 md:px-0">
 						{#each searchResult.items as item (item['@id'])}
-							<SearchCard {item} />
+							<li>
+								<SearchCard {item} />
+							</li>
 						{/each}
 					</ol>
 					<Pagination data={searchResult} />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/+layout.svelte
@@ -96,13 +96,22 @@
 								</span>
 							{/if}
 						</a>
-						<span
-							class="hits pt-4 text-secondary text-3-cond-bold md:pt-0"
-							role="status"
-							data-testid="result-info"
-						>
+						<span class="hits pt-4 text-secondary md:pt-0" role="status" data-testid="result-info">
 							{#if numHits && numHits > 0}
-								{numHits.toLocaleString($page.data.locale)}
+								{#if numHits > searchResult.itemsPerPage}
+									<span class="text-3-cond-bold">
+										{(searchResult.itemOffset + 1).toLocaleString($page.data.locale)}
+										-
+										{Math.min(
+											numHits,
+											searchResult.itemOffset + searchResult.itemsPerPage
+										).toLocaleString($page.data.locale)}
+									</span>
+									{$page.data.t('search.hitsOf')}
+								{/if}
+								<span class="text-3-cond-bold">
+									{numHits.toLocaleString($page.data.locale)}
+								</span>
 								{#if $page.data.instances}
 									{numHits == 1
 										? $page.data.t('search.relatedOne')

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -201,13 +201,17 @@
 		@apply text-sm;
 
 		@container (min-width: 768px) {
-			@apply text-base;
+			@apply mt-2 text-base;
 		}
 	}
 
 	.card-footer {
 		grid-area: footer;
 		@apply mt-1;
+
+		@container (min-width: 768px) {
+			@apply mt-3;
+		}
 	}
 
 	.card-header-title {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -237,7 +237,4 @@
 	:global(.card-header [data-property='_script']) {
 		display: block;
 	}
-	:global(.card-header *:has(> [data-property='_script']) > ._contentBefore) {
-		display: none;
-	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -76,7 +76,7 @@
 					{/if}
 				{:else}
 					<div class="flex items-center justify-center">
-						<img src={placeholder} alt="" class="h-20 w-20 rounded-sm object-contain" />
+						<img src={placeholder} alt="" class="h-20 w-20 rounded-sm object-contain object-top" />
 						{#if getTypeIcon(item['@type'])}
 							<svelte:component
 								this={getTypeIcon(item['@type'])}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -8,35 +8,55 @@
 	$: footerId = `card-footer-${item['@id']}`;
 </script>
 
-<article class="search-card">
-	<!-- svelte-ignore a11y-missing-content -->
-	<!-- (content shouldn't be needed as we're using aria-labelledby, see: https://github.com/sveltejs/svelte/issues/8296) -->
-	<a class="card-link" href="/" aria-labelledby={titleId} aria-describedby={`${bodyId} ${footerId}`}
-	></a>
-	<div class="card-image"></div>
-	<header class="card-header" id={titleId}>
-		<hgroup>
-			<h1 class="text-4-cond-bold">title</h1>
-			<p>transliteration</p>
-		</hgroup>
-		<p><a href="/test">original title</a></p>
-	</header>
-	<div class="card-body" id={bodyId}>body</div>
-	<footer class="card-footer" id={footerId}>footer</footer>
-</article>
+<div class="search-card-container">
+	<article class="search-card">
+		<!-- svelte-ignore a11y-missing-content -->
+		<!-- (content shouldn't be needed as we're using aria-labelledby, see: https://github.com/sveltejs/svelte/issues/8296) -->
+		<a
+			class="card-link"
+			href="/"
+			aria-labelledby={titleId}
+			aria-describedby={`${bodyId} ${footerId}`}
+		></a>
+		<div class="card-image"></div>
+		<header class="card-header" id={titleId}>
+			<hgroup>
+				<h1 class="text-4-cond-bold">title</h1>
+				<p>transliteration</p>
+			</hgroup>
+			<p><a href="/test">original title</a></p>
+		</header>
+		<div class="card-body" id={bodyId}>body</div>
+		<footer class="card-footer" id={footerId}>footer</footer>
+	</article>
+</div>
 
 <style lang="postcss">
+	.search-card-container {
+		container-type: inline-size;
+	}
+
 	.search-card {
+		@apply border-b border-b-primary/16;
+
 		display: grid;
+		width: 100%;
 		position: relative;
+		background: theme(backgroundColor.cards);
+		border-radius: theme(borderRadius.md);
+		padding: theme(padding.4);
 		grid-template-areas:
 			'image header'
 			'image body'
 			'image footer';
-		grid-template-columns: 128px 1fr;
+		grid-template-columns: 64px 1fr;
 
 		&:has(a:hover) {
 			@apply shadow-xl;
+		}
+
+		@container (min-width: theme(screens.sm)) {
+			grid-template-columns: 128px 1fr;
 		}
 	}
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -45,7 +45,7 @@
 </script>
 
 <div class="search-card-container">
-	<article class="search-card">
+	<article class="search-card" data-testid="search-card">
 		<!-- svelte-ignore a11y-missing-content -->
 		<!-- (content shouldn't be needed as we're using aria-labelledby, see: https://github.com/sveltejs/svelte/issues/8296) -->
 		<a

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -3,28 +3,26 @@
 
 	export let item: SearchResultItem;
 
-	$: console.log('item', item);
+	$: titleId = `card-title-${item['@id']}`;
+	$: bodyId = `card-body-${item['@id']}`;
+	$: footerId = `card-footer-${item['@id']}`;
 </script>
 
 <article class="search-card">
 	<!-- svelte-ignore a11y-missing-content -->
 	<!-- (content shouldn't be needed as we're using aria-labelledby, see: https://github.com/sveltejs/svelte/issues/8296) -->
-	<a
-		class="card-link"
-		href="/"
-		aria-labelledby="id-title-here"
-		aria-describedby="id-body-here id-footer-here"
+	<a class="card-link" href="/" aria-labelledby={titleId} aria-describedby={`${bodyId} ${footerId}`}
 	></a>
 	<div class="card-image"></div>
-	<header class="card-header" id="id-title-here">
+	<header class="card-header" id={titleId}>
 		<hgroup>
 			<h1 class="text-4-cond-bold">title</h1>
 			<p>transliteration</p>
 		</hgroup>
 		<p><a href="/test">original title</a></p>
 	</header>
-	<div class="card-body" id="id-body-here">body</div>
-	<footer class="card-footer" id="id-footer-here">footer</footer>
+	<div class="card-body" id={bodyId}>body</div>
+	<footer class="card-footer" id={footerId}>footer</footer>
 </article>
 
 <style lang="postcss">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -92,11 +92,6 @@
 				<h2 class="card-header-title">
 					<DecoratedData data={item['card-heading']} showLabels={ShowLabelsOptions.Never} />
 				</h2>
-				<!-- TODO: add transliteration here 
-				{#if item['_script']}
-					<p>transliteration</p>
-				{/if}
-				-->
 			</hgroup>
 			{#if item[LensType.WebCardHeaderExtra]?._display}
 				<p class="card-header-extra">
@@ -230,10 +225,19 @@
 	}
 
 	.card-header-extra,
-	.card-footer {
+	.card-footer,
+	.card-header :global([data-property='_script']) {
 		@apply text-xs text-secondary;
 		@container (min-width: 768px) {
 			@apply text-sm;
 		}
+	}
+
+	/** TODO: Set transliteration styling via display-web.json? */
+	:global(.card-header [data-property='_script']) {
+		display: block;
+	}
+	:global(.card-header *:has(> [data-property='_script']) > ._contentBefore) {
+		display: none;
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -47,6 +47,7 @@
 		width: 100%;
 		height: 100%;
 		z-index: 0;
+		cursor: pointer;
 	}
 
 	a:not(.card-link) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -62,9 +62,10 @@
 						width={item.image.widthṔx}
 						height={item.image.heightPx}
 						alt={$page.data.t('general.latestInstanceCover')}
-						class="h-auto w-full rounded-sm object-contain object-top"
+						class:rounded-full={item['@type'] === 'Person'}
+						class="h-auto w-full object-contain object-top"
 					/>
-					{#if item['@type'] !== 'Text' && getTypeIcon(item['@type'])}
+					{#if item['@type'] !== 'Text' && item['@type'] !== 'Person' && getTypeIcon(item['@type'])}
 						<div class="absolute -left-4 -top-4">
 							<div class="rounded-md bg-cards p-1.5">
 								<svelte:component
@@ -76,7 +77,13 @@
 					{/if}
 				{:else}
 					<div class="flex items-center justify-center">
-						<img src={placeholder} alt="" class="h-20 w-20 rounded-sm object-contain object-top" />
+						<img
+							src={placeholder}
+							alt=""
+							class:rounded-full={item['@type'] === 'Person'}
+							class:rounded-sm={item['@type'] !== 'Person'}
+							class="h-20 w-20 object-contain object-top"
+						/>
 						{#if getTypeIcon(item['@type'])}
 							<svelte:component
 								this={getTypeIcon(item['@type'])}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -1,11 +1,47 @@
 <script lang="ts">
+	import jmespath from 'jmespath';
 	import type { SearchResultItem } from './search';
+	import DecoratedData from '$lib/components/DecoratedData.svelte';
+	import type { ResourceData } from '$lib/types/ResourceData';
+	import { ShowLabelsOptions } from '$lib/types/DecoratedData';
+	import { relativizeUrl } from '$lib/utils/http';
+	import { LensType } from '$lib/utils/xl';
+	import { LxlLens } from '$lib/utils/display.types';
+	import placeholder from '$lib/assets/img/placeholder.svg';
+	import getTypeIcon from '$lib/utils/getTypeIcon';
+	import { page } from '$app/stores';
 
 	export let item: SearchResultItem;
 
-	$: titleId = `card-title-${item['@id']}`;
-	$: bodyId = `card-body-${item['@id']}`;
-	$: footerId = `card-footer-${item['@id']}`;
+	$: id = relativizeUrl(item['@id']);
+	$: titleId = `card-title-${id}`;
+	$: bodyId = `card-body-${id}`;
+	$: footerId = `card-footer-${id}`;
+
+	function getInstanceData(instances: ResourceData) {
+		if (typeof instances === 'object') {
+			let years: string = '';
+			let count = 1;
+			let query = '_display[].publication[].*[][?year].year[]';
+
+			if (Array.isArray(instances)) {
+				count = instances.length;
+				query = '[]._display[].publication[].*[][?year].year[]';
+			}
+
+			let res = jmespath.search(instances, query) as string[] | null;
+			if (res) {
+				years = res
+					.filter((el, i, arr) => !isNaN(parseInt(el)) && arr.indexOf(el) === i)
+					.sort()
+					.filter((el, i, arr) => i === 0 || i === arr.length - 1)
+					.join('-');
+			}
+
+			return { count, years };
+		}
+		return null;
+	}
 </script>
 
 <div class="search-card-container">
@@ -14,20 +50,99 @@
 		<!-- (content shouldn't be needed as we're using aria-labelledby, see: https://github.com/sveltejs/svelte/issues/8296) -->
 		<a
 			class="card-link"
-			href="/"
+			href={id}
 			aria-labelledby={titleId}
 			aria-describedby={`${bodyId} ${footerId}`}
 		></a>
-		<div class="card-image"></div>
+		<div class="card-image">
+			<div class="pointer-events-none relative flex h-full max-h-20 w-full max-w-20">
+				{#if item.image}
+					<img
+						src={item.image.url}
+						width={item.image.widthṔx}
+						height={item.image.heightPx}
+						alt={$page.data.t('general.latestInstanceCover')}
+						class="h-auto w-full rounded-sm object-contain object-top"
+					/>
+					{#if item['@type'] !== 'Text' && getTypeIcon(item['@type'])}
+						<div class="absolute -left-4 -top-4">
+							<div class="rounded-md bg-cards p-1.5">
+								<svelte:component
+									this={getTypeIcon(item['@type'])}
+									class="h-6 w-6 text-icon-strong"
+								/>
+							</div>
+						</div>
+					{/if}
+				{:else}
+					<div class="flex items-center justify-center">
+						<img src={placeholder} alt="" class="h-20 w-20 rounded-sm object-contain" />
+						{#if getTypeIcon(item['@type'])}
+							<svelte:component
+								this={getTypeIcon(item['@type'])}
+								class="absolute text-xl text-icon"
+							/>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		</div>
 		<header class="card-header" id={titleId}>
 			<hgroup>
-				<h1 class="text-4-cond-bold">title</h1>
-				<p>transliteration</p>
+				<h2 class="card-header-title">
+					<DecoratedData data={item['card-heading']} showLabels={ShowLabelsOptions.Never} />
+				</h2>
+				<!-- TODO: add transliteration here 
+				{#if item['_script']}
+					<p>transliteration</p>
+				{/if}
+				-->
 			</hgroup>
-			<p><a href="/test">original title</a></p>
+			{#if item[LensType.WebCardHeaderExtra]?._display}
+				<p class="card-header-extra">
+					{#each item[LensType.WebCardHeaderExtra]?._display as obj}
+						<span>
+							<DecoratedData data={obj} showLabels={ShowLabelsOptions.DefaultOn} />
+						</span>
+					{/each}
+				</p>
+			{/if}
 		</header>
-		<div class="card-body" id={bodyId}>body</div>
-		<footer class="card-footer" id={footerId}>footer</footer>
+		{#if item[LxlLens.CardBody]?._display}
+			<div class="card-body" id={bodyId}>
+				{#each item[LxlLens.CardBody]?._display as obj}
+					<div>
+						<DecoratedData data={obj} showLabels={ShowLabelsOptions.Never} block />
+					</div>
+				{/each}
+			</div>
+		{/if}
+		<footer class="card-footer" id={footerId}>
+			<span class="font-bold">
+				{item.typeStr}
+			</span>
+			{#each item[LensType.WebCardFooter]?._display as obj}
+				{' • '}
+				{#if 'hasInstance' in obj}
+					{@const instances = getInstanceData(obj.hasInstance)}
+					{#if instances?.years}
+						<span>
+							{#if instances.count > 1}
+								{instances?.count}
+								{$page.data.t('search.editions')}
+								{`(${instances.years})`}
+							{:else}
+								{instances.years}
+							{/if}
+						</span>
+					{/if}
+				{:else}
+					<span>
+						<DecoratedData data={obj} showLabels={ShowLabelsOptions.Never} />
+					</span>
+				{/if}
+			{/each}
+		</footer>
 	</article>
 </div>
 
@@ -37,26 +152,26 @@
 	}
 
 	.search-card {
-		@apply border-b border-b-primary/16;
+		@apply gap-x-4 border-b border-b-primary/16 p-5 transition-shadow;
 
 		display: grid;
 		width: 100%;
 		position: relative;
 		background: theme(backgroundColor.cards);
 		border-radius: theme(borderRadius.md);
-		padding: theme(padding.4);
 		grid-template-areas:
 			'image header'
 			'image body'
 			'image footer';
 		grid-template-columns: 64px 1fr;
 
-		&:has(a:hover) {
-			@apply shadow-xl;
+		&:hover,
+		&:focus-within {
+			@apply shadow-lg;
 		}
 
-		@container (min-width: theme(screens.sm)) {
-			grid-template-columns: 128px 1fr;
+		@container (min-width: 768px) {
+			grid-template-columns: 96px 1fr;
 		}
 	}
 
@@ -68,8 +183,9 @@
 		cursor: pointer;
 	}
 
-	a:not(.card-link) {
-		position: relative; /* needed to allow mouse events on links above card-link */
+	:global(a):not(.card-link),
+	:global(.definition) {
+		position: relative; /* needed for supporting mouse events on links and definitions above card-link */
 	}
 
 	.card-image {
@@ -82,9 +198,38 @@
 
 	.card-body {
 		grid-area: body;
+		@apply text-sm;
+
+		@container (min-width: 768px) {
+			@apply text-base;
+		}
 	}
 
 	.card-footer {
 		grid-area: footer;
+		@apply mt-1;
+	}
+
+	.card-header-title {
+		@apply text-3-cond;
+		& :global([data-property='mainTitle']) {
+			@apply font-bold;
+		}
+
+		@container (min-width: 768px) {
+			@apply text-4-cond;
+
+			& :global([data-property='mainTitle']) {
+				@apply font-bold;
+			}
+		}
+	}
+
+	.card-header-extra,
+	.card-footer {
+		@apply text-xs text-secondary;
+		@container (min-width: 768px) {
+			@apply text-sm;
+		}
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/SearchCard.svelte
@@ -54,7 +54,7 @@
 			aria-labelledby={titleId}
 			aria-describedby={`${bodyId} ${footerId}`}
 		></a>
-		<div class="card-image">
+		<div class="card-image mt-1">
 			<div class="pointer-events-none relative flex h-full max-h-20 w-full max-w-20">
 				{#if item.image}
 					<img

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/(find)/[fnurgel=fnurgel]/+page.svelte
@@ -130,7 +130,9 @@
 		<Modal close={handleCloseHoldings}>
 			<span slot="title">{data.t('holdings.findAtYourNearestLibrary')}</span>
 			<div class="flex flex-col">
-				<div class="search-card mb-4 flex flex-col !gap-4 !p-4 text-sm">
+				<div
+					class="relative mb-4 flex w-full flex-col gap-x-4 rounded-md border-b border-b-primary/16 bg-cards p-5 text-sm transition-shadow"
+				>
 					<div
 						id="instance-details"
 						class="overview relative"
@@ -167,7 +169,7 @@
 						/>
 					</div>
 					<button
-						class="text-left underline"
+						class="mt-2 text-left underline"
 						on:click={() => (expandedHoldingsInstance = !expandedHoldingsInstance)}
 						aria-expanded={expandedHoldingsInstance}
 						aria-controls="instance-details"

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -149,11 +149,17 @@ export default {
 				'.text-3-regular': {
 					'@apply text-base font-normal': {}
 				},
+				'.text-3-cond': {
+					'@apply text-base font-condensed': {}
+				},
 				'.text-3-cond-bold': {
 					'@apply text-base font-condensed font-bold': {}
 				},
 				'.text-4-regular': {
 					'@apply text-lg font-normal': {}
+				},
+				'.text-4-cond': {
+					'@apply text-lg font-condensed': {}
 				},
 				'.text-4-cond-bold': {
 					'@apply text-lg font-condensed font-bold': {}

--- a/lxl-web/tests/find.spec.ts
+++ b/lxl-web/tests/find.spec.ts
@@ -27,8 +27,8 @@ test('displays 10 search cards on a page', async ({ page }) => {
 	await expect(page.getByTestId('search-card')).toHaveCount(10);
 });
 
-test('search card heading contains a link', async ({ page }) => {
-	await expect(page.getByTestId('search-card-heading').first()).toHaveAttribute('href');
+test('search card contains a link', async ({ page }) => {
+	await expect(page.getByTestId('search-card').first().getByRole('link')).toHaveAttribute('href');
 });
 
 test('has a facet panel', async ({ page }) => {


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-152](https://kbse.atlassian.net/browse/LWS-152)

### Solves

Redesign of the search card items showing more relevant information (e.g. more than one contributor) in semantically separated card sections (header, body, and footer).

The content is placed in separate sections using the new fresnel lenses `web-card-header-extra` and `web-card-footer` (together with the previously used derived lens`LxlLens.CardBody`).

**After:**
<img width="1210" alt="Skärmavbild 2024-05-28 kl  10 26 48" src="https://github.com/libris/lxlviewer/assets/10220360/451ffea3-b4e5-404d-b750-01686a6a28ca">

**Before:**
<img width="1198" alt="Skärmavbild 2024-05-28 kl  10 27 21" src="https://github.com/libris/lxlviewer/assets/10220360/468082d0-3026-4da0-9ca4-1581538e0107">


### Summary of changes

- Split search card information into sections using new lenses
- Add new search card layout using container queries for responsive design