### PR TITLE
LWS-313: Yet another pagination bugfix

### DIFF
--- a/lxl-web/src/lib/components/find/Pagination.svelte
+++ b/lxl-web/src/lib/components/find/Pagination.svelte
@@ -33,7 +33,6 @@
 </script>
 
 {#if data.items.length > 0 && totalItems > itemsPerPage}
-	{console.log(pageSequence)}
 	<nav aria-label={$page.data.t('search.pagination')} data-testid="pagination">
 		<ul class="my-4 flex justify-center gap-1.5 sm:gap-2">
 			<!-- prev -->

--- a/lxl-web/src/lib/components/find/Pagination.svelte
+++ b/lxl-web/src/lib/components/find/Pagination.svelte
@@ -36,63 +36,58 @@
 
 {#if data.items.length > 0 && totalItems > itemsPerPage}
 	<nav aria-label="paginering" data-testid="pagination">
-		<ul class="my-4 flex justify-center">
-			<!-- prev and first -->
+		<ul class="my-4 flex justify-center gap-1.5 sm:gap-2">
+			<!-- prev -->
 			{#if !isFirstPage || itemOffset > 0}
 				<li>
 					<a
-						class="button-ghost mx-2 w-11 p-0"
+						class="button-ghost"
 						href={getOffsetLink(itemOffset - itemsPerPage)}
 						aria-label={$page.data.t('search.previous')}
 						><BiChevronLeft aria-hidden="true" class="text-icon" /></a
 					>
 				</li>
-				{#if sequenceStart > 1}
-					<li>
-						<a
-							aria-label="{$page.data.t('search.page')} 1"
-							class="button-ghost mx-1"
-							href={first['@id']}>1</a
-						>
-					</li>
-				{/if}
 			{/if}
+			<!-- first -->
+			<li>
+				<a
+					aria-label="{$page.data.t('search.page')} 1"
+					class={isFirstPage ? 'button-primary' : 'button-ghost'}
+					href={first['@id']}>1</a
+				>
+			</li>
 			{#if sequenceStart > 2}
-				<li class="mx-1 flex items-end text-3-cond-bold"><span>...</span></li>
+				<li class="flex items-end text-3-cond-bold"><span>...</span></li>
 			{/if}
 			<!-- page sequence -->
 			{#each pageSequence as p}
-				<li>
-					<a
-						class="mx-1
-							{p === currentPage ? 'button-primary' : 'button-ghost'}
-							{p !== currentPage && p !== 2 ? 'hidden sm:flex' : ''}"
-						href={getOffsetLink(itemsPerPage * (p - 1))}
-						aria-label="{$page.data.t('search.page')} {p}"
-						aria-current={p === currentPage ? 'page' : null}
-						>{p.toLocaleString($page.data.locale)}</a
-					>
-				</li>
-			{/each}
-			{#if lastPage - sequenceEnd > 1}
-				<li class="mx-1 flex items-end text-3-cond-bold"><span>...</span></li>
-			{/if}
-			<!-- last and next -->
-			{#if !isLastPage}
-				{#if sequenceEnd !== lastPage}
+				{#if p !== 1 && p !== lastPage}
 					<li>
 						<a
-							aria-label="{$page.data.t('search.page')} {lastPage}"
-							class="button-ghost mx-1"
-							href={last['@id']}>{lastPage.toLocaleString($page.data.locale)}</a
+							class={p === currentPage ? 'button-primary' : 'button-ghost'}
+							href={getOffsetLink(itemsPerPage * (p - 1))}
+							aria-label="{$page.data.t('search.page')} {p}"
+							aria-current={p === currentPage ? 'page' : null}
+							>{p.toLocaleString($page.data.locale)}</a
 						>
 					</li>
 				{/if}
+			{/each}
+			{#if lastPage - sequenceEnd > 1}
+				<li class="flex items-end text-3-cond-bold"><span>...</span></li>
+			{/if}
+			<!-- last -->
+			<li>
+				<a
+					aria-label="{$page.data.t('search.page')} {lastPage}"
+					class={isLastPage ? 'button-primary' : 'button-ghost'}
+					href={last['@id']}>{lastPage.toLocaleString($page.data.locale)}</a
+				>
+			</li>
+			<!-- next -->
+			{#if next}
 				<li>
-					<a
-						class="button-ghost mx-2 w-11 p-0"
-						href={next?.['@id']}
-						aria-label={$page.data.t('search.next')}
+					<a class="button-ghost" href={next?.['@id']} aria-label={$page.data.t('search.next')}
 						><BiChevronRight aria-hidden="true" class="text-icon" /></a
 					>
 				</li>
@@ -100,3 +95,9 @@
 		</ul>
 	</nav>
 {/if}
+
+<style lang="postcss">
+	nav li > a {
+		@apply mobile-only:h-8 mobile-only:px-2.5;
+	}
+</style>

--- a/lxl-web/src/lib/components/find/Pagination.svelte
+++ b/lxl-web/src/lib/components/find/Pagination.svelte
@@ -34,7 +34,7 @@
 
 {#if data.items.length > 0 && totalItems > itemsPerPage}
 	<nav aria-label={$page.data.t('search.pagination')} data-testid="pagination">
-		<ul class="my-4 flex justify-center gap-1.5 sm:gap-2">
+		<ul class="flex flex-wrap justify-center gap-1.5 overflow-hidden page-padding sm:gap-2">
 			<!-- prev -->
 			{#if !isFirstPage || itemOffset > 0}
 				<li>
@@ -96,6 +96,6 @@
 
 <style lang="postcss">
 	nav li > a {
-		@apply mobile-only:h-8 mobile-only:px-2.5;
+		@apply min-h-11 min-w-11 !px-2;
 	}
 </style>

--- a/lxl-web/src/lib/components/find/Pagination.svelte
+++ b/lxl-web/src/lib/components/find/Pagination.svelte
@@ -30,7 +30,7 @@
 
 	function getOffsetLink(offset: number) {
 		let o = offset < 0 ? 0 : offset;
-		const params = new URLSearchParams($page.url.searchParams.toString());
+		const params = new URLSearchParams(first['@id']);
 		params.set('_offset', o.toString());
 		return `${$page.url.pathname}?${params.toString()}`;
 	}
@@ -38,12 +38,12 @@
 
 {#if data.items.length > 0 && totalItems > itemsPerPage}
 	<nav aria-label="paginering" data-testid="pagination">
-		<ul class="my-4 flex justify-center gap-2">
+		<ul class="my-4 flex justify-center">
 			<!-- prev and first -->
 			{#if !isFirstPage || itemOffset > 0}
 				<li>
 					<a
-						class="button-ghost"
+						class="button-ghost mx-1 w-11 p-0"
 						href={getOffsetLink(itemOffset - itemsPerPage)}
 						aria-label={$page.data.t('search.previous')}
 						><BiChevronLeft aria-hidden="true" class="text-icon" /></a
@@ -51,20 +51,24 @@
 				</li>
 				{#if sequenceStart > 1}
 					<li>
-						<a aria-label="{$page.data.t('search.page')} 1" class="button-ghost" href={first['@id']}
-							>1</a
+						<a
+							aria-label="{$page.data.t('search.page')} 1"
+							class="button-ghost mx-1"
+							href={first['@id']}>1</a
 						>
 					</li>
 				{/if}
 			{/if}
 			{#if sequenceStart > 2}
-				<li class="flex items-end text-3-cond-bold"><span>...</span></li>
+				<li class="mx-1 flex items-end text-3-cond-bold"><span>...</span></li>
 			{/if}
 			<!-- page sequence -->
 			{#each pageSequence as p}
 				<li>
 					<a
-						class={p === currentPage ? 'button-primary' : 'button-ghost hidden sm:flex'}
+						class="mx-1
+							{p === currentPage ? 'button-primary' : 'button-ghost'}
+							{p !== currentPage && p !== 2 ? 'hidden sm:flex' : ''}"
 						href={getOffsetLink(itemsPerPage * (p - 1))}
 						aria-label="{$page.data.t('search.page')} {p}"
 						aria-current={p === currentPage ? 'page' : null}
@@ -73,7 +77,7 @@
 				</li>
 			{/each}
 			{#if lastPage - sequenceEnd > 1}
-				<li class="flex items-end text-3-cond-bold"><span>...</span></li>
+				<li class="mx-1 flex items-end text-3-cond-bold"><span>...</span></li>
 			{/if}
 			<!-- last and next -->
 			{#if !isLastPage}
@@ -81,13 +85,16 @@
 					<li>
 						<a
 							aria-label="{$page.data.t('search.page')} {lastPage}"
-							class="button-ghost"
+							class="button-ghost mx-1"
 							href={last['@id']}>{lastPage.toLocaleString($page.data.locale)}</a
 						>
 					</li>
 				{/if}
 				<li>
-					<a class="button-ghost" href={next?.['@id']} aria-label={$page.data.t('search.next')}
+					<a
+						class="button-ghost mx-1 w-11 p-0"
+						href={next?.['@id']}
+						aria-label={$page.data.t('search.next')}
 						><BiChevronRight aria-hidden="true" class="text-icon" /></a
 					>
 				</li>

--- a/lxl-web/src/lib/components/find/Pagination.svelte
+++ b/lxl-web/src/lib/components/find/Pagination.svelte
@@ -35,7 +35,7 @@
 </script>
 
 {#if data.items.length > 0 && totalItems > itemsPerPage}
-	<nav aria-label="paginering" data-testid="pagination">
+	<nav aria-label={$page.data.t('search.pagination')} data-testid="pagination">
 		<ul class="my-4 flex justify-center gap-1.5 sm:gap-2">
 			<!-- prev -->
 			{#if !isFirstPage || itemOffset > 0}

--- a/lxl-web/src/lib/components/find/Pagination.svelte
+++ b/lxl-web/src/lib/components/find/Pagination.svelte
@@ -30,9 +30,7 @@
 
 	function getOffsetLink(offset: number) {
 		let o = offset < 0 ? 0 : offset;
-		const params = new URLSearchParams(first['@id']);
-		params.set('_offset', o.toString());
-		return `${$page.url.pathname}?${params.toString()}`;
+		return `${first['@id']}&_offset=${o}`;
 	}
 </script>
 
@@ -43,7 +41,7 @@
 			{#if !isFirstPage || itemOffset > 0}
 				<li>
 					<a
-						class="button-ghost mx-1 w-11 p-0"
+						class="button-ghost mx-2 w-11 p-0"
 						href={getOffsetLink(itemOffset - itemsPerPage)}
 						aria-label={$page.data.t('search.previous')}
 						><BiChevronLeft aria-hidden="true" class="text-icon" /></a
@@ -92,7 +90,7 @@
 				{/if}
 				<li>
 					<a
-						class="button-ghost mx-1 w-11 p-0"
+						class="button-ghost mx-2 w-11 p-0"
 						href={next?.['@id']}
 						aria-label={$page.data.t('search.next')}
 						><BiChevronRight aria-hidden="true" class="text-icon" /></a

--- a/lxl-web/src/lib/components/find/Pagination.svelte
+++ b/lxl-web/src/lib/components/find/Pagination.svelte
@@ -34,7 +34,7 @@
 
 {#if data.items.length > 0 && totalItems > itemsPerPage}
 	<nav aria-label={$page.data.t('search.pagination')} data-testid="pagination">
-		<ul class="flex flex-wrap justify-center gap-1.5 overflow-hidden page-padding sm:gap-2">
+		<ul class="flex justify-center overflow-hidden page-padding">
 			<!-- prev -->
 			{#if !isFirstPage || itemOffset > 0}
 				<li>
@@ -55,14 +55,16 @@
 				>
 			</li>
 			{#if sequenceStart > 2}
-				<li class="flex items-end text-3-cond-bold"><span>...</span></li>
+				<li class="hidden items-end text-3-cond-bold sm:flex"><span>...</span></li>
 			{/if}
 			<!-- page sequence -->
 			{#each pageSequence as p}
 				{#if p !== 1 && p !== lastPage}
 					<li>
 						<a
-							class={p === currentPage ? 'button-primary' : 'button-ghost'}
+							class={p === currentPage
+								? 'button-primary !mx-4 sm:!mx-0.5'
+								: 'button-ghost hidden sm:flex'}
 							href={getOffsetLink(itemsPerPage * (p - 1))}
 							aria-label="{$page.data.t('search.page')} {p}"
 							aria-current={p === currentPage ? 'page' : null}
@@ -72,7 +74,7 @@
 				{/if}
 			{/each}
 			{#if lastPage - sequenceEnd > 1}
-				<li class="flex items-end text-3-cond-bold"><span>...</span></li>
+				<li class="hidden items-end text-3-cond-bold sm:flex"><span>...</span></li>
 			{/if}
 			<!-- last -->
 			<li>
@@ -95,6 +97,10 @@
 {/if}
 
 <style lang="postcss">
+	nav li > * {
+		@apply mx-0.5;
+	}
+
 	nav li > a {
 		@apply min-h-11 min-w-11 !px-2;
 	}

--- a/lxl-web/src/lib/components/find/Pagination.svelte
+++ b/lxl-web/src/lib/components/find/Pagination.svelte
@@ -13,11 +13,9 @@
 	$: isLastPage = currentPage === lastPage;
 
 	// How many pages to display in a sequence (excl first & last)
-	let sequenceSize = 3;
+	const MAX_SIZE = 8;
+	$: sequenceSize = MAX_SIZE > lastPage ? lastPage : MAX_SIZE;
 
-	$: if (sequenceSize > lastPage) {
-		sequenceSize = lastPage;
-	}
 	$: sequenceStart = (() => {
 		if (currentPage + (sequenceSize - 1) >= lastPage) {
 			return lastPage - (sequenceSize - 1);
@@ -35,6 +33,7 @@
 </script>
 
 {#if data.items.length > 0 && totalItems > itemsPerPage}
+	{console.log(pageSequence)}
 	<nav aria-label={$page.data.t('search.pagination')} data-testid="pagination">
 		<ul class="my-4 flex justify-center gap-1.5 sm:gap-2">
 			<!-- prev -->

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -83,6 +83,7 @@ export default {
 		type: 'Type',
 		related: 'related',
 		relatedOne: 'related',
+		pagination: 'pagination',
 		previous: 'Previous page',
 		page: 'Page',
 		next: 'Next page',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -82,6 +82,7 @@ export default {
 		type: 'Typ',
 		related: 'relaterade',
 		relatedOne: 'relaterad',
+		pagination: 'paginering',
 		previous: 'Föregående sida',
 		page: 'Sida',
 		next: 'Nästa sida',

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -11,6 +11,7 @@ export interface SearchResult {
 	first: Link;
 	last: Link;
 	next?: Link;
+	previous?: Link;
 	items: SearchResultItem[];
 	facetGroups: FacetGroup[];
 	predicates: MultiSelectFacet[];

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -32,6 +32,7 @@ export async function asResult(
 	const translate = await getTranslator(locale);
 	return {
 		...('next' in view && { next: replacePath(view.next as Link, usePath) }),
+		...('previous' in view && { previous: replacePath(view.previous as Link, usePath) }),
 		itemOffset: view.itemOffset,
 		itemsPerPage: view.itemsPerPage,
 		totalItems: view.totalItems,

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/en.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/en.md
@@ -12,6 +12,7 @@ Here we will continuously provide information about newly added features and pla
 
 - Improve help text
 - Selectable text in search results
+- Improved pagination
 
 ### 2024-05-29
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
@@ -12,6 +12,7 @@ Här kommer vi kontinuerligt berätta om nytillkomna funktioner och planerad utv
 
 - Förbättra hjälptext
 - Markerbar text i sökträffarna
+- Förbättrad paginering
 
 ### 2024-05-29
 

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -129,7 +129,7 @@ export default {
 	},
 	plugins: [
 		/** @type {import('tailwindcss/types/config').PluginCreator} */
-		({ addUtilities }) => {
+		({ addUtilities, addVariant }) => {
 			addUtilities({
 				// typography 1-6 variants in design
 				'.text-1-regular': {
@@ -192,6 +192,7 @@ export default {
 					'@apply p-4 sm:px-6': {}
 				}
 			});
+			addVariant('mobile-only', "@media screen and (max-width: theme('screens.sm'))");
 		}
 	]
 };

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -129,7 +129,7 @@ export default {
 	},
 	plugins: [
 		/** @type {import('tailwindcss/types/config').PluginCreator} */
-		({ addUtilities, addVariant }) => {
+		({ addUtilities }) => {
 			addUtilities({
 				// typography 1-6 variants in design
 				'.text-1-regular': {
@@ -192,7 +192,6 @@ export default {
 					'@apply p-4 sm:px-6': {}
 				}
 			});
-			addVariant('mobile-only', "@media screen and (max-width: theme('screens.sm'))");
 		}
 	]
 };

--- a/lxl-web/tests/find.spec.ts
+++ b/lxl-web/tests/find.spec.ts
@@ -67,5 +67,5 @@ test('can paginate to next and previous', async ({ page }) => {
 	await page.getByTestId('pagination').getByLabel('Nästa sida').click();
 	await expect(page).toHaveURL(/_offset=10/);
 	await page.getByTestId('pagination').getByLabel('Föregående sida').click();
-	await expect(page).toHaveURL(/_offset=0/);
+	await expect(page).not.toHaveURL(/_offset=/);
 });


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-131](https://kbse.atlassian.net/browse/LWS-131)

### Solves

Paginating the relation search does not work in some cases.

Because: simply appending `_offset` to the link causes a new double-fetch (introduced with the predicate tabs) that ultimately uses the predicate `view` to get the data. That link excludes any applied `_offset`, fetching the first 10 hits again.

By using a backend-made link as template for all pagination links, we avoid the problem (and double fetch) since they include the `_p` param.

### Summary of changes

* Fix pagination links
* Tweak pagination template
* Mobile look tweaks
