### PR TITLE
LWS-143: Related hits search

### DIFF
--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -9,9 +9,11 @@
 	export let autofocus: boolean = false;
 
 	$: showAdvanced = $page.url.searchParams.get('_x') === 'advanced';
-	let q = showAdvanced
-		? $page.url.searchParams.get('_q')?.trim()
-		: $page.url.searchParams.get('_i')?.trim();
+	let q = $page.params.fnurgel
+		? '' //don't reflect related search on resource pages
+		: showAdvanced
+			? $page.url.searchParams.get('_q')?.trim()
+			: $page.url.searchParams.get('_i')?.trim();
 
 	let params = getSortedSearchParams(addDefaultSearchParams($page.url.searchParams));
 	// Always reset these params on new search
@@ -22,10 +24,10 @@
 	const searchParams = Array.from(params);
 
 	afterNavigate(({ to }) => {
-		/** Update input value after navigation */
+		/** Update input value after navigation on /find route */
 		if (to?.url) {
 			let param = showAdvanced ? '_q' : '_i';
-			q = new URL(to.url).searchParams.get(param)?.trim();
+			q = $page.params.fnurgel ? '' : new URL(to.url).searchParams.get(param)?.trim();
 		}
 	});
 

--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -48,7 +48,7 @@
 		type="search"
 		name="_q"
 		{placeholder}
-		aria-label="Sök"
+		aria-label={$page.data.t('search.search')}
 		spellcheck="false"
 		bind:value={q}
 		{autofocus}

--- a/lxl-web/src/lib/components/find/FacetRange.svelte
+++ b/lxl-web/src/lib/components/find/FacetRange.svelte
@@ -53,7 +53,6 @@
 			bind:value={rangeTo}
 		/>
 	</div>
-	<!-- todo: reusable button classes -->
 	<button disabled={!rangeFrom && !rangeTo} class="button-primary" type="submit"
 		>{$page.data.t('general.apply')}</button
 	>

--- a/lxl-web/src/lib/components/find/SearchRelated.svelte
+++ b/lxl-web/src/lib/components/find/SearchRelated.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import BiSearch from '~icons/bi/search';
 	import { page } from '$app/stores';
 	import type { Link } from '$lib/utils/xl';
 
@@ -17,15 +18,19 @@
 	}
 </script>
 
-<form action="" on:submit={handleSubmit} class="flex gap-2">
+<form action="" on:submit={handleSubmit} class="flex w-full max-w-xl gap-2">
 	<label for="search-related" class="sr-only">{$page.data.t('search.RelatedSearchLabel')}</label>
 	<input
+		class="flex-1"
 		id="search-related"
 		type="search"
 		placeholder={$page.data.t('search.RelatedSearchLabel')}
 		bind:value={_i}
 	/>
-	<button class="button-primary" type="submit">{$page.data.t('search.search')}</button>
+	<button class="button-primary" type="submit">
+		<BiSearch fill="currentColor" aria-hidden="true" />
+		<span class="sr-only sm:not-sr-only">{$page.data.t('search.search')}</span>
+	</button>
 
 	{#each searchParams as [name, value]}
 		{#if name !== '_i' && name !== '_q'}

--- a/lxl-web/src/lib/components/find/SearchRelated.svelte
+++ b/lxl-web/src/lib/components/find/SearchRelated.svelte
@@ -10,9 +10,9 @@
 	let searchParams = new URLSearchParams(url.search);
 	searchParams.set('_sort', $page.url.searchParams.get('_sort')?.trim() || '');
 
-	function handleSubmit(e: SubmitEvent) {
+	function handleSubmit() {
 		if (!_i) {
-			e.preventDefault();
+			_i = '*';
 		}
 	}
 </script>
@@ -25,9 +25,7 @@
 		placeholder={$page.data.t('search.RelatedSearchLabel')}
 		bind:value={_i}
 	/>
-	<button disabled={!_i} class="button-primary" type="submit"
-		>{$page.data.t('search.search')}</button
-	>
+	<button class="button-primary" type="submit">{$page.data.t('search.search')}</button>
 
 	{#each searchParams as [name, value]}
 		{#if name !== '_i' && name !== '_q'}

--- a/lxl-web/src/lib/components/find/SearchRelated.svelte
+++ b/lxl-web/src/lib/components/find/SearchRelated.svelte
@@ -19,12 +19,12 @@
 </script>
 
 <form action="" on:submit={handleSubmit} class="flex w-full max-w-xl gap-2">
-	<label for="search-related" class="sr-only">{$page.data.t('search.RelatedSearchLabel')}</label>
+	<label for="search-related" class="sr-only">{$page.data.t('search.relatedSearchLabel')}</label>
 	<input
 		class="flex-1"
 		id="search-related"
 		type="search"
-		placeholder={$page.data.t('search.RelatedSearchLabel')}
+		placeholder={$page.data.t('search.relatedSearchLabel')}
 		bind:value={_i}
 	/>
 	<button class="button-primary" type="submit">

--- a/lxl-web/src/lib/components/find/SearchRelated.svelte
+++ b/lxl-web/src/lib/components/find/SearchRelated.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import getDefaultSearchParams from '$lib/utils/addDefaultSearchParams';
+	import getSortedSearchParams from '$lib/utils/getSortedSearchParams';
+
+	let q = $page.url.searchParams.get('_i')?.trim();
+	let searchParams = getSortedSearchParams(getDefaultSearchParams($page.url.searchParams));
+
+	function handleSubmit(e: SubmitEvent) {
+		if (!q) {
+			e.preventDefault();
+			alert('preventing!');
+		}
+	}
+</script>
+
+<form action="" on:submit={handleSubmit}>
+	<label for="search-related" class="sr-only">{$page.data.t('search.RelatedSearchLabel')}</label>
+	<input
+		id="search-related"
+		type="search"
+		placeholder={$page.data.t('search.RelatedSearchLabel')}
+		bind:value={q}
+	/>
+
+	{#each searchParams as [name, value]}
+		<input type="hidden" {name} {value} />
+	{/each}
+</form>

--- a/lxl-web/src/lib/components/find/SearchRelated.svelte
+++ b/lxl-web/src/lib/components/find/SearchRelated.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import getDefaultSearchParams from '$lib/utils/addDefaultSearchParams';
-	import getSortedSearchParams from '$lib/utils/getSortedSearchParams';
+	import type { Link } from '$lib/utils/xl';
 
-	export let predicate;
+	export let view: Link;
 
-	let _i = $page.url.searchParams.get('_i')?.trim();
-	let searchParams = getSortedSearchParams(getDefaultSearchParams($page.url.searchParams));
+	let _i = $page.url.searchParams.get('_i')?.trim() || '';
 
-	searchParams.delete('_offset');
-	console.log(predicate);
-	// todo: iterate predicate
+	let url = new URL($page.url.origin + view['@id']);
+	let searchParams = new URLSearchParams(url.search);
+	searchParams.set('_sort', $page.url.searchParams.get('_sort')?.trim() || '');
 
 	function handleSubmit(e: SubmitEvent) {
 		if (!_i) {
@@ -27,7 +25,9 @@
 		placeholder={$page.data.t('search.RelatedSearchLabel')}
 		bind:value={_i}
 	/>
-	<button class="button-primary" type="submit">{$page.data.t('search.search')}</button>
+	<button disabled={!_i} class="button-primary" type="submit"
+		>{$page.data.t('search.search')}</button
+	>
 
 	{#each searchParams as [name, value]}
 		{#if name !== '_i' && name !== '_q'}

--- a/lxl-web/src/lib/components/find/SearchRelated.svelte
+++ b/lxl-web/src/lib/components/find/SearchRelated.svelte
@@ -18,7 +18,7 @@
 	}
 </script>
 
-<form action="" on:submit={handleSubmit} class="flex w-full max-w-xl gap-2">
+<form action="" on:submit={handleSubmit} class="flex w-full gap-2 lg:max-w-xl">
 	<label for="search-related" class="sr-only">{$page.data.t('search.relatedSearchLabel')}</label>
 	<input
 		class="flex-1"

--- a/lxl-web/src/lib/components/find/SearchRelated.svelte
+++ b/lxl-web/src/lib/components/find/SearchRelated.svelte
@@ -3,27 +3,37 @@
 	import getDefaultSearchParams from '$lib/utils/addDefaultSearchParams';
 	import getSortedSearchParams from '$lib/utils/getSortedSearchParams';
 
-	let q = $page.url.searchParams.get('_i')?.trim();
+	export let predicate;
+
+	let _i = $page.url.searchParams.get('_i')?.trim();
 	let searchParams = getSortedSearchParams(getDefaultSearchParams($page.url.searchParams));
 
+	searchParams.delete('_offset');
+	console.log(predicate);
+	// todo: iterate predicate
+
 	function handleSubmit(e: SubmitEvent) {
-		if (!q) {
+		if (!_i) {
 			e.preventDefault();
-			alert('preventing!');
 		}
 	}
 </script>
 
-<form action="" on:submit={handleSubmit}>
+<form action="" on:submit={handleSubmit} class="flex gap-2">
 	<label for="search-related" class="sr-only">{$page.data.t('search.RelatedSearchLabel')}</label>
 	<input
 		id="search-related"
 		type="search"
 		placeholder={$page.data.t('search.RelatedSearchLabel')}
-		bind:value={q}
+		bind:value={_i}
 	/>
+	<button class="button-primary" type="submit">{$page.data.t('search.search')}</button>
 
 	{#each searchParams as [name, value]}
-		<input type="hidden" {name} {value} />
+		{#if name !== '_i' && name !== '_q'}
+			<input type="hidden" {name} {value} />
+		{/if}
 	{/each}
+	<input type="hidden" name="_i" value={_i} />
+	<input type="hidden" name="_q" value={_i} />
 </form>

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -154,7 +154,7 @@
 						</span>
 						{#if $page.params.fnurgel && numHits > 0}
 							{@const activePredicate = searchResult.predicates.filter((p) => p.selected)}
-							<SearchRelated predicate={activePredicate} />
+							<SearchRelated view={activePredicate[0].view} />
 						{/if}
 						{#if numHits > 0}
 							<div

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -10,6 +10,7 @@
 	import BiChevronDown from '~icons/bi/chevron-down';
 	import type { SearchResult, DisplayMapping } from '$lib/types/search';
 	import { shouldShowMapping } from '$lib/utils/search';
+	import SearchRelated from './SearchRelated.svelte';
 
 	let showFiltersModal = false;
 	export let searchResult: SearchResult;
@@ -151,6 +152,9 @@
 								{$page.data.t('search.noResults')}
 							{/if}
 						</span>
+						{#if $page.params.fnurgel && numHits > 0}
+							<SearchRelated />
+						{/if}
 						{#if numHits > 0}
 							<div
 								class="sort-select flex flex-col items-end justify-self-end"
@@ -192,8 +196,8 @@
 	.toolbar {
 		display: grid;
 		grid-template-areas:
-			'filter-modal-toggle sort-select'
-			'hits hits';
+			'filter-modal-toggle search'
+			'hits sort-select';
 	}
 
 	.find-layout {
@@ -227,6 +231,10 @@
 		grid-area: hits;
 	}
 
+	.search {
+		grid-area: search;
+	}
+
 	@media screen and (min-width: theme('screens.md')) {
 		.filters {
 			display: block;
@@ -237,7 +245,7 @@
 		}
 
 		.toolbar {
-			grid-template-areas: 'hits sort-select';
+			grid-template-areas: 'hits search sort-select';
 		}
 	}
 	.tab-header {

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -109,6 +109,7 @@
 				<div class="results max-w-content">
 					<div
 						class="toolbar flex min-h-14 items-center justify-between page-padding md:min-h-fit md:p-0 md:pb-4"
+						class:has-search={$page.params.fnurgel}
 					>
 						<a
 							href={`${$page.url.pathname}?${$page.url.searchParams.toString()}#filters`}
@@ -152,10 +153,12 @@
 								{$page.data.t('search.noResults')}
 							{/if}
 						</span>
-						{#if $page.params.fnurgel}
-							{@const activePredicate = searchResult.predicates.filter((p) => p.selected)}
-							<SearchRelated view={activePredicate[0].view} />
-						{/if}
+						<div class="search-related flex justify-start">
+							{#if $page.params.fnurgel}
+								{@const activePredicate = searchResult.predicates.filter((p) => p.selected)}
+								<SearchRelated view={activePredicate[0].view} />
+							{/if}
+						</div>
 						{#if numHits > 0}
 							<div
 								class="sort-select flex flex-col items-end justify-self-end"
@@ -195,10 +198,15 @@
 
 <style lang="postcss">
 	.toolbar {
-		display: grid;
+		@apply grid;
 		grid-template-areas:
-			'filter-modal-toggle search'
-			'hits sort-select';
+			'search-related search-related'
+			'filter-modal-toggle sort-select'
+			'hits .';
+	}
+
+	.toolbar.has-search {
+		@apply gap-4;
 	}
 
 	.find-layout {
@@ -232,8 +240,17 @@
 		grid-area: hits;
 	}
 
-	.search {
-		grid-area: search;
+	.search-related {
+		grid-area: search-related;
+	}
+
+	@media screen and (min-width: theme('screens.sm')) {
+		.toolbar {
+			grid-template-areas:
+				'filter-modal-toggle search-related'
+				'hits sort-select';
+			grid-template-columns: auto 1fr;
+		}
 	}
 
 	@media screen and (min-width: theme('screens.md')) {
@@ -246,7 +263,9 @@
 		}
 
 		.toolbar {
-			grid-template-areas: 'hits search sort-select';
+			grid-template-areas:
+				'search-related search-related'
+				'hits sort-select';
 		}
 	}
 	.tab-header {
@@ -261,5 +280,12 @@
 	.tab-selected {
 		@apply border-primary pb-3.5;
 		border-bottom-width: 0.125rem;
+	}
+
+	@media screen and (min-width: theme('screens.lg')) {
+		.toolbar {
+			grid-template-areas: 'hits search-related sort-select';
+			grid-template-columns: auto minmax(auto, theme('screens.sm')) auto;
+		}
 	}
 </style>

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -200,8 +200,8 @@
 	.toolbar {
 		@apply grid;
 		grid-template-areas:
-			'search-related search-related'
 			'filter-modal-toggle .'
+			'search-related search-related'
 			'hits sort-select';
 	}
 

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -153,7 +153,8 @@
 							{/if}
 						</span>
 						{#if $page.params.fnurgel && numHits > 0}
-							<SearchRelated />
+							{@const activePredicate = searchResult.predicates.filter((p) => p.selected)}
+							<SearchRelated predicate={activePredicate} />
 						{/if}
 						{#if numHits > 0}
 							<div

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -152,7 +152,7 @@
 								{$page.data.t('search.noResults')}
 							{/if}
 						</span>
-						{#if $page.params.fnurgel && numHits > 0}
+						{#if $page.params.fnurgel}
 							{@const activePredicate = searchResult.predicates.filter((p) => p.selected)}
 							<SearchRelated view={activePredicate[0].view} />
 						{/if}

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -201,8 +201,8 @@
 		@apply grid;
 		grid-template-areas:
 			'search-related search-related'
-			'filter-modal-toggle sort-select'
-			'hits .';
+			'filter-modal-toggle .'
+			'hits sort-select';
 	}
 
 	.toolbar.has-search {

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -90,7 +90,8 @@ export default {
 		showFewer: 'Show fewer',
 		showDetails: 'Show more',
 		hideDetails: 'Show less',
-		occursAs: 'as'
+		occursAs: 'as',
+		RelatedSearchLabel: 'Search the results'
 	},
 	sort: {
 		sort: 'Sort',

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -91,7 +91,7 @@ export default {
 		showDetails: 'Show more',
 		hideDetails: 'Show less',
 		occursAs: 'as',
-		RelatedSearchLabel: 'Search the results'
+		relatedSearchLabel: 'Search the results'
 	},
 	sort: {
 		sort: 'Sort',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -90,7 +90,7 @@ export default {
 		showDetails: 'Visa mer',
 		hideDetails: 'Visa mindre',
 		occursAs: 'förekommer som',
-		RelatedSearchLabel: 'Sök i resultaten'
+		relatedSearchLabel: 'Sök i resultaten'
 	},
 	sort: {
 		sort: 'Sortera',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -89,7 +89,8 @@ export default {
 		showFewer: 'Visa färre',
 		showDetails: 'Visa mer',
 		hideDetails: 'Visa mindre',
-		occursAs: 'förekommer som'
+		occursAs: 'förekommer som',
+		RelatedSearchLabel: 'Sök i resultaten'
 	},
 	sort: {
 		sort: 'Sortera',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -90,7 +90,10 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 
 		if (resourceId) {
 			searchParams.set('_o', resourceId);
-			searchParams.set('_i', '*');
+
+			if (!searchParams.has('_i')) {
+				searchParams.set('_i', '*');
+			}
 			searchParams = getSortedSearchParams(addDefaultSearchParams(searchParams));
 		}
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -111,8 +111,7 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 			}
 		}
 
-		// Hide zero results from resource page
-		if (result.totalItems > 0) {
+		if (result) {
 			return (await asResult(
 				result,
 				displayUtil,


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-143](https://kbse.atlassian.net/browse/LWS-143)

### Solves

Adds a search input in the toolbar section for the related search result

### Summary of changes

* Added component `SearchRelated` that searches in the context of the current `_o` and `_p`.
* Zero results for the related search is no longer hidden, as it can now happen as a result of an active search.
* Some modifications to 'main search' to stay independent of related search.

Limits/todos:

* Searching completely clears any existing filters, due to frontends inability to modify `_q` param in a safe way. If we need to keep the filters, maybe template links (such as in year range) could be a solution.
* Layout/placement of the search bar for different widths is debatable (lack of design in Figma).