### PR TITLE
Alternative to external link icon

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -527,7 +527,7 @@
 			"fresnel:resourceStyle": ["link"]
 		},
 		"seeAlso-format": {
-			"@id": "genreForm-format",
+			"@id": "seeAlso-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Agent"],
 			"fresnel:propertyFormatDomain": ["seeAlso"],
@@ -571,7 +571,7 @@
 			"@id": "MediaObject-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["MediaObject"],
-			"fresnel:resourceStyle": ["ext-link", "uriToId()", "text-3-cond-bold"]
+			"fresnel:resourceStyle": ["ext-link", "uriToId()", "text-3-cond-bold", "block"]
 		},
 		"Document-format": {
 			"@id": "Document-format",

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -6,7 +6,6 @@
 	import { hasStyle, getStyle, getResourceId, getPropertyValue } from '$lib/utils/resourceData';
 	import { relativizeUrl } from '$lib/utils/http';
 	import { getSupportedLocale } from '$lib/i18n/locales';
-	import BiBoxArrowUpRight from '~icons/bi/box-arrow-up-right';
 
 	export let data: ResourceData;
 	export let depth = 0;
@@ -246,17 +245,6 @@
 					{data._contentAfter}
 				</span>
 			{/if}
-			{#if hasStyle(data, 'ext-link')}
-				<a href={getLink(data)} target="_blank">
-					<span class="ext-link inline-block pl-1">
-						<BiBoxArrowUpRight />
-					</span>
-					<!-- FIXME don't hardcode MediaObject -->
-					{#if data['@type'] === 'MediaObject'}
-						<span class="whitespace-pre after:content-['\a']"></span>
-					{/if}
-				</a>
-			{/if}
 		{/if}
 	{:else}
 		{data}
@@ -264,6 +252,11 @@
 {/key}
 
 <style lang="postcss">
+	.ext-link::after {
+		content: ' ↗';
+		@apply text-icon;
+	}
+
 	.definition {
 		@apply text-sm text-secondary underline decoration-dotted;
 	}

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -253,8 +253,8 @@
 
 <style lang="postcss">
 	.ext-link::after {
-		content: ' ↗';
-		@apply text-icon;
+		content: '\2009↗';
+		@apply align-[10%] text-icon;
 	}
 
 	.definition {


### PR DESCRIPTION
### Tickets involved
[LWS-194](https://kbse.atlassian.net/browse/LWS-194)

### Summary of changes

The implementation for showing an icon after external links was severely shoehorned into the decorated data logic, with hard coded types etc to make it work. A fix for LWS-194 conforming to this implementation would require even more special handling, and felt strained.
This is an attempt at a more simple solution, that should work for properties regardless of their current presentation/style. 

It looks like this:
![Screenshot from 2024-06-03 15-18-49](https://github.com/libris/lxlviewer/assets/48950665/d1022139-7a7d-4420-a85b-53c29b492691)

![Screenshot from 2024-06-03 15-19-12](https://github.com/libris/lxlviewer/assets/48950665/1c6d8258-1966-4730-bf79-b15d5d0b612a)

Inspired by top bar at https://iconify.design/docs/usage/svg/unplugin/:
![Screenshot from 2024-06-03 15-36-55](https://github.com/libris/lxlviewer/assets/48950665/f3f29904-5bf8-459e-8965-a562f3647f80)

Could maybe be fine tuned with a slight vertical raise?
