### PR TITLE
Make card-header-extra text selectable

### DIFF
--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -193,6 +193,7 @@
 	}
 
 	:global(a):not(.card-link),
+	.card-header-extra :global(> span),
 	.card-body :global(span:first-of-type),
 	.card-footer :global(> span) {
 		position: relative; /* needed for supporting mouse events on text, links and definitions above card-link */


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-195](https://kbse.atlassian.net/browse/LWS-195)

### Solves

Make `card-header-extra` text in search card selectable.

### Summary of changes

- Make card-header-extra text selectable