### PR TITLE
LWS-196: Hide freetext mappings

### DIFF
--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -5,6 +5,7 @@
 	import { page } from '$app/stores';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import { getModalContext } from '$lib/contexts/modal';
+	import { getMappingsWithoutFreeText } from '$lib/utils/search';
 	import BiXLg from '~icons/bi/x-lg';
 	import BiPencil from '~icons/bi/pencil';
 	import BiPencilFill from '~icons/bi/pencil-fill';
@@ -23,6 +24,8 @@
 	$: toggleEditUrl = editActive
 		? $page.url.href.replace('&_x=advanced', '')
 		: `${$page.url.href}&_x=advanced`;
+
+	$: filteredMappings = getMappingsWithoutFreeText(mapping);
 
 	function getRelationSymbol(operator: keyof typeof SearchOperators): string {
 		switch (operator) {
@@ -49,7 +52,7 @@
 </script>
 
 <ul class="flex flex-wrap items-center gap-2">
-	{#each mapping as m}
+	{#each filteredMappings as m}
 		<li
 			class="mapping-item {m.children ? 'pill-group' : 'pill'} pill-{m.operator}"
 			class:wildcard={m.operator === 'equals' && m.display === '*'}

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -86,6 +86,7 @@
 				<nav
 					class="hidden md:flex md:px-6 md:pb-0 md:pt-4"
 					aria-label={$page.data.t('search.selectedFilters')}
+					data-testid="search-mapping"
 				>
 					<SearchMapping mapping={searchResult.mapping} />
 				</nav>

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -40,9 +40,7 @@
 	}
 
 	function getFiltersCount(mapping: DisplayMapping[]) {
-		return (mapping[0].children || mapping).filter(
-			(filterItem) => !(filterItem.display === '*' && filterItem.operator === 'equals') // TODO: probably best to do wildcard-filtering in an earlier step (in search.ts)?
-		).length;
+		return (mapping[0].children || mapping).length - 1; //  TODO: probably best to do free text-filtering in an earlier step (in search.ts)?
 	}
 </script>
 

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -222,8 +222,23 @@ function replacePath(view: Link, usePath: string) {
 }
 
 export function shouldShowMapping(mapping: DisplayMapping[]) {
-	if (mapping.length === 1 && mapping[0].display === '*' && mapping[0].operator === 'equals') {
-		return false; // hide if only wildcard search
+	if (!getMappingsWithoutFreeText(mapping).length) {
+		return false;
 	}
+
 	return true;
+}
+
+export function getMappingsWithoutFreeText(mappings: DisplayMapping[]) {
+	return mappings.reduce((acc: DisplayMapping[], currentMapping) => {
+		if (
+			currentMapping.children?.length ||
+			(currentMapping?.up?.['@id'] &&
+				new RegExp(/(_i=)[^+&]+(?=&)?/).test(currentMapping.up['@id'])) // checks if there is an _i param value by matching any characters after _i except & (which indicates the end of an search param)
+		) {
+			return [...acc, currentMapping];
+		}
+
+		return acc;
+	}, []);
 }

--- a/lxl-web/tests/find.spec.ts
+++ b/lxl-web/tests/find.spec.ts
@@ -69,3 +69,9 @@ test('can paginate to next and previous', async ({ page }) => {
 	await page.getByTestId('pagination').getByLabel('Föregående sida').click();
 	await expect(page).not.toHaveURL(/_offset=/);
 });
+
+test('shows no selected facet for free text searches', async ({ page }) => {
+	await expect(page.getByTestId('search-mapping')).not.toBeVisible();
+	await page.goto('/find?_i=d&_q=d+%22rdf:type%22:Text&_limit=10');
+	await expect(page.getByTestId('search-mapping')).toBeVisible();
+});


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-196](https://kbse.atlassian.net/browse/LWS-196)

### Solves
Removes free text mappings from the list of selected facets.

### Summary of changes

- Hide free text mappings
- Add test

### Before
![Skärmavbild 2024-06-18 kl  13 49 25](https://github.com/libris/lxlviewer/assets/10220360/f672618c-039f-4732-ad61-3870ab88dd75)

### After
![Skärmavbild 2024-06-18 kl  13 49 19](https://github.com/libris/lxlviewer/assets/10220360/b7a9e49e-6362-4004-80f9-4ed791183028)
