### PR TITLE
LWS-211: Fix support for closing initially opened holdings modals

### DIFF
--- a/lxl-web/src/lib/components/Modal.svelte
+++ b/lxl-web/src/lib/components/Modal.svelte
@@ -94,6 +94,7 @@
 					autofocus
 					class="icon-button"
 					aria-label={$page.data.t('general.close')}
+					data-testid="close-modal"
 				>
 					<IconClose />
 				</button>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { afterNavigate, goto } from '$app/navigation';
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
 	import { Width } from '$lib/types/auxd';
 	import getPageTitle from '$lib/utils/getPageTitle';
@@ -20,6 +21,7 @@
 	let latestHoldingUrl: string | undefined;
 	let holdingsInstanceElement: HTMLElement | null;
 	let expandedHoldingsInstance = false;
+	let previousPage: string;
 
 	$: selectedHoldingInstance = selectedHolding
 		? data.instances?.find((instanceItem) => instanceItem['@id'].includes(selectedHolding)) ||
@@ -47,8 +49,22 @@
 	$: expandableHoldingsInstance =
 		holdingsInstanceElement?.scrollHeight > ASIDE_SEARCH_CARD_MAX_HEIGHT;
 
+	afterNavigate(({ from }) => {
+		if (from) {
+			previousPage = from.url.pathname;
+		}
+	});
+
 	function handleCloseHoldings() {
-		history.back();
+		if (previousPage) {
+			history.back();
+		} else {
+			const newSearchParams = new URLSearchParams([
+				...Array.from($page.url.searchParams.entries())
+			]);
+			newSearchParams.delete('holdings');
+			goto($page.url.pathname + `?${newSearchParams.toString()}`, { replaceState: false });
+		}
 	}
 </script>
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -21,7 +21,7 @@
 	let latestHoldingUrl: string | undefined;
 	let holdingsInstanceElement: HTMLElement | null;
 	let expandedHoldingsInstance = false;
-	let previousPage: string;
+	let previousURL: URL;
 
 	$: selectedHoldingInstance = selectedHolding
 		? data.instances?.find((instanceItem) => instanceItem['@id'].includes(selectedHolding)) ||
@@ -49,21 +49,21 @@
 	$: expandableHoldingsInstance =
 		holdingsInstanceElement?.scrollHeight > ASIDE_SEARCH_CARD_MAX_HEIGHT;
 
-	afterNavigate(({ from }) => {
-		if (from) {
-			previousPage = from.url.pathname;
+	afterNavigate(({ to }) => {
+		if (to) {
+			previousURL = to.url;
 		}
 	});
 
 	function handleCloseHoldings() {
-		if (previousPage) {
+		if (!previousURL.searchParams.has('holdings')) {
 			history.back();
 		} else {
 			const newSearchParams = new URLSearchParams([
 				...Array.from($page.url.searchParams.entries())
 			]);
 			newSearchParams.delete('holdings');
-			goto($page.url.pathname + `?${newSearchParams.toString()}`, { replaceState: false });
+			goto($page.url.pathname + `?${newSearchParams.toString()}`, { replaceState: true });
 		}
 	}
 </script>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/en.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/en.md
@@ -11,6 +11,7 @@ Here we will continuously provide information about newly added features and pla
 ### 2024-06-26
 
 - Hide labels for free text queries and add quotes instead
+- Fix bug which prevented closing of initially opened holdings modal
 
 ### 2024-06-12
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
@@ -11,6 +11,7 @@ Här kommer vi kontinuerligt berätta om nytillkomna funktioner och planerad utv
 ### 2024-06-26
 
 - Dölj etikett för fritext-sökningar och lägg till citattecken istället
+- Fixa bugg som förhindrade stängning av ursprungligt öppen beståndsmodal
 
 ### 2024-06-12
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
@@ -10,8 +10,8 @@ Här kommer vi kontinuerligt berätta om nytillkomna funktioner och planerad utv
 
 ### 2024-06-26
 
-- Dölj etikett för fritext-sökningar och lägg till citattecken istället
-- Fixa bugg som förhindrade stängning av ursprungligt öppen beståndsmodal
+- Dölj etikett för fritextsökningar och lägg till citattecken istället
+- Rätta bugg som förhindrade stängning av beståndsmodal
 
 ### 2024-06-12
 

--- a/lxl-web/tests/resource.spec.ts
+++ b/lxl-web/tests/resource.spec.ts
@@ -8,6 +8,16 @@ test('decorated data label visibilty is correct after page navigations', async (
 	await expect(page.getByText('Språk')).toBeVisible();
 });
 
+test('initially opened holdings modals are closable', async ({ page }) => {
+	await page.goto('/h08ndxddfg5v2pjf?holdings=Electronic');
+	await page.getByTestId('close-modal').first().click();
+	await expect(page).toHaveURL('/h08ndxddfg5v2pjf');
+	await expect(page.getByTestId('modal')).toBeHidden();
+	await page.getByTestId('holding-link').first().click();
+	await expect(page.getByTestId('modal')).toBeVisible();
+	await expect(page).toHaveURL('/h08ndxddfg5v2pjf?holdings=Electronic');
+});
+
 test('decorated data in holdings modal is not duplicated while closing modal', async ({ page }) => {
 	await page.goto('/h08ndxddfg5v2pjf');
 	await page.getByTestId('holding-link').first().click();


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-211](https://kbse.atlassian.net/browse/LWS-211)

### Solves

Adds support for closing initially opened holdings modals

### Summary of changes

- Add support for closing initially opened holdings modals
- Add test