### PR TITLE
LWS-213: Change default limit of results to 20

### DIFF
--- a/lxl-web/src/lib/utils/addDefaultSearchParams.test.ts
+++ b/lxl-web/src/lib/utils/addDefaultSearchParams.test.ts
@@ -6,7 +6,7 @@ describe('addDefaultSearchParams', () => {
 		expect(addDefaultSearchParams(new URLSearchParams())).toStrictEqual(
 			new URLSearchParams([
 				['_q', '*'],
-				['_limit', '10'],
+				['_limit', '20'],
 				['_offset', '0'],
 				['_sort', '']
 			])
@@ -16,7 +16,7 @@ describe('addDefaultSearchParams', () => {
 		expect(addDefaultSearchParams(new URLSearchParams([['_q', 'test']]))).toStrictEqual(
 			new URLSearchParams([
 				['_q', 'test'],
-				['_limit', '10'],
+				['_limit', '20'],
 				['_offset', '0'],
 				['_sort', '']
 			])
@@ -27,7 +27,7 @@ describe('addDefaultSearchParams', () => {
 			new URLSearchParams([
 				['_offset', '30'],
 				['_q', '*'],
-				['_limit', '10'],
+				['_limit', '20'],
 				['_sort', '']
 			])
 		);

--- a/lxl-web/src/lib/utils/addDefaultSearchParams.ts
+++ b/lxl-web/src/lib/utils/addDefaultSearchParams.ts
@@ -8,7 +8,7 @@ function addDefaultSearchParams(searchParams: URLSearchParams): URLSearchParams 
 		params.set('_q', '*');
 	}
 	if (!params.has('_limit')) {
-		params.set('_limit', '10');
+		params.set('_limit', '20');
 	}
 	if (!params.has('_offset')) {
 		params.set('_offset', '0');

--- a/lxl-web/src/lib/utils/http.test.ts
+++ b/lxl-web/src/lib/utils/http.test.ts
@@ -8,8 +8,8 @@ describe('relativize', () => {
 		);
 	});
 	it('removes the opening slash from a relative path', () => {
-		expect(relativizeUrl('/find?q=*&@type=Work&_limit=10')).toStrictEqual(
-			'find?q=*&@type=Work&_limit=10'
+		expect(relativizeUrl('/find?q=*&@type=Work&_limit=20')).toStrictEqual(
+			'find?q=*&@type=Work&_limit=20'
 		);
 	});
 });

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/en.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/en.md
@@ -13,7 +13,7 @@ Here we will continuously provide information about newly added features and pla
 - Change default number of hits per page to 20
 - Added search on result list for people and subjects
 - Hide labels for free text queries and add quotes instead
-- Fix bug which prevented closing of initially opened holdings modal
+- Bug fixes
 
 ### 2024-06-12
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/en.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/en.md
@@ -8,8 +8,9 @@ title: 'Hjälp'
 
 Here we will continuously provide information about newly added features and planned developments:
 
-### 2024-06-26
+### 2024-06-27
 
+- Change default number of hits per page to 20
 - Added search on result list for people and subjects
 - Hide labels for free text queries and add quotes instead
 - Fix bug which prevented closing of initially opened holdings modal

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
@@ -8,8 +8,9 @@ title: 'Hjälp'
 
 Här kommer vi kontinuerligt berätta om nytillkomna funktioner och planerad utveckling:
 
-### 2024-06-26
+### 2024-06-27
 
+- Ändra antalet sökträffar per sida till 20
 - Dölj etikett för fritextsökningar och lägg till citattecken istället
 - Rätta bugg som förhindrade stängning av beståndsmodal
 - Stöd för sök i träfflistan för personer och ämnen

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
@@ -12,7 +12,7 @@ Här kommer vi kontinuerligt berätta om nytillkomna funktioner och planerad utv
 
 - Ändra antalet sökträffar per sida till 20
 - Dölj etikett för fritextsökningar och lägg till citattecken istället
-- Rätta bugg som förhindrade stängning av beståndsmodal
+- Buggrättningar
 - Stöd för sök i träfflistan för personer och ämnen
 
 ### 2024-06-12

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
@@ -103,19 +103,19 @@ Här följer några exempel som går att skriva in som sökfrågor direkt i sök
 
 Engelska och franska verk som matchar sökfrasen "pippi långstrump" som givits ut efter år 2002:
 
-[`pippi långstrump språk:(engelska OR franska) ÅR>2002`](<https://beta.libris-qa.kb.se/find?_i=pippi+l%C3%A5ngstrump&_q=pippi+l%C3%A5ngstrump+SPR%C3%85K:(engelska%20OR%20franska)&_limit=10&_x=advanced>)
+[`pippi långstrump språk:(engelska OR franska) ÅR>2002`](<https://beta.libris-qa.kb.se/find?_i=pippi+l%C3%A5ngstrump&_q=pippi+l%C3%A5ngstrump+SPR%C3%85K:(engelska%20OR%20franska)&_limit=20&_x=advanced>)
 
 Material med utgivning mellan 2010 och 2024, som är på svenska och har [drakar](https://id.kb.se/term/sao/Drakar) som ämne:
 
-[`språk:svenska ÅR>2010 ÅR<=2024 ämne:"sao:Drakar"`](https://beta.libris-qa.kb.se/find?_i=&_q=SPR%C3%85K:svenska+%C3%85R%3E2010+%C3%85R%3C%3D2024+subject:%22sao:Drakar%22&_limit=10&_x=advanced)
+[`språk:svenska ÅR>2010 ÅR<=2024 ämne:"sao:Drakar"`](https://beta.libris-qa.kb.se/find?_i=&_q=SPR%C3%85K:svenska+%C3%85R%3E2010+%C3%85R%3C%3D2024+subject:%22sao:Drakar%22&_limit=20&_x=advanced)
 
 Fritextsökning på träd\*, där alla träffar ingår i bibliografin Digitaliserat Svenskt Tryck men som inte har verkstyp "Text":
 
-[`träd* bibliografi:"sigel:DST" NOT typ:Text`](https://beta.libris-qa.kb.se/find?_i=tr%C3%A4d*&_q=tr%C3%A4d*+bibliography:%22sigel:DST%22+NOT+%22rdf:type%22:Text&_limit=10&_x=advanced)
+[`träd* bibliografi:"sigel:DST" NOT typ:Text`](https://beta.libris-qa.kb.se/find?_i=tr%C3%A4d*&_q=tr%C3%A4d*+bibliography:%22sigel:DST%22+NOT+%22rdf:type%22:Text&_limit=20&_x=advanced)
 
 Verk där Selma Lagerlöf är författare som har minst en upplaga som är en elektronisk resurs:
 
-[`författare:"selma lagerlöf" "hasInstanceType":Electronic`](https://beta.libris-qa.kb.se/find?_i=&_q=F%C3%96RF:%22selma+lagerl%C3%B6f%22+hasInstanceType:Electronic&_limit=10&_x=advanced)
+[`författare:"selma lagerlöf" "hasInstanceType":Electronic`](https://beta.libris-qa.kb.se/find?_i=&_q=F%C3%96RF:%22selma+lagerl%C3%B6f%22+hasInstanceType:Electronic&_limit=20&_x=advanced)
 
 ### Detaljvyn
 

--- a/lxl-web/tests/error.spec.ts
+++ b/lxl-web/tests/error.spec.ts
@@ -44,7 +44,7 @@ test.describe('Missing resource page', () => {
 test.describe('Find page with invalid query', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto(
-			'/find?_i=geh&_q=test+unrecognizedproperty:%22https://id.kb.se/language/swe%22&_limit=10'
+			'/find?_i=geh&_q=test+unrecognizedproperty:%22https://id.kb.se/language/swe%22&_limit=20'
 		);
 	});
 	test('has expected h1', async ({ page }) => {

--- a/lxl-web/tests/find.spec.ts
+++ b/lxl-web/tests/find.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
 test.beforeEach(async ({ page }) => {
-	await page.goto('/find?_q=d&_limit=10&_offset=0&_sort=&_i=d');
+	await page.goto('/find?_q=f&_limit=20&_offset=0&_sort=&_i=f');
 });
 
 test('should not have any detectable a11y issues', async ({ page }) => {
@@ -23,8 +23,8 @@ test('can change the language', async ({ page }) => {
 	await expect(page).toHaveURL(/\/en\/find/);
 });
 
-test('displays 10 search cards on a page', async ({ page }) => {
-	await expect(page.getByTestId('search-card')).toHaveCount(10);
+test('displays 20 search cards on a page', async ({ page }) => {
+	await expect(page.getByTestId('search-card')).toHaveCount(20);
 });
 
 test('search card contains a link', async ({ page }) => {
@@ -63,9 +63,9 @@ test('has pagination', async ({ page }) => {
 });
 
 test('can paginate to next and previous', async ({ page }) => {
-	await expect(page).not.toHaveURL(/_offset=10/);
+	await expect(page).not.toHaveURL(/_offset=20/);
 	await page.getByTestId('pagination').getByLabel('Nästa sida').click();
-	await expect(page).toHaveURL(/_offset=10/);
+	await expect(page).toHaveURL(/_offset=20/);
 	await page.getByTestId('pagination').getByLabel('Föregående sida').click();
 	await expect(page).not.toHaveURL(/_offset=/);
 });

--- a/lxl-web/tests/index.spec.ts
+++ b/lxl-web/tests/index.spec.ts
@@ -34,5 +34,5 @@ test('url is populated with correct searchparams', async ({ page }) => {
 	await page.getByTestId('main-search').click();
 	await page.getByTestId('main-search').fill('somephrase');
 	await page.getByTestId('main-search').press('Enter');
-	await expect(page).toHaveURL(/_q=somephrase&_limit=10&_offset=0&_sort=&_i=somephrase/);
+	await expect(page).toHaveURL(/_q=somephrase&_limit=20&_offset=0&_sort=&_i=somephrase/);
 });


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-213](https://kbse.atlassian.net/browse/LWS-213)

### Solves

Changes the default limit of results from 10 to 20.
This should be customizable when we have added user settings (see: [LWS-93](https://kbse.atlassian.net/browse/LWS-93))

### Summary of changes

- Change the default limit of results to 20.
