### PR TITLE
Add Content-Security-Policy to Svelte config

### DIFF
--- a/lxl-web/svelte.config.js
+++ b/lxl-web/svelte.config.js
@@ -15,6 +15,17 @@ const config = {
 		adapter: adapter(),
 		paths: {
 			relative: false
+		},
+		csp: {
+			directives: {
+				'default-src': ['self'],
+				'script-src': ['self', 'https://analytics.kb.se'],
+				'style-src': ['self', 'unsafe-inline'],
+				'base-uri': ['self'],
+				'form-action': ['self'],
+				'frame-ancestors': ['none'],
+				'img-src': ['self', 'kb.se', '*.kb.se', 'data:']
+			}
 		}
 	}
 };


### PR DESCRIPTION
See https://kbse.atlassian.net/browse/LWS-215

Protects against XSS (among other things). https://kit.svelte.dev/docs/configuration#csp

Svelte automatically adds/sets nonces:
```
~ curl -I http://localhost:5173/
HTTP/1.1 200 OK
...
content-security-policy: default-src 'self'; img-src 'self' kb.se *.kb.se data:; script-src 'self' https://analytics.kb.se 'nonce-KS7ArPuN4IbXFqoAts03vg=='; style-src 'self' 'unsafe-inline'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
```

I don't like style-src's `unsafe-inline`, but Svelte adds it automatically anyway; perhaps it can't (at this point) work without it. There's an open issue: https://github.com/sveltejs/kit/issues/11747

I set style-src explicitly in `svelte.config.js` because otherwise, for some reason, `unsafe-inline` is _not_ automatically added when running the integration tests, resulting in two tests failing. 
