### PR TITLE
LWS-209: Add spinner

### DIFF
--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -32,6 +32,7 @@
 				"lxljs": "file:../lxljs",
 				"magic-string": "^0.30.7",
 				"mdsvex": "^0.11.2",
+				"nprogress": "^0.2.0",
 				"postcss": "^8.4.38",
 				"postcss-import": "^16.1.0",
 				"prettier": "^3.3.2",
@@ -4098,6 +4099,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/nprogress": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+			"integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
+			"dev": true
 		},
 		"node_modules/nth-check": {
 			"version": "2.1.1",

--- a/lxl-web/package.json
+++ b/lxl-web/package.json
@@ -46,6 +46,7 @@
 		"lxljs": "file:../lxljs",
 		"magic-string": "^0.30.7",
 		"mdsvex": "^0.11.2",
+		"nprogress": "^0.2.0",
 		"postcss": "^8.4.38",
 		"postcss-import": "^16.1.0",
 		"prettier": "^3.3.2",

--- a/lxl-web/src/ambient.d.ts
+++ b/lxl-web/src/ambient.d.ts
@@ -3,3 +3,4 @@ declare module 'lxljs/data';
 declare module 'lxljs/display';
 declare module 'lxljs/string';
 declare module 'lxljs/vocab';
+declare module 'nprogress';

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -6,11 +6,11 @@
 	import SearchCard from './SearchCard.svelte';
 	import Pagination from './Pagination.svelte';
 	import Filters from './Filters.svelte';
+	import SearchRelated from './SearchRelated.svelte';
 	import IconSliders from '~icons/bi/sliders';
 	import BiChevronDown from '~icons/bi/chevron-down';
 	import type { SearchResult, DisplayMapping } from '$lib/types/search';
 	import { shouldShowMapping } from '$lib/utils/search';
-	import SearchRelated from './SearchRelated.svelte';
 
 	let showFiltersModal = false;
 	export let searchResult: SearchResult;
@@ -48,153 +48,148 @@
 
 <slot />
 {#if searchResult}
-	{#await searchResult}
-		<p class="p-4">{$page.data.t('search.loading')}</p>
-	{:then searchResult}
-		{#if searchResult}
-			{@const facets = searchResult.facetGroups}
-			{@const numHits = searchResult.totalItems}
-			{@const filterCount = getFiltersCount(searchResult.mapping)}
-			{#if searchResult.predicates.length > 0}
-				<nav
-					class="border-b border-primary/16 px-4 md:flex lg:px-6"
-					aria-label={$page.data.t('search.selectedFilters')}
-				>
-					<ul class="flex flex-wrap items-center gap-2">
-						<li class="tab-header max-w-80 truncate font-bold">{$page.data.title}</li>
-						<span class="tab-header">{$page.data.t('search.occursAs')}</span>
+	{@const facets = searchResult.facetGroups}
+	{@const numHits = searchResult.totalItems}
+	{@const filterCount = getFiltersCount(searchResult.mapping)}
+	{#if searchResult.predicates.length > 0}
+		<nav
+			class="border-b border-primary/16 px-4 md:flex lg:px-6"
+			aria-label={$page.data.t('search.selectedFilters')}
+		>
+			<ul class="flex flex-wrap items-center gap-2">
+				<li class="tab-header max-w-80 truncate font-bold">{$page.data.title}</li>
+				<span class="tab-header">{$page.data.t('search.occursAs')}</span>
 
-						{#each searchResult.predicates as p}
-							<li>
-								<a
-									class="tab"
-									class:active={true}
-									class:tab-selected={p.selected}
-									data-sveltekit-replacestate
-									href={p.view['@id']}
-								>
-									{p.str}
-									<span
-										class="mb-px rounded-sm bg-pill/4 px-1 text-sm text-secondary md:text-xs lg:text-sm"
-										aria-label="{p.totalItems} {$page.data.t('search.hits')}">{p.totalItems}</span
-									>
-								</a>
-							</li>
-						{/each}
-					</ul>
-				</nav>
-			{/if}
-			{#if shouldShowMapping(searchResult.mapping)}
-				<nav
-					class="hidden md:flex md:px-6 md:pb-0 md:pt-4"
-					aria-label={$page.data.t('search.selectedFilters')}
-				>
-					<SearchMapping mapping={searchResult.mapping} />
-				</nav>
-			{/if}
-			<div class="relative gap-y-4 find-layout md:page-padding">
-				{#if showFiltersModal}
-					<Modal position="left" close={toggleFiltersModal}>
-						<span slot="title">
-							{$page.data.t('search.filters')} ({numHits.toLocaleString($page.data.locale)}
-							{numHits == 1 ? $page.data.t('search.hitsOne') : $page.data.t('search.hits')})
-						</span>
-						<Filters {facets} mapping={searchResult.mapping} />
-					</Modal>
-				{/if}
-				<div class="filters hidden md:block" id="filters">
-					<Filters {facets} mapping={searchResult.mapping} />
-				</div>
-
-				<div class="results max-w-content">
-					<div
-						class="toolbar flex min-h-14 items-center justify-between page-padding md:min-h-fit md:p-0 md:pb-4"
-						class:has-search={$page.params.fnurgel}
-					>
+				{#each searchResult.predicates as p}
+					<li>
 						<a
-							href={`${$page.url.pathname}?${$page.url.searchParams.toString()}#filters`}
-							class="filter-modal-toggle button-ghost md:hidden"
-							aria-label={$page.data.t('search.filters')}
-							on:click|preventDefault={toggleFiltersModal}
+							class="tab"
+							class:active={true}
+							class:tab-selected={p.selected}
+							data-sveltekit-replacestate
+							href={p.view['@id']}
 						>
-							<IconSliders width={20} height={20} />
-							{$page.data.t('search.filters')}
-							{#if filterCount}
-								<span
-									class="flex h-5 w-5 items-center justify-center rounded-full bg-pill text-xs font-bold leading-none text-primary-inv"
-								>
-									{filterCount}
-								</span>
-							{/if}
-						</a>
-						<span class="hits pt-4 text-secondary md:pt-0" role="status" data-testid="result-info">
-							{#if numHits && numHits > 0}
-								{#if numHits > searchResult.itemsPerPage}
-									<span class="text-3-cond-bold">
-										{(searchResult.itemOffset + 1).toLocaleString($page.data.locale)}
-										-
-										{Math.min(
-											numHits,
-											searchResult.itemOffset + searchResult.itemsPerPage
-										).toLocaleString($page.data.locale)}
-									</span>
-									{$page.data.t('search.hitsOf')}
-								{/if}
-								<span class="text-3-cond-bold">
-									{numHits.toLocaleString($page.data.locale)}
-								</span>
-								{#if $page.data.instances}
-									{numHits == 1
-										? $page.data.t('search.relatedOne')
-										: $page.data.t('search.related')}
-								{/if}
-								{numHits == 1 ? $page.data.t('search.hitsOne') : $page.data.t('search.hits')}
-							{:else}
-								{$page.data.t('search.noResults')}
-							{/if}
-						</span>
-						<div class="search-related flex justify-start">
-							{#if $page.params.fnurgel}
-								{@const activePredicate = searchResult.predicates.filter((p) => p.selected)}
-								<SearchRelated view={activePredicate[0].view} />
-							{/if}
-						</div>
-						{#if numHits > 0}
-							<div
-								class="sort-select flex flex-col items-end justify-self-end"
-								data-testid="sort-select"
+							{p.str}
+							<span
+								class="mb-px rounded-sm bg-pill/4 px-1 text-sm text-secondary md:text-xs lg:text-sm"
+								aria-label="{p.totalItems} {$page.data.t('search.hits')}">{p.totalItems}</span
 							>
-								<label class="pr-6 text-secondary text-2-regular" for="search-sort">
-									{$page.data.t('sort.sort')}
-								</label>
-								<div class="relative">
-									<select id="search-sort" form="main-search" on:change={handleSortChange}>
-										{#each sortOptions as option}
-											<option value={option.value} selected={option.value === sortOrder}
-												>{option.label}</option
-											>
-										{/each}
-									</select>
-									<span class="pointer-events-none absolute right-0 top-[5px]">
-										<BiChevronDown aria-hidden="true" class="text-icon" />
-									</span>
-								</div>
-							</div>
-						{/if}
-					</div>
-					<ol class="flex flex-col gap-0.5 md:px-0">
-						{#each searchResult.items as item (item['@id'])}
-							<li>
-								<SearchCard {item} />
-							</li>
-						{/each}
-					</ol>
-					<Pagination data={searchResult} />
-				</div>
-			</div>
+						</a>
+					</li>
+				{/each}
+			</ul>
+		</nav>
+	{/if}
+	{#if shouldShowMapping(searchResult.mapping)}
+		<nav
+			class="hidden md:flex md:px-6 md:pb-0 md:pt-4"
+			aria-label={$page.data.t('search.selectedFilters')}
+		>
+			<SearchMapping mapping={searchResult.mapping} />
+		</nav>
+	{/if}
+	<div class="relative gap-y-4 find-layout md:page-padding">
+		{#if showFiltersModal}
+			<Modal position="left" close={toggleFiltersModal}>
+				<span slot="title">
+					{$page.data.t('search.filters')} ({numHits.toLocaleString($page.data.locale)}
+					{numHits == 1 ? $page.data.t('search.hitsOne') : $page.data.t('search.hits')})
+				</span>
+				<Filters {facets} mapping={searchResult.mapping} />
+			</Modal>
 		{/if}
-	{/await}
+		<div class="filters hidden md:block" id="filters">
+			<Filters {facets} mapping={searchResult.mapping} />
+		</div>
+
+		<div class="results max-w-content">
+			<div
+				class="toolbar flex min-h-14 items-center justify-between page-padding md:min-h-fit md:p-0 md:pb-4"
+				class:has-search={$page.params.fnurgel}
+			>
+				<a
+					href={`${$page.url.pathname}?${$page.url.searchParams.toString()}#filters`}
+					class="filter-modal-toggle button-ghost md:hidden"
+					aria-label={$page.data.t('search.filters')}
+					on:click|preventDefault={toggleFiltersModal}
+				>
+					<IconSliders width={20} height={20} />
+					{$page.data.t('search.filters')}
+					{#if filterCount}
+						<span
+							class="flex h-5 w-5 items-center justify-center rounded-full bg-pill text-xs font-bold leading-none text-primary-inv"
+						>
+							{filterCount}
+						</span>
+					{/if}
+				</a>
+				<span class="hits pt-4 text-secondary md:pt-0" role="status" data-testid="result-info">
+					{#if numHits && numHits > 0}
+						{#if numHits > searchResult.itemsPerPage}
+							<span class="text-3-cond-bold">
+								{(searchResult.itemOffset + 1).toLocaleString($page.data.locale)}
+								-
+								{Math.min(
+									numHits,
+									searchResult.itemOffset + searchResult.itemsPerPage
+								).toLocaleString($page.data.locale)}
+							</span>
+							{$page.data.t('search.hitsOf')}
+						{/if}
+						<span class="text-3-cond-bold">
+							{numHits.toLocaleString($page.data.locale)}
+						</span>
+						{#if $page.data.instances}
+							{numHits == 1
+								? $page.data.t('search.relatedOne')
+								: $page.data.t('search.related')}
+						{/if}
+						{numHits == 1 ? $page.data.t('search.hitsOne') : $page.data.t('search.hits')}
+					{:else}
+						{$page.data.t('search.noResults')}
+					{/if}
+				</span>
+				<div class="search-related flex justify-start">
+					{#if $page.params.fnurgel}
+						{@const activePredicate = searchResult.predicates.filter((p) => p.selected)}
+						<SearchRelated view={activePredicate[0].view} />
+					{/if}
+				</div>
+				{#if numHits > 0}
+					<div
+						class="sort-select flex flex-col items-end justify-self-end"
+						data-testid="sort-select"
+					>
+						<label class="pr-6 text-secondary text-2-regular" for="search-sort">
+							{$page.data.t('sort.sort')}
+						</label>
+						<div class="relative">
+							<select id="search-sort" form="main-search" on:change={handleSortChange}>
+								{#each sortOptions as option}
+									<option value={option.value} selected={option.value === sortOrder}
+										>{option.label}</option
+									>
+								{/each}
+							</select>
+							<span class="pointer-events-none absolute right-0 top-[5px]">
+								<BiChevronDown aria-hidden="true" class="text-icon" />
+							</span>
+						</div>
+					</div>
+				{/if}
+			</div>
+			<ol class="flex flex-col gap-0.5 md:px-0">
+				{#each searchResult.items as item (item['@id'])}
+					<li>
+						<SearchCard {item} />
+					</li>
+				{/each}
+			</ol>
+			<Pagination data={searchResult} />
+		</div>
+	</div>
 {/if}
+
 
 <style lang="postcss">
 	.toolbar {

--- a/lxl-web/src/nprogress.css
+++ b/lxl-web/src/nprogress.css
@@ -1,0 +1,30 @@
+/* Make clicks pass-through */
+#nprogress {
+  pointer-events: none;
+}
+
+#nprogress .bar {
+  @apply bg-positive-dark;
+
+  position: fixed;
+  z-index: 1031;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+}
+
+/* Fancy blur effect */
+#nprogress .peg {
+  display: block;
+  position: absolute;
+  right: 0px;
+  width: 100px;
+  height: 100%;
+  box-shadow: 0 0 10px #6e6e6e, 0 0 5px #6e6e6e;
+  opacity: 1.0;
+
+  -webkit-transform: rotate(3deg) translate(0px, -4px);
+      -ms-transform: rotate(3deg) translate(0px, -4px);
+          transform: rotate(3deg) translate(0px, -4px);
+}

--- a/lxl-web/src/routes/+layout.svelte
+++ b/lxl-web/src/routes/+layout.svelte
@@ -1,5 +1,28 @@
 <script lang="ts">
 	import '../app.css';
+	import NProgress from 'nprogress'
+  import { navigating } from '$app/stores'
+	import '../nprogress.css';
+
+  NProgress.configure({
+		//https://github.com/rstacruz/nprogress#configuration
+		minimum: 0.16,
+		showSpinner: false
+	})
+
+	let progressBarTimeout: number | undefined = undefined;
+	const progressDelay = 200;
+
+  $: {
+    if ($navigating) {
+			clearTimeout(progressBarTimeout);
+			progressBarTimeout = setTimeout(NProgress.start, progressDelay);
+    }
+    if (!$navigating) {
+      clearTimeout(progressBarTimeout);
+			NProgress.done();
+    }
+  }
 </script>
 
 <div class="flex min-h-screen flex-col">


### PR DESCRIPTION
## Description
Adds a loading indicator

### Tickets involved
[LWS-209](https://kbse.atlassian.net/browse/LWS-209)

### Solves
No indication of anything happening when for example searching.

### Summary of changes

* Added a progress bar (rather than a spinner) using the [nProgress](https://www.npmjs.com/package/nprogress) package. It runs on every navigation but i've added a small delay to avoid showing it on instant navigations. This can of course be tweaked further.
* With this in place, I tried removing the streaming of search results on resource pages. This would otherwise require a _second_ spinner to replace the 'loading' text. I think this works well - with the indicator in place, it's quite satisfying to get the whole page at once.
* Made some minor related adjustments to the `load` function on the resource page. The `getRelated()` / `await getRelated()` call was done as the last thing before returning, not optimal when everything else is ready. We want to do it as soon as possible (i.e when there's a `resourceId`), but not wait for it, blocking subsequent operations. So we now make the call early and store the promise in a variable, awaiting it at the very end.