### PR TITLE
Display spelling suggestions in cataloging client

### DIFF
--- a/vue-client/src/components/search/search-form.vue
+++ b/vue-client/src/components/search/search-form.vue
@@ -31,7 +31,7 @@ export default {
       },
       helpToggled: false,
       vocabUrl: 'https://id.kb.se/vocab/',
-      staticProps: { _limit: 20 },
+      staticProps: { _limit: 20, _spell: true },
       searchPhrase: '',
       searchParams: PropertyMappings,
       activeSearchParam: null,

--- a/vue-client/src/components/search/search-result.vue
+++ b/vue-client/src/components/search/search-result.vue
@@ -1,5 +1,5 @@
 <script>
-import { translatePhrase } from '@/utils/filters';
+import { asAppPath, translatePhrase } from '@/utils/filters';
 import ResultList from './result-list.vue';
 import ResultControls from './result-controls.vue';
 
@@ -21,6 +21,7 @@ export default {
   },
   methods: {
     translatePhrase,
+    asAppPath,
     doSort(newsort) {
       const newQuery = Object.assign({}, this.$route.query, { _sort: newsort, _offset: 0 });
       this.$router.push({ query: newQuery });
@@ -85,6 +86,19 @@ export default {
       <span v-if="!status.resultList.error" class="is-status">{{ translatePhrase("Fetching results") }}</span>
       <span v-if="status.resultList.error" class="is-error">{{status.resultList.info}}</span>
     </div>
+    <div
+      class="suggestions"
+      v-if="!status.resultList.loading && !status.resultList.error && result['_spell']"
+    >
+      <p :key="suggestion" v-for="suggestion in result['_spell']">
+        {{translatePhrase('Did you mean')}}
+        <router-link
+          :to="asAppPath(suggestion.view['@id'], this.$route.params.tool === 'changes')"
+        >
+          <span v-html="suggestion.labelHTML" />
+        </router-link>?
+      </p>
+    </div>
     <result-controls
       class="SearchResult-controls"
       v-if="!status.resultList.loading && !status.resultList.error"
@@ -100,7 +114,7 @@ export default {
       :import-data="importData"
       :compact="user.settings.resultListType === 'compact'"
       :isChangeView="isChangeView"
-    />  
+    />
     <result-controls
       class="SearchResult-controls"
       v-if="!status.resultList.loading && !status.resultList.error && hasPagination"
@@ -117,6 +131,10 @@ export default {
 
   @media (min-width: @screen-md) {
     padding: 0 0 2rem 0;
+  }
+
+  & .suggestions {
+    margin-top: 1em;
   }
 
   &-loadingText {

--- a/vue-client/src/components/search/search-result.vue
+++ b/vue-client/src/components/search/search-result.vue
@@ -6,12 +6,18 @@ import ResultControls from './result-controls.vue';
 export default {
   name: 'search-result',
   props: {
-    result: null,
+    result: {
+      type: Object,
+      default: null,
+    },
     query: {
       type: String,
       default: '',
     },
-    importData: Array,
+    importData: {
+      type: Array,
+      default: null,
+    },
   },
   data() {
     return {
@@ -58,7 +64,7 @@ export default {
     },
     isChangeView() {
       return this.$route.params.tool === 'changes';
-    }
+    },
   },
   components: {
     'result-controls': ResultControls,

--- a/vue-client/src/resources/json/i18n.json
+++ b/vue-client/src/resources/json/i18n.json
@@ -349,6 +349,7 @@
     "Hide instructions": "Dölj instruktioner",
     "Show properties": "Visa egenskaper",
     "Hide properties": "Dölj egenskaper",
+    "Did you mean": "Menade du",
     "Sorting": "Sortering",
     "Relevance": "Relevans",
     "Publication year (descending)": "Utgivningsår (nyast först)",


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

## Description

Display spelling suggestions from search API in main search screen.

![Skärmbild från 2024-08-02 14-34-41](https://github.com/user-attachments/assets/286e38ce-fe3c-4c1d-b41e-0e92a749c6c7)

### Tickets involved
[LWS-87](https://jira.kb.se/browse/LWS-87)
