### PR TITLE
Block id.kb.se and libris.kb.se datasets from being edited

### DIFF
--- a/vue-client/src/components/inspector/toolbar.vue
+++ b/vue-client/src/components/inspector/toolbar.vue
@@ -301,6 +301,15 @@ export default {
       ).map((id) => StringUtil.getCompactUri(id, this.resources.context));
       return baseClasses.indexOf(type) > -1;
     },
+    isInReadOnlyDataset(record) {
+      // TODO: get from backend
+      // TODO: implement proper access control mechanism in backend
+      return (record.inDataset || []).find((dataset) => {
+        const id = dataset['@id'] || '';
+        return id.startsWith('https://id.kb.se/dataset/')
+          || id.startsWith('https://libris.kb.se/dataset/');
+      });
+    },
     download(text) {
       let focusId = this.inspector.data.record['@id'];
       if (this.recordType === 'Item') {
@@ -416,6 +425,9 @@ export default {
           mainEntity,
           { '@id': this.user.getActiveLibraryUri() },
         ))) {
+        return false;
+      }
+      if (this.isInReadOnlyDataset(record)) {
         return false;
       }
       if (mainEntity['@type'] === 'ShelfMarkSequence') {


### PR DESCRIPTION
Do a simple hardcoded check for dataset URI prefixes for now. Until we have decided on an how to specify this in backend. See for example EntityContainers for Concepts.

## Description

### Tickets involved
[LXL-4254](https://jira.kb.se/browse/LXL-4254)

### Solves
Prevents accidental editing of language, library and other definitions from externally defined datasets.
There is still no access control mechanism for these in backend. This does not guard against malicious changes.