### PR TITLE
LWS-219: Fix resource image placement on Safari

### DIFF
--- a/lxl-web/src/lib/components/ResourceImage.svelte
+++ b/lxl-web/src/lib/components/ResourceImage.svelte
@@ -24,7 +24,7 @@
 </script>
 
 {#if image && thumb}
-	<figure class="table aspect-square max-h-40 overflow-hidden">
+	<figure class="table aspect-square h-40 overflow-hidden">
 		{#if linkToFull && full}
 			<a href={full.url} target="_blank" class="object-[inherit]">
 				<img

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -74,7 +74,7 @@
 <article>
 	<div class="resource gap-8 find-layout page-padding" class:bg-header={shouldShowHeaderBackground}>
 		<div
-			class="mb-2 mt-4 flex justify-center self-center object-center md:mx-auto md:justify-start md:self-start md:px-2 xl:px-0"
+			class="w-full mb-2 mt-4 flex justify-center self-center object-center md:mx-auto md:justify-start md:self-start md:px-2 xl:px-0"
 			class:hidden={!$page.data.images?.length}
 		>
 			{#if data.images.length}


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-219](https://kbse.atlassian.net/browse/LWS-219)

### Solves

Weird placement of resource images in Safari. (Not just mobile, this is desktop Safari:)

<img width="1159" alt="Skärmavbild 2024-08-08 kl  15 29 05" src="https://github.com/user-attachments/assets/a005010c-d862-4aee-aadc-98834ee9812d">

### Summary of changes

* Clearly, Safari doesn't respect the `max-height` of an element with `display:table` (introduced with the `figcaption` stuff). Using only `height` works - it doesn't seem to break anything else...
* Setting `w-full` on the image container allows the image to align to the page left margin on md+ screens. This seems to be desired since it has `justify-center md:justify-start`.

