### PR TITLE
LWS-201/203: Fix pill labels

### DIFF
--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -61,10 +61,10 @@
 			{:else if m.operator === 'existence' || m.operator === 'notExistence'}
 				{@const symbol = getRelationSymbol(m.operator)}
 				<span class="pill-relation">{symbol}</span>
-				<div class="pill-label inline-block text-2-regular first-letter:uppercase">{m.label}</div>
+				<div class="pill-label inline text-2-regular">{m.label}</div>
 			{:else if 'label' in m && 'display' in m}
 				{@const symbol = getRelationSymbol(m.operator)}
-				<div class="pill-label inline-block text-2-regular first-letter:uppercase">{m.label}</div>
+				<div class="pill-label inline text-2-regular">{m.label}</div>
 				<span class="pill-relation">{symbol}</span>
 				<span class="pill-value">
 					<DecoratedData data={m.display} showLabels={ShowLabelsOptions['Never']} />

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -82,7 +82,7 @@ function displayMappings(
 					display: displayUtil.lensAndFormat(property, LensType.Chip, locale),
 					label: m.alias
 						? translate(`facet.${m.alias}`)
-						: m.property?.labelByLang?.[locale] || m.property?.['@id'] || 'no label', // lensandformat?
+						: capitalize(m.property?.labelByLang?.[locale] || m.property?.label) || m.property?.['@id'] || 'No label', // lensandformat?
 					operator,
 					...('up' in m && { up: replacePath(m.up as Link, usePath) })
 				} as DisplayMapping;
@@ -220,6 +220,12 @@ function replacePath(view: Link, usePath: string) {
 	return {
 		'@id': view['@id'].replace('/find', usePath)
 	};
+}
+
+function capitalize(str: string | undefined) {
+	if (str && typeof str === 'string') {
+		return str[0].toUpperCase() + str.slice(1);
+	} return str;
 }
 
 export function shouldShowMapping(mapping: DisplayMapping[]) {


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-201](https://kbse.atlassian.net/browse/LWS-201)
[LWS-203](https://kbse.atlassian.net/browse/LWS-203)

### Solves

* Firefox chip gap
* Missing labels for ISBN & ISSN

### Summary of changes

Giving up on trying to fix both lowercase labels & weird Firefox pill gap with pure CSS, we now do it "for real" in the FE-backend.

In the process I discovered that the label is sometimes found in `property.label` (duh!) which we never check before falling back on the `@id`. This fixes both examples (ISBN and ISSN) in LWS-203. Don't know if you've seen more cases @poacherone?
