### PR TITLE
LXL-4457: Keep sort options when doing new searches

### DIFF
--- a/vue-client/src/components/search/search-form.vue
+++ b/vue-client/src/components/search/search-form.vue
@@ -236,7 +236,9 @@ export default {
     prefSort() {
       if (
         this.$route.query?._sort
-        && this.settings.sortOptions[this.activeSearchType]?.find((sortOption) => sortOption.query === this.$route.query._sort)
+        && this.settings.sortOptions[this.activeSearchType]
+          ?.find((sortOption) => this.$route.query._sort.includes(sortOption.query))
+          // use includes instead of strict equality check to allow localized _sortKeyByLang (e.g. _sortKeyByLang.sv)
       ) {
         return { _sort: this.$route.query._sort };
       }

--- a/vue-client/src/components/search/search-form.vue
+++ b/vue-client/src/components/search/search-form.vue
@@ -234,6 +234,9 @@ export default {
       return { '@type': type };
     },
     prefSort() {
+      if (this.$route.query?._sort) {
+        return { _sort: this.$route.query?._sort }
+      }
       if (this.user && this.user.settings.sort) {
         const availableSorts = this.settings.sortOptions[this.user.settings.searchType];
 

--- a/vue-client/src/components/search/search-form.vue
+++ b/vue-client/src/components/search/search-form.vue
@@ -234,8 +234,11 @@ export default {
       return { '@type': type };
     },
     prefSort() {
-      if (this.$route.query?._sort) {
-        return { _sort: this.$route.query?._sort }
+      if (
+        this.$route.query?._sort
+        && this.settings.sortOptions[this.activeSearchType]?.find((sortOption) => sortOption.query === this.$route.query._sort)
+      ) {
+        return { _sort: this.$route.query._sort };
       }
       if (this.user && this.user.settings.sort) {
         const availableSorts = this.settings.sortOptions[this.user.settings.searchType];


### PR DESCRIPTION
## Checklist:
- [X] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4457](https://kbse.atlassian.net/browse/LXL-4457)

### Solves

Keeps sort options when doing new searches from the search result page.

This works by reusing old sort query param for new searches. Note that this doesn't involve the local storage functionality (which currently only works if the user is signed in), so the last selected sort option isn't persisted if an unauthenticated user navigates to the start page and enters a new search query. 

### Summary of changes

- Use _sort value from route as preferred sort
- Check if sort value from route query param is available for active search type
