### PR TITLE
Fix display of user's own holding in hitlist

### DIFF
--- a/vue-client/src/components/inspector/reverse-relations.vue
+++ b/vue-client/src/components/inspector/reverse-relations.vue
@@ -112,11 +112,19 @@ export default {
       return this.myHolding !== null;
     },
     myHolding() {
+      const isLink = (o) => Object.keys(o).length === 1 && Object.keys(o).includes('@id');
+
       if (this.user.isLoggedIn) {
         // Check if my sigel has holding
         const libraryUri = this.user.getActiveLibraryUri();
         const holdings = get(this.mainEntity, ['@reverse', 'itemOf'], []);
-        const myHolding = holdings.find((h) => get(h, ['heldBy', '@id']) === libraryUri);
+        const myHolding = holdings.find((h) => {
+          if (isLink(h)) {
+            return get(this.inspector?.data?.quoted || {}, [h['@id'], 'heldBy', '@id']) === libraryUri;
+          } else {
+            return get(h, ['heldBy', '@id']) === libraryUri;
+          }
+        });
         if (myHolding) {
           return myHolding['@id'];
         }

--- a/vue-client/src/components/inspector/reverse-relations.vue
+++ b/vue-client/src/components/inspector/reverse-relations.vue
@@ -64,7 +64,7 @@ export default {
         return;
       }
 
-      if (this.mode == 'items' && this.mainEntity.reverseLinks && this.mainEntity.reverseLinks.totalItemsByRelation) {
+      if (this.mode === 'items' && this.mainEntity.reverseLinks && this.mainEntity.reverseLinks.totalItemsByRelation) {
         this.numberOfRelations = this.mainEntity.reverseLinks.totalItemsByRelation.itemOf || 0;
         this.checkingRelations = false;
         query['itemOf.@id'] = this.mainEntity['@id'];


### PR DESCRIPTION
Was broken by the early return in c4434a0.
We can always find the holdings in `@reverse/itemOf` for each Instance in the search result. 
So remove the code that does an additional query for the holding.

## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

### Tickets involved
[LXL-4541](https://kbse.atlassian.net/browse/LXL-4541)
