### PR TITLE
LXL-4485: Add date & sigel to cxz message comment

### DIFF
--- a/vue-client/src/components/care/create-message.vue
+++ b/vue-client/src/components/care/create-message.vue
@@ -1,8 +1,9 @@
 <script>
 import { mapGetters } from 'vuex';
 import { sortBy, set, pick } from 'lodash-es';
-import CreationCard from "@/components/create/creation-card.vue";
-import * as RecordUtil from "@/utils/record";
+import CreationCard from '@/components/create/creation-card.vue';
+import { formatDate } from '@/utils/datetime';
+import * as RecordUtil from '@/utils/record';
 import * as StringUtil from 'lxljs/string';
 
 export default {
@@ -31,7 +32,7 @@ export default {
         set(preparedTemplate, ['@graph', 1, 'concerning'], []);
       }
       if (preparedTemplate['@graph'][1].hasOwnProperty('descriptionCreator')) {
-        set(preparedTemplate, ['@graph', 1, 'descriptionCreator'], {'@id': StringUtil.getLibraryUri(this.user.settings.activeSigel)});
+        set(preparedTemplate, ['@graph', 1, 'descriptionCreator'], { '@id': StringUtil.getLibraryUri(this.user.settings.activeSigel) });
       }
       this.thingData = preparedTemplate;
     },
@@ -45,10 +46,19 @@ export default {
       'userFlagged',
       'user',
       'resources',
-      'templates'
+      'templates',
     ]),
     messageTemplates() {
-      const sorted = sortBy(this.templates.combined['messages'], (template) => template.label);
+      // Pre-fill comments with date & current sigel
+      const templatesWithComment = this.templates.combined.messages.map((template) => {
+        const temp = Object.assign({}, template);
+        if (temp.value && temp.value.mainEntity && Object.hasOwn(temp.value.mainEntity, 'comment')) {
+          temp.value.mainEntity.comment = `${formatDate(new Date())} ${this.user.settings.activeSigel}: `;
+        }
+        return temp;
+      });
+
+      const sorted = sortBy(templatesWithComment, (template) => template.label);
       return sorted;
     },
   },
@@ -60,15 +70,15 @@ export default {
 <template>
   <div class="CreateMessage-cards">
     <creation-card
-        v-for="(template, index) in messageTemplates"
-        :key="index"
-        :is-base="false"
-        :is-allowed="true"
-        :template="template"
-        :index="index + 1"
-        :active-index="activeIndex"
-        @use-template="useTemplate"
-        @set-active-index="setActiveIndex" />
+      v-for="(template, index) in messageTemplates"
+      :key="index"
+      :is-base="false"
+      :is-allowed="true"
+      :template="template"
+      :index="index + 1"
+      :active-index="activeIndex"
+      @use-template="useTemplate"
+      @set-active-index="setActiveIndex" />
   </div>
 </template>
 

--- a/vue-client/src/components/care/create-message.vue
+++ b/vue-client/src/components/care/create-message.vue
@@ -2,7 +2,6 @@
 import { mapGetters } from 'vuex';
 import { sortBy, set, pick } from 'lodash-es';
 import CreationCard from '@/components/create/creation-card.vue';
-import { formatDate } from '@/utils/datetime';
 import * as RecordUtil from '@/utils/record';
 import * as StringUtil from 'lxljs/string';
 
@@ -49,16 +48,7 @@ export default {
       'templates',
     ]),
     messageTemplates() {
-      // Pre-fill comments with date & current sigel
-      const templatesWithComment = this.templates.combined.messages.map((template) => {
-        const temp = Object.assign({}, template);
-        if (temp.value && temp.value.mainEntity && Object.hasOwn(temp.value.mainEntity, 'comment')) {
-          temp.value.mainEntity.comment = `${formatDate(new Date())} ${this.user.settings.activeSigel}: `;
-        }
-        return temp;
-      });
-
-      const sorted = sortBy(templatesWithComment, (template) => template.label);
+      const sorted = sortBy(this.templates.combined.messages, (template) => template.label);
       return sorted;
     },
   },

--- a/vue-client/src/components/inspector/language-entry.vue
+++ b/vue-client/src/components/inspector/language-entry.vue
@@ -3,7 +3,9 @@ import AutoSize from 'autosize';
 import { mapGetters } from 'vuex';
 import { Menu } from 'floating-vue';
 import { isEqual } from 'lodash-es';
+import * as VocabUtil from 'lxljs/vocab';
 import { translatePhrase } from '@/utils/filters';
+import { formatDate } from '@/utils/datetime';
 import PreviewCard from '@/components/shared/preview-card.vue';
 import LanguageMixin from '@/components/mixins/language-mixin.vue';
 import EntityAdder from './entity-adder.vue';
@@ -71,6 +73,7 @@ export default {
       'resources',
       'supportedTags',
       'status',
+      'user',
     ]),
     isByLang() {
       return this.itemPath.includes('ByLang');
@@ -120,6 +123,17 @@ export default {
       }
       return false;
     },
+    templateText() {
+      // comment template for CXZ messages
+      if (this.itemPath === 'mainEntity.comment' && VocabUtil.isSubClassOf(
+        this.inspector.data.mainEntity['@type'],
+        'AdministrativeAction',
+        this.resources.vocab,
+        this.resources.context,
+      )) {
+        return `${formatDate(new Date())} ${this.user.settings.activeSigel}: `;
+      } return false;
+    },
   },
   components: {
     Menu,
@@ -147,6 +161,9 @@ export default {
     initializeTextarea() {
       this.$nextTick(() => {
         const textarea = this.$refs.textarea;
+        if (this.templateText && !this.modelValue) {
+          this.$emit('update:model-value', this.templateText);
+        }
         AutoSize(textarea);
         AutoSize.update(textarea);
       });


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4485](https://kbse.atlassian.net/browse/LXL-4485)
### Solves

Pre-fill cxz comment with sigel & current date for better orientation when listing messages.

### Summary of changes

Add the template text to `language-entry` textarea on init if conditions are met: It's an empty `comment` whose mainEntity type is subclass of `AdministrativeAction`.
