### PR TITLE
LXL-4539: handle multiple types

### DIFF
--- a/lxljs/display.js
+++ b/lxljs/display.js
@@ -467,7 +467,7 @@ export function getDisplayObject(item, level, resources, quoted, settings) {
           settings.language,
           resources,
         );
-        result[property] = `{${StringUtil.getLabelByLang(trueItem['@type'], settings.language, resources)} ${StringUtil.getUiPhraseByLang('without', settings.language, resources.i18n)} ${expectedClassName.toLowerCase()}}`;
+        result[property] = `{${StringUtil.getLabelByLang(displayType, settings.language, resources)} ${StringUtil.getUiPhraseByLang('without', settings.language, resources.i18n)} ${expectedClassName.toLowerCase()}}`;
       }
     } else {
       // Property is object, lets calculate that

--- a/vue-client/src/components/inspector/field.vue
+++ b/vue-client/src/components/inspector/field.vue
@@ -873,7 +873,7 @@ export default {
           :is-locked="locked"
           :container-accepted-types="parentAcceptedTypes"
           :field-key="fieldKey"
-          :field-value="fieldValue"
+          :field-value="item"
           :entity-type="entityType"
           :parent-path="path" />
       </div>

--- a/vue-client/src/components/inspector/toolbar.vue
+++ b/vue-client/src/components/inspector/toolbar.vue
@@ -294,14 +294,12 @@ export default {
       this.showAdminInfoDetails = !this.showAdminInfoDetails;
     },
     isSubClassOf(type) {
-      const mainEntityType = this.inspector.data.mainEntity['@type'];
-      const baseClasses = VocabUtil.getBaseClasses(
-        // If more than one type, choose the first
-        Array.isArray(mainEntityType) ? mainEntityType[0] : mainEntityType,
+      return VocabUtil.isSubClassOf(
+        this.inspector.data.mainEntity['@type'],
+        type,
         this.resources.vocab,
         this.resources.context,
-      ).map((id) => StringUtil.getCompactUri(id, this.resources.context));
-      return baseClasses.indexOf(type) > -1;
+      );
     },
     isInReadOnlyDataset(record) {
       // TODO: get from backend

--- a/vue-client/src/components/inspector/toolbar.vue
+++ b/vue-client/src/components/inspector/toolbar.vue
@@ -294,8 +294,10 @@ export default {
       this.showAdminInfoDetails = !this.showAdminInfoDetails;
     },
     isSubClassOf(type) {
+      const mainEntityType = this.inspector.data.mainEntity['@type'];
       const baseClasses = VocabUtil.getBaseClasses(
-        this.inspector.data.mainEntity['@type'],
+        // If more than one type, choose the first
+        Array.isArray(mainEntityType) ? mainEntityType[0] : mainEntityType,
         this.resources.vocab,
         this.resources.context,
       ).map((id) => StringUtil.getCompactUri(id, this.resources.context));


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-4539](https://kbse.atlassian.net/browse/LXL-4539)

### Solves

* Result list breaking when a hit has multiple `@type`s (locally - in production showing empty boxes:)
<img width="873" alt="Skärmavbild 2024-08-16 kl  11 41 12" src="https://github.com/user-attachments/assets/64dc83f8-3691-4efa-a69d-dbc9ce8b070d">

* [local](http://localhost:8080/katalogisering/search/libris?q=*&@type=Concept&_limit=20&_sort=_sortKeyByLang.sv&_spell=true&and-inScheme.@id=https://id.kb.se/marc&_offset=0)
[dev](https://libris-dev.kb.se/katalogisering/search/libris?q=*&@type=Concept&_limit=20&_sort=_sortKeyByLang.sv&_spell=true&and-inScheme.@id=https://id.kb.se/marc&_offset=0)


* Inspector breaking when `mainEntity` has multiple `@type`s (locally, in production some information is just missing)
[local](http://localhost:8080/katalogisering/9h0hfnvdc4crddn5)
[dev](https://libris-dev.kb.se/katalogisering/9h0hfnvdc4crddn5)

### Summary of changes

* In the result list, the culprit is the `DisplayUtil.getDisplayObject` passing the type array to `getLabelByLang`. A few lines up we actually save the _first_ type in a variable, so let's use that:
https://github.com/libris/lxlviewer/blob/3f4125b3c203100701529b5f6c8191e4b8d5e86f/lxljs/display.js#L418

* In the inspector, `item-type.vue` gets the array as its `field-value`, which it doesn't like. But the component is actually looped out, so we can just use the current `value` instead.
* In logged in mode, the toolbar relies heavily on `mainEntity['@type']` being a string to determine what can be edited etc. Not exactly sure what consequences this has, but the breaking error is fixed by passing the first type to `VocabUtil.getBaseClasses`.

...The whole app seems to be built upon the assumption of a single `@type`, so I don't know if these records cause trouble in places I didn't think of. Prop-check still warns that `entityType` cannot be an array. Should we fix it because it can, or can it?  