### PR TITLE
LWS-227: Extend formatter styling possibilites

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -417,6 +417,7 @@
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Contribution"],
 			"fresnel:propertyFormatDomain": ["role"],
+			"fresnel:propertyStyle": ["secondary", "small"],
 			"fresnel:propertyFormat": {
 				"fresnel:contentBefore": " (",
 				"fresnel:contentFirst": "(",
@@ -473,7 +474,7 @@
 			"@id": "genreForm-format",
 			"@type": "fresnel:Format",
 			"fresnel:propertyFormatDomain": ["genreForm"],
-			"fresnel:propertyStyle": ["pill", "nolabel"],
+			"fresnel:propertyStyle": ["nolabel"],
 			"fresnel:valueFormat": {
 				"fresnel:contentBefore": "",
 				"fresnel:contentFirst": ""
@@ -670,6 +671,7 @@
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Collection"],
 			"fresnel:propertyFormatDomain": ["sigel"],
+			"fresnel:propertyStyle": ["secondary", "small"],
 			"fresnel:propertyFormat": {
 				"fresnel:contentBefore": " (",
 				"fresnel:contentFirst": "(",

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -161,7 +161,7 @@
 			{/if}
 		{:else}
 			{#if shouldShowContentBefore()}
-				<span class="_contentBefore">
+				<span class={`_contentBefore ${getStyleClasses(data)}`}>
 					{data._contentBefore}
 				</span>
 			{/if}
@@ -217,7 +217,11 @@
 			{:else}
 				{@const [propertyName, propertyData] = getProperty(data)}
 				{#if propertyName && propertyData}
-					<svelte:element this={getElementType(propertyData)} data-property={propertyName}>
+					<svelte:element
+						this={getElementType(propertyData)}
+						data-property={propertyName}
+						class={getStyleClasses(data)}
+					>
 						{#if shouldShowLabels()}
 							<svelte:element this={block ? 'div' : 'span'}>
 								<!-- Add inner span with inline-block to achieve first letter capitalization while still supporting inline whitespaces -->
@@ -245,7 +249,7 @@
 				{/if}
 			{/if}
 			{#if shouldShowContentAfter()}
-				<span class="_contentAfter">
+				<span class={`_contentAfter ${getStyleClasses(data)}`}>
 					{data._contentAfter}
 				</span>
 			{/if}
@@ -257,7 +261,15 @@
 
 <style lang="postcss">
 	.definition {
-		@apply text-sm text-secondary underline decoration-dotted;
+		@apply underline decoration-dotted;
+	}
+
+	.small {
+		@apply text-sm;
+	}
+
+	.secondary {
+		@apply text-secondary;
 	}
 
 	.pill {
@@ -265,10 +277,6 @@
 	}
 	a.pill {
 		@apply hover:bg-pill/16 focus:bg-pill/16;
-	}
-
-	.text-large {
-		@apply text-lg;
 	}
 
 	.remainder {


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-227](https://kbse.atlassian.net/browse/LWS-227)

### Solves

See discussion in https://github.com/libris/lxlviewer/pull/1093 
Extend the possibilites to style the decorated data using formatters.

### Summary of changes

* DecoratedData now applies classes from the current "level" not only for data-types, but for data-properties, `contentBefore` and `contentAfter`.
* Some changes to the displayfile to reflect this

For example:

```
"Role-format": {
	"@id": "Role-format",
	"@type": "fresnel:Format",
	"fresnel:classFormatDomain": ["Role"],
	"fresnel:resourceStyle": ["definition"]
},

"Contribution-role-format": {
	"@id": "Contribution-role-format",
	"@type": "fresnel:Format",
	"fresnel:classFormatDomain": ["Contribution"],
	"fresnel:propertyFormatDomain": ["role"],
	"fresnel:propertyStyle": ["secondary", "small"],
	"fresnel:propertyFormat": {
		"fresnel:contentBefore": " (",
		"fresnel:contentFirst": "(",
		"fresnel:contentAfter": ")",
		"fresnel:contentLast": ")"
	}
},
```

yields

```
{
    "_style": [
        "secondary",
        "small"
    ],
    "_contentBefore": " (",
    "_contentAfter": ")",
    "role": {
        "@id": "https://libris-dev.kb.se/01671gl323zxzzhh",
        "@type": "Role",
        "_display": [
            {
                "prefLabel": "Författare",
                "_label": "föredragen benämning"
            }
        ],
        "_style": [
            "definition"
        ],
        "_label": "Funktion"
    },
    "_label": "funktion"
}
```

and

```
<span class="_contentBefore secondary small s-gtrp40c2vEko"> (</span>
<span data-property="role" class="secondary small s-gtrp40c2vEko">
   <span data-type="Role" class="definition s-gtrp40c2vEko">
      <span data-property="prefLabel" class=" s-gtrp40c2vEko">Författare</span>
   </span>
</span>
<span class="_contentAfter secondary small s-gtrp40c2vEko">)</span>
```

outputs
<img width="80" alt="Skärmavbild 2024-08-23 kl  15 45 35" src="https://github.com/user-attachments/assets/cdb66a7c-6ba7-474c-833f-eee7ceab5998">



