### PR TITLE
LWS-210: Filter libraries

### DIFF
--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -131,6 +131,7 @@ export default {
 		availableAt: 'Available at',
 		library: 'library',
 		libraries: 'libraries',
+		findLibrary: 'Find library',
 		findAtYourNearestLibrary: 'Find it at your nearest library',
 		location: 'Location',
 		shelf: 'Shelf',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -130,6 +130,7 @@ export default {
 		availableAt: 'Finns på',
 		library: 'bibliotek',
 		libraries: 'bibliotek',
+		findLibrary: 'Hitta bibliotek',
 		findAtYourNearestLibrary: 'Hitta på ditt närmaste bibliotek',
 		location: 'Placering',
 		shelf: 'Hylla',

--- a/lxl-web/src/lib/types/holdings.ts
+++ b/lxl-web/src/lib/types/holdings.ts
@@ -27,4 +27,5 @@ export type HoldersByType = {
 export type DecoratedHolder = {
 	obj: DisplayDecorated;
 	sigel: string;
+	str: string;
 };

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -3,7 +3,7 @@ import isFnurgel from '$lib/utils/isFnurgel';
 import { relativizeUrl } from '$lib/utils/http';
 import { LensType, type FramedData } from '$lib/types/xl';
 import type { BibIdObj, HoldersByType, HoldingsByInstanceId } from '$lib/types/holdings';
-import { DisplayUtil } from '$lib/utils/xl.js';
+import { DisplayUtil, toString } from '$lib/utils/xl.js';
 import type { LocaleCode } from '$lib/i18n/locales';
 
 export function getHoldingsLink(url: URL, value: string) {
@@ -60,7 +60,8 @@ export function getHoldingsByInstanceId(
 					...holding,
 					heldBy: {
 						obj: displayUtil.lensAndFormat(holding.heldBy, LensType.Chip, locale),
-						sigel: holding.heldBy?.sigel
+						sigel: holding.heldBy?.sigel,
+						str: toString(displayUtil.lensAndFormat(holding.heldBy, LensType.Chip, locale)) || ''
 					}
 				};
 			})
@@ -142,7 +143,8 @@ export function getHoldersByType(
 		const heldBys = holdings.map((holdingItem) => {
 			return {
 				obj: displayUtil.lensAndFormat(holdingItem.heldBy, LensType.Chip, locale),
-				sigel: holdingItem.heldBy.sigel
+				sigel: holdingItem.heldBy.sigel,
+				str: toString(displayUtil.lensAndFormat(holdingItem.heldBy, LensType.Chip, locale)) || ''
 			};
 		});
 		const uniqueHeldBys = [


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-210](https://kbse.atlassian.net/browse/LWS-210)

### Solves

Adds an input to find libraries in the holdings list. 

Works/looks very similar to the search in the facet panel, with some differences:
* The search string is used to create a filtered list, rather than sent to the individual components. This felt like a cleaner way to do it + we can display 'no hits'. Trade-of is components are unmounted/mounted on search, meaning we have to perform the api call again if re-displayed, re-expanded.
* The search is matched anywhere in the string (`indexOf`) to allow searching for sigel, for example.

* ATM the search string remains in the input if panel is closed and re-opened. Don't know if that's good or bad?

### Summary of changes
* Add the rendered (searchable) string to `DecoratedHolder` obj
* Add reactive variables `displayedHolders` / `filteredHolders`
* Add input


