### PR TITLE
Fix [object object] for popovers

### DIFF
--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -222,7 +222,7 @@
 						data-property={propertyName}
 						class={getStyleClasses(data)}
 					>
-						{#if shouldShowLabels()}
+						{#if shouldShowLabels() && typeof data._label === 'string'}
 							<svelte:element this={block ? 'div' : 'span'}>
 								<!-- Add inner span with inline-block to achieve first letter capitalization while still supporting inline whitespaces -->
 								<span


### PR DESCRIPTION
### Solves

Checking that the `_label` is a string to prevent printing `[object object]`, currently displaying in the `role` popovers.

example [before](https://beta.libris-dev.kb.se/ztt50fk21529dw1p) / [after](http://localhost:5173/ztt50fk21529dw1p)

---
A bit more in-depth...
Data looking like:

```
"domain": {
   "@id": "https://id.kb.se/vocab/Work"
},
"_label": {
   "@id": "http://www.w3.org/2000/01/rdf-schema#domain",
   "labelByLang": {
      "en": "Domain",
      "sv": "Förekommer på"
   }
}
```

`_label` not being flattened to "Förekommer på", is that a bug? In the next recursion, `domain` content is hidden, since it contains an `@id`.

In any which case, I think the string check makes sense...

