### PR TITLE
LWS-243: Facet limit info

### DIFF
--- a/lxl-web/src/colors.css
+++ b/lxl-web/src/colors.css
@@ -11,7 +11,7 @@ see https://tailwindcss.com/docs/customizing-colors#using-css-variables */
 	--color-beige: 247 246 242;
 	--color-pink: 239 214 189;
 	--color-dark-beige: 240 238 233;
-	--color-red: 202 85 85;
+	--color-red: 187 54 54;
 
 	/* Fundament */
 	--color-primary: var(--color-brown);

--- a/lxl-web/src/colors.css
+++ b/lxl-web/src/colors.css
@@ -11,6 +11,7 @@ see https://tailwindcss.com/docs/customizing-colors#using-css-variables */
 	--color-beige: 247 246 242;
 	--color-pink: 239 214 189;
 	--color-dark-beige: 240 238 233;
+	--color-red: 202 85 85;
 
 	/* Fundament */
 	--color-primary: var(--color-brown);
@@ -19,6 +20,7 @@ see https://tailwindcss.com/docs/customizing-colors#using-css-variables */
 	--color-accent-light: var(--color-light-green);
 	--color-subtle: var(--color-beige);
 	--color-highlight: var(--color-pink);
+	--color-error: var(--color-red);
 
 	/* Text colors */
 	--text-primary: var(--color-primary);
@@ -26,6 +28,7 @@ see https://tailwindcss.com/docs/customizing-colors#using-css-variables */
 	--text-link: var(--color-primary);
 	--text-positive: var(--color-accent-dark);
 	--icon-default: var(--color-primary);
+	--text-error: var(--color-error);
 
 	/* Bg colors */
 	--bg-primary: var(--color-primary);

--- a/lxl-web/src/lib/actions/popover/Popover.svelte
+++ b/lxl-web/src/lib/actions/popover/Popover.svelte
@@ -67,7 +67,7 @@
 	Note that `Popover.svelte` isn't intended to be used directly in page templates – use the `use:popover` instead (see `$lib/actions/popover`).
 -->
 <div
-	class="absolute left-0 top-0 z-50 max-w-sm rounded-md border border-primary/16 bg-cards text-sm shadow-xl"
+	class="absolute left-0 top-0 z-50 w-max max-w-sm rounded-md border border-primary/16 bg-cards text-sm shadow-xl"
 	role="complementary"
 	bind:this={popoverElement}
 	on:mouseover={onMouseOver}

--- a/lxl-web/src/lib/actions/popover/index.ts
+++ b/lxl-web/src/lib/actions/popover/index.ts
@@ -23,12 +23,17 @@ export const popover: Action<
 	{
 		title?: string;
 		resource?: { id: string; lang: LocaleCode } | { data: ResourceData[] };
+		placeAsSibling?: boolean; // place popover next to node in the DOM (to force it on top of modal, for example)
 	}
-> = (node: HTMLElement, { title = undefined, resource = undefined }) => {
+> = (node: HTMLElement, { title = undefined, resource = undefined, placeAsSibling = false }) => {
 	const FETCH_DELAY = 250;
 	const ATTACH_DELAY = 500;
 	const REMOVE_DELAY = 200;
-	const container = document.getElementById('floating-elements-container') || document.body; // See https://atfzl.com/articles/don-t-attach-tooltips-to-document-body
+	let container = document.getElementById('floating-elements-container') || document.body; // See https://atfzl.com/articles/don-t-attach-tooltips-to-document-body
+
+	if (placeAsSibling && node.parentElement) {
+		container = node.parentElement;
+	}
 
 	let attached = false;
 	let floatingElement: Popover | null = null;

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -181,6 +181,18 @@
 						"marc:arrangedStatementForMusic",
 						"originDate"
 					]
+				},
+				"Library": {
+					"@id": "Library-chips",
+					"@type": "fresnel:Lens",
+					"showProperties": ["name", "qualifier"],
+					"classLensDomain": "Library"
+				},
+				"Bibliography": {
+					"@id": "Bibliography-chips",
+					"@type": "fresnel:Lens",
+					"showProperties": ["name", "qualifier"],
+					"classLensDomain": "Bibliography"
 				}
 			}
 		},

--- a/lxl-web/src/lib/components/ResourceImage.svelte
+++ b/lxl-web/src/lib/components/ResourceImage.svelte
@@ -66,7 +66,7 @@
 						{/if}
 					</span>
 					<!-- This could be based on if attribution required by license.
-						 For now, display if there is any attribution info available -->
+						For now, display if there is any attribution info available -->
 					{#if geometry === 'circle'}
 						{$page.data.t('general.cropped')}
 					{/if}

--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -106,13 +106,13 @@
 				class="pointer-events-none absolute right-0 top-0 m-1.5 w-3 rotate-90 text-icon-strong"
 			/>
 		</div>
-		<div class="mb-4 text-sm">
+		<div class="text-md mb-4 md:text-sm">
 			{#if group.search && !(searchPhrase && hasHits)}
 				<!-- facet range inputs; hide in filter search results -->
 				<FacetRange search={group.search} />
 			{/if}
 			<ol
-				class="flex max-h-[437px] flex-col gap-1 overflow-y-auto overflow-x-clip pl-6 pr-0.5"
+				class="flex max-h-72 flex-col gap-1 overflow-y-auto overflow-x-clip pl-6 pr-0.5 sm:max-h-[437px]"
 				data-testid="facet-list"
 			>
 				{#each shownFacets as facet (facet.view['@id'])}
@@ -144,7 +144,7 @@
 							</span>
 							{#if facet.totalItems > 0}
 								<span
-									class="facet-total mb-px rounded-sm bg-pill/4 px-1 text-xs text-secondary"
+									class="facet-total mb-px rounded-sm bg-pill/4 px-1 text-sm text-secondary md:text-xs"
 									aria-label="{facet.totalItems} {$page.data.t('search.hits')}"
 									>{facet.totalItems.toLocaleString(locale)}</span
 								>

--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -1,24 +1,28 @@
 <script lang="ts">
-	import type { LocaleCode } from '$lib/i18n/locales';
 	import { page } from '$app/stores';
+	import type { LocaleCode } from '$lib/i18n/locales';
 	import type { FacetGroup, Facet, MultiSelectFacet } from '$lib/types/search';
-	import BiChevronRight from '~icons/bi/chevron-right';
-	import BiSortDown from '~icons/bi/sort-down';
-	import CheckSquareFill from '~icons/bi/check-square-fill';
-	import Square from '~icons/bi/square';
+	import { ShowLabelsOptions } from '$lib/types/decoratedData';
+	import { DEFAULT_FACET_SORT, DEFAULT_FACETS_SHOWN, FACET_LIMITS } from '$lib/constants/facets';
+	import { saveUserSetting } from '$lib/utils/userSettings';
+	import { popover } from '$lib/actions/popover';
 	import FacetRange from './FacetRange.svelte';
 	import DecoratedData from '../DecoratedData.svelte';
-	import { ShowLabelsOptions } from '$lib/types/decoratedData';
-	import { DEFAULT_FACET_SORT, DEFAULT_FACETS_SHOWN } from '$lib/constants/facets';
-	import { saveUserSetting } from '$lib/utils/userSettings';
+	import BiChevronRight from '~icons/bi/chevron-right';
+	import BiSortDown from '~icons/bi/sort-down';
+	import BiCheckSquareFill from '~icons/bi/check-square-fill';
+	import BiSquare from '~icons/bi/square';
+	import BiInfo from '~icons/bi/info-circle';
 
 	export let group: FacetGroup;
 	export let locale: LocaleCode;
 	export let searchPhrase = '';
 
 	let facetsShown = DEFAULT_FACETS_SHOWN;
-	const userSort = $page.data.userSettings?.facetSort?.[group.dimension];
+	const facetLimit: number | undefined =
+		FACET_LIMITS[group.dimension as keyof typeof FACET_LIMITS]?.itemLimit;
 
+	const userSort = $page.data.userSettings?.facetSort?.[group.dimension];
 	let currentSort = userSort || DEFAULT_FACET_SORT;
 
 	const sortOptions = [
@@ -53,7 +57,7 @@
 		saveUserSetting('facetSort', { [group.dimension]: target.value });
 	}
 
-	$: numfacets = group.facets.length;
+	$: numFacets = group.facets.length;
 	$: hasHits = filteredFacets.length > 0;
 	$: expanded = searchPhrase && hasHits;
 	$: sortedFacets = group.facets.sort(sortFn);
@@ -66,11 +70,13 @@
 	$: shownFacets = filteredFacets.filter((facet, index) => index < facetsShown);
 	$: canShowMoreFacets = filteredFacets.length > facetsShown;
 	$: canShowLessFacets = !canShowMoreFacets && filteredFacets.length > DEFAULT_FACETS_SHOWN;
+	$: facetLimitReached = numFacets === facetLimit;
 </script>
 
 <li
 	class="border-b border-primary/16 first:border-t"
 	class:hidden={searchPhrase && !hasHits}
+	class:has-hits={hasHits}
 	data-dimension={group.dimension}
 >
 	<details class="relative" open={!!expanded}>
@@ -100,13 +106,13 @@
 				class="pointer-events-none absolute right-0 top-0 m-1.5 w-3 rotate-90 text-icon-strong"
 			/>
 		</div>
-		<div class="mb-4 md:text-sm lg:text-base">
+		<div class="mb-4 text-sm">
 			{#if group.search && !(searchPhrase && hasHits)}
 				<!-- facet range inputs; hide in filter search results -->
 				<FacetRange search={group.search} />
 			{/if}
 			<ol
-				class="flex max-h-[437px] flex-col gap-1 overflow-y-auto overflow-x-clip py-2 pl-6 pr-0.5"
+				class="flex max-h-[437px] flex-col gap-1 overflow-y-auto overflow-x-clip pl-6 pr-0.5"
 				data-testid="facet-list"
 			>
 				{#each shownFacets as facet (facet.view['@id'])}
@@ -115,17 +121,17 @@
 							class="facet-link flex items-end justify-between gap-2 no-underline"
 							href={facet.view['@id']}
 						>
-							<span class="flex items-baseline">
+							<span class="overflow-hidden text-ellipsis whitespace-nowrap" title={facet.str}>
 								{#if 'selected' in facet}
 									<!-- checkboxes -->
 									<span class="sr-only"
 										>{facet.selected ? $page.data.t('search.activeFilter') : ''}</span
 									>
-									<div class="mr-2 flex h-[13px] w-[13px] rounded-sm bg-[white]" aria-hidden="true">
+									<div class="mr-1 inline-block h-[13px] w-[13px]" aria-hidden="true">
 										{#if facet.selected}
-											<CheckSquareFill height="13px" />
+											<BiCheckSquareFill height="13px" />
 										{:else}
-											<Square height="13px" />
+											<BiSquare height="13px" />
 										{/if}
 									</div>
 								{/if}
@@ -138,7 +144,7 @@
 							</span>
 							{#if facet.totalItems > 0}
 								<span
-									class="facet-total mb-px rounded-sm bg-pill/4 px-1 text-sm text-secondary md:text-xs lg:text-sm"
+									class="facet-total mb-px rounded-sm bg-pill/4 px-1 text-xs text-secondary"
 									aria-label="{facet.totalItems} {$page.data.t('search.hits')}"
 									>{facet.totalItems.toLocaleString(locale)}</span
 								>
@@ -147,18 +153,30 @@
 					</li>
 				{/each}
 			</ol>
-			{#if canShowMoreFacets || canShowLessFacets}
-				<button
-					class="ml-6 mt-4 underline"
-					on:click={() =>
-						canShowMoreFacets ? (facetsShown = numfacets) : (facetsShown = DEFAULT_FACETS_SHOWN)}
-				>
-					{canShowMoreFacets ? $page.data.t('search.showMore') : $page.data.t('search.showFewer')}
-				</button>
-			{/if}
-			{#if searchPhrase && filteredFacets.length === 0}
-				<span role="status" aria-atomic="true">{$page.data.t('search.noResults')}</span>
-			{/if}
+			<div class="flex">
+				<!-- 'show more' btn -->
+				{#if canShowMoreFacets || canShowLessFacets}
+					<button
+						class="ml-6 mt-4 underline"
+						on:click={() =>
+							canShowMoreFacets ? (facetsShown = numFacets) : (facetsShown = DEFAULT_FACETS_SHOWN)}
+					>
+						{canShowMoreFacets ? $page.data.t('search.showMore') : $page.data.t('search.showFewer')}
+					</button>
+				{/if}
+				<!-- limit reached info -->
+				{#if facetLimitReached && canShowLessFacets && !searchPhrase}
+					<div
+						role="alert"
+						aria-live="polite"
+						class="ml-auto mt-4 flex gap-1 rounded-sm bg-pill/4 px-2 py-1 text-error"
+						use:popover={{ title: $page.data.t('facet.limitText') }}
+					>
+						<p class="text-xs">{$page.data.t('facet.limitInfo')}</p>
+						<BiInfo />
+					</div>
+				{/if}
+			</div>
 		</div>
 	</details>
 </li>

--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -3,7 +3,7 @@
 	import type { LocaleCode } from '$lib/i18n/locales';
 	import type { FacetGroup, Facet, MultiSelectFacet } from '$lib/types/search';
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
-	import { DEFAULT_FACET_SORT, DEFAULT_FACETS_SHOWN, FACET_LIMITS } from '$lib/constants/facets';
+	import { DEFAULT_FACET_SORT, DEFAULT_FACETS_SHOWN } from '$lib/constants/facets';
 	import { saveUserSetting } from '$lib/utils/userSettings';
 	import { popover } from '$lib/actions/popover';
 	import FacetRange from './FacetRange.svelte';
@@ -19,8 +19,7 @@
 	export let searchPhrase = '';
 
 	let facetsShown = DEFAULT_FACETS_SHOWN;
-	const facetLimit: number | undefined =
-		FACET_LIMITS[group.dimension as keyof typeof FACET_LIMITS]?.itemLimit;
+	const maxFacets = group.maxItems;
 
 	const userSort = $page.data.userSettings?.facetSort?.[group.dimension];
 	let currentSort = userSort || DEFAULT_FACET_SORT;
@@ -70,7 +69,7 @@
 	$: shownFacets = filteredFacets.filter((facet, index) => index < facetsShown);
 	$: canShowMoreFacets = filteredFacets.length > facetsShown;
 	$: canShowLessFacets = !canShowMoreFacets && filteredFacets.length > DEFAULT_FACETS_SHOWN;
-	$: facetLimitReached = numFacets === facetLimit;
+	$: maxFacetsReached = numFacets === maxFacets;
 </script>
 
 <li
@@ -165,7 +164,7 @@
 					</button>
 				{/if}
 				<!-- limit reached info -->
-				{#if facetLimitReached && canShowLessFacets && !searchPhrase}
+				{#if maxFacetsReached && canShowLessFacets}
 					<div
 						role="alert"
 						aria-live="polite"

--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -165,14 +165,17 @@
 				{/if}
 				<!-- limit reached info -->
 				{#if maxFacetsReached && canShowLessFacets}
-					<div
-						role="alert"
-						aria-live="polite"
-						class="ml-auto mt-4 flex gap-1 rounded-sm bg-pill/4 px-2 py-1 text-error"
-						use:popover={{ title: $page.data.t('facet.limitText') }}
-					>
-						<p class="text-xs">{$page.data.t('facet.limitInfo')}</p>
-						<BiInfo />
+					<div class="ml-auto mt-4 flex gap-1 rounded-sm bg-pill/4 px-2 py-1">
+						<p role="status" class="text-xs text-error">{$page.data.t('facet.limitInfo')}</p>
+						<button
+							aria-label={$page.data.t('facet.limitInfo')}
+							use:popover={{
+								title: $page.data.t('facet.limitText'),
+								placeAsSibling: true
+							}}
+						>
+							<BiInfo aria-hidden="true" class="text-error" />
+						</button>
 					</div>
 				{/if}
 			</div>

--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -23,7 +23,7 @@
 	{/if}
 	{#if facets?.length}
 		<nav
-			class="relative flex flex-col gap-4"
+			class="facet-nav relative flex flex-col gap-4"
 			aria-label={$page.data.t('search.filters')}
 			data-testid="facets"
 		>
@@ -40,6 +40,16 @@
 					<FacetGroup {group} locale={$page.data.locale} {searchPhrase} />
 				{/each}
 			</ol>
+			<span role="status" class="no-hits-msg px-2" aria-atomic="true"
+				>{$page.data.t('search.noResults')}</span
+			>
 		</nav>
 	{/if}
 </div>
+
+<style>
+	/* hide 'no hits' msg as long as there's results displaying */
+	:global(.facet-nav:has(.has-hits) .no-hits-msg) {
+		@apply hidden;
+	}
+</style>

--- a/lxl-web/src/lib/constants/facets.ts
+++ b/lxl-web/src/lib/constants/facets.ts
@@ -1,19 +1,2 @@
 export const DEFAULT_FACETS_SHOWN = 5;
 export const DEFAULT_FACET_SORT = 'hits.desc';
-// Copied from https://github.com/libris/definitions/blob/develop/source/apps.jsonld, TODO better solution...
-export const FACET_LIMITS = {
-	instanceOfType: { itemLimit: 100 },
-	'rdf:type': { itemLimit: 100 },
-	hasInstanceType: { itemLimit: 100 },
-	contributor: { itemLimit: 20 },
-	genreForm: { itemLimit: 100 },
-	subject: { itemLimit: 100 },
-	language: { itemLimit: 100 },
-	intendedAudience: { itemLimit: 100 },
-	yearPublished: { itemLimit: 500 },
-	bibliography: { itemLimit: 200 },
-	itemHeldBy: { itemLimit: 1000 },
-	nationality: { itemLimit: 100 },
-	hasOccupation: { itemLimit: 100 },
-	fieldOfActivity: { itemLimit: 100 }
-};

--- a/lxl-web/src/lib/constants/facets.ts
+++ b/lxl-web/src/lib/constants/facets.ts
@@ -1,2 +1,19 @@
 export const DEFAULT_FACETS_SHOWN = 5;
 export const DEFAULT_FACET_SORT = 'hits.desc';
+// Copied from https://github.com/libris/definitions/blob/develop/source/apps.jsonld, TODO better solution...
+export const FACET_LIMITS = {
+	instanceOfType: { itemLimit: 100 },
+	'rdf:type': { itemLimit: 100 },
+	hasInstanceType: { itemLimit: 100 },
+	contributor: { itemLimit: 20 },
+	genreForm: { itemLimit: 100 },
+	subject: { itemLimit: 100 },
+	language: { itemLimit: 100 },
+	intendedAudience: { itemLimit: 100 },
+	yearPublished: { itemLimit: 500 },
+	bibliography: { itemLimit: 200 },
+	itemHeldBy: { itemLimit: 1000 },
+	nationality: { itemLimit: 100 },
+	hasOccupation: { itemLimit: 100 },
+	fieldOfActivity: { itemLimit: 100 }
+};

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -58,7 +58,10 @@ export default {
 		nationality: 'Nationality',
 		hasOccupation: 'Has Occupation',
 		fieldOfActivity: 'Field of Activity',
-		boolFilters: 'Other'
+		boolFilters: 'Other',
+		limitInfo: 'Some options are not displayed',
+		limitText:
+			'The list shows a limited number of options, the most common ones related to your search. Try narrowing your search to get other, more relevant options.'
 	},
 	search: {
 		search: 'Search',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -57,7 +57,10 @@ export default {
 		nationality: 'Nationalitet/verksamhetsland',
 		hasOccupation: 'Har yrke eller sysselsättning',
 		fieldOfActivity: 'Verksamhetsområde',
-		boolFilters: 'Övrigt'
+		boolFilters: 'Övrigt',
+		limitInfo: 'Alla val kan ej visas',
+		limitText:
+			'Listan visar ett begränsat antal alternativ, de mest förekommande kopplade till din sökning. Prova att avgränsa din sökning för att få andra, mer relevanta alternativ.'
 	},
 	search: {
 		search: 'Sök',

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -42,6 +42,7 @@ export interface FacetGroup {
 	label: string;
 	dimension: FacetGroupId;
 	search?: FacetSearch;
+	maxItems?: number;
 	// TODO better to do this distinction on the group level?
 	facets: (Facet | MultiSelectFacet)[];
 }
@@ -102,6 +103,7 @@ interface Slice {
 	dimension: FacetGroupId;
 	observation: Observation[];
 	search?: FacetSearch;
+	maxItems: number;
 }
 
 interface Observation {

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -169,6 +169,7 @@ function displayFacetGroups(
 		return {
 			label: translate(`facet.${g.alias || g.dimension}`),
 			dimension: g.dimension,
+			maxItems: g.maxItems,
 			...('search' in g && { search: g.search }),
 			facets: g.observation.map((o) => {
 				return {

--- a/lxl-web/tailwind.config.js
+++ b/lxl-web/tailwind.config.js
@@ -21,6 +21,7 @@ export default {
 			disabled: 'rgb(var(--text-primary) / 0.6)',
 			positive: 'rgb(var(--text-positive) / 1)',
 			hover: 'rgb(var(--text-link) / 1)',
+			error: 'rgb(var(--text-error) / 1)',
 			icon: {
 				DEFAULT: 'rgb(var(--icon-default) / 0.4)',
 				strong: 'rgb(var(--icon-default) / 0.8)'


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-243](https://kbse.atlassian.net/browse/LWS-243)

### Solves

Add info text + popover when number of facets in a group reaches its limit + more tweaks

### Summary of changes

* Add limit notification (can be seen for subject or genre/form with a wide search, when clicking 'show more')

~~The limits are set in [the apps file](https://github.com/libris/definitions/blob/develop/source/apps.jsonld) and the current solution has simply copied this to the frontend. Not ideal since sync:ing that will be easily forgotten. Possible other solutions is to a) fetch the file somehow b) Get the limit/limit reached with the api response?~~

* 'No search result' text displayed when searching in filters. This was sort of implemented but not working.

#### Proposing the following additional changes:

To improve readability in filter panel (open for discussion on these 😄 )

* Facet items ellipses after one line instead of breaking + `title` attribute to display in browser tooltip
* Reducing the font size on the filter items 16 -> 14px to fit more text (not on small screens).
* Removing the sigel from the library/bibliography chips. Save some space + means nothing for most people?


