### PR TITLE
Encode comma in requests to backend

### DIFF
--- a/idkbse/src/plugins/env.js
+++ b/idkbse/src/plugins/env.js
@@ -27,7 +27,8 @@ export function encodeSpecialChars(path) {
   return path
     .replace(/\(/g, '%28')
     .replace(/\)/g, '%29')
-    .replace(/&/g, '%26');
+    .replace(/&/g, '%26')
+    .replace(/,/g, '%2C');
 }
 
 export function activeSite(xForwardedHost, siteAlias, siteConfig, defaultSite) {


### PR DESCRIPTION
## Description
Terms containing a comma don't work:

* [https://id.kb.se/term/sao/Frihet--teori%2C%20filosofi](https://id.kb.se/term/sao/Frihet--teori,%20filosofi)
* https://id.kb.se/term/sao/Berlinmurens%20fall%2C%20Tyskland%2C%201989
* several hundred more

This is because we doesn't encode the comma when sending it to the backend. Solution: encode the comma. (Perhaps it gets decoded along the way to Nuxt or by something in Nuxt -- anyway, this fixes the problem like we previously fixed similar problems)

### Tickets involved
[LXL-4047](https://kbse.atlassian.net/browse/LXL-4047)
