### PR TITLE
LWS-226: Bump lxl-web dependencies

### DIFF
--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -533,10 +533,11 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.17.1.tgz",
-			"integrity": "sha512-BlYOpej8AQ8Ev9xVqroV7a02JK3SkBAaN9GfMMH9W6Ch8FlQlkjGw4Ir7+FgYwfirivAf4t+GtzuAxqfukmISA==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
+			"integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.4",
 				"debug": "^4.3.1",
@@ -551,6 +552,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -561,11 +563,22 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/@eslint/core": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.6.0.tgz",
+			"integrity": "sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -655,10 +668,11 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.9.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.9.0.tgz",
-			"integrity": "sha512-hhetes6ZHP3BlXLxmd8K2SNgkhNSi+UcecbnwWKwpP7kyi/uC75DJ1lOOBO3xrC4jyojtGE3YxKZPHfk4yrgug==",
+			"version": "9.11.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.1.tgz",
+			"integrity": "sha512-/qu+TWz8WwPWc7/HcIJKi+c+MOm46GdVaSlTTQcaqaL53+GsoA6MxWp5PtTx48qbSP7ylM1Kn7nhvkugfJvRSA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -668,6 +682,20 @@
 			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
 			"integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
 			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/plugin-kit": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
+			"integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"levn": "^0.4.1"
+			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -1521,10 +1549,11 @@
 			"dev": true
 		},
 		"node_modules/@types/eslint": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
-			"integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -1574,16 +1603,17 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.1.0.tgz",
-			"integrity": "sha512-LlNBaHFCEBPHyD4pZXb35mzjGkuGKXU5eeCA1SxvHfiRES0E82dOounfVpL4DCqYvJEKab0bZIA0gCRpdLKkCw==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
+			"integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.1.0",
-				"@typescript-eslint/type-utils": "8.1.0",
-				"@typescript-eslint/utils": "8.1.0",
-				"@typescript-eslint/visitor-keys": "8.1.0",
+				"@typescript-eslint/scope-manager": "8.7.0",
+				"@typescript-eslint/type-utils": "8.7.0",
+				"@typescript-eslint/utils": "8.7.0",
+				"@typescript-eslint/visitor-keys": "8.7.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
@@ -1607,15 +1637,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.1.0.tgz",
-			"integrity": "sha512-U7iTAtGgJk6DPX9wIWPPOlt1gO57097G06gIcl0N0EEnNw8RGD62c+2/DiP/zL7KrkqnnqF7gtFGR7YgzPllTA==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
+			"integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.1.0",
-				"@typescript-eslint/types": "8.1.0",
-				"@typescript-eslint/typescript-estree": "8.1.0",
-				"@typescript-eslint/visitor-keys": "8.1.0",
+				"@typescript-eslint/scope-manager": "8.7.0",
+				"@typescript-eslint/types": "8.7.0",
+				"@typescript-eslint/typescript-estree": "8.7.0",
+				"@typescript-eslint/visitor-keys": "8.7.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1635,13 +1666,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.1.0.tgz",
-			"integrity": "sha512-DsuOZQji687sQUjm4N6c9xABJa7fjvfIdjqpSIIVOgaENf2jFXiM9hIBZOL3hb6DHK9Nvd2d7zZnoMLf9e0OtQ==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
+			"integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.1.0",
-				"@typescript-eslint/visitor-keys": "8.1.0"
+				"@typescript-eslint/types": "8.7.0",
+				"@typescript-eslint/visitor-keys": "8.7.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1652,13 +1684,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.1.0.tgz",
-			"integrity": "sha512-oLYvTxljVvsMnldfl6jIKxTaU7ok7km0KDrwOt1RHYu6nxlhN3TIx8k5Q52L6wR33nOwDgM7VwW1fT1qMNfFIA==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
+			"integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.1.0",
-				"@typescript-eslint/utils": "8.1.0",
+				"@typescript-eslint/typescript-estree": "8.7.0",
+				"@typescript-eslint/utils": "8.7.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.3.0"
 			},
@@ -1676,10 +1709,11 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.1.0.tgz",
-			"integrity": "sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
+			"integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -1689,15 +1723,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.1.0.tgz",
-			"integrity": "sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
+			"integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/types": "8.1.0",
-				"@typescript-eslint/visitor-keys": "8.1.0",
+				"@typescript-eslint/types": "8.7.0",
+				"@typescript-eslint/visitor-keys": "8.7.0",
 				"debug": "^4.3.4",
-				"globby": "^11.1.0",
+				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
 				"minimatch": "^9.0.4",
 				"semver": "^7.6.0",
@@ -1717,15 +1752,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.1.0.tgz",
-			"integrity": "sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
+			"integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.1.0",
-				"@typescript-eslint/types": "8.1.0",
-				"@typescript-eslint/typescript-estree": "8.1.0"
+				"@typescript-eslint/scope-manager": "8.7.0",
+				"@typescript-eslint/types": "8.7.0",
+				"@typescript-eslint/typescript-estree": "8.7.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1739,12 +1775,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.1.0.tgz",
-			"integrity": "sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
+			"integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.1.0",
+				"@typescript-eslint/types": "8.7.0",
 				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
@@ -2006,15 +2043,6 @@
 			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.3"
-			}
-		},
-		"node_modules/array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/assertion-error": {
@@ -2698,18 +2726,6 @@
 			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
 			"dev": true
 		},
-		"node_modules/dir-glob": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"dev": true,
-			"dependencies": {
-				"path-type": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/dlv": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -2895,19 +2911,24 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.9.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.9.0.tgz",
-			"integrity": "sha512-JfiKJrbx0506OEerjK2Y1QlldtBxkAlLxT5OEcRF8uaQ86noDe2k31Vw9rnSWv+MXZHj7OOUV/dA0AhdLFcyvA==",
+			"version": "9.11.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.1.tgz",
+			"integrity": "sha512-MobhYKIoAO1s1e4VUrgx1l1Sk2JBR/Gqjjgw8+mfgoLE2xwsHur4gdfTxyTgShrhvdVFTaJSgMiQBl1jv/AWxg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.11.0",
-				"@eslint/config-array": "^0.17.1",
+				"@eslint/config-array": "^0.18.0",
+				"@eslint/core": "^0.6.0",
 				"@eslint/eslintrc": "^3.1.0",
-				"@eslint/js": "9.9.0",
+				"@eslint/js": "9.11.1",
+				"@eslint/plugin-kit": "^0.2.0",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.3.0",
 				"@nodelib/fs.walk": "^1.2.8",
+				"@types/estree": "^1.0.6",
+				"@types/json-schema": "^7.0.15",
 				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -2927,7 +2948,6 @@
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.4.1",
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
@@ -2981,10 +3001,11 @@
 			}
 		},
 		"node_modules/eslint-plugin-svelte": {
-			"version": "2.43.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.43.0.tgz",
-			"integrity": "sha512-REkxQWvg2pp7QVLxQNa+dJ97xUqRe7Y2JJbSWkHSuszu0VcblZtXkPBPckkivk99y5CdLw4slqfPylL2d/X4jQ==",
+			"version": "2.44.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.44.1.tgz",
+			"integrity": "sha512-w6wkoJPw1FJKFtM/2oln21rlu5+HTd2CSkkzhm32A+trNoW2EYQqTQAbDTU6k2GI/6Vh64rBHYQejqEgDld7fw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@jridgewell/sourcemap-codec": "^1.4.15",
@@ -2996,7 +3017,7 @@
 				"postcss-safe-parser": "^6.0.0",
 				"postcss-selector-parser": "^6.1.0",
 				"semver": "^7.6.2",
-				"svelte-eslint-parser": "^0.41.0"
+				"svelte-eslint-parser": "^0.41.1"
 			},
 			"engines": {
 				"node": "^14.17.0 || >=16.0.0"
@@ -3019,6 +3040,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
 			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -3120,6 +3142,7 @@
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
 			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
@@ -3480,26 +3503,6 @@
 			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
 			"dev": true
 		},
-		"node_modules/globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
-			"dependencies": {
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/globrex": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
@@ -3516,7 +3519,8 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
@@ -4543,15 +4547,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/path-type": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/pathe": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -5261,6 +5256,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"engines": {
 				"node": ">=12.0"
 			},
@@ -5792,15 +5788,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/slash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/slice-ansi": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
@@ -6127,10 +6114,11 @@
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
-			"version": "0.41.0",
-			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.41.0.tgz",
-			"integrity": "sha512-L6f4hOL+AbgfBIB52Z310pg1d2QjRqm7wy3kI1W6hhdhX5bvu7+f0R6w4ykp5HoDdzq+vGhIJmsisaiJDGmVfA==",
+			"version": "0.41.1",
+			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.41.1.tgz",
+			"integrity": "sha512-08ndI6zTghzI8SuJAFpvMbA/haPSGn3xz19pjre19yYMw8Nw/wQJ2PrZBI/L8ijGTgtkWCQQiLLy+Z1tfaCwNA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"eslint-scope": "^7.2.2",
 				"eslint-visitor-keys": "^3.4.3",
@@ -6498,6 +6486,7 @@
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
 			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=16"
 			},
@@ -6545,14 +6534,15 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.1.0.tgz",
-			"integrity": "sha512-prB2U3jXPJLpo1iVLN338Lvolh6OrcCZO+9Yv6AR+tvegPPptYCDBIHiEEUdqRi8gAv2bXNKfMUrgAd2ejn/ow==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.7.0.tgz",
+			"integrity": "sha512-nEHbEYJyHwsuf7c3V3RS7Saq+1+la3i0ieR3qP0yjqWSzVmh8Drp47uOl9LjbPANac4S7EFSqvcYIKXUUwIfIQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.1.0",
-				"@typescript-eslint/parser": "8.1.0",
-				"@typescript-eslint/utils": "8.1.0"
+				"@typescript-eslint/eslint-plugin": "8.7.0",
+				"@typescript-eslint/parser": "8.7.0",
+				"@typescript-eslint/utils": "8.7.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -105,12 +105,14 @@
 			}
 		},
 		"node_modules/@antfu/install-pkg": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-0.3.3.tgz",
-			"integrity": "sha512-nHHsk3NXQ6xkCfiRRC8Nfrg8pU5kkr3P3Y9s9dKqiuRmBD0Yap7fymNDjGFKeWhZQHqqbCS5CfeMy9wtExM24w==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-0.4.1.tgz",
+			"integrity": "sha512-T7yB5QNG29afhWVkVq7XeIMBa5U/vs9mX69YqayXypPRmYzUmzwnYltplHmPtZ4HPCn+sQKeXW8I47wCbuBOjw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jsdevtools/ez-spawn": "^3.0.4"
+				"package-manager-detector": "^0.2.0",
+				"tinyexec": "^0.3.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -1016,21 +1018,6 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
-			}
-		},
-		"node_modules/@jsdevtools/ez-spawn": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@jsdevtools/ez-spawn/-/ez-spawn-3.0.4.tgz",
-			"integrity": "sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==",
-			"dev": true,
-			"dependencies": {
-				"call-me-maybe": "^1.0.1",
-				"cross-spawn": "^7.0.3",
-				"string-argv": "^0.3.1",
-				"type-detect": "^4.0.8"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -2189,12 +2176,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/call-me-maybe": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-			"integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
-			"dev": true
 		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
@@ -4494,6 +4475,13 @@
 			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
 			"dev": true
 		},
+		"node_modules/package-manager-detector": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.0.tgz",
+			"integrity": "sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6521,10 +6509,11 @@
 			"dev": true
 		},
 		"node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-			"dev": true
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+			"dev": true,
+			"license": "0BSD"
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -6538,20 +6527,12 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/typescript": {
-			"version": "5.5.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-			"integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+			"integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -6618,12 +6599,13 @@
 			}
 		},
 		"node_modules/unplugin-icons": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/unplugin-icons/-/unplugin-icons-0.19.2.tgz",
-			"integrity": "sha512-QkQJ/Iz3PFr/EoiOvFUQYvqbbJZ7Vs3hObKAFHh5eywTU1PQagSNeXKGRD+JpzXSTnUNLtG0u/xEA5Ec2OeANQ==",
+			"version": "0.19.3",
+			"resolved": "https://registry.npmjs.org/unplugin-icons/-/unplugin-icons-0.19.3.tgz",
+			"integrity": "sha512-EUegRmsAI6+rrYr0vXjFlIP+lg4fSC4zb62zAZKx8FGXlWAGgEGBCa3JDe27aRAXhistObLPbBPhwa/0jYLFkQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@antfu/install-pkg": "^0.3.3",
+				"@antfu/install-pkg": "^0.4.1",
 				"@antfu/utils": "^0.7.10",
 				"@iconify/utils": "^2.1.29",
 				"debug": "^4.3.6",

--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -1521,6 +1521,7 @@
 			"resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
 			"integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=10.13.0"
 			}
@@ -2078,7 +2079,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
 			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.1",
@@ -2180,6 +2182,7 @@
 			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
 			"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.0.0",
 				"caniuse-lite": "^1.0.0",
@@ -2359,7 +2362,8 @@
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
 			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/colorette": {
 			"version": "2.0.20",
@@ -2423,6 +2427,7 @@
 			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
 			"integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
@@ -2435,6 +2440,7 @@
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
 			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"boolbase": "^1.0.0",
 				"css-what": "^6.1.0",
@@ -2464,6 +2470,7 @@
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
 			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">= 6"
 			},
@@ -2484,12 +2491,13 @@
 			}
 		},
 		"node_modules/cssnano": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.5.tgz",
-			"integrity": "sha512-Aq0vqBLtpTT5Yxj+hLlLfNPFuRQCDIjx5JQAhhaedQKLNDvDGeVziF24PS+S1f0Z5KCxWvw0QVI3VNHNBITxVQ==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.6.tgz",
+			"integrity": "sha512-54woqx8SCbp8HwvNZYn68ZFAepuouZW4lTwiMVnBErM3VkO7/Sd4oTOt3Zz3bPx3kxQ36aISppyXj2Md4lg8bw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"cssnano-preset-default": "^7.0.5",
+				"cssnano-preset-default": "^7.0.6",
 				"lilconfig": "^3.1.2"
 			},
 			"engines": {
@@ -2504,27 +2512,28 @@
 			}
 		},
 		"node_modules/cssnano-preset-default": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.5.tgz",
-			"integrity": "sha512-Jbzja0xaKwc5JzxPQoc+fotKpYtWEu4wQLMQe29CM0FjjdRjA4omvbGHl2DTGgARKxSTpPssBsok+ixv8uTBqw==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.6.tgz",
+			"integrity": "sha512-ZzrgYupYxEvdGGuqL+JKOY70s7+saoNlHSCK/OGn1vB2pQK8KSET8jvenzItcY+kA7NoWvfbb/YhlzuzNKjOhQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.23.3",
 				"css-declaration-sorter": "^7.2.0",
 				"cssnano-utils": "^5.0.0",
-				"postcss-calc": "^10.0.1",
+				"postcss-calc": "^10.0.2",
 				"postcss-colormin": "^7.0.2",
-				"postcss-convert-values": "^7.0.3",
-				"postcss-discard-comments": "^7.0.2",
+				"postcss-convert-values": "^7.0.4",
+				"postcss-discard-comments": "^7.0.3",
 				"postcss-discard-duplicates": "^7.0.1",
 				"postcss-discard-empty": "^7.0.0",
 				"postcss-discard-overridden": "^7.0.0",
-				"postcss-merge-longhand": "^7.0.3",
-				"postcss-merge-rules": "^7.0.3",
+				"postcss-merge-longhand": "^7.0.4",
+				"postcss-merge-rules": "^7.0.4",
 				"postcss-minify-font-values": "^7.0.0",
 				"postcss-minify-gradients": "^7.0.0",
 				"postcss-minify-params": "^7.0.2",
-				"postcss-minify-selectors": "^7.0.3",
+				"postcss-minify-selectors": "^7.0.4",
 				"postcss-normalize-charset": "^7.0.0",
 				"postcss-normalize-display-values": "^7.0.0",
 				"postcss-normalize-positions": "^7.0.0",
@@ -2538,7 +2547,7 @@
 				"postcss-reduce-initial": "^7.0.2",
 				"postcss-reduce-transforms": "^7.0.0",
 				"postcss-svgo": "^7.0.1",
-				"postcss-unique-selectors": "^7.0.2"
+				"postcss-unique-selectors": "^7.0.3"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -2552,6 +2561,7 @@
 			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.0.tgz",
 			"integrity": "sha512-Uij0Xdxc24L6SirFr25MlwC2rCFX6scyUmuKpzI+JQ7cyqDEwD42fJ0xfB3yLfOnRDU5LKGgjQ9FA6LYh76GWQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
 			},
@@ -2564,6 +2574,7 @@
 			"resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
 			"integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"css-tree": "~2.2.0"
 			},
@@ -2577,6 +2588,7 @@
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
 			"integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"mdn-data": "2.0.28",
 				"source-map-js": "^1.0.1"
@@ -2590,7 +2602,8 @@
 			"version": "2.0.28",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
 			"integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-			"dev": true
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/debug": {
 			"version": "4.3.6",
@@ -2687,6 +2700,7 @@
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
 			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.2",
@@ -2706,13 +2720,15 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/fb55"
 				}
-			]
+			],
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/domhandler": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
 			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"domelementtype": "^2.3.0"
 			},
@@ -2728,6 +2744,7 @@
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
 			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"dom-serializer": "^2.0.0",
 				"domelementtype": "^2.3.0",
@@ -2771,6 +2788,7 @@
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
 			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.12"
 			},
@@ -3509,10 +3527,11 @@
 			}
 		},
 		"node_modules/husky": {
-			"version": "9.1.4",
-			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.4.tgz",
-			"integrity": "sha512-bho94YyReb4JV7LYWRWxZ/xr6TtOTt8cMfmQ39MQYJ7f/YE268s3GdghGwi+y4zAeqewE5zYLvuhV0M0ijsDEA==",
+			"version": "9.1.6",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
+			"integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"husky": "bin.js"
 			},
@@ -3827,10 +3846,11 @@
 			"dev": true
 		},
 		"node_modules/lint-staged": {
-			"version": "15.2.9",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.9.tgz",
-			"integrity": "sha512-BZAt8Lk3sEnxw7tfxM7jeZlPRuT4M68O0/CwZhhaw6eeWu0Lz5eERE3m386InivXB64fp/mDID452h48tvKlRQ==",
+			"version": "15.2.10",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
+			"integrity": "sha512-5dY5t743e1byO19P9I4b3x8HJwalIznL5E1FWYnU6OWw33KxNBSLAc6Cy7F2PsFEO8FKnLwjwm5hx7aMF0jzZg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"chalk": "~5.3.0",
 				"commander": "~12.1.0",
@@ -3838,7 +3858,7 @@
 				"execa": "~8.0.1",
 				"lilconfig": "~3.1.2",
 				"listr2": "~8.2.4",
-				"micromatch": "~4.0.7",
+				"micromatch": "~4.0.8",
 				"pidtree": "~0.6.0",
 				"string-argv": "~0.3.2",
 				"yaml": "~2.5.0"
@@ -3923,7 +3943,8 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -3935,7 +3956,8 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/log-update": {
 			"version": "6.1.0",
@@ -4327,6 +4349,7 @@
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
 			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"boolbase": "^1.0.0"
 			},
@@ -4670,6 +4693,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.0.2.tgz",
 			"integrity": "sha512-DT/Wwm6fCKgpYVI7ZEWuPJ4az8hiEHtCUeYjZXqU7Ou4QqYh1Df2yCQ7Ca6N7xqKPFkxN3fhf+u9KSoOCJNAjg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-selector-parser": "^6.1.2",
 				"postcss-value-parser": "^4.2.0"
@@ -4686,6 +4710,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.2.tgz",
 			"integrity": "sha512-YntRXNngcvEvDbEjTdRWGU606eZvB5prmHG4BF0yLmVpamXbpsRJzevyy6MZVyuecgzI2AWAlvFi8DAeCqwpvA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.23.3",
 				"caniuse-api": "^3.0.0",
@@ -4700,10 +4725,11 @@
 			}
 		},
 		"node_modules/postcss-convert-values": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.3.tgz",
-			"integrity": "sha512-yJhocjCs2SQer0uZ9lXTMOwDowbxvhwFVrZeS6NPEij/XXthl73ggUmfwVvJM+Vaj5gtCKJV1jiUu4IhAUkX/Q==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.4.tgz",
+			"integrity": "sha512-e2LSXPqEHVW6aoGbjV9RsSSNDO3A0rZLCBxN24zvxF25WknMPpX8Dm9UxxThyEbaytzggRuZxaGXqaOhxQ514Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.23.3",
 				"postcss-value-parser": "^4.2.0"
@@ -4716,12 +4742,13 @@
 			}
 		},
 		"node_modules/postcss-discard-comments": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.2.tgz",
-			"integrity": "sha512-/Hje9Ls1IYcB9duELO/AyDUJI6aQVY3h5Rj1ziXgaLYCTi1iVBLnjg/TS0D6NszR/kDG6I86OwLmAYe+bvJjiQ==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.3.tgz",
+			"integrity": "sha512-q6fjd4WU4afNhWOA2WltHgCbkRhZPgQe7cXF74fuVB/ge4QbM9HEaOIzGSiMvM+g/cOsNAUGdf2JDzqA2F8iLA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"postcss-selector-parser": "^6.1.1"
+				"postcss-selector-parser": "^6.1.2"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -4735,6 +4762,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.1.tgz",
 			"integrity": "sha512-oZA+v8Jkpu1ct/xbbrntHRsfLGuzoP+cpt0nJe5ED2FQF8n8bJtn7Bo28jSmBYwqgqnqkuSXJfSUEE7if4nClQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
 			},
@@ -4747,6 +4775,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.0.tgz",
 			"integrity": "sha512-e+QzoReTZ8IAwhnSdp/++7gBZ/F+nBq9y6PomfwORfP7q9nBpK5AMP64kOt0bA+lShBFbBDcgpJ3X4etHg4lzA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
 			},
@@ -4759,6 +4788,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.0.tgz",
 			"integrity": "sha512-GmNAzx88u3k2+sBTZrJSDauR0ccpE24omTQCVmaTTZFz1du6AasspjaUPMJ2ud4RslZpoFKyf+6MSPETLojc6w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
 			},
@@ -4850,13 +4880,14 @@
 			}
 		},
 		"node_modules/postcss-merge-longhand": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.3.tgz",
-			"integrity": "sha512-8waYomFxshdv6M9Em3QRM9MettRLDRcH2JQi2l0Z1KlYD/vhal3gbkeSES0NuACXOlZBB0V/B0AseHZaklzWOA==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.4.tgz",
+			"integrity": "sha512-zer1KoZA54Q8RVHKOY5vMke0cCdNxMP3KBfDerjH/BYHh4nCIh+1Yy0t1pAEQF18ac/4z3OFclO+ZVH8azjR4A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0",
-				"stylehacks": "^7.0.3"
+				"stylehacks": "^7.0.4"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -4866,15 +4897,16 @@
 			}
 		},
 		"node_modules/postcss-merge-rules": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.3.tgz",
-			"integrity": "sha512-2eSas2p3voPxNfdI5sQrvIkMaeUHpVc3EezgVs18hz/wRTQAC9U99tp9j3W5Jx9/L3qHkEDvizEx/LdnmumIvQ==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.4.tgz",
+			"integrity": "sha512-ZsaamiMVu7uBYsIdGtKJ64PkcQt6Pcpep/uO90EpLS3dxJi6OXamIobTYcImyXGoW0Wpugh7DSD3XzxZS9JCPg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.23.3",
 				"caniuse-api": "^3.0.0",
 				"cssnano-utils": "^5.0.0",
-				"postcss-selector-parser": "^6.1.1"
+				"postcss-selector-parser": "^6.1.2"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -4888,6 +4920,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.0.tgz",
 			"integrity": "sha512-2ckkZtgT0zG8SMc5aoNwtm5234eUx1GGFJKf2b1bSp8UflqaeFzR50lid4PfqVI9NtGqJ2J4Y7fwvnP/u1cQog==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -4903,6 +4936,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.0.tgz",
 			"integrity": "sha512-pdUIIdj/C93ryCHew0UgBnL2DtUS3hfFa5XtERrs4x+hmpMYGhbzo6l/Ir5de41O0GaKVpK1ZbDNXSY6GkXvtg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"colord": "^2.9.3",
 				"cssnano-utils": "^5.0.0",
@@ -4920,6 +4954,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.2.tgz",
 			"integrity": "sha512-nyqVLu4MFl9df32zTsdcLqCFfE/z2+f8GE1KHPxWOAmegSo6lpV2GNy5XQvrzwbLmiU7d+fYay4cwto1oNdAaQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.23.3",
 				"cssnano-utils": "^5.0.0",
@@ -4933,13 +4968,14 @@
 			}
 		},
 		"node_modules/postcss-minify-selectors": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.3.tgz",
-			"integrity": "sha512-SxTgUQSgBk6wEqzQZKEv1xQYIp9UBju6no9q+npohzSdhuSICQdkqmD1UMKkZWItS3olJSJMDDEY9WOJ5oGJew==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.4.tgz",
+			"integrity": "sha512-JG55VADcNb4xFCf75hXkzc1rNeURhlo7ugf6JjiiKRfMsKlDzN9CXHZDyiG6x/zGchpjQS+UAgb1d4nqXqOpmA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
-				"postcss-selector-parser": "^6.1.1"
+				"postcss-selector-parser": "^6.1.2"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -4972,6 +5008,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.0.tgz",
 			"integrity": "sha512-ABisNUXMeZeDNzCQxPxBCkXexvBrUHV+p7/BXOY+ulxkcjUZO0cp8ekGBwvIh2LbCwnWbyMPNJVtBSdyhM2zYQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
 			},
@@ -4984,6 +5021,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.0.tgz",
 			"integrity": "sha512-lnFZzNPeDf5uGMPYgGOw7v0BfB45+irSRz9gHQStdkkhiM0gTfvWkWB5BMxpn0OqgOQuZG/mRlZyJxp0EImr2Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -4999,6 +5037,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.0.tgz",
 			"integrity": "sha512-I0yt8wX529UKIGs2y/9Ybs2CelSvItfmvg/DBIjTnoUSrPxSV7Z0yZ8ShSVtKNaV/wAY+m7bgtyVQLhB00A1NQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -5014,6 +5053,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.0.tgz",
 			"integrity": "sha512-o3uSGYH+2q30ieM3ppu9GTjSXIzOrRdCUn8UOMGNw7Af61bmurHTWI87hRybrP6xDHvOe5WlAj3XzN6vEO8jLw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -5029,6 +5069,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.0.tgz",
 			"integrity": "sha512-w/qzL212DFVOpMy3UGyxrND+Kb0fvCiBBujiaONIihq7VvtC7bswjWgKQU/w4VcRyDD8gpfqUiBQ4DUOwEJ6Qg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -5044,6 +5085,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.0.tgz",
 			"integrity": "sha512-tNgw3YV0LYoRwg43N3lTe3AEWZ66W7Dh7lVEpJbHoKOuHc1sLrzMLMFjP8SNULHaykzsonUEDbKedv8C+7ej6g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -5059,6 +5101,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.2.tgz",
 			"integrity": "sha512-ztisabK5C/+ZWBdYC+Y9JCkp3M9qBv/XFvDtSw0d/XwfT3UaKeW/YTm/MD/QrPNxuecia46vkfEhewjwcYFjkg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.23.3",
 				"postcss-value-parser": "^4.2.0"
@@ -5075,6 +5118,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.0.tgz",
 			"integrity": "sha512-+d7+PpE+jyPX1hDQZYG+NaFD+Nd2ris6r8fPTBAjE8z/U41n/bib3vze8x7rKs5H1uEw5ppe9IojewouHk0klQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -5090,6 +5134,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.0.tgz",
 			"integrity": "sha512-37/toN4wwZErqohedXYqWgvcHUGlT8O/m2jVkAfAe9Bd4MzRqlBmXrJRePH0e9Wgnz2X7KymTgTOaaFizQe3AQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -5105,6 +5150,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.1.tgz",
 			"integrity": "sha512-irWScWRL6nRzYmBOXReIKch75RRhNS86UPUAxXdmW/l0FcAsg0lvAXQCby/1lymxn/o0gVa6Rv/0f03eJOwHxw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cssnano-utils": "^5.0.0",
 				"postcss-value-parser": "^4.2.0"
@@ -5121,6 +5167,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.2.tgz",
 			"integrity": "sha512-pOnu9zqQww7dEKf62Nuju6JgsW2V0KRNBHxeKohU+JkHd/GAH5uvoObqFLqkeB2n20mr6yrlWDvo5UBU5GnkfA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.23.3",
 				"caniuse-api": "^3.0.0"
@@ -5137,6 +5184,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.0.tgz",
 			"integrity": "sha512-pnt1HKKZ07/idH8cpATX/ujMbtOGhUfE+m8gbqwJE05aTaNw8gbo34a2e3if0xc0dlu75sUOiqvwCGY3fzOHew==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -5207,6 +5255,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.0.1.tgz",
 			"integrity": "sha512-0WBUlSL4lhD9rA5k1e5D8EN5wCEyZD6HJk0jIvRxl+FDVOMlJ7DePHYWGGVc5QRqrJ3/06FTXM0bxjmJpmTPSA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0",
 				"svgo": "^3.3.2"
@@ -5219,12 +5268,13 @@
 			}
 		},
 		"node_modules/postcss-unique-selectors": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.2.tgz",
-			"integrity": "sha512-CjSam+7Vf8cflJQsHrMS0P2hmy9u0+n/P001kb5eAszLmhjMqrt/i5AqQuNFihhViwDvEAezqTmXqaYXL2ugMw==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.3.tgz",
+			"integrity": "sha512-J+58u5Ic5T1QjP/LDV9g3Cx4CNOgB5vz+kM6+OxHHhFACdcDeKhBXjQmB7fnIZM12YSTvsL0Opwco83DmacW2g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"postcss-selector-parser": "^6.1.1"
+				"postcss-selector-parser": "^6.1.2"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -5927,13 +5977,14 @@
 			}
 		},
 		"node_modules/stylehacks": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.3.tgz",
-			"integrity": "sha512-4DqtecvI/Nd+2BCvW9YEF6lhBN5UM50IJ1R3rnEAhBwbCKf4VehRf+uqvnVArnBayjYD/WtT3g0G/HSRxWfTRg==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.4.tgz",
+			"integrity": "sha512-i4zfNrGMt9SB4xRK9L83rlsFCgdGANfeDAYacO1pkqcE7cRHPdWHwnKZVz7WY17Veq/FvyYsRAU++Ga+qDFIww==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.23.3",
-				"postcss-selector-parser": "^6.1.1"
+				"postcss-selector-parser": "^6.1.2"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -6167,6 +6218,7 @@
 			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
 			"integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@trysound/sax": "0.2.0",
 				"commander": "^7.2.0",
@@ -6192,6 +6244,7 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
 			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 10"
 			}

--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -1188,9 +1188,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.3.tgz",
-			"integrity": "sha512-MmKSfaB9GX+zXl6E8z4koOr/xU63AMVleLEa64v7R0QF/ZloMs5vcD1sHgM64GXXS1csaJutG+ddtzcueI/BLg==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.5.tgz",
+			"integrity": "sha512-SU5cvamg0Eyu/F+kLeMXS7GoahL+OoizlclVFX3l5Ql6yNlywJJ0OuqTzUx0v+aHhPHEB/56CT06GQrRrGNYww==",
 			"cpu": [
 				"arm"
 			],
@@ -1201,9 +1201,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.3.tgz",
-			"integrity": "sha512-zrt8ecH07PE3sB4jPOggweBjJMzI1JG5xI2DIsUbkA+7K+Gkjys6eV7i9pOenNSDJH3eOr/jLb/PzqtmdwDq5g==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.5.tgz",
+			"integrity": "sha512-S4pit5BP6E5R5C8S6tgU/drvgjtYW76FBuG6+ibG3tMvlD1h9LHVF9KmlmaUBQ8Obou7hEyS+0w+IR/VtxwNMQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1214,9 +1214,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.3.tgz",
-			"integrity": "sha512-P0UxIOrKNBFTQaXTxOH4RxuEBVCgEA5UTNV6Yz7z9QHnUJ7eLX9reOd/NYMO3+XZO2cco19mXTxDMXxit4R/eQ==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.5.tgz",
+			"integrity": "sha512-250ZGg4ipTL0TGvLlfACkIxS9+KLtIbn7BCZjsZj88zSg2Lvu3Xdw6dhAhfe/FjjXPVNCtcSp+WZjVsD3a/Zlw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1227,9 +1227,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.3.tgz",
-			"integrity": "sha512-L1M0vKGO5ASKntqtsFEjTq/fD91vAqnzeaF6sfNAy55aD+Hi2pBI5DKwCO+UNDQHWsDViJLqshxOahXyLSh3EA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.5.tgz",
+			"integrity": "sha512-D8brJEFg5D+QxFcW6jYANu+Rr9SlKtTenmsX5hOSzNYVrK5oLAEMTUgKWYJP+wdKyCdeSwnapLsn+OVRFycuQg==",
 			"cpu": [
 				"x64"
 			],
@@ -1240,9 +1240,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.3.tgz",
-			"integrity": "sha512-btVgIsCjuYFKUjopPoWiDqmoUXQDiW2A4C3Mtmp5vACm7/GnyuprqIDPNczeyR5W8rTXEbkmrJux7cJmD99D2g==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.5.tgz",
+			"integrity": "sha512-PNqXYmdNFyWNg0ma5LdY8wP+eQfdvyaBAojAXgO7/gs0Q/6TQJVXAXe8gwW9URjbS0YAammur0fynYGiWsKlXw==",
 			"cpu": [
 				"arm"
 			],
@@ -1253,9 +1253,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.3.tgz",
-			"integrity": "sha512-zmjbSphplZlau6ZTkxd3+NMtE4UKVy7U4aVFMmHcgO5CUbw17ZP6QCgyxhzGaU/wFFdTfiojjbLG3/0p9HhAqA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.5.tgz",
+			"integrity": "sha512-kSSCZOKz3HqlrEuwKd9TYv7vxPYD77vHSUvM2y0YaTGnFc8AdI5TTQRrM1yIp3tXCKrSL9A7JLoILjtad5t8pQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1266,9 +1266,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.3.tgz",
-			"integrity": "sha512-nSZfcZtAnQPRZmUkUQwZq2OjQciR6tEoJaZVFvLHsj0MF6QhNMg0fQ6mUOsiCUpTqxTx0/O6gX0V/nYc7LrgPw==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.5.tgz",
+			"integrity": "sha512-oTXQeJHRbOnwRnRffb6bmqmUugz0glXaPyspp4gbQOPVApdpRrY/j7KP3lr7M8kTfQTyrBUzFjj5EuHAhqH4/w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1279,9 +1279,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.3.tgz",
-			"integrity": "sha512-MnvSPGO8KJXIMGlQDYfvYS3IosFN2rKsvxRpPO2l2cum+Z3exiExLwVU+GExL96pn8IP+GdH8Tz70EpBhO0sIQ==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.5.tgz",
+			"integrity": "sha512-qnOTIIs6tIGFKCHdhYitgC2XQ2X25InIbZFor5wh+mALH84qnFHvc+vmWUpyX97B0hNvwNUL4B+MB8vJvH65Fw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1292,9 +1292,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.3.tgz",
-			"integrity": "sha512-+W+p/9QNDr2vE2AXU0qIy0qQE75E8RTwTwgqS2G5CRQ11vzq0tbnfBd6brWhS9bCRjAjepJe2fvvkvS3dno+iw==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.5.tgz",
+			"integrity": "sha512-TMYu+DUdNlgBXING13rHSfUc3Ky5nLPbWs4bFnT+R6Vu3OvXkTkixvvBKk8uO4MT5Ab6lC3U7x8S8El2q5o56w==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1305,9 +1305,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.3.tgz",
-			"integrity": "sha512-yXH6K6KfqGXaxHrtr+Uoy+JpNlUlI46BKVyonGiaD74ravdnF9BUNC+vV+SIuB96hUMGShhKV693rF9QDfO6nQ==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.5.tgz",
+			"integrity": "sha512-PTQq1Kz22ZRvuhr3uURH+U/Q/a0pbxJoICGSprNLAoBEkyD3Sh9qP5I0Asn0y0wejXQBbsVMRZRxlbGFD9OK4A==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1318,9 +1318,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.3.tgz",
-			"integrity": "sha512-R8cwY9wcnApN/KDYWTH4gV/ypvy9yZUHlbJvfaiXSB48JO3KpwSpjOGqO4jnGkLDSk1hgjYkTbTt6Q7uvPf8eg==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.5.tgz",
+			"integrity": "sha512-bR5nCojtpuMss6TDEmf/jnBnzlo+6n1UhgwqUvRoe4VIotC7FG1IKkyJbwsT7JDsF2jxR+NTnuOwiGv0hLyDoQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -1331,9 +1331,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.3.tgz",
-			"integrity": "sha512-kZPbX/NOPh0vhS5sI+dR8L1bU2cSO9FgxwM8r7wHzGydzfSjLRCFAT87GR5U9scj2rhzN3JPYVC7NoBbl4FZ0g==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.5.tgz",
+			"integrity": "sha512-N0jPPhHjGShcB9/XXZQWuWBKZQnC1F36Ce3sDqWpujsGjDz/CQtOL9LgTrJ+rJC8MJeesMWrMWVLKKNR/tMOCA==",
 			"cpu": [
 				"x64"
 			],
@@ -1344,9 +1344,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.3.tgz",
-			"integrity": "sha512-S0Yq+xA1VEH66uiMNhijsWAafffydd2X5b77eLHfRmfLsRSpbiAWiRHV6DEpz6aOToPsgid7TI9rGd6zB1rhbg==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.5.tgz",
+			"integrity": "sha512-uBa2e28ohzNNwjr6Uxm4XyaA1M/8aTgfF2T7UIlElLaeXkgpmIJ2EitVNQxjO9xLLLy60YqAgKn/AqSpCUkE9g==",
 			"cpu": [
 				"x64"
 			],
@@ -1357,9 +1357,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.3.tgz",
-			"integrity": "sha512-9isNzeL34yquCPyerog+IMCNxKR8XYmGd0tHSV+OVx0TmE0aJOo9uw4fZfUuk2qxobP5sug6vNdZR6u7Mw7Q+Q==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.5.tgz",
+			"integrity": "sha512-RXT8S1HP8AFN/Kr3tg4fuYrNxZ/pZf1HemC5Tsddc6HzgGnJm0+Lh5rAHJkDuW3StI0ynNXukidROMXYl6ew8w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1370,9 +1370,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.3.tgz",
-			"integrity": "sha512-nMIdKnfZfzn1Vsk+RuOvl43ONTZXoAPUUxgcU0tXooqg4YrAqzfKzVenqqk2g5efWh46/D28cKFrOzDSW28gTA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.5.tgz",
+			"integrity": "sha512-ElTYOh50InL8kzyUD6XsnPit7jYCKrphmddKAe1/Ytt74apOxDq5YEcbsiKs0fR3vff3jEneMM+3I7jbqaMyBg==",
 			"cpu": [
 				"ia32"
 			],
@@ -1383,9 +1383,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.3.tgz",
-			"integrity": "sha512-fOvu7PCQjAj4eWDEuD8Xz5gpzFqXzGlxHZozHP4b9Jxv9APtdxL6STqztDzMLuRXEc4UpXGGhx029Xgm91QBeA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.5.tgz",
+			"integrity": "sha512-+lvL/4mQxSV8MukpkKyyvfwhH266COcWlXE/1qxwN08ajovta3459zrjLghYMgDerlzNwLAcFpvU+WWE5y6nAQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1507,9 +1507,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true
 		},
 		"node_modules/@types/jmespath": {
@@ -5430,12 +5430,12 @@
 			"dev": true
 		},
 		"node_modules/rollup": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.3.tgz",
-			"integrity": "sha512-7sqRtBNnEbcBtMeRVc6VRsJMmpI+JU1z9VTvW8D4gXIYQFz0aLcsE6rRkyghZkLfEgUZgVvOG7A5CVz/VW5GIA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.5.tgz",
+			"integrity": "sha512-WoinX7GeQOFMGznEcWA1WrTQCd/tpEbMkc3nuMs9BT0CPjMdSjPMTVClwWd4pgSQwJdP65SK9mTCNvItlr5o7w==",
 			"dev": true,
 			"dependencies": {
-				"@types/estree": "1.0.5"
+				"@types/estree": "1.0.6"
 			},
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -5445,22 +5445,22 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.21.3",
-				"@rollup/rollup-android-arm64": "4.21.3",
-				"@rollup/rollup-darwin-arm64": "4.21.3",
-				"@rollup/rollup-darwin-x64": "4.21.3",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.21.3",
-				"@rollup/rollup-linux-arm-musleabihf": "4.21.3",
-				"@rollup/rollup-linux-arm64-gnu": "4.21.3",
-				"@rollup/rollup-linux-arm64-musl": "4.21.3",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.21.3",
-				"@rollup/rollup-linux-riscv64-gnu": "4.21.3",
-				"@rollup/rollup-linux-s390x-gnu": "4.21.3",
-				"@rollup/rollup-linux-x64-gnu": "4.21.3",
-				"@rollup/rollup-linux-x64-musl": "4.21.3",
-				"@rollup/rollup-win32-arm64-msvc": "4.21.3",
-				"@rollup/rollup-win32-ia32-msvc": "4.21.3",
-				"@rollup/rollup-win32-x64-msvc": "4.21.3",
+				"@rollup/rollup-android-arm-eabi": "4.22.5",
+				"@rollup/rollup-android-arm64": "4.22.5",
+				"@rollup/rollup-darwin-arm64": "4.22.5",
+				"@rollup/rollup-darwin-x64": "4.22.5",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.22.5",
+				"@rollup/rollup-linux-arm-musleabihf": "4.22.5",
+				"@rollup/rollup-linux-arm64-gnu": "4.22.5",
+				"@rollup/rollup-linux-arm64-musl": "4.22.5",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.22.5",
+				"@rollup/rollup-linux-riscv64-gnu": "4.22.5",
+				"@rollup/rollup-linux-s390x-gnu": "4.22.5",
+				"@rollup/rollup-linux-x64-gnu": "4.22.5",
+				"@rollup/rollup-linux-x64-musl": "4.22.5",
+				"@rollup/rollup-win32-arm64-msvc": "4.22.5",
+				"@rollup/rollup-win32-ia32-msvc": "4.22.5",
+				"@rollup/rollup-win32-x64-msvc": "4.22.5",
 				"fsevents": "~2.3.2"
 			}
 		},

--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -5345,20 +5345,22 @@
 			}
 		},
 		"node_modules/prettier-plugin-svelte": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.2.6.tgz",
-			"integrity": "sha512-Y1XWLw7vXUQQZmgv1JAEiLcErqUniAF2wO7QJsw8BVMvpLET2dI5WpEIEJx1r11iHVdSMzQxivyfrH9On9t2IQ==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.2.7.tgz",
+			"integrity": "sha512-/Dswx/ea0lV34If1eDcG3nulQ63YNr5KPDfMsjbdtpSWOxKKJ7nAc2qlVuYwEvCr4raIuredNoR7K4JCkmTGaQ==",
 			"dev": true,
+			"license": "MIT",
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
 			}
 		},
 		"node_modules/prettier-plugin-tailwindcss": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.6.tgz",
-			"integrity": "sha512-OPva5S7WAsPLEsOuOWXATi13QrCKACCiIonFgIR6V4lYv4QLp++UXVhZSzRbZxXGimkQtQT86CC6fQqTOybGng==",
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.8.tgz",
+			"integrity": "sha512-dGu3kdm7SXPkiW4nzeWKCl3uoImdd5CTZEJGxyypEPL37Wj0HT2pLqjrvSei1nTeuQfO4PUfjeW5cTUNRLZ4sA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.21.3"
 			},
@@ -6281,10 +6283,11 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.4.10",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.10.tgz",
-			"integrity": "sha512-KWZkVPm7yJRhdu4SRSl9d4AK2wM3a50UsvgHZO7xY77NQr2V+fIrEuoDGQcbvswWvFGbS2f6e+jC/6WJm1Dl0w==",
+			"version": "3.4.13",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.13.tgz",
+			"integrity": "sha512-KqjHOJKogOUt5Bs752ykCeiwvi0fKVkr5oqsFNt/8px/tA8scFPIlkygsf6jXrfCqGHz7VflA6+yytWuM+XhFw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",
 				"arg": "^5.0.2",

--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -41,7 +41,7 @@
 				"prettier-plugin-svelte": "^3.2.6",
 				"prettier-plugin-tailwindcss": "^0.6.6",
 				"svelte": "^4.2.19",
-				"svelte-check": "^3.8.5",
+				"svelte-check": "^4.0.4",
 				"tailwindcss": "^3.4.10",
 				"tslib": "^2.6.3",
 				"typescript": "^5.5.4",
@@ -1583,12 +1583,6 @@
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
-		"node_modules/@types/pug": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
-			"integrity": "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==",
-			"dev": true
-		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -2186,15 +2180,6 @@
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
-		"node_modules/buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/cac": {
 			"version": "6.7.14",
 			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2704,15 +2689,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/detect-indent": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-			"integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/devalue": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.1.1.tgz",
@@ -2844,12 +2820,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/es6-promise": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-			"integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
-			"dev": true
 		},
 		"node_modules/esbuild": {
 			"version": "0.21.5",
@@ -3390,12 +3360,6 @@
 				"url": "https://github.com/sponsors/rawify"
 			}
 		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true
-		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -3509,12 +3473,6 @@
 			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
 			"dev": true
 		},
-		"node_modules/graceful-fs": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true
-		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3611,22 +3569,6 @@
 			"engines": {
 				"node": ">=0.8.19"
 			}
-		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"dev": true,
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -4189,15 +4131,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/min-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -4213,15 +4146,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/minipass": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -4229,18 +4153,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
 			}
 		},
 		"node_modules/mlly": {
@@ -4402,15 +4314,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
 		"node_modules/onetime": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -4505,15 +4408,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-key": {
@@ -5651,72 +5545,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/sander": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
-			"integrity": "sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==",
-			"dev": true,
-			"dependencies": {
-				"es6-promise": "^3.1.2",
-				"graceful-fs": "^4.1.3",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.5.2"
-			}
-		},
-		"node_modules/sander/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/sander/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"dev": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/sander/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/sander/node_modules/rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			}
-		},
 		"node_modules/semver": {
 			"version": "7.6.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
@@ -5814,21 +5642,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/sorcery": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.11.0.tgz",
-			"integrity": "sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.14",
-				"buffer-crc32": "^0.2.5",
-				"minimist": "^1.2.0",
-				"sander": "^0.5.0"
-			},
-			"bin": {
-				"sorcery": "bin/sorcery"
 			}
 		},
 		"node_modules/source-map-js": {
@@ -5972,18 +5785,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/strip-indent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-			"dev": true,
-			"dependencies": {
-				"min-indent": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -6094,23 +5895,57 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "3.8.5",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.8.5.tgz",
-			"integrity": "sha512-3OGGgr9+bJ/+1nbPgsvulkLC48xBsqsgtc8Wam281H4G9F5v3mYGa2bHRsPuwHC5brKl4AxJH95QF73kmfihGQ==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.0.4.tgz",
+			"integrity": "sha512-AcHWIPuZb1mh/jKoIrww0ebBPpAvwWd1bfXCnwC2dx4OkydNMaiG//+Xnry91RJMHFH7CiE+6Y2p332DRIaOXQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.17",
-				"chokidar": "^3.4.1",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"chokidar": "^4.0.1",
+				"fdir": "^6.2.0",
 				"picocolors": "^1.0.0",
-				"sade": "^1.7.4",
-				"svelte-preprocess": "^5.1.3",
-				"typescript": "^5.0.3"
+				"sade": "^1.7.4"
 			},
 			"bin": {
 				"svelte-check": "bin/svelte-check"
 			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
 			"peerDependencies": {
-				"svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0"
+				"svelte": "^4.0.0 || ^5.0.0-next.0",
+				"typescript": ">=5.0.0"
+			}
+		},
+		"node_modules/svelte-check/node_modules/chokidar": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+			"integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/svelte-check/node_modules/readdirp": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
+			"integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
@@ -6151,69 +5986,6 @@
 			},
 			"peerDependencies": {
 				"svelte": "^3.19.0 || ^4.0.0"
-			}
-		},
-		"node_modules/svelte-preprocess": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.1.3.tgz",
-			"integrity": "sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"@types/pug": "^2.0.6",
-				"detect-indent": "^6.1.0",
-				"magic-string": "^0.30.5",
-				"sorcery": "^0.11.0",
-				"strip-indent": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 16.0.0",
-				"pnpm": "^8.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.10.2",
-				"coffeescript": "^2.5.1",
-				"less": "^3.11.3 || ^4.0.0",
-				"postcss": "^7 || ^8",
-				"postcss-load-config": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
-				"pug": "^3.0.0",
-				"sass": "^1.26.8",
-				"stylus": "^0.55.0",
-				"sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0",
-				"svelte": "^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0",
-				"typescript": ">=3.9.5 || ^4.0.0 || ^5.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@babel/core": {
-					"optional": true
-				},
-				"coffeescript": {
-					"optional": true
-				},
-				"less": {
-					"optional": true
-				},
-				"postcss": {
-					"optional": true
-				},
-				"postcss-load-config": {
-					"optional": true
-				},
-				"pug": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				},
-				"sugarss": {
-					"optional": true
-				},
-				"typescript": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/svelte/node_modules/estree-walker": {
@@ -7016,12 +6788,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
 		},
 		"node_modules/yaml": {
 			"version": "2.5.0",

--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -1101,17 +1101,19 @@
 			"dev": true
 		},
 		"node_modules/@rollup/plugin-commonjs": {
-			"version": "26.0.1",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-26.0.1.tgz",
-			"integrity": "sha512-UnsKoZK6/aGIH6AdkptXhNvhaqftcjq3zZdT+LY5Ftms6JR06nADcDsYp5hTU9E2lbJUEOhdlY5J4DNTneM+jQ==",
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.0.tgz",
+			"integrity": "sha512-BJcu+a+Mpq476DMXG+hevgPSl56bkUoi88dKT8t3RyUp8kGuOh+2bU8Gs7zXDlu+fyZggnJ+iOBGrb/O1SorYg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@rollup/pluginutils": "^5.0.1",
 				"commondir": "^1.0.1",
 				"estree-walker": "^2.0.2",
-				"glob": "^10.4.1",
+				"fdir": "^6.1.1",
 				"is-reference": "1.2.1",
-				"magic-string": "^0.30.3"
+				"magic-string": "^0.30.3",
+				"picomatch": "^2.3.1"
 			},
 			"engines": {
 				"node": ">=16.0.0 || 14 >= 14.17"
@@ -1123,6 +1125,19 @@
 				"rollup": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/@rollup/plugin-json": {
@@ -1146,15 +1161,15 @@
 			}
 		},
 		"node_modules/@rollup/plugin-node-resolve": {
-			"version": "15.2.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
-			"integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+			"version": "15.3.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.0.tgz",
+			"integrity": "sha512-9eO5McEICxMzJpDW9OnMYSv4Sta3hmt7VtBFz5zR9273suNOydOyq/FrGeGy+KsTRFm8w0SLVhzig2ILFT63Ag==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@rollup/pluginutils": "^5.0.1",
 				"@types/resolve": "1.20.2",
 				"deepmerge": "^4.2.2",
-				"is-builtin-module": "^3.2.1",
 				"is-module": "^1.0.0",
 				"resolve": "^1.22.1"
 			},
@@ -1190,6 +1205,19 @@
 				"rollup": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@rollup/pluginutils/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1401,14 +1429,15 @@
 			]
 		},
 		"node_modules/@sveltejs/adapter-node": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.2.2.tgz",
-			"integrity": "sha512-BCX4zP0cf86TXpmvLQTnnT/tp7P12UMezf+5LwljP1MJC1fFzn9XOXpAHQCyP+pyHGy2K7p5gY0LyLcZFAL02w==",
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.2.5.tgz",
+			"integrity": "sha512-FVeysFqeIlKFpDF1Oj38gby34f6uA9FuXnV330Z0RHmSyOR9JzJs70/nFKy1Ue3fWtf7S0RemOrP66Vr9Jcmew==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@rollup/plugin-commonjs": "^26.0.1",
+				"@rollup/plugin-commonjs": "^28.0.0",
 				"@rollup/plugin-json": "^6.1.0",
-				"@rollup/plugin-node-resolve": "^15.2.3",
+				"@rollup/plugin-node-resolve": "^15.3.0",
 				"rollup": "^4.9.5"
 			},
 			"peerDependencies": {
@@ -1416,15 +1445,16 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.5.24",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.5.24.tgz",
-			"integrity": "sha512-Nr2oxsCsDfEkdS/zzQQQbsPYTbu692Qs3/iE3L7VHzCVjG2+WujF9oMUozWI7GuX98KxYSoPMlAsfmDLSg44hQ==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.6.1.tgz",
+			"integrity": "sha512-QFlch3GPGZYidYhdRAub0fONw8UTguPICFHUSPxNkA/jdlU1p6C6yqq19J1QWdxIHS2El/ycDCGrHb3EAiMNqg==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/cookie": "^0.6.0",
 				"cookie": "^0.6.0",
-				"devalue": "^5.0.0",
+				"devalue": "^5.1.0",
 				"esm-env": "^1.0.0",
 				"import-meta-resolve": "^4.1.0",
 				"kleur": "^4.1.5",
@@ -1545,7 +1575,8 @@
 			"version": "1.20.2",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
 			"integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/unist": {
 			"version": "2.0.10",
@@ -1920,6 +1951,19 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/anymatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/arg": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -2096,18 +2140,6 @@
 			"dev": true,
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/builtin-modules": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cac": {
@@ -2348,7 +2380,8 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -2619,10 +2652,11 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.0.0.tgz",
-			"integrity": "sha512-gO+/OMXF7488D+u3ue+G7Y4AA3ZmUnB3eHJXmBTgNHvr4ZNzl36A0ZtG+XCRNYCkYx/bFmw4qtkoFLa+wSrwAA==",
-			"dev": true
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.1.1.tgz",
+			"integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/didyoumean": {
 			"version": "1.2.2",
@@ -3191,6 +3225,21 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"node_modules/fdir": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.0.tgz",
+			"integrity": "sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3546,21 +3595,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-builtin-module": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
-			"integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
-			"dev": true,
-			"dependencies": {
-				"builtin-modules": "^3.3.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/is-core-module": {
 			"version": "2.13.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
@@ -3610,7 +3644,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
 			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
@@ -3635,6 +3670,7 @@
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
 			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "*"
 			}
@@ -4065,6 +4101,19 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/micromatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -4501,12 +4550,15 @@
 			"dev": true
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
 			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -5362,6 +5414,19 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/resolve": {

--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -1478,10 +1478,11 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.1.tgz",
-			"integrity": "sha512-rimpFEAboBBHIlzISibg94iP09k/KYdHgVhJlcsTfn7KMBhc70jFX/GRWkRdFCc2fdnk+4+Bdfej23cMDnJS6A==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.2.tgz",
+			"integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
 				"debug": "^4.3.4",
@@ -1768,13 +1769,14 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
-			"integrity": "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.1.tgz",
+			"integrity": "sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "2.0.5",
-				"@vitest/utils": "2.0.5",
+				"@vitest/spy": "2.1.1",
+				"@vitest/utils": "2.1.1",
 				"chai": "^5.1.1",
 				"tinyrainbow": "^1.2.0"
 			},
@@ -1782,11 +1784,50 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
-		"node_modules/@vitest/pretty-format": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.5.tgz",
-			"integrity": "sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==",
+		"node_modules/@vitest/mocker": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.1.tgz",
+			"integrity": "sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "^2.1.0-beta.1",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.11"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@vitest/spy": "2.1.1",
+				"msw": "^2.3.5",
+				"vite": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/mocker/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.1.tgz",
+			"integrity": "sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"tinyrainbow": "^1.2.0"
 			},
@@ -1795,12 +1836,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.5.tgz",
-			"integrity": "sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.1.tgz",
+			"integrity": "sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "2.0.5",
+				"@vitest/utils": "2.1.1",
 				"pathe": "^1.1.2"
 			},
 			"funding": {
@@ -1808,13 +1850,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.5.tgz",
-			"integrity": "sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.1.tgz",
+			"integrity": "sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "2.0.5",
-				"magic-string": "^0.30.10",
+				"@vitest/pretty-format": "2.1.1",
+				"magic-string": "^0.30.11",
 				"pathe": "^1.1.2"
 			},
 			"funding": {
@@ -1822,10 +1865,11 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.5.tgz",
-			"integrity": "sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.1.tgz",
+			"integrity": "sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"tinyspy": "^3.0.0"
 			},
@@ -1834,27 +1878,18 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.5.tgz",
-			"integrity": "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.1.tgz",
+			"integrity": "sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "2.0.5",
-				"estree-walker": "^3.0.3",
+				"@vitest/pretty-format": "2.1.1",
 				"loupe": "^3.1.1",
 				"tinyrainbow": "^1.2.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/utils/node_modules/estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
-			"dependencies": {
-				"@types/estree": "^1.0.0"
 			}
 		},
 		"node_modules/acorn": {
@@ -2000,6 +2035,7 @@
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
 			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			}
@@ -2149,6 +2185,7 @@
 			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
 			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -2215,6 +2252,7 @@
 			"resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
 			"integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"assertion-error": "^2.0.1",
 				"check-error": "^2.1.1",
@@ -2247,6 +2285,7 @@
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
 			"integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 16"
 			}
@@ -2627,6 +2666,7 @@
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
 			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -3392,6 +3432,7 @@
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
 			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
@@ -4053,6 +4094,7 @@
 			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
 			"integrity": "sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"get-func-name": "^2.0.1"
 			}
@@ -4533,6 +4575,7 @@
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
 			"integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 14.16"
 			}
@@ -6402,6 +6445,13 @@
 			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
 			"dev": true
 		},
+		"node_modules/tinyexec": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.0.tgz",
+			"integrity": "sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tinypool": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.1.tgz",
@@ -6416,15 +6466,17 @@
 			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
 			"integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/tinyspy": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.0.tgz",
-			"integrity": "sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+			"integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -6667,10 +6719,11 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "5.4.6",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.6.tgz",
-			"integrity": "sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==",
+			"version": "5.4.8",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
+			"integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -6726,15 +6779,15 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.5.tgz",
-			"integrity": "sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.1.tgz",
+			"integrity": "sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cac": "^6.7.14",
-				"debug": "^4.3.5",
+				"debug": "^4.3.6",
 				"pathe": "^1.1.2",
-				"tinyrainbow": "^1.2.0",
 				"vite": "^5.0.0"
 			},
 			"bin": {
@@ -6776,29 +6829,30 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.5.tgz",
-			"integrity": "sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.1.tgz",
+			"integrity": "sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.3.0",
-				"@vitest/expect": "2.0.5",
-				"@vitest/pretty-format": "^2.0.5",
-				"@vitest/runner": "2.0.5",
-				"@vitest/snapshot": "2.0.5",
-				"@vitest/spy": "2.0.5",
-				"@vitest/utils": "2.0.5",
+				"@vitest/expect": "2.1.1",
+				"@vitest/mocker": "2.1.1",
+				"@vitest/pretty-format": "^2.1.1",
+				"@vitest/runner": "2.1.1",
+				"@vitest/snapshot": "2.1.1",
+				"@vitest/spy": "2.1.1",
+				"@vitest/utils": "2.1.1",
 				"chai": "^5.1.1",
-				"debug": "^4.3.5",
-				"execa": "^8.0.1",
-				"magic-string": "^0.30.10",
+				"debug": "^4.3.6",
+				"magic-string": "^0.30.11",
 				"pathe": "^1.1.2",
 				"std-env": "^3.7.0",
-				"tinybench": "^2.8.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.0",
 				"tinypool": "^1.0.0",
 				"tinyrainbow": "^1.2.0",
 				"vite": "^5.0.0",
-				"vite-node": "2.0.5",
+				"vite-node": "2.1.1",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -6813,8 +6867,8 @@
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
 				"@types/node": "^18.0.0 || >=20.0.0",
-				"@vitest/browser": "2.0.5",
-				"@vitest/ui": "2.0.5",
+				"@vitest/browser": "2.1.1",
+				"@vitest/ui": "2.1.1",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},

--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -126,12 +126,13 @@
 			}
 		},
 		"node_modules/@axe-core/playwright": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.9.1.tgz",
-			"integrity": "sha512-8m4WZbZq7/aq7ZY5IG8GqV+ZdvtGn/iJdom+wBg+iv/3BAOBIfNQtIu697a41438DzEEyptXWmC3Xl5Kx/o9/g==",
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.0.tgz",
+			"integrity": "sha512-kEr3JPEVUSnKIYp/egV2jvFj+chIjCjPp3K3zlpJMza/CB3TFw8UZNbI9agEC2uMz4YbgAOyzlbUy0QS+OofFA==",
 			"dev": true,
+			"license": "MPL-2.0",
 			"dependencies": {
-				"axe-core": "~4.9.1"
+				"axe-core": "~4.10.0"
 			},
 			"peerDependencies": {
 				"playwright-core": ">= 1.0.0"
@@ -679,20 +680,22 @@
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.6.10",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
-			"integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+			"version": "1.6.11",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.11.tgz",
+			"integrity": "sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/core": "^1.6.0",
-				"@floating-ui/utils": "^0.2.7"
+				"@floating-ui/utils": "^0.2.8"
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
-			"integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
-			"dev": true
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+			"integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@humanwhocodes/module-importer": {
 			"version": "1.0.1",
@@ -1992,10 +1995,11 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
-			"integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+			"integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
 			"dev": true,
+			"license": "MPL-2.0",
 			"engines": {
 				"node": ">=4"
 			}

--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -724,10 +724,11 @@
 			}
 		},
 		"node_modules/@iconify-json/bi": {
-			"version": "1.1.24",
-			"resolved": "https://registry.npmjs.org/@iconify-json/bi/-/bi-1.1.24.tgz",
-			"integrity": "sha512-K8U7s6Hm0Y06q9z41AGLLe+zuwZ7t8LNLG0EUkzZMvUMoZwZosmzFWlp2ajit1MGX+ealu4IKkMioKgjVNQ5ZQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@iconify-json/bi/-/bi-1.2.0.tgz",
+			"integrity": "sha512-kaBV87cQlyeMkBBiMqsf3b43Nsxdk/rYKvR29dnktht57WUyHCnBAuH+ca/bscX856CzRpVX+sYs7arjrJD0qA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@iconify/types": "*"
 			}
@@ -1078,12 +1079,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.46.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.1.tgz",
-			"integrity": "sha512-Fq6SwLujA/DOIvNC2EL/SojJnkKf/rAwJ//APpJJHRyMi1PdKrY3Az+4XNQ51N4RTbItbIByQ0jgd1tayq1aeA==",
+			"version": "1.47.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.2.tgz",
+			"integrity": "sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.46.1"
+				"playwright": "1.47.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -4552,12 +4554,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.46.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.1.tgz",
-			"integrity": "sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==",
+			"version": "1.47.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.2.tgz",
+			"integrity": "sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.46.1"
+				"playwright-core": "1.47.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -4570,10 +4573,11 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.46.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.1.tgz",
-			"integrity": "sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==",
+			"version": "1.47.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.2.tgz",
+			"integrity": "sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},

--- a/lxl-web/package.json
+++ b/lxl-web/package.json
@@ -55,7 +55,7 @@
 		"prettier-plugin-svelte": "^3.2.6",
 		"prettier-plugin-tailwindcss": "^0.6.6",
 		"svelte": "^4.2.19",
-		"svelte-check": "^3.8.5",
+		"svelte-check": "^4.0.4",
 		"tailwindcss": "^3.4.10",
 		"tslib": "^2.6.3",
 		"typescript": "^5.5.4",


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-226](https://kbse.atlassian.net/browse/LWS-226)

### Solves

Bumps dependencies

### Summary of changes

- Fix rollup vulnerability

update the following:

```
@axe-core/playwright 4.9.1 -> 4.10.0
@floating-ui/dom 1.6.10 -> 1.6.11
@iconify-json/bi 1.1.24 -> 1.2.0
@playwright/test 1.46.1 -> 1.47.2
@sveltejs/adapter-node 5.2.2 -> 5.2.5
@sveltejs/kit 2.5.24 -> 2.6.1
@sveltejs/vite-plugin-svelte 3.1.1 -> 3.1.2
@types/eslint 9.6.0 -> 9.6.1
cssnano 7.0.5 -> 7.0.6
eslint 9.9.0 -> 9.11.1
eslint-plugin-svelte 2.43.0 -> 2.44.1
husky 9.1.4 -> 9.1.6
lint-staged 15.2.9 -> 15.2.10
prettier-plugin-svelte 3.2.6 -> 3.2.7
prettier-plugin-tailwindcss 0.6.6 -> 0.6.8
svelte-check 3.8.5 -> 4.0.4
tailwindcss 3.4.10 -> 3.4.13
tslib 2.6.3 -> 2.7.0
typescript 5.5.4 -> 5.6.2
typescript-eslint 8.1.0 -> 8.7.0
unplugin-icons 0.19.2 -> 0.19.3
vite 5.4.6 -> 5.4.8
vitest 2.0.5 -> 2.1.1
```
