### PR TITLE
LWS-175: Link subdivision

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -527,6 +527,12 @@
 			"fresnel:classFormatDomain": ["Subject"],
 			"fresnel:resourceStyle": ["link"]
 		},
+		"Subdivision-format": {
+			"@id": "Subdivision-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Subdivision"],
+			"fresnel:resourceStyle": ["link"]
+		},
 		"Instance-format": {
 			"@id": "Instance-format",
 			"@type": "fresnel:Format",


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-175](https://kbse.atlassian.net/browse/LWS-175)

### Solves

See description in ticket. Subject term components that are subterms are not being linked.
`Topic` (Subject) -- `TopicSubdivision` (Subdivision)

Fixing by giving Subdivision the link class. Hope this does not produce oddities in other places in GUI :)
Also this does not solve the first bullet point (subterms not showing up in facets?)

Examples: 
[QA](https://beta.libris-qa.kb.se/g0s59brs1hkp3bc#work-record) [local](http://localhost:5173/g0s59brs1hkp3bc#work-record) [cat](https://libris.kb.se/katalogisering/g0s59brs1hkp3bc)

### Summary of changes

Add formatter for Subdivision class
