### PR TITLE
LWS-244: Tweaks to filter sorting

### DIFF
--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -3,7 +3,11 @@
 	import type { LocaleCode } from '$lib/i18n/locales';
 	import type { FacetGroup, Facet, MultiSelectFacet } from '$lib/types/search';
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
-	import { DEFAULT_FACET_SORT, DEFAULT_FACETS_SHOWN } from '$lib/constants/facets';
+	import {
+		DEFAULT_FACETS_SHOWN,
+		DEFAULT_FACET_SORT,
+		CUSTOM_FACET_SORT
+	} from '$lib/constants/facets';
 	import { saveUserSetting } from '$lib/utils/userSettings';
 	import { popover } from '$lib/actions/popover';
 	import FacetRange from './FacetRange.svelte';
@@ -22,7 +26,10 @@
 	const maxFacets = group.maxItems;
 
 	const userSort = $page.data.userSettings?.facetSort?.[group.dimension];
-	let currentSort = userSort || DEFAULT_FACET_SORT;
+	let currentSort =
+		userSort ||
+		CUSTOM_FACET_SORT[group.dimension as keyof typeof CUSTOM_FACET_SORT] ||
+		DEFAULT_FACET_SORT;
 
 	const sortOptions = [
 		{ value: 'hits.desc', label: $page.data.t('sort.hitsDesc') },
@@ -164,17 +171,18 @@
 					</button>
 				{/if}
 				<!-- limit reached info -->
-				{#if maxFacetsReached && canShowLessFacets}
-					<div class="ml-auto mt-4 flex gap-1 rounded-sm bg-pill/4 px-2 py-1">
-						<p role="status" class="text-xs text-error">{$page.data.t('facet.limitInfo')}</p>
+				{#if maxFacetsReached && (canShowLessFacets || (!canShowMoreFacets && searchPhrase))}
+					<div class="ml-auto mt-4">
 						<button
-							aria-label={$page.data.t('facet.limitInfo')}
+							class="flex items-center gap-1 rounded-sm bg-pill/4 px-2 py-1 text-xs text-error"
 							use:popover={{
 								title: $page.data.t('facet.limitText'),
 								placeAsSibling: true
 							}}
 						>
-							<BiInfo aria-hidden="true" class="text-error" />
+							<span>{$page.data.t('facet.limitInfo')}</span>
+							<span class="sr-only">{$page.data.t('facet.limitText')}</span>
+							<BiInfo aria-hidden="true" />
 						</button>
 					</div>
 				{/if}

--- a/lxl-web/src/lib/constants/facets.ts
+++ b/lxl-web/src/lib/constants/facets.ts
@@ -1,2 +1,6 @@
 export const DEFAULT_FACETS_SHOWN = 5;
 export const DEFAULT_FACET_SORT = 'hits.desc';
+export const CUSTOM_FACET_SORT = {
+	bibliography: 'alpha.asc',
+	itemHeldBy: 'alpha.asc'
+};

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/en.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/en.md
@@ -8,6 +8,11 @@ title: 'Help'
 
 Here we will continuously provide information about newly added features and planned developments:
 
+### TBA
+
+- Improvements in the filter panel, filter items can now be sorted by preference.
+- Bug fixes
+
 ### 2024-09-09
 
 - Loan status information now shown in the library holdings list

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/sv.md
@@ -8,6 +8,11 @@ title: 'Hjälp'
 
 Här kommer vi kontinuerligt berätta om nytillkomna funktioner och planerad utveckling:
 
+### TBA
+
+- Generella förbättringar i filterpanelen, t.ex möjlighet att sortera innehållet.
+- Buggfixar
+
 ### 2024-09-09
 
 - Lånestatus visas nu i listan över bibliotek som innehar en viss resurs


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-244](https://kbse.atlassian.net/browse/LWS-244)

### Summary of changes

After feedback:

* Change default sorting of `bibiography`, `itemHeldBy` to a-z
* Make sure the limit info is visible when searching
* Bigger surface for triggering limit info popover  
