### PR TITLE
Move inScheme from chip to card for Subdivision

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -111,6 +111,10 @@
 						"keyword",
 						"termComponentList"
 					]
+				},
+				"Subdivision": {
+					"fresnel:extends": { "@id": "Subdivision-chips" },
+					"showProperties": ["fresnel:super", "inScheme", "inCollection", "scopeNote"]
 				}
 			}
 		},
@@ -131,6 +135,15 @@
 					"showProperties": [
 						{
 							"alternateProperties": ["prefLabel", "label", "termComponentList", "code"]
+						}
+					]
+				},
+				"Subdivision": {
+					"@id": "Subdivision-chips",
+					"@type": "fresnel:Lens",
+					"showProperties": [
+						{
+							"alternateProperties": ["prefLabel", "code"]
 						}
 					]
 				},


### PR DESCRIPTION
Override the definition in [display.jsonld](https://github.com/libris/definitions/blob/fe537471562816cf3b01c72443f0cd43e45625e3/source/vocab/display.jsonld#L448) so that it is displayed in the same way as Concept.

before
![bild](https://github.com/user-attachments/assets/84590dae-9ca7-4f85-8068-bb03102bee95)


after
![bild](https://github.com/user-attachments/assets/09554ff7-2ffb-4fd4-aeac-d62873b93ea1)
