### PR TITLE
LWS-144: Style unlinked pills etc

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -528,7 +528,13 @@
 			"@id": "GenreForm-relations-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["GenreForm"],
-			"fresnel:propertyFormatDomain": ["narrower", "closeMatch", "broader", "hasVariant"],
+			"fresnel:propertyFormatDomain": [
+				"narrower",
+				"closeMatch",
+				"broader",
+				"hasVariant",
+				"related"
+			],
 			"fresnel:valueFormat": {
 				"fresnel:contentBefore": "",
 				"fresnel:contentFirst": ""

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -265,10 +265,11 @@
 	}
 
 	.pill {
-		@apply mb-1 mr-1 inline-block rounded-full bg-pill/8 px-3 py-1 no-underline;
+		@apply mb-1 mr-1 inline-block rounded-full border border-primary/8 px-3 py-1 no-underline;
 	}
+
 	a.pill {
-		@apply hover:bg-pill/16 focus:bg-pill/16;
+		@apply border-primary/0 bg-pill/8 hover:bg-pill/16 focus:bg-pill/16;
 	}
 
 	.remainder {

--- a/lxl-web/src/routes/api/holdingstatus/+server.ts
+++ b/lxl-web/src/routes/api/holdingstatus/+server.ts
@@ -20,6 +20,7 @@ function replaceChars(data: Response) {
 		.replaceAll('Ã\\?', 'Ö')
 		.replaceAll('Ã„', 'Ä')
 		.replaceAll('Ã¶', 'ö')
+		.replaceAll('&quot;', '\\"')
 		.replaceAll('Ã©', 'é');
 
 	return JSON.parse(d);


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-144](https://kbse.atlassian.net/browse/LWS-144)

### Solves

Three 'lil fixes

* Style unlinked genre/form pills more clearly.

Before/after [link](http://localhost:5173/07swlsq4xwsn32j0)

<img width="649" alt="Skärmavbild 2024-10-03 kl  11 05 11" src="https://github.com/user-attachments/assets/5059e4f5-ceb3-49b1-babc-da55f987bd5e">
<img width="649" alt="Skärmavbild 2024-10-03 kl  11 05 32" src="https://github.com/user-attachments/assets/c3168254-83f4-4108-a3c2-ec7c2a3e3a09">

----
* Include 'related' in genre/form formatting to fix weirdness

Before/after [link](http://localhost:5173/42gkpppn0qmwc3g)

<img width="777" alt="Skärmavbild 2024-10-03 kl  11 08 16" src="https://github.com/user-attachments/assets/757cf0d1-122c-45ca-b243-888f12314459">
<img width="777" alt="Skärmavbild 2024-10-03 kl  11 08 37" src="https://github.com/user-attachments/assets/9287c3aa-950b-4ada-85ec-6337f6ed8169">

----
* Replace ISO-encoded quote in loan status

before/after [link](http://localhost:5173/07wrgx1sx24j25pn?holdings=StillImageInstance)
<img width="463" alt="Skärmavbild 2024-10-03 kl  11 13 15" src="https://github.com/user-attachments/assets/ee285854-c996-44d9-adde-c1dd0dace0ee">
<img width="463" alt="Skärmavbild 2024-10-03 kl  11 13 33" src="https://github.com/user-attachments/assets/f20e18c3-e29b-4503-9b4e-fc2303f61ea1">
