### PR TITLE
LWS-166: Show reproduction instance chip

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -716,6 +716,15 @@
 				"fresnel:contentLast": ")"
 			}
 		},
+		"hasReproduction-format": {
+			"@id": "hasReproduction-format",
+			"@type": "fresnel:Format",
+			"fresnel:propertyFormatDomain": ["hasReproduction", "hasTitle"],
+			"fresnel:propertyStyle": ["block"],
+			"fresnel:valueFormat": {
+				"fresnel:contentBefore": ""
+			}
+		},
 		"default-separators": {
 			"@id": "default-separators",
 			"@type": "fresnel:Format",

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -122,6 +122,11 @@ export class DisplayUtil {
 			return LensType.Card;
 		}
 
+		// FIXME - hardcoded workaround to get the instance chip in these cases
+		if (propertyName === 'reproductionOf' || propertyName === 'hasReproduction') {
+			return LensType.Chip;
+		}
+
 		if (this.vocabUtil.hasCategory(propertyName, Platform.integral)) {
 			return lensType;
 		}
@@ -954,11 +959,11 @@ function invertRecord<K extends string | number | symbol, V extends string | num
 
 /*
 export function mapValuesOfObject<V, V2>(obj: Record<string, V>, fn: (v: V, k: string, i: number) => V2): Record<string, V2> {
-    return Object.fromEntries(
-        Object.entries(obj).map(
-            ([k, v], i) => [k, fn(v, k, i)]
-        )
-    )
+		return Object.fromEntries(
+				Object.entries(obj).map(
+						([k, v], i) => [k, fn(v, k, i)]
+				)
+		)
 }
 
  */


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-166](https://kbse.atlassian.net/browse/LWS-166)

### Solves

`reproductionOf` / `hasReproduction` on resource page show instance cards, which becomes messy.
Don't know if more properties need a similar fix?

before / after [link](http://localhost:5173/6nsmclp44mn98b3w)

<img width="623" alt="Skärmavbild 2024-10-03 kl  13 59 17" src="https://github.com/user-attachments/assets/06465e9f-2370-4712-9d94-59f3accc5242">

/

<img width="623" alt="Skärmavbild 2024-10-03 kl  13 59 44" src="https://github.com/user-attachments/assets/6e33e8d7-fdf7-4b55-b60c-bb7eb53721f3">

Displaying `hasReproduction` as block elements

<img width="509" alt="Skärmavbild 2024-10-03 kl  14 02 26" src="https://github.com/user-attachments/assets/279d2d6a-2bb8-4826-b826-1aae0629f9c9">

### Summary of changes

Adding another hardcoded exception to the lens selector. Not super happy about that, maybe this 'sublens' thing is the long term solution?
