### PR TITLE
Use unspecified type as default in bulk change view

### DIFF
--- a/cataloging/src/components/care/bulk-changes.vue
+++ b/cataloging/src/components/care/bulk-changes.vue
@@ -692,10 +692,8 @@ export default {
         </div>
       </div>
       <div>
-
-
 <!--        SPECIFICATION-->
-<!--        <pre>{{this.currentBulkChange}}</pre>-->
+<!--        <pre>{{ this.currentBulkChange }}</pre>-->
 <!--        ENTITY FORM-->
 <!--        <pre>{{ this.dataObj }}</pre>-->
 

--- a/cataloging/src/components/care/form-builder.vue
+++ b/cataloging/src/components/care/form-builder.vue
@@ -66,7 +66,6 @@ export default {
           :is-active="true"
           :form-data="formData"
           :locked="!isActive"
-          :in-bulk-change-view="true"
         />
       </div>
     </div>

--- a/cataloging/src/components/inspector/entity-adder.vue
+++ b/cataloging/src/components/inspector/entity-adder.vue
@@ -138,6 +138,9 @@ export default {
     hasSingleCreatable() {
       return this.rangeCreatable.length === 1;
     },
+    hasCreateable() {
+      return this.rangeCreatable.length > 0;
+    },
     isVocabField() {
       return VocabUtil.getContextValue(this.fieldKey, '@type', this.resources.context) === '@vocab';
     },
@@ -189,6 +192,9 @@ export default {
         }
       }
       return false;
+    },
+    inBulkChangeView() {
+      return this.$route.path.includes('bulkchanges');
     },
   },
   mounted() {
@@ -611,11 +617,16 @@ export default {
           <div class="EntityAdder-create">
             <button
               class="EntityAdder-createBtn btn btn-primary btn--sm"
-              v-if="hasSingleCreatable && allowLocal"
+              v-if="hasSingleCreatable && allowLocal && !inBulkChangeView"
               v-on:click="addEmpty(rangeCreatable[0])">{{ translatePhrase("Create local entity") }}
             </button>
+            <button
+              class="EntityAdder-createBtn btn btn-primary btn--sm"
+              v-if="inBulkChangeView && hasCreateable && allowLocal"
+              v-on:click="addEmpty('Any')">{{ translatePhrase("Create local entity") }}
+            </button>
             <filter-select
-              v-if="!hasSingleCreatable"
+              v-if="!hasSingleCreatable && !inBulkChangeView"
               :input-id="'createselectInput'"
               :class-name="'js-createSelect'"
               :options="{ tree: selectOptions, priority: priorityOptions }"

--- a/cataloging/src/components/inspector/item-local.vue
+++ b/cataloging/src/components/inspector/item-local.vue
@@ -204,7 +204,7 @@ export default {
       return this.$route.path.includes('bulkchanges');
     },
     typeLabel() {
-      return this.item['@type'] === 'Any' ? translatePhrase('Unspecified') : labelByLang(item['@type']);
+      return this.item['@type'] === 'Any' ? translatePhrase('Unspecified') : labelByLang(this.item['@type']);
     }
   },
   methods: {

--- a/cataloging/src/components/inspector/item-local.vue
+++ b/cataloging/src/components/inspector/item-local.vue
@@ -202,6 +202,9 @@ export default {
     },
     isBulkChangeView() {
       return this.$route.path.includes('bulkchanges');
+    },
+    typeLabel() {
+      return this.item['@type'] === 'Any' ? translatePhrase('Unspecified') : labelByLang(item['@type']);
     }
   },
   methods: {
@@ -578,7 +581,7 @@ export default {
             {{ translatePhrase("Extracted when the record is saved") }}
           </span>
           <span v-if="!expanded || !isExtracting">
-            {{ capitalize(labelByLang(item['@type'])) }}:
+            {{ capitalize(typeLabel) }}:
           </span>
         </span>
         <span class="ItemLocal-collapsedLabel" v-show="!expanded || isEmpty">

--- a/cataloging/src/components/inspector/item-type.vue
+++ b/cataloging/src/components/inspector/item-type.vue
@@ -42,6 +42,9 @@ export default {
     isDisabled() {
       return this.onMainEntity && this.numberOfRelations !== 0 && this.unlockedByUser === false;
     },
+    typeLabel() {
+      return this.fieldValue === 'Any' ? translatePhrase('Unspecified') : labelByLang(this.fieldValue);
+    }
   },
   methods: {
     translatePhrase,
@@ -143,7 +146,7 @@ export default {
     </div>
     <span
       class="ItemType-text"
-      v-if="isLocked">{{ labelByLang(fieldValue) }}
+      v-if="isLocked">{{ typeLabel }}
     </span>
     <modal-component
       title="Byte av typ"

--- a/cataloging/src/components/inspector/item-type.vue
+++ b/cataloging/src/components/inspector/item-type.vue
@@ -31,15 +31,6 @@ export default {
     ...mapGetters([
       'resources',
     ]),
-    range() {
-      const docType = VocabUtil.getRecordType(this.entityType, this.resources.vocab, this.resources.context);
-      const combined = [docType].concat(VocabUtil.getAllSubClasses(docType, this.resources.vocabClasses, this.resources.context));
-      const filtered = filter(combined, (o) => {
-        const term = VocabUtil.getTermObject(o, this.resources.vocab, this.resources.context);
-        return term.abstract !== true;
-      });
-      return filtered;
-    },
     onMainEntity() {
       return this.path === 'mainEntity.@type';
     },
@@ -56,7 +47,11 @@ export default {
     translatePhrase,
     labelByLang,
     getLabelWithTreeDepth(term) {
-      return DisplayUtil.getLabelWithTreeDepth(term, this.settings, this.resources);
+      if (term?.id === 'Any') {
+        return translatePhrase('Unspecified');
+      } else {
+        return DisplayUtil.getLabelWithTreeDepth(term, this.settings, this.resources);
+      }
     },
     unlockEdit() {
       this.unlockedByUser = true;

--- a/cataloging/src/components/inspector/item-type.vue
+++ b/cataloging/src/components/inspector/item-type.vue
@@ -1,5 +1,5 @@
 <script>
-import { filter } from 'lodash-es';
+import {filter, isEmpty} from 'lodash-es';
 import { mapGetters } from 'vuex';
 import * as VocabUtil from 'lxljs/vocab';
 import * as DisplayUtil from 'lxljs/display';
@@ -50,6 +50,9 @@ export default {
     translatePhrase,
     labelByLang,
     getLabelWithTreeDepth(term) {
+      if (isEmpty(term)) {
+        return;
+      }
       if (term?.id === 'Any') {
         return translatePhrase('Unspecified');
       } else {

--- a/cataloging/src/settings.js
+++ b/cataloging/src/settings.js
@@ -40,6 +40,7 @@ export default {
     'PlaceholderRecord',
     'CacheRecord',
     'ComplexSubject.termComponentList',
+    'Any'
   ],
   keysToClear: {
     duplication: [

--- a/lxljs/vocab.js
+++ b/lxljs/vocab.js
@@ -540,6 +540,12 @@ export function getPropertiesFromArray(typeArray, vocabClasses, vocabProperties,
   return props;
 }
 
+export function getAllVocabProperties(vocabProperties) {
+  return [...vocabProperties].map( (prop) => {
+    return {'item' : prop[1] };
+  });
+}
+
 export function isEmbedded(classId, vocab, settings, context) {
   if (!classId || typeof classId === 'undefined') {
     throw new Error('isEmbedded was called with an undefined class id');


### PR DESCRIPTION
--** Soft type matching **--

This uses a hard coded dummy "Any" type. Maybe it should be` "@type" : "Unspecified"` instead? Maybe it should be a real type, so that the correct label is presented automatically?


TODO: fix "Any" type label in side panel.

IN THE FUTURE: move 'Add local entity' button from property-adder.vue to field.vue?