### PR TITLE
LWS-231: Cookie consent

### DIFF
--- a/lxl-web/package-lock.json
+++ b/lxl-web/package-lock.json
@@ -8,7 +8,8 @@
 			"name": "lxl-web",
 			"version": "0.0.1",
 			"dependencies": {
-				"dotenv": "^16.4.5"
+				"dotenv": "^16.4.5",
+				"vanilla-cookieconsent": "^3.0.1"
 			},
 			"devDependencies": {
 				"@axe-core/playwright": "^4.9.1",
@@ -6450,6 +6451,12 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
+		},
+		"node_modules/vanilla-cookieconsent": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/vanilla-cookieconsent/-/vanilla-cookieconsent-3.0.1.tgz",
+			"integrity": "sha512-gqc4x7O9t1I4xWr7x6/jtQWPr4PZK26SmeA0iyTv1WyoECfAGnu5JEOExmMEP+5Fz66AT9OiCBO3GII4wDQHLw==",
+			"license": "MIT"
 		},
 		"node_modules/vfile-message": {
 			"version": "2.0.4",

--- a/lxl-web/package.json
+++ b/lxl-web/package.json
@@ -65,6 +65,7 @@
 		"vitest": "^2.0.5"
 	},
 	"dependencies": {
-		"dotenv": "^16.4.5"
+		"dotenv": "^16.4.5",
+		"vanilla-cookieconsent": "^3.0.1"
 	}
 }

--- a/lxl-web/src/lib/components/CookieConsent.svelte
+++ b/lxl-web/src/lib/components/CookieConsent.svelte
@@ -7,7 +7,7 @@
 	import { page } from '$app/stores';
 	import { getMatomoTracker } from '$lib/contexts/matomo';
 
-	const matomo = getMatomoTracker();
+	const matomoTracker = getMatomoTracker();
 
 	const config: CookieConsent.CookieConsentConfig = {
 		guiOptions: {
@@ -36,14 +36,14 @@
 		},
 		onConsent: ({ cookie }) => {
 			if (cookie.categories.includes('analytics')) {
-				$matomo.rememberConsentGiven(24 * 356 * 5); // 5 years?
+				$matomoTracker.rememberConsentGiven(24 * 356 * 5); // 5 years?
 			}
 		},
 		onChange: ({ cookie }) => {
 			if (cookie.categories.includes('analytics')) {
-				$matomo.rememberConsentGiven(24 * 356 * 5);
+				$matomoTracker.rememberConsentGiven(24 * 356 * 5);
 			} else {
-				$matomo.forgetConsentGiven();
+				$matomoTracker.forgetConsentGiven();
 			}
 		},
 		language: {

--- a/lxl-web/src/lib/components/CookieConsent.svelte
+++ b/lxl-web/src/lib/components/CookieConsent.svelte
@@ -36,12 +36,12 @@
 		},
 		onConsent: ({ cookie }) => {
 			if (cookie.categories.includes('analytics')) {
-				$matomoTracker.rememberConsentGiven(24 * 356 * 5); // 5 years?
+				$matomoTracker.rememberConsentGiven();
 			}
 		},
 		onChange: ({ cookie }) => {
 			if (cookie.categories.includes('analytics')) {
-				$matomoTracker.rememberConsentGiven(24 * 356 * 5);
+				$matomoTracker.rememberConsentGiven();
 			} else {
 				$matomoTracker.forgetConsentGiven();
 			}

--- a/lxl-web/src/lib/components/CookieConsent.svelte
+++ b/lxl-web/src/lib/components/CookieConsent.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import * as CookieConsent from 'vanilla-cookieconsent';
+	import 'vanilla-cookieconsent/dist/cookieconsent.css';
+	import svTranslations from '$lib/i18n/locales/cookieConsent.sv';
+	import enTranslations from '$lib/i18n/locales/cookieConsent.en';
+	import { page } from '$app/stores';
+	import { getMatomoTracker } from '$lib/contexts/matomo';
+
+	const matomo = getMatomoTracker();
+
+	const config: CookieConsent.CookieConsentConfig = {
+		guiOptions: {
+			consentModal: {
+				layout: 'bar',
+				position: 'bottom right'
+			},
+			preferencesModal: {
+				layout: 'box'
+			}
+		},
+		categories: {
+			necessary: {
+				readOnly: true,
+				enabled: true
+			},
+			analytics: {
+				autoClear: {
+					cookies: [
+						{
+							name: /^_pk.*/
+						}
+					]
+				}
+			}
+		},
+		onConsent: ({ cookie }) => {
+			if (cookie.categories.includes('analytics')) {
+				$matomo.rememberConsentGiven(24 * 356 * 5); // 5 years?
+			}
+		},
+		onChange: ({ cookie }) => {
+			if (cookie.categories.includes('analytics')) {
+				$matomo.rememberConsentGiven(24 * 356 * 5);
+			} else {
+				$matomo.forgetConsentGiven();
+			}
+		},
+		language: {
+			default: $page.data.locale,
+			translations: {
+				sv: svTranslations,
+				en: enTranslations
+			}
+		}
+	};
+
+	onMount(() => {
+		CookieConsent.run(config);
+	});
+</script>
+
+<style lang="postcss">
+	/* heading */
+	:global(#cc-main .cm__title, #cc-main .pm__title) {
+		@apply text-primary text-4-cond-bold;
+	}
+
+	/* subheading */
+	:global(#cc-main .pm__section-title) {
+		@apply text-primary text-3-cond;
+	}
+
+	/* body text */
+	:global(#cc-main .cm__desc, #cc-main .pm__section-desc) {
+		@apply text-primary text-2-regular;
+	}
+
+	/* btns */
+	:global(#cc-main .cm__btn, #cc-main .pm__btn) {
+		@apply text-3-cond;
+	}
+</style>

--- a/lxl-web/src/lib/contexts/matomo.ts
+++ b/lxl-web/src/lib/contexts/matomo.ts
@@ -14,7 +14,7 @@ function initMatomo() {
 			const tracker = matomo.getTracker(`${env.PUBLIC_MATOMO_URL}/matomo.php`, MATOMO_ID);
 
 			if (tracker) {
-				tracker.disableCookies(); // TODO - remove when cookie consent implemented
+				tracker.requireConsent();
 				tracker.enableLinkTracking();
 				return tracker;
 			}

--- a/lxl-web/src/lib/i18n/locales/cookieConsent.en.js
+++ b/lxl-web/src/lib/i18n/locales/cookieConsent.en.js
@@ -2,25 +2,25 @@ export default {
 	consentModal: {
 		title: 'We use cookies',
 		description:
-			'Tjänsten Libris använder olika typer av kakor (cookies). Dessa är till för att förbättra användarupplevelsen samt för att tjänsten och dess funktioner ska fungera som de ska. Nedan kan du välja dina inställningar för vilka kakor du ger ditt samtycke till. Du kan alltid ändra dina val senare genom att klicka på “Hantera cookies” längst ner på sidan.',
+			'The Libris service uses various types of cookies. These are intended to enhance the user experience and ensure that the service and its functions work as they should. Below, you can choose your preferences for which cookies you consent to. You can always change your choices later by clicking on "Manage cookies" at the bottom of the page.',
 		acceptAllBtn: 'Accept all cookies',
 		acceptNecessaryBtn: 'Accept only necessary',
-		showPreferencesBtn: 'Manage Individual preferences'
+		showPreferencesBtn: 'Cookie settings'
 	},
 	preferencesModal: {
 		title: 'Cookie settings',
 		acceptAllBtn: 'Accept all cookies',
 		acceptNecessaryBtn: 'Accept only necessary',
-		savePreferencesBtn: 'Manage individual preferences',
+		savePreferencesBtn: 'Save and close',
 		closeIconLabel: 'Close',
 		sections: [
 			{
-				title: 'Your Privacy Choices',
+				title: 'About the use of cookies',
 				description:
-					'Webbplatsen Libris använder kakor (cookies). En kaka är en liten textfil som lagras i besökarens dator. KB:s tjänster är designade för att minska risken för spridning av uppgifter om vad du söker efter och tittar på till andra. Informationen som lagras via kakor kan inte användas av tredje part i marknadsföringssyfte.'
+					"The Libris website uses cookies. A cookie is a small text file that is stored on the visitor's computer. The National Library's services are designed to reduce the risk of your information being disseminated. The information stored via cookies can never be used by third parties for marketing purposes."
 			},
 			{
-				title: 'Strictly Necessary cookies',
+				title: 'Necessary cookies',
 				description:
 					'These cookies are essential for the proper functioning of the website and cannot be disabled.',
 				linkedCategory: 'necessary'
@@ -28,13 +28,13 @@ export default {
 			{
 				title: 'Analytical cookies',
 				description:
-					'These cookies collect information about how you use our website, allowing us to improve the user experience.',
+					'Cookies that provide us with information about how the website is used, allowing us to maintain, operate, and improve the user experience.',
 				linkedCategory: 'analytics'
 			},
 			{
 				title: 'More information',
 				description:
-					'You can always review your choices by clicking "Manage cookies" in the site footer.'
+					'You can always change your choices by clicking on "Manage cookies" at the bottom of the page in the footer.'
 			}
 		]
 	}

--- a/lxl-web/src/lib/i18n/locales/cookieConsent.en.js
+++ b/lxl-web/src/lib/i18n/locales/cookieConsent.en.js
@@ -1,0 +1,41 @@
+export default {
+	consentModal: {
+		title: 'We use cookies',
+		description:
+			'Tjänsten Libris använder olika typer av kakor (cookies). Dessa är till för att förbättra användarupplevelsen samt för att tjänsten och dess funktioner ska fungera som de ska. Nedan kan du välja dina inställningar för vilka kakor du ger ditt samtycke till. Du kan alltid ändra dina val senare genom att klicka på “Hantera cookies” längst ner på sidan.',
+		acceptAllBtn: 'Accept all cookies',
+		acceptNecessaryBtn: 'Accept only necessary',
+		showPreferencesBtn: 'Manage Individual preferences'
+	},
+	preferencesModal: {
+		title: 'Cookie settings',
+		acceptAllBtn: 'Accept all cookies',
+		acceptNecessaryBtn: 'Accept only necessary',
+		savePreferencesBtn: 'Manage individual preferences',
+		closeIconLabel: 'Close',
+		sections: [
+			{
+				title: 'Your Privacy Choices',
+				description:
+					'Webbplatsen Libris använder kakor (cookies). En kaka är en liten textfil som lagras i besökarens dator. KB:s tjänster är designade för att minska risken för spridning av uppgifter om vad du söker efter och tittar på till andra. Informationen som lagras via kakor kan inte användas av tredje part i marknadsföringssyfte.'
+			},
+			{
+				title: 'Strictly Necessary cookies',
+				description:
+					'These cookies are essential for the proper functioning of the website and cannot be disabled.',
+				linkedCategory: 'necessary'
+			},
+			{
+				title: 'Analytical cookies',
+				description:
+					'These cookies collect information about how you use our website, allowing us to improve the user experience.',
+				linkedCategory: 'analytics'
+			},
+			{
+				title: 'More information',
+				description:
+					'You can always review your choices by clicking "Manage cookies" in the site footer.'
+			}
+		]
+	}
+};

--- a/lxl-web/src/lib/i18n/locales/cookieConsent.sv.js
+++ b/lxl-web/src/lib/i18n/locales/cookieConsent.sv.js
@@ -16,9 +16,9 @@ export default {
 		closeIconLabel: 'Stäng',
 		sections: [
 			{
-				title: 'Cookie-användning',
+				title: 'Om användning av kakor',
 				description:
-					'Webbplatsen Libris använder kakor (cookies). En kaka är en liten textfil som lagras i besökarens dator. KB:s tjänster är designade för att minska risken för spridning av uppgifter om vad du söker efter och tittar på till andra. Informationen som lagras via kakor kan inte användas av tredje part i marknadsföringssyfte.'
+					'Webbplatsen Libris använder kakor (cookies). En kaka är en liten textfil som lagras i besökarens dator. KB:s tjänster är designade för att minska risken för spridning av dina uppgifter. Informationen som lagras via kakor kan aldrig användas av tredje part i marknadsföringssyfte.'
 			},
 			{
 				title: 'Nödvändiga kakor',

--- a/lxl-web/src/lib/i18n/locales/cookieConsent.sv.js
+++ b/lxl-web/src/lib/i18n/locales/cookieConsent.sv.js
@@ -1,0 +1,42 @@
+// https://cookieconsent.orestbida.com/reference/configuration-reference.html#language-translations
+export default {
+	consentModal: {
+		title: 'Vi använder kakor',
+		description:
+			'Tjänsten Libris använder olika typer av kakor (cookies). Dessa är till för att förbättra användarupplevelsen samt för att tjänsten och dess funktioner ska fungera som de ska. Nedan kan du välja dina inställningar för vilka kakor du ger ditt samtycke till. Du kan alltid ändra dina val senare genom att klicka på “Hantera cookies” längst ner på sidan.',
+		acceptAllBtn: 'Tillåt alla kakor',
+		acceptNecessaryBtn: 'Tillåt bara nödvändiga kakor',
+		showPreferencesBtn: 'Inställningar'
+	},
+	preferencesModal: {
+		title: 'Inställningar för kakor',
+		acceptAllBtn: 'Tillåt alla kakor',
+		acceptNecessaryBtn: 'Tillåt bara nödvändiga kakor',
+		savePreferencesBtn: 'Spara och stäng',
+		closeIconLabel: 'Stäng',
+		sections: [
+			{
+				title: 'Cookie-användning',
+				description:
+					'Webbplatsen Libris använder kakor (cookies). En kaka är en liten textfil som lagras i besökarens dator. KB:s tjänster är designade för att minska risken för spridning av uppgifter om vad du söker efter och tittar på till andra. Informationen som lagras via kakor kan inte användas av tredje part i marknadsföringssyfte.'
+			},
+			{
+				title: 'Nödvändiga kakor',
+				description:
+					'Dessa kakor krävs för att tjänsten ska vara säker och fungera som den ska. Därför går de inte att inaktivera.',
+				linkedCategory: 'necessary'
+			},
+			{
+				title: 'Analytiska kakor',
+				description:
+					'Kakor som ger oss information om hur webbplatsen används som gör att vi kan underhålla, driva och förbättra användarupplevelsen.',
+				linkedCategory: 'analytics'
+			},
+			{
+				title: 'Mer information',
+				description:
+					'Du kan alltid ändra dina val genom att klicka på “Hantera cookies” längst ner på sidan i sidfoten.'
+			}
+		]
+	}
+};

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -16,7 +16,8 @@ export default {
 		contact: 'Contact',
 		feedback: 'Give feedback',
 		feedbackLink: 'http://survey.kb.se/librisbeta/en',
-		customerSupport: 'Libris customer support'
+		customerSupport: 'Libris customer support',
+		cookies: 'Manage cookies'
 	},
 	facet: {
 		q: 'Free text search',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -15,7 +15,8 @@ export default {
 		contact: 'Kontakt',
 		feedback: 'Lämna synpunkter',
 		feedbackLink: 'https://survey.kb.se/librisbeta',
-		customerSupport: 'Libris kundtjänst'
+		customerSupport: 'Libris kundtjänst',
+		cookies: 'Hantera cookies'
 	},
 	facet: {
 		q: 'Fritextsökning',

--- a/lxl-web/src/lib/types/matomo.ts
+++ b/lxl-web/src/lib/types/matomo.ts
@@ -61,7 +61,7 @@ export interface MatomoTracker {
 	 * The next time the user visits the site, Matomo will remember that they consented, and track them.
 	 * If you call this method, you do not need to call setConsentGiven
 	 */
-	rememberConsentGiven: (hoursToExpire: number) => void;
+	rememberConsentGiven: (hoursToExpire?: number) => void;
 
 	// Manage cookies
 	/** Disable all first party cookies. Existing Matomo cookies for this website will be deleted on the next page view.

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteFooter.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteFooter.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import KbLogo from '$lib/assets/img/kb_logo_text_black.svg';
 	import { page } from '$app/stores';
+	import * as CookieConsent from 'vanilla-cookieconsent';
 </script>
 
 <footer
@@ -16,6 +17,11 @@
 					<a
 						href="https://www.kb.se/samverkan-och-utveckling/libris/fragor-och-svar-om-libris-nya-soktjanst.html"
 						>{$page.data.t('footer.faq')}</a
+					>
+				</li>
+				<li>
+					<button class="underline" on:click={CookieConsent.showPreferences}
+						>{$page.data.t('footer.cookies')}</button
 					>
 				</li>
 			</ul>

--- a/lxl-web/src/routes/+layout.svelte
+++ b/lxl-web/src/routes/+layout.svelte
@@ -2,8 +2,9 @@
 	import '../app.css';
 	import NProgress from 'nprogress';
 	import '../nprogress.css';
-	import Matomo from '$lib/components/Matomo.svelte';
 	import { navigating } from '$app/stores';
+	import Matomo from '$lib/components/Matomo.svelte';
+	import CookieConsent from '$lib/components/CookieConsent.svelte';
 
 	NProgress.configure({
 		//https://github.com/rstacruz/nprogress#configuration
@@ -29,5 +30,6 @@
 <div class="flex min-h-screen flex-col">
 	<Matomo>
 		<slot />
+		<CookieConsent />
 	</Matomo>
 </div>


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-231](https://kbse.atlassian.net/browse/LWS-231)

### Solves

Adds cookie consent functionality using [vanilla-cookieconsent](https://cookieconsent.orestbida.com/) package.

Using the same implementation as Tidningar, i.e if user opts out of analytical cookies, we don't track them _at all_.

To test:
* No post requests to matomo.php are being made until user accepts all cookies.
* Post requests to matomo.php are made when user consents to all cookies.
* Requests to matomo.php stops when user redacts their consent (using the settings link in the footer) and matomo cookies (`_pk*`) are cleared.

### Summary of changes

Add cookie package, cookie component & translation files.
