### PR TITLE
Matomo tracker load fix

### DIFF
--- a/lxl-web/src/lib/contexts/matomo.ts
+++ b/lxl-web/src/lib/contexts/matomo.ts
@@ -7,6 +7,8 @@ import { setContext, getContext } from 'svelte';
 
 const MATOMO_ID: number = +env.PUBLIC_MATOMO_ID;
 
+const tracker = writable<MatomoTracker>();
+
 function initMatomo() {
 	if (browser) {
 		const matomo = window.Matomo;
@@ -16,6 +18,7 @@ function initMatomo() {
 			if (tracker) {
 				tracker.disableCookies(); // TODO - remove when cookie consent implemented
 				tracker.enableLinkTracking();
+				tracker.trackPageView();
 				return tracker;
 			}
 		}
@@ -25,9 +28,14 @@ function initMatomo() {
 export function setMatomoTracker() {
 	const initializedMatomoTracker = initMatomo();
 	if (initializedMatomoTracker) {
-		const tracker = writable<MatomoTracker>(initializedMatomoTracker);
-		setContext('matomo', tracker);
+		tracker.set(initializedMatomoTracker);
+		console.info('Matomo tracker set');
 	}
+}
+
+export function setMatomoContext() {
+	setMatomoTracker();
+	setContext('matomo', tracker);
 }
 
 export function getMatomoTracker() {


### PR DESCRIPTION
## Description

### Solves

I've discovered a bug in the Matomo implementation. Sometimes `initMatomo` is called before the matomo.js script has loaded, causing the whole thing to fail silently and nothing is logged (until a page reload - when the script is probably cached). Try it out by opening a fresh incognito tab and visit beta-dev a couple of times.

### Summary of changes

We need to `setContext` during component initialization, but we can update it with the tracker when the script is ready. Here  using an `on:load` handler. Also doing a `trackPageView` in the init function so we don't miss to track the first page load. 
