### PR TITLE
Handle quoted qualifier value

### DIFF
--- a/lxl-web/src/lib/components/SuperSearch.svelte
+++ b/lxl-web/src/lib/components/SuperSearch.svelte
@@ -354,7 +354,6 @@
 				</div>
 				<nav>
 					{#if editedParts.word || editedParts.phrase}
-						{console.log('WORD: ', editedParts.word, 'PHRASE: ', editedParts.phrase)}
 						{#if fetchedValue === value && !qualifierItems.length && !workItems.length}
 							<div class="no-results">Inga träffar</div>
 						{:else}

--- a/lxl-web/src/lib/components/SuperSearch.svelte
+++ b/lxl-web/src/lib/components/SuperSearch.svelte
@@ -354,6 +354,7 @@
 				</div>
 				<nav>
 					{#if editedParts.word || editedParts.phrase}
+						{console.log('WORD: ', editedParts.word, 'PHRASE: ', editedParts.phrase)}
 						{#if fetchedValue === value && !qualifierItems.length && !workItems.length}
 							<div class="no-results">Inga träffar</div>
 						{:else}

--- a/lxl-web/src/lib/utils/codemirror/getEditedParts.ts
+++ b/lxl-web/src/lib/utils/codemirror/getEditedParts.ts
@@ -2,9 +2,7 @@ import type { EditedRange } from '$lib/components/CodeMirror.svelte';
 
 // const QUALIFIER_REGEX = RegExp(/((")?[0-9a-zA-ZåäöÅÄÖ:]+\2):((")?[0-9a-zA-ZåäöÅÄÖ:%#-.]+\4?)?/);
 
-const QUALIFIER_REGEX = RegExp(
-	/^([0-9a-zA-ZåäöÅÄÖ:]*?):\s*(".*?"|[^"\s]+)(?:\s+[0-9a-zA-ZåäöÅÄÖ:%#-.]*)?$/
-);
+const QUALIFIER_REGEX = RegExp(/^([0-9a-zA-ZåäöÅÄÖ:]*?):(.*?)$/);
 const PHRASE_REGEX = RegExp(/(^|\s)((")?[0-9a-zA-ZåäöÅÄÖ:]+\3:(")?[0-9a-zA-ZåäöÅÄÖ:%#-.]+\4?)/);
 
 /**

--- a/lxl-web/src/lib/utils/codemirror/getEditedParts.ts
+++ b/lxl-web/src/lib/utils/codemirror/getEditedParts.ts
@@ -20,12 +20,12 @@ function getEditedParts({ value, cursor }: { value: string; cursor: number }): {
 	qualifierValue: string | undefined | null;
 } {
 	// word start = last whitespace not in quote from start to cursor
-	const wordFromIndex = whiteSpacesOutsideOfQuotes(value.slice(0, cursor)).pop() || 0;
+	const wordFromIndex = whitespacesOutsideOfQuotes(value.slice(0, cursor)).pop() || 0;
 
 	// word end = first whitespace not in quote from word start to end
 	const wordToIndex =
 		wordFromIndex +
-		(whiteSpacesOutsideOfQuotes(value.slice(wordFromIndex)).shift() || value.length);
+		(whitespacesOutsideOfQuotes(value.slice(wordFromIndex)).shift() || value.length);
 
 	const word = value.slice(wordFromIndex, wordToIndex).trim();
 	const wordRange = { from: wordFromIndex, to: wordToIndex };
@@ -73,7 +73,7 @@ function getEditedParts({ value, cursor }: { value: string; cursor: number }): {
 /**
  * Returns the index positions of whitespace outside of quotes in a string
  */
-function whiteSpacesOutsideOfQuotes(str: string) {
+function whitespacesOutsideOfQuotes(str: string) {
 	const resultArr = [];
 	let inQuotes = false;
 

--- a/lxl-web/src/lib/utils/codemirror/getEditedParts.ts
+++ b/lxl-web/src/lib/utils/codemirror/getEditedParts.ts
@@ -1,8 +1,9 @@
 import type { EditedRange } from '$lib/components/CodeMirror.svelte';
 
-// const QUALIFIER_REGEX = RegExp(/((")?[0-9a-zA-ZåäöÅÄÖ:]+\2):((")?[0-9a-zA-ZåäöÅÄÖ:%#-.]+\4?)?/);
-
-const QUALIFIER_REGEX = RegExp(/^([0-9a-zA-ZåäöÅÄÖ:]*?):(.*?)$/);
+// qualifierType = allowed chars in quotes or no quotes : qualifierValue = anything (but something)
+const QUALIFIER_REGEX = RegExp(
+	/^(?<qualifierType>"[0-9a-zA-ZåäöÅÄÖ:]+?"|[0-9a-zA-ZåäöÅÄÖ:]+):(?<qualifierValue>.+)$/
+);
 const PHRASE_REGEX = RegExp(/(^|\s)((")?[0-9a-zA-ZåäöÅÄÖ:]+\3:(")?[0-9a-zA-ZåäöÅÄÖ:%#-.]+\4?)/);
 
 /**
@@ -14,8 +15,8 @@ function getEditedParts({ value, cursor }: { value: string; cursor: number }): {
 	wordRange: EditedRange;
 	phrase: string | null; // a group of words/strings (e.g. Astrid Lindgren)
 	phraseRange: EditedRange | null;
-	qualifierType: string | null;
-	qualifierValue: string | null;
+	qualifierType: string | undefined | null;
+	qualifierValue: string | undefined | null;
 } {
 	// word start = last blankspace not in quote from start to cursor
 	const wordFromIndex = blankSpacesOutsideOfQuotes(value.slice(0, cursor)).pop() || 0;
@@ -31,8 +32,7 @@ function getEditedParts({ value, cursor }: { value: string; cursor: number }): {
 	const qualifierMatch = word.match(QUALIFIER_REGEX);
 
 	if (qualifierMatch) {
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const [match, qualifierType, qualifierValue] = qualifierMatch;
+		const { qualifierType, qualifierValue } = qualifierMatch.groups || {};
 
 		return {
 			word,

--- a/lxl-web/src/lib/utils/codemirror/getEditedParts.ts
+++ b/lxl-web/src/lib/utils/codemirror/getEditedParts.ts
@@ -1,7 +1,7 @@
 import type { EditedRange } from '$lib/components/CodeMirror.svelte';
 
 /**
- * qualifierType = preceded by a blankspace or beginning; allowed chars in quotes or no quotes :
+ * qualifierType = preceded by a whitespace or beginning; allowed chars in quotes or no quotes :
  * qualifierValue = captures up until blankspace or end quote
  */
 const QUALIFIER_REGEX =
@@ -19,13 +19,13 @@ function getEditedParts({ value, cursor }: { value: string; cursor: number }): {
 	qualifierType: string | undefined | null;
 	qualifierValue: string | undefined | null;
 } {
-	// word start = last blankspace not in quote from start to cursor
-	const wordFromIndex = blankSpacesOutsideOfQuotes(value.slice(0, cursor)).pop() || 0;
+	// word start = last whitespace not in quote from start to cursor
+	const wordFromIndex = whiteSpacesOutsideOfQuotes(value.slice(0, cursor)).pop() || 0;
 
-	// word end = first blankspace not in quote from word start to end
+	// word end = first whitespace not in quote from word start to end
 	const wordToIndex =
 		wordFromIndex +
-		(blankSpacesOutsideOfQuotes(value.slice(wordFromIndex)).shift() || value.length);
+		(whiteSpacesOutsideOfQuotes(value.slice(wordFromIndex)).shift() || value.length);
 
 	const word = value.slice(wordFromIndex, wordToIndex).trim();
 	const wordRange = { from: wordFromIndex, to: wordToIndex };
@@ -71,9 +71,9 @@ function getEditedParts({ value, cursor }: { value: string; cursor: number }): {
 }
 
 /**
- * Returns the index positions of blank spaces outside of quotes in a string
+ * Returns the index positions of whitespace outside of quotes in a string
  */
-function blankSpacesOutsideOfQuotes(str: string) {
+function whiteSpacesOutsideOfQuotes(str: string) {
 	const resultArr = [];
 	let inQuotes = false;
 
@@ -81,7 +81,7 @@ function blankSpacesOutsideOfQuotes(str: string) {
 		const char = str[i];
 		if (char === '"') {
 			inQuotes = !inQuotes;
-		} else if (char === ' ' && !inQuotes) {
+		} else if (/\s/.test(char) && !inQuotes) {
 			if (i > 0) {
 				// ignore opening whitespace
 				resultArr.push(i);

--- a/lxl-web/src/lib/utils/codemirror/getEditedParts.ts
+++ b/lxl-web/src/lib/utils/codemirror/getEditedParts.ts
@@ -1,6 +1,10 @@
 import type { EditedRange } from '$lib/components/CodeMirror.svelte';
 
-const QUALIFIER_REGEX = RegExp(/((")?[0-9a-zA-ZåäöÅÄÖ:]+\2):((")?[0-9a-zA-ZåäöÅÄÖ:%#-.]+\4?)?/);
+// const QUALIFIER_REGEX = RegExp(/((")?[0-9a-zA-ZåäöÅÄÖ:]+\2):((")?[0-9a-zA-ZåäöÅÄÖ:%#-.]+\4?)?/);
+
+const QUALIFIER_REGEX = RegExp(
+	/^([0-9a-zA-ZåäöÅÄÖ:]*?):\s*(".*?"|[^"\s]+)(?:\s+[0-9a-zA-ZåäöÅÄÖ:%#-.]*)?$/
+);
 const PHRASE_REGEX = RegExp(/(^|\s)((")?[0-9a-zA-ZåäöÅÄÖ:]+\3:(")?[0-9a-zA-ZåäöÅÄÖ:%#-.]+\4?)/);
 
 /**
@@ -15,16 +19,22 @@ function getEditedParts({ value, cursor }: { value: string; cursor: number }): {
 	qualifierType: string | null;
 	qualifierValue: string | null;
 } {
-	const wordFromIndex = value.slice(0, cursor).lastIndexOf(' ') + 1;
-	const wordToIndex = cursor + value.slice(cursor).split(/\s+/)[0].length || 0;
-	const word = value.slice(wordFromIndex, wordToIndex);
+	// word start = last blankspace not in quote from start to cursor
+	const wordFromIndex = blankSpacesOutsideOfQuotes(value.slice(0, cursor)).pop() || 0;
+
+	// word end = first blankspace not in quote from word start to end
+	const wordToIndex =
+		wordFromIndex +
+		(blankSpacesOutsideOfQuotes(value.slice(wordFromIndex)).shift() || value.length);
+
+	const word = value.slice(wordFromIndex, wordToIndex).trim();
 	const wordRange = { from: wordFromIndex, to: wordToIndex };
 
 	const qualifierMatch = word.match(QUALIFIER_REGEX);
 
 	if (qualifierMatch) {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const [match, qualifierType, delimiter, qualifierValue] = qualifierMatch;
+		const [match, qualifierType, qualifierValue] = qualifierMatch;
 
 		return {
 			word,
@@ -35,6 +45,7 @@ function getEditedParts({ value, cursor }: { value: string; cursor: number }): {
 			qualifierValue
 		};
 	} else {
+		// todo: phrases does not yet take quotations in qualifiers into account
 		const phraseBefore = value.slice(0, cursor).split(PHRASE_REGEX).pop() || ''; // get last string before cursor which isn't a qualifier
 		const phraseAfter = value.slice(cursor).split(PHRASE_REGEX)?.[0] || ''; // get first string after cursor which isn't a qualifier
 		const phrase = (phraseBefore + phraseAfter).trim();
@@ -51,6 +62,27 @@ function getEditedParts({ value, cursor }: { value: string; cursor: number }): {
 			qualifierValue: null
 		};
 	}
+}
+
+/**
+ * Returns the index positions of blank spaces outside of quotes in a string
+ */
+function blankSpacesOutsideOfQuotes(str: string) {
+	const resultArr = [];
+	let inQuotes = false;
+
+	for (let i = 0; i < str.length; i++) {
+		const char = str[i];
+		if (char === '"') {
+			inQuotes = !inQuotes;
+		} else if (char === ' ' && !inQuotes) {
+			if (i > 0) {
+				// ignore opening whitespace
+				resultArr.push(i);
+			}
+		}
+	}
+	return resultArr;
 }
 
 export default getEditedParts;


### PR DESCRIPTION
### Solves

Edited `word` getting sliced at nearest blankspace, regardless of being part of a quoted phrase.
Example `person:"Astrid lindgren"` resulted in a search for `contributor:"Astrid` and `lindgren"`

### Summary of changes

* `fromWordIndex`, `toWordIndex` now postitioning at nearest blankspace but ignoring those within quotes.
* Update `QUALIFIER_REGEX` to allow the value to have blank spaces in quotes.

try console.logging `word` to see how it works.

**Examples of searches and resulting suggestions:**

`person:"Lindgren, Astrid"`
Before: 
`Medverkande: Thelander, Astrid`
After:
`Medverkande: Lindgren, Astrid`

`titel:"på spaning efter den tid som flytt"`
Before:
`Genre/form: Sedesskildringar`
After:
`Verk: På spaning efter den tid som flytt`

`subject:”vintern i konsten”`
Before:
`Ämne: Poeter i konsten`
After:
`Ämne: Vintern i konsten`

