### PR TITLE
New qualifier decorator

### DIFF
--- a/lxl-web/src/lib/components/CodeMirror.svelte
+++ b/lxl-web/src/lib/components/CodeMirror.svelte
@@ -29,6 +29,7 @@
 	import { tags } from '@lezer/highlight';
 	import { syntaxHighlighting, HighlightStyle } from '@codemirror/language';
 	import {
+		qualifierDecoration,
 		qualifierNameDecoration,
 		qualifierValueDecoration
 	} from '$lib/utils/codemirror/extensions/qualifierDecoration';
@@ -129,6 +130,7 @@
 		syntaxHighlighting(lxlQueryHighlightStyle),
 		qualifierNameDecoration,
 		qualifierValueDecoration,
+		qualifierDecoration,
 		//qualifierLinter(validQualifiers),
 		//qualifierWidgets,
 		...extensions
@@ -292,6 +294,10 @@
 	.codemirror-container :global(.lxlquery-qualifier-name),
 	.codemirror-container :global(.lxlquery-qualifier-name *) {
 		color: var(--color-link); /* ensures highlighted styles are overwritten */
-		font-weight: 500;
+		/* font-weight: 500; */
+	}
+
+	.codemirror-container :global(.lxlquery-qualifier-unlinked) {
+		border-bottom: 2px solid var(--border-color);
 	}
 </style>

--- a/lxl-web/src/lib/components/SuperSearch.svelte
+++ b/lxl-web/src/lib/components/SuperSearch.svelte
@@ -260,7 +260,7 @@
 	}
 
 	onMount(() => {
-		dialogElement?.addEventListener('click', handleClickOutsideDialog);
+		dialogElement?.addEventListener('mousedown', handleClickOutsideDialog);
 	});
 
 	onDestroy(() => {

--- a/lxl-web/src/lib/utils/codemirror/extensions/preventInsertBeforeQualifier.ts
+++ b/lxl-web/src/lib/utils/codemirror/extensions/preventInsertBeforeQualifier.ts
@@ -2,6 +2,7 @@ import { EditorState, Prec } from '@codemirror/state';
 import { QUALIFIER_REGEXP } from '$lib/utils/codemirror/extensions/qualifierWidgets';
 
 const ENDS_WITH_WHITESPACE = new RegExp(/\s$/);
+const BEGINS_WITH_WHITESPACE = new RegExp(/^\s/);
 
 /**
  * Prevents existing qualifier widgets to be edited if inserting a character before them (by adding an extra whitespace after the inserted character)
@@ -22,7 +23,8 @@ const preventInsertBeforeQualifier = Prec.highest(
 				inserted.length &&
 				(fromA === 0 || ENDS_WITH_WHITESPACE.test(contentBefore)) && // test if editing the beginning of the string or if there is a whitespace before the inserted characters
 				!ENDS_WITH_WHITESPACE.test(inserted.toString()) && // only proceed if inserted content doesn't end with a whitespace
-				QUALIFIER_REGEXP.test(contentAfter) // test if inserted character is followed by a qualifier
+				QUALIFIER_REGEXP.test(contentAfter) && // test if inserted character is followed by a qualifier
+				!BEGINS_WITH_WHITESPACE.test(contentAfter) // if we already inserted whitespace, we don't want to keep doing it
 			) {
 				insertSpacePos = toB;
 			}

--- a/lxl-web/src/lib/utils/codemirror/extensions/qualifierDecoration.ts
+++ b/lxl-web/src/lib/utils/codemirror/extensions/qualifierDecoration.ts
@@ -7,6 +7,30 @@ import {
 	type DecorationSet
 } from '@codemirror/view';
 
+const qualifierMatcher = new MatchDecorator({
+	regexp:
+		/(?<=^|\s)(?<qualifierType>("[0-9a-zA-ZåäöÅÄÖ:]+")|([0-9a-zA-ZåäöÅÄÖ:]+)):(?<qualifierValue>("[^"]*"|[0-9a-zA-ZåäöÅÄÖ:%#".-]+))/g,
+	decoration: () =>
+		Decoration.mark({
+			class: 'lxlquery-qualifier-unlinked'
+		})
+});
+
+export const qualifierDecoration = ViewPlugin.fromClass(
+	class {
+		qualifiers: DecorationSet;
+		constructor(view: EditorView) {
+			this.qualifiers = qualifierMatcher.createDeco(view);
+		}
+		update(update: ViewUpdate) {
+			this.qualifiers = qualifierMatcher.updateDeco(update, this.qualifiers);
+		}
+	},
+	{
+		decorations: (instance) => instance.qualifiers
+	}
+);
+
 const qualifierNameMatcher = new MatchDecorator({
 	regexp: /(?<!\S+)((")?([0-9a-zA-ZåäöÅÄÖ:]+)\2):/g,
 	decoration: () =>

--- a/lxl-web/src/lib/utils/codemirror/getEditedParts.test.ts
+++ b/lxl-web/src/lib/utils/codemirror/getEditedParts.test.ts
@@ -7,13 +7,17 @@ describe('getEditedParts', () => {
 			word: 'astrid',
 			wordRange: { from: 0, to: 6 },
 			phrase: null,
-			phraseRange: null
+			phraseRange: null,
+			qualifierType: null,
+			qualifierValue: null
 		});
 		expect(getEditedParts({ value: 'astrid', cursor: 3 })).toEqual({
 			word: 'astrid',
 			wordRange: { from: 0, to: 6 },
 			phrase: null,
-			phraseRange: null
+			phraseRange: null,
+			qualifierType: null,
+			qualifierValue: null
 		});
 	});
 	it('returns edited word and phrase if two or more words', () => {
@@ -21,27 +25,41 @@ describe('getEditedParts', () => {
 			word: 'lindgren',
 			wordRange: { from: 7, to: 15 },
 			phrase: 'astrid lindgren',
-			phraseRange: { from: 0, to: 15 }
+			phraseRange: { from: 0, to: 15 },
+			qualifierType: null,
+			qualifierValue: null
 		});
 		expect(getEditedParts({ value: 'astrid lindgren', cursor: 6 })).toEqual({
 			word: 'astrid',
 			wordRange: { from: 0, to: 6 },
 			phrase: 'astrid lindgren',
-			phraseRange: { from: 0, to: 15 }
+			phraseRange: { from: 0, to: 15 },
+			qualifierType: null,
+			qualifierValue: null
 		});
 	});
 	it('returns matched qualifier-like names and values', () => {
 		expect(getEditedParts({ value: 'astrid lindgren hasTitle:', cursor: 25 })).toEqual({
 			word: 'hasTitle:',
 			wordRange: { from: 16, to: 25 },
-			phrase: null,
-			phraseRange: null
+			// should a qualifier without value be a qualifier?
+			// phrase: null,
+			// phraseRange: null,
+			phrase: 'astrid lindgren hasTitle:',
+			phraseRange: {
+				from: 0,
+				to: 25
+			},
+			qualifierType: null,
+			qualifierValue: null
 		});
 		expect(getEditedParts({ value: 'astrid lindgren hasTitle:Pippi', cursor: 30 })).toEqual({
 			word: 'hasTitle:Pippi',
 			wordRange: { from: 16, to: 30 },
 			phrase: null,
-			phraseRange: null
+			phraseRange: null,
+			qualifierType: 'hasTitle',
+			qualifierValue: 'Pippi'
 		});
 	});
 	it('works with quoted qualifiers', () => {
@@ -49,7 +67,9 @@ describe('getEditedParts', () => {
 			word: '"rdf:type":Text',
 			wordRange: { from: 16, to: 31 },
 			phrase: null,
-			phraseRange: null
+			phraseRange: null,
+			qualifierType: '"rdf:type"',
+			qualifierValue: 'Text'
 		});
 		expect(
 			getEditedParts({ value: 'astrid lindgren "rdf:type":Text itemHeldBy:"sigel:S"', cursor: 50 })
@@ -57,7 +77,22 @@ describe('getEditedParts', () => {
 			word: 'itemHeldBy:"sigel:S"',
 			wordRange: { from: 32, to: 52 },
 			phrase: null,
-			phraseRange: null
+			phraseRange: null,
+			qualifierType: 'itemHeldBy',
+			qualifierValue: '"sigel:S"'
+		});
+		expect(
+			getEditedParts({
+				value: 'astrid lindgren title:"Pippi Långstrump" some more text',
+				cursor: 23
+			})
+		).toEqual({
+			word: 'title:"Pippi Långstrump"',
+			wordRange: { from: 16, to: 40 },
+			phrase: null,
+			phraseRange: null,
+			qualifierType: 'title',
+			qualifierValue: '"Pippi Långstrump"'
 		});
 	});
 	it('gets relevant part between qualfiers', () => {
@@ -67,7 +102,9 @@ describe('getEditedParts', () => {
 			word: 'lind',
 			wordRange: { from: 17, to: 21 },
 			phrase: 'astrid lind',
-			phraseRange: { from: 10, to: 21 }
+			phraseRange: { from: 10, to: 21 },
+			qualifierType: null,
+			qualifierValue: null
 		});
 	});
 	it('trims words and phrases', () => {
@@ -75,13 +112,17 @@ describe('getEditedParts', () => {
 			word: 'astrid',
 			wordRange: { from: 1, to: 7 },
 			phrase: null,
-			phraseRange: null
+			phraseRange: null,
+			qualifierType: null,
+			qualifierValue: null
 		});
 		expect(getEditedParts({ value: ' astrid lindgren   ', cursor: 16 })).toEqual({
 			word: 'lindgren',
 			wordRange: { from: 8, to: 16 },
 			phrase: 'astrid lindgren',
-			phraseRange: { from: 1, to: 16 }
+			phraseRange: { from: 1, to: 16 },
+			qualifierType: null,
+			qualifierValue: null
 		});
 	});
 });

--- a/lxl-web/src/lib/utils/codemirror/getEditedParts.ts
+++ b/lxl-web/src/lib/utils/codemirror/getEditedParts.ts
@@ -20,12 +20,15 @@ function getEditedParts({ value, cursor }: { value: string; cursor: number }): {
 	qualifierValue: string | undefined | null;
 } {
 	// word start = last whitespace not in quote from start to cursor
-	const wordFromIndex = whitespacesOutsideOfQuotes(value.slice(0, cursor)).pop() || 0;
+	const lastWhitespacePosition = whitespacesOutsideOfQuotes(value.slice(0, cursor)).pop();
+	const wordFromIndex =
+		typeof lastWhitespacePosition !== 'undefined' ? lastWhitespacePosition + 1 : 0;
 
 	// word end = first whitespace not in quote from word start to end
 	const wordToIndex =
 		wordFromIndex +
-		(whitespacesOutsideOfQuotes(value.slice(wordFromIndex)).shift() || value.length);
+		(whitespacesOutsideOfQuotes(value.slice(wordFromIndex)).shift() ||
+			value.slice(wordFromIndex).length);
 
 	const word = value.slice(wordFromIndex, wordToIndex).trim();
 	const wordRange = { from: wordFromIndex, to: wordToIndex };
@@ -82,10 +85,7 @@ function whitespacesOutsideOfQuotes(str: string) {
 		if (char === '"') {
 			inQuotes = !inQuotes;
 		} else if (/\s/.test(char) && !inQuotes) {
-			if (i > 0) {
-				// ignore opening whitespace
-				resultArr.push(i);
-			}
+			resultArr.push(i);
 		}
 	}
 	return resultArr;


### PR DESCRIPTION
* Decorates a valid qualifier key:value pair.
(I noticed there are now multiple qualifier regex:es around the app, maybe we should look into that...)
* Fixes a small annoyance where the expanded search closes when selecting text and releasing the mouse outside of the box.
* Fixes a bug inserting more and more whitespace before a qualifier.
(you can see it by typing `key:value` and then before it, `df df df df df df d df df` 
* Fix broken unit tests + add one