### PR TITLE
feat(lxl-web): clickable Identifier uri, e.g. ISNI

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -62,7 +62,7 @@
 		@apply mx-auto px-4 sm:px-8;
 	}
 
-	.ext-link::after {
+	a.ext-link::after {
 		content: '\2009↗';
 		@apply align-[10%] text-icon;
 	}

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -498,7 +498,7 @@
 			"@id": "Identifier-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Identifier"],
-			"fresnel:resourceStyle": ["displayType()", "uriToId()"]
+			"fresnel:resourceStyle": ["ext-link", "displayType()", "uriToId()"]
 		},
 		"contribution-format": {
 			"@id": "contribution-format",
@@ -620,13 +620,13 @@
 			"@id": "MediaObject-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["MediaObject"],
-			"fresnel:resourceStyle": ["uriToId()", "text-3-cond-bold", "block"]
+			"fresnel:resourceStyle": ["ext-link", "uriToId()", "text-3-cond-bold", "block"]
 		},
 		"Document-format": {
 			"@id": "Document-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Document"],
-			"fresnel:resourceStyle": ["uriToId()"]
+			"fresnel:resourceStyle": ["ext-link", "uriToId()"]
 		},
 		"MediaObject-publicNote-format": {
 			"FIXME": "this is just to hide the interpunct before caused by uriToId() not fixing contentBefore",

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -206,6 +206,17 @@
 					"@type": "fresnel:Lens",
 					"showProperties": ["name", "qualifier"],
 					"classLensDomain": "Bibliography"
+				},
+				"Identifier": {
+					"@id": "Identifier-chips",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "Identifier",
+					"showProperties": [
+						{ "alternateProperties": ["value", "marc:hiddenValue"] },
+						"typeNote",
+						"hasNote",
+						"uri"
+					]
 				}
 			}
 		},
@@ -487,7 +498,7 @@
 			"@id": "Identifier-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Identifier"],
-			"fresnel:resourceStyle": ["displayType()"]
+			"fresnel:resourceStyle": ["displayType()", "uriToId()"]
 		},
 		"contribution-format": {
 			"@id": "contribution-format",
@@ -609,13 +620,13 @@
 			"@id": "MediaObject-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["MediaObject"],
-			"fresnel:resourceStyle": ["ext-link", "uriToId()", "text-3-cond-bold", "block"]
+			"fresnel:resourceStyle": ["uriToId()", "text-3-cond-bold", "block"]
 		},
 		"Document-format": {
 			"@id": "Document-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Document"],
-			"fresnel:resourceStyle": ["ext-link", "uriToId()"]
+			"fresnel:resourceStyle": ["uriToId()"]
 		},
 		"MediaObject-publicNote-format": {
 			"FIXME": "this is just to hide the interpunct before caused by uriToId() not fixing contentBefore",

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -588,7 +588,6 @@ class Formatter {
 						// Is there anything else to display as link label?
 						display.splice(ix, 1);
 					}
-					v[Fmt.STYLE] = (v[Fmt.STYLE] || []).concat(['ext-link']);
 				}
 			}
 

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -588,6 +588,7 @@ class Formatter {
 						// Is there anything else to display as link label?
 						display.splice(ix, 1);
 					}
+					v[Fmt.STYLE] = (v[Fmt.STYLE] || []).concat(['ext-link']);
 				}
 			}
 


### PR DESCRIPTION
## Description
Display `uri` in `Identifier` as external link.

Example:
![bild](https://github.com/user-attachments/assets/db5f79fe-b908-406c-8c7b-44516aec6af0)

![bild](https://github.com/user-attachments/assets/f143022d-47fb-420b-8576-e0c8b3f463c1)

### Summary of changes
* Add `uri` to `Identifier-chips`
* Use `uriToId()` to make uri a "fake `@id`" for Identifier
* Only show ext-link arrow on a elements