### PR TITLE
Bump node version in github action for lxl-web

### DIFF
--- a/.github/workflows/lxl-web.yml
+++ b/.github/workflows/lxl-web.yml
@@ -16,11 +16,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Setup yarn
-        run: npm install -g yarn
-      - name: Install lxljs dependency
-        run: yarn install --frozen-lockfile
-        working-directory: ./lxljs
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers
@@ -48,11 +43,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Setup yarn
-        run: npm install -g yarn
-      - name: Install lxljs dependency
-        run: yarn install --frozen-lockfile
-        working-directory: ./lxljs
       - name: Install dependencies
         run: npm ci
       - name: Build and run Lighthouse CI

--- a/.github/workflows/lxl-web.yml
+++ b/.github/workflows/lxl-web.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Setup yarn
         run: npm install -g yarn
       - name: Install lxljs dependency
@@ -47,7 +47,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Setup yarn
         run: npm install -g yarn
       - name: Install lxljs dependency


### PR DESCRIPTION
## Description

### Solves

Bumps Node.js to latest LTS version (v22) in `lxl-web` GitHub workflow file

### Summary of changes

- Bump node version in github workflow
- Remove redundant usage of yarn (npm ci and npm packages removes the need of yarn)