### PR TITLE
LWS-266: Add automatic formatting and linting to codemirror-lang-lxlquery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32863,9 +32863,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.13.0.tgz",
-      "integrity": "sha512-IFLyoY4d72Z5y/6o/BazFBezupzI/taV8sGumxTAVw3lXG9A6md1Dc34T9s1FoD/an9pJH8RHbAxsaEbBed9lA==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
+      "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -33598,17 +33598,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.12.2.tgz",
-      "integrity": "sha512-gQxbxM8mcxBwaEmWdtLCIGLfixBMHhQjBqR8sVWNTPpcj45WlYL2IObS/DNMLH1DBP0n8qz+aiiLTGfopPEebw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.13.0.tgz",
+      "integrity": "sha512-nQtBLiZYMUPkclSeC3id+x4uVd1SGtHuElTxL++SfP47jR0zfkZBJHc+gL4qPsgTuypz0k8Y2GheaDYn6Gy3rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.12.2",
-        "@typescript-eslint/type-utils": "8.12.2",
-        "@typescript-eslint/utils": "8.12.2",
-        "@typescript-eslint/visitor-keys": "8.12.2",
+        "@typescript-eslint/scope-manager": "8.13.0",
+        "@typescript-eslint/type-utils": "8.13.0",
+        "@typescript-eslint/utils": "8.13.0",
+        "@typescript-eslint/visitor-keys": "8.13.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -33632,16 +33632,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.12.2.tgz",
-      "integrity": "sha512-MrvlXNfGPLH3Z+r7Tk+Z5moZAc0dzdVjTgUgwsdGweH7lydysQsnSww3nAmsq8blFuRD5VRlAr9YdEFw3e6PBw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.13.0.tgz",
+      "integrity": "sha512-w0xp+xGg8u/nONcGw1UXAr6cjCPU1w0XVyBs6Zqaj5eLmxkKQAByTdV/uGgNN5tVvN/kKpoQlP2cL7R+ajZZIQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.12.2",
-        "@typescript-eslint/types": "8.12.2",
-        "@typescript-eslint/typescript-estree": "8.12.2",
-        "@typescript-eslint/visitor-keys": "8.12.2",
+        "@typescript-eslint/scope-manager": "8.13.0",
+        "@typescript-eslint/types": "8.13.0",
+        "@typescript-eslint/typescript-estree": "8.13.0",
+        "@typescript-eslint/visitor-keys": "8.13.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -33661,14 +33661,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.12.2.tgz",
-      "integrity": "sha512-gPLpLtrj9aMHOvxJkSbDBmbRuYdtiEbnvO25bCMza3DhMjTQw0u7Y1M+YR5JPbMsXXnSPuCf5hfq0nEkQDL/JQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.13.0.tgz",
+      "integrity": "sha512-XsGWww0odcUT0gJoBZ1DeulY1+jkaHUciUq4jKNv4cpInbvvrtDoyBH9rE/n2V29wQJPk8iCH1wipra9BhmiMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.12.2",
-        "@typescript-eslint/visitor-keys": "8.12.2"
+        "@typescript-eslint/types": "8.13.0",
+        "@typescript-eslint/visitor-keys": "8.13.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -33679,14 +33679,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.12.2.tgz",
-      "integrity": "sha512-bwuU4TAogPI+1q/IJSKuD4shBLc/d2vGcRT588q+jzayQyjVK2X6v/fbR4InY2U2sgf8MEvVCqEWUzYzgBNcGQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.13.0.tgz",
+      "integrity": "sha512-Rqnn6xXTR316fP4D2pohZenJnp+NwQ1mo7/JM+J1LWZENSLkJI8ID8QNtlvFeb0HnFSK94D6q0cnMX6SbE5/vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.12.2",
-        "@typescript-eslint/utils": "8.12.2",
+        "@typescript-eslint/typescript-estree": "8.13.0",
+        "@typescript-eslint/utils": "8.13.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -33704,9 +33704,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.12.2.tgz",
-      "integrity": "sha512-VwDwMF1SZ7wPBUZwmMdnDJ6sIFk4K4s+ALKLP6aIQsISkPv8jhiw65sAK6SuWODN/ix+m+HgbYDkH+zLjrzvOA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.13.0.tgz",
+      "integrity": "sha512-4cyFErJetFLckcThRUFdReWJjVsPCqyBlJTi6IDEpc1GWCIIZRFxVppjWLIMcQhNGhdWJJRYFHpHoDWvMlDzng==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -33718,14 +33718,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.12.2.tgz",
-      "integrity": "sha512-mME5MDwGe30Pq9zKPvyduyU86PH7aixwqYR2grTglAdB+AN8xXQ1vFGpYaUSJ5o5P/5znsSBeNcs5g5/2aQwow==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.13.0.tgz",
+      "integrity": "sha512-v7SCIGmVsRK2Cy/LTLGN22uea6SaUIlpBcO/gnMGT/7zPtxp90bphcGf4fyrCQl3ZtiBKqVTG32hb668oIYy1g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.12.2",
-        "@typescript-eslint/visitor-keys": "8.12.2",
+        "@typescript-eslint/types": "8.13.0",
+        "@typescript-eslint/visitor-keys": "8.13.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -33773,16 +33773,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.12.2.tgz",
-      "integrity": "sha512-UTTuDIX3fkfAz6iSVa5rTuSfWIYZ6ATtEocQ/umkRSyC9O919lbZ8dcH7mysshrCdrAM03skJOEYaBugxN+M6A==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.13.0.tgz",
+      "integrity": "sha512-A1EeYOND6Uv250nybnLZapeXpYMl8tkzYUxqmoKAWnI4sei3ihf2XdZVd+vVOmHGcp3t+P7yRrNsyyiXTvShFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.12.2",
-        "@typescript-eslint/types": "8.12.2",
-        "@typescript-eslint/typescript-estree": "8.12.2"
+        "@typescript-eslint/scope-manager": "8.13.0",
+        "@typescript-eslint/types": "8.13.0",
+        "@typescript-eslint/typescript-estree": "8.13.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -33796,13 +33796,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.12.2.tgz",
-      "integrity": "sha512-PChz8UaKQAVNHghsHcPyx1OMHoFRUEA7rJSK/mDhdq85bk+PLsUHUBqTQTFt18VJZbmxBovM65fezlheQRsSDA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.13.0.tgz",
+      "integrity": "sha512-7N/+lztJqH4Mrf0lb10R/CbI1EaAMMGyF5y0oJvFoAhafwgiRA7TXyd8TFn8FC8k5y2dTsYogg238qavRGNnlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/types": "8.13.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -34733,22 +34733,22 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.13.0.tgz",
-      "integrity": "sha512-EYZK6SX6zjFHST/HRytOdA/zE72Cq/bfw45LSyuwrdvcclb/gqV8RRQxywOBEWO2+WDpva6UZa4CcDeJKzUCFA==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
+      "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.11.0",
+        "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.18.0",
         "@eslint/core": "^0.7.0",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.13.0",
+        "@eslint/js": "9.14.0",
         "@eslint/plugin-kit": "^0.2.0",
-        "@humanfs/node": "^0.16.5",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.3.1",
+        "@humanwhocodes/retry": "^0.4.0",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -34756,9 +34756,9 @@
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.1.0",
-        "eslint-visitor-keys": "^4.1.0",
-        "espree": "^10.2.0",
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -34919,6 +34919,20 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@humanwhocodes/retry": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/esm-env": {
@@ -35356,9 +35370,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.11.0.tgz",
-      "integrity": "sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.12.0.tgz",
+      "integrity": "sha512-1+gLErljJFhbOVyaetcwJiJ4+eLe45S2E7P5UiZ9xGfeq3ATQf5DOv9G7MH3gGbKQLkzmNh2DxfZwLdw+j6oTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -37632,15 +37646,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.12.2.tgz",
-      "integrity": "sha512-UbuVUWSrHVR03q9CWx+JDHeO6B/Hr9p4U5lRH++5tq/EbFq1faYZe50ZSBePptgfIKLEti0aPQ3hFgnPVcd8ZQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.13.0.tgz",
+      "integrity": "sha512-vIMpDRJrQd70au2G8w34mPps0ezFSPMEX4pXkTzUkrNbRX+36ais2ksGWN0esZL+ZMaFJEneOBHzCgSqle7DHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.12.2",
-        "@typescript-eslint/parser": "8.12.2",
-        "@typescript-eslint/utils": "8.12.2"
+        "@typescript-eslint/eslint-plugin": "8.13.0",
+        "@typescript-eslint/parser": "8.13.0",
+        "@typescript-eslint/utils": "8.13.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -38160,10 +38174,17 @@
       },
       "devDependencies": {
         "@lezer/generator": "^1.0.0",
+        "eslint": "^9.14.0",
+        "eslint-config-prettier": "^9.1.0",
+        "globals": "^15.12.0",
+        "husky": "^9.1.6",
+        "lint-staged": "^15.2.10",
+        "prettier": "^3.3.3",
         "rollup": "^2.60.2",
         "rollup-plugin-dts": "^4.0.1",
         "rollup-plugin-ts": "^3.0.2",
         "typescript": "^4.3.4",
+        "typescript-eslint": "^8.13.0",
         "vitest": "^2.1.4"
       }
     },

--- a/packages/codemirror-lang-lxlquery/.husky/pre-commit
+++ b/packages/codemirror-lang-lxlquery/.husky/pre-commit
@@ -1,0 +1,1 @@
+cd ./packages/codemirror-lang-lxlquery && npx lint-staged

--- a/packages/codemirror-lang-lxlquery/.prettierrc
+++ b/packages/codemirror-lang-lxlquery/.prettierrc
@@ -1,0 +1,6 @@
+{
+	"useTabs": true,
+	"singleQuote": true,
+	"trailingComma": "none",
+	"printWidth": 100
+}

--- a/packages/codemirror-lang-lxlquery/README.md
+++ b/packages/codemirror-lang-lxlquery/README.md
@@ -4,18 +4,18 @@ This is an example repository containing a minimal [CodeMirror](https://codemirr
 
 Things you'll need to do (see the [language support example](https://codemirror.net/6/examples/lang-package/) for a more detailed tutorial):
 
- * `git grep EXAMPLE` and replace all instances with your language name.
+- `git grep EXAMPLE` and replace all instances with your language name.
 
- * Rewrite the grammar in `src/syntax.grammar` to cover your language. See the [Lezer system guide](https://lezer.codemirror.net/docs/guide/#writing-a-grammar) for information on this file format.
+- Rewrite the grammar in `src/syntax.grammar` to cover your language. See the [Lezer system guide](https://lezer.codemirror.net/docs/guide/#writing-a-grammar) for information on this file format.
 
- * Adjust the metadata in `src/index.ts` to work with your new grammar.
+- Adjust the metadata in `src/index.ts` to work with your new grammar.
 
- * Adjust the grammar tests in `test/cases.txt`.
+- Adjust the grammar tests in `test/cases.txt`.
 
- * Build (`npm run prepare`) and test (`npm test`).
+- Build (`npm run prepare`) and test (`npm test`).
 
- * Rewrite this readme file.
+- Rewrite this readme file.
 
- * Optionally add a license.
+- Optionally add a license.
 
- * Publish. Put your package on npm under a name like `codemirror-lang-EXAMPLE`.
+- Publish. Put your package on npm under a name like `codemirror-lang-EXAMPLE`.

--- a/packages/codemirror-lang-lxlquery/eslint.config.js
+++ b/packages/codemirror-lang-lxlquery/eslint.config.js
@@ -1,0 +1,21 @@
+import prettier from 'eslint-config-prettier';
+import js from '@eslint/js';
+import globals from 'globals';
+import ts from 'typescript-eslint';
+
+export default ts.config(
+	js.configs.recommended,
+	...ts.configs.recommended,
+	prettier,
+	{
+		languageOptions: {
+			globals: {
+				...globals.browser,
+				...globals.node
+			}
+		}
+	},
+	{
+		ignores: ['dist/']
+	}
+);

--- a/packages/codemirror-lang-lxlquery/package.json
+++ b/packages/codemirror-lang-lxlquery/package.json
@@ -4,7 +4,9 @@
 	"description": "Libris XL query language support for CodeMirror",
 	"scripts": {
 		"test": "vitest",
-		"prepare": "rollup -c"
+		"prepare": "husky && rollup -c",
+    "lint": "eslint . && prettier --check .",
+		"format": "prettier --write ."
 	},
 	"lint-staged": {
 		"*.{js,ts,md,json}": [

--- a/packages/codemirror-lang-lxlquery/package.json
+++ b/packages/codemirror-lang-lxlquery/package.json
@@ -1,32 +1,46 @@
 {
-  "name": "codemirror-lang-lxlquery",
-  "version": "0.1.0",
-  "description": "Libris XL query language support for CodeMirror",
-  "scripts": {
-    "test": "vitest",
-    "prepare": "rollup -c"
-  },
-  "type": "module",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
-  },
-  "types": "dist/index.d.ts",
-  "sideEffects": false,
-  "dependencies": {
-    "@codemirror/language": "^6.0.0",
-    "@lezer/highlight": "^1.0.0",
-    "@lezer/lr": "^1.0.0"
-  },
-  "devDependencies": {
-    "@lezer/generator": "^1.0.0",
-    "rollup": "^2.60.2",
-    "rollup-plugin-dts": "^4.0.1",
-    "rollup-plugin-ts": "^3.0.2",
-    "typescript": "^4.3.4",
-    "vitest": "^2.1.4"
-  },
-  "license": "MIT"
+	"name": "codemirror-lang-lxlquery",
+	"version": "0.1.0",
+	"description": "Libris XL query language support for CodeMirror",
+	"scripts": {
+		"test": "vitest",
+		"prepare": "rollup -c"
+	},
+	"lint-staged": {
+		"*.{js,ts,md,json}": [
+			"prettier --write --plugin-search-dir=.",
+			"prettier --check --plugin-search-dir=."
+		],
+		"*.{js,ts}": "eslint"
+	},
+	"type": "module",
+	"main": "dist/index.cjs",
+	"module": "dist/index.js",
+	"exports": {
+		"import": "./dist/index.js",
+		"require": "./dist/index.cjs"
+	},
+	"types": "dist/index.d.ts",
+	"sideEffects": false,
+	"dependencies": {
+		"@codemirror/language": "^6.0.0",
+		"@lezer/highlight": "^1.0.0",
+		"@lezer/lr": "^1.0.0"
+	},
+	"devDependencies": {
+		"@lezer/generator": "^1.0.0",
+		"eslint": "^9.14.0",
+		"eslint-config-prettier": "^9.1.0",
+		"globals": "^15.12.0",
+		"husky": "^9.1.6",
+		"lint-staged": "^15.2.10",
+		"prettier": "^3.3.3",
+		"rollup": "^2.60.2",
+		"rollup-plugin-dts": "^4.0.1",
+		"rollup-plugin-ts": "^3.0.2",
+		"typescript": "^4.3.4",
+		"typescript-eslint": "^8.13.0",
+		"vitest": "^2.1.4"
+	},
+	"license": "MIT"
 }

--- a/packages/codemirror-lang-lxlquery/rollup.config.js
+++ b/packages/codemirror-lang-lxlquery/rollup.config.js
@@ -1,12 +1,12 @@
-import typescript from "rollup-plugin-ts"
-import {lezer} from "@lezer/generator/rollup"
+import typescript from 'rollup-plugin-ts';
+import { lezer } from '@lezer/generator/rollup';
 
 export default {
-  input: "src/index.ts",
-  external: id => id != "tslib" && !/^(\.?\/|\w:)/.test(id),
-  output: [
-    {file: "dist/index.cjs", format: "cjs"},
-    {dir: "./dist", format: "es"}
-  ],
-  plugins: [lezer(), typescript()]
-}
+	input: 'src/index.ts',
+	external: (id) => id != 'tslib' && !/^(\.?\/|\w:)/.test(id),
+	output: [
+		{ file: 'dist/index.cjs', format: 'cjs' },
+		{ dir: './dist', format: 'es' }
+	],
+	plugins: [lezer(), typescript()]
+};

--- a/packages/codemirror-lang-lxlquery/src/index.ts
+++ b/packages/codemirror-lang-lxlquery/src/index.ts
@@ -1,22 +1,22 @@
-import { parser } from "./syntax.grammar"
-import { LRLanguage, LanguageSupport } from "@codemirror/language"
-import { styleTags, tags as t } from "@lezer/highlight"
+import { parser } from './syntax.grammar';
+import { LRLanguage, LanguageSupport } from '@codemirror/language';
+import { styleTags, tags as t } from '@lezer/highlight';
 
 export const lxlQueryLanguage = LRLanguage.define({
-  name: "Libris XL query",
-  parser: parser.configure({
-    props: [
-      styleTags({
-        Identifier: t.variableName,
-        String: t.string,
-        CompareOperator: t.compareOperator,
-        "( )": t.paren
-      })
-    ]
-  }),
-  languageData: {}
-})
+	name: 'Libris XL query',
+	parser: parser.configure({
+		props: [
+			styleTags({
+				Identifier: t.variableName,
+				String: t.string,
+				CompareOperator: t.compareOperator,
+				'( )': t.paren
+			})
+		]
+	}),
+	languageData: {}
+});
 
 export function lxlQuery() {
-  return new LanguageSupport(lxlQueryLanguage)
+	return new LanguageSupport(lxlQueryLanguage);
 }

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar.d.ts
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar.d.ts
@@ -1,3 +1,3 @@
-import {LRParser} from "@lezer/lr"
+import { LRParser } from '@lezer/lr';
 
-export declare const parser: LRParser
+export declare const parser: LRParser;

--- a/packages/codemirror-lang-lxlquery/test/test.js
+++ b/packages/codemirror-lang-lxlquery/test/test.js
@@ -1,18 +1,18 @@
-import { lxlQueryLanguage } from "../dist/index.js"
-import { fileTests } from "@lezer/generator/dist/test"
+import { lxlQueryLanguage } from '../dist/index.js';
+import { fileTests } from '@lezer/generator/dist/test';
 import { describe, it } from 'vitest';
 
-import * as fs from "fs"
-import * as path from "path"
+import * as fs from 'fs';
+import * as path from 'path';
 import { fileURLToPath } from 'url';
-let caseDir = path.dirname(fileURLToPath(import.meta.url))
+let caseDir = path.dirname(fileURLToPath(import.meta.url));
 
 for (let file of fs.readdirSync(caseDir)) {
-  if (!/\.txt$/.test(file)) continue
+	if (!/\.txt$/.test(file)) continue;
 
-  let name = /^[^\.]*/.exec(file)[0]
-  describe(name, () => {
-    for (let {name, run} of fileTests(fs.readFileSync(path.join(caseDir, file), "utf8"), file))
-      it(name, () => run(lxlQueryLanguage.parser))
-  })
+	let name = /^[^.]*/.exec(file)[0];
+	describe(name, () => {
+		for (let { name, run } of fileTests(fs.readFileSync(path.join(caseDir, file), 'utf8'), file))
+			it(name, () => run(lxlQueryLanguage.parser));
+	});
 }

--- a/packages/codemirror-lang-lxlquery/tsconfig.json
+++ b/packages/codemirror-lang-lxlquery/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "compilerOptions": {
-    "strict": true,
-    "target": "es6",
-    "module": "es2020",
-    "newLine": "lf",
-    "declaration": true,
-    "moduleResolution": "node"
-  },
-  "include": ["src/*.ts"]
+	"compilerOptions": {
+		"strict": true,
+		"target": "es6",
+		"module": "es2020",
+		"newLine": "lf",
+		"declaration": true,
+		"moduleResolution": "node"
+	},
+	"include": ["src/*.ts"]
 }

--- a/packages/codemirror-lang-lxlquery/vitest.config.ts
+++ b/packages/codemirror-lang-lxlquery/vitest.config.ts
@@ -1,8 +1,7 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  test: {
-    include: ['test/test.js']
-  }
-})
-
+	test: {
+		include: ['test/test.js']
+	}
+});


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-266](https://kbse.atlassian.net/browse/LWS-266)

### Solves

Adds automatic formatting and linting on commits using [prettier](https://prettier.io/) and [eslint](https://eslint.org/) in conjuction with [husky](https://typicode.github.io/husky/) and [lint-staged](https://github.com/lint-staged/lint-staged).

The code formatting and linting adheres to the normalized code formatting in `lxl-web` and the `supersearch` package.

### Summary of changes

- Add automatic formatting and linting on commits
- Format and lint all existing files
- Add format and lint scripts to package.json
