### PR TITLE
Add placeholder compartment/prop

### DIFF
--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -45,7 +45,7 @@
 
 <form class="relative w-full" action="find" on:submit={handleSubmit}>
 	{#if env?.PUBLIC_USE_SUPERSEARCH === 'true'}
-		<SuperSearch language={lxlQueryLanguage} />
+		<SuperSearch language={lxlQueryLanguage} placeholder={$page.data.t('search.search')} />
 	{:else}
 		<!-- svelte-ignore a11y-autofocus -->
 		<input

--- a/packages/supersearch/src/lib/components/CodeMirror.svelte
+++ b/packages/supersearch/src/lib/components/CodeMirror.svelte
@@ -15,12 +15,14 @@
 		value?: string;
 		extensions?: Extension[];
 		onchange?: (event: ChangeCodeMirrorEvent) => void;
+		editorView?: EditorView | undefined;
 	};
 
 	let {
 		value = '', // value isn't bindable as it can easily cause undo/redo history issues when changing the value from outside – it's preferable to dispatch changes instead
 		extensions = [],
-		onchange = () => {}
+		onchange = () => {},
+		editorView = $bindable()
 	}: CodeMirrorProps = $props();
 
 	const updateHandler = EditorView.updateListener.of((update) => {
@@ -33,7 +35,6 @@
 		}
 	});
 
-	let editorView: EditorView | undefined = $state();
 	let codemirrorContainerElement: HTMLDivElement | undefined = $state();
 	let extensionsWithBaseHandlers: Extension[] = $derived([updateHandler, ...extensions]);
 	let prevExtensions: Extension[] = extensions;

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -1,16 +1,39 @@
 <script lang="ts">
 	import CodeMirror, { type ChangeCodeMirrorEvent } from '$lib/components/CodeMirror.svelte';
-	import { placeholder } from '@codemirror/view';
+	import { EditorView, placeholder as placeholderExtension } from '@codemirror/view';
+	import { Compartment } from '@codemirror/state';
 	import { type LRLanguage } from '@codemirror/language';
 
-	let value = $state('');
-	let { language }: { language?: LRLanguage } = $props();
+	interface Props {
+		language?: LRLanguage;
+		placeholder?: string;
+	}
 
-	const extensions = [placeholder('Search'), ...(language ? [language] : [])];
+	let { language, placeholder = '' }: Props = $props();
+
+	let value = $state('');
+	let editorView: EditorView | undefined = $state();
+
+	let placeholderCompartment = new Compartment();
+	let prevPlaceholder = placeholder;
+
+	const extensions = [
+		...(language ? [language] : []),
+		placeholderCompartment.of(placeholderExtension(placeholder))
+	];
 
 	function handleChangeCodeMirror(event: ChangeCodeMirrorEvent) {
 		value = event.value;
 	}
+
+	$effect(() => {
+		if (placeholder !== prevPlaceholder) {
+			editorView?.dispatch({
+				effects: placeholderCompartment.reconfigure(placeholderExtension(placeholder))
+			});
+			prevPlaceholder = placeholder;
+		}
+	});
 </script>
 
-<CodeMirror {value} {extensions} onchange={handleChangeCodeMirror} />
+<CodeMirror {value} {extensions} onchange={handleChangeCodeMirror} bind:editorView />

--- a/packages/supersearch/src/routes/+page.svelte
+++ b/packages/supersearch/src/routes/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
 	import SuperSearch from '$lib/components/SuperSearch.svelte';
+
+	let placeholder = $state('Search');
 </script>
 
-<SuperSearch />
+<SuperSearch {placeholder} />
+
+<label>Placeholder:<input type="text" bind:value={placeholder} /></label>


### PR DESCRIPTION
### Solves

Add placeholder compartment/prop for [partial dynamic configuration](https://codemirror.net/examples/config/#dynamic-configuration) of the placeholder extension.

It acts of an example of how to use CodeMirrors [compartments](https://codemirror.net/examples/config/#compartments).

I'm a little bit torn/unsure if we should treat `editorView` as a [bindable](https://svelte.dev/docs/svelte/$bindable) prop, or if we should expose the current editor view using an event handler function (e.g. `onmount` from the `CodeMirror.svelte` component combined with a `handleMountCodeMirror` function inside `SuperSearch.svelte`). 

The bindable approach will result in fewer lines of code but we probably don't want the bindable prop for it's two-way binding abilites, as we should generally be careful to mutate the CodeMirror related data directly (dispatching changes is totally fine!). At least that's the case when working with history.

### Summary of changes

- Add placeholder compartment/prop
