### PR TITLE
Add bulk script for removing topic subdivisions

### DIFF
--- a/cataloging/src/components/care/bulk-changes.vue
+++ b/cataloging/src/components/care/bulk-changes.vue
@@ -204,7 +204,7 @@ export default {
       return this.specType === Type.Update;
     },
     isMergeSpec() {
-      return this.specType === Type.Merge;
+      return this.specType === Type.Merge || this.specType === Type.Other;
     },
     isCreateSpec() {
       return this.specType === Type.Create;

--- a/cataloging/src/components/care/bulk-changes.vue
+++ b/cataloging/src/components/care/bulk-changes.vue
@@ -122,7 +122,11 @@ export default {
       return `${this.steps.indexOf('form') + 1}. ${translatePhrase('Selection')}`;
     },
     mergeTitle() {
-      return `${this.steps.indexOf('mergeSpec') + 1}. ${translatePhrase('Merge')}`;
+      const title = this.isOtherSpec
+        ? translatePhrase('Change')
+        : translatePhrase('Merge');
+
+      return `${this.steps.indexOf('mergeSpec') + 1}. ${title}`;
     },
     changesTitle() {
       if (this.specType === Type.Create) {
@@ -205,6 +209,9 @@ export default {
     },
     isMergeSpec() {
       return this.specType === Type.Merge || this.specType === Type.Other;
+    },
+    isOtherSpec() {
+      return this.specType === Type.Other;
     },
     isCreateSpec() {
       return this.specType === Type.Create;

--- a/cataloging/src/components/care/bulk-changes.vue
+++ b/cataloging/src/components/care/bulk-changes.vue
@@ -472,29 +472,24 @@ export default {
         this.previousPreviewLink = result.prev;
         this.itemOffset = result.itemOffset;
 
-        if (this.specType === Type.Update) {
-          let before = result.items[0].changeSets[0].version;
-          let after = result.items[0].changeSets[1].version;
-          const changeset = result.items[0].changeSets[1];
 
-          const [displayData, displayPaths] = HistoryUtil.buildDisplayData(
-            before,
-            after,
-            changeset.addedPaths.map(el => el.slice(2)), //temporary hack to remove [@graph, 1, ...
-            changeset.removedPaths.map(el => el.slice(2)),
-            (s) => StringUtil.getLabelByLang(s, this.user.settings.language, this.resources),
-          );
+        let before = result.items[0].changeSets[0].version;
+        let after = result.items[0].changeSets[1].version;
+        const changeset = result.items[0].changeSets[1];
 
-          this.fullPreviewData = displayData;
-          this.fullPreviewDiff.removed = displayPaths.removed.map(path => `mainEntity.${path}`);
-          this.fullPreviewDiff.added = displayPaths.added.map(path => `mainEntity.${path}`);
-          this.fullPreviewDiff.modified = displayPaths.modified.map(path => `mainEntity.${path}`);
-        } else if (this.specType === Type.Delete) {
-          this.fullPreviewDiff.removed = [];
-          this.fullPreviewDiff.added = [];
-          this.fullPreviewDiff.modifed = [];
-          this.fullPreviewData = result.items[0].changeSets[0].version;
-        }
+        const [displayData, displayPaths] = HistoryUtil.buildDisplayData(
+          before,
+          after,
+          changeset.addedPaths.map(el => el.slice(2)), //temporary hack to remove [@graph, 1, ...
+          changeset.removedPaths.map(el => el.slice(2)),
+          (s) => StringUtil.getLabelByLang(s, this.user.settings.language, this.resources),
+        );
+
+        this.fullPreviewData = displayData;
+        this.fullPreviewDiff.removed = displayPaths.removed.map(path => `mainEntity.${path}`);
+        this.fullPreviewDiff.added = displayPaths.added.map(path => `mainEntity.${path}`);
+        this.fullPreviewDiff.modified = displayPaths.modified.map(path => `mainEntity.${path}`);
+
         DataUtil.fetchMissingLinkedToQuoted(this.fullPreviewData, this.$store);
         this.loadingPreview.next = false;
         this.loadingPreview.previous = false;
@@ -807,7 +802,6 @@ export default {
           :total-items="totalItems"
           :finished="isFinished"
           :has-unsaved="hasUnsavedChanges"
-          :spec-type="specType"
           @onActive="focusPreview"
         />
       </div>

--- a/cataloging/src/components/care/merge-spec.vue
+++ b/cataloging/src/components/care/merge-spec.vue
@@ -73,6 +73,7 @@ export default {
           :is-active="true"
           :form-data="formData"
           :locked="!isActive"
+          :hide-top-level-properties="['@type', 'bulk:script']"
         />
       </div>
     </div>

--- a/cataloging/src/components/care/preview.vue
+++ b/cataloging/src/components/care/preview.vue
@@ -50,10 +50,10 @@ export default {
       type: Boolean,
       default: false,
     },
-    specType: {
-      type: String,
-      default: '',
-    }
+    complete: {
+      type: Boolean,
+      default: true,
+    },
   },
   computed: {
     ...mapGetters([
@@ -82,21 +82,6 @@ export default {
         return translatePhrase('No matching records');
       }
     },
-    deleteSpecLabel() {
-      return translatePhrase('Delete record');
-    },
-    completedLabel() {
-      return StringUtil.getLabelByLang(Status.Completed, this.user.settings.language, this.resources)
-    },
-    isDeleteSpec() {
-      return this.specType === Type.Delete;
-    },
-    isUpdateSpec() {
-      return this.specType === Type.Update;
-    },
-    isMergeSpec() {
-      return this.specType === Type.Merge;
-    }
   },
   emits: ['onInactive', 'onActive'],
   methods: {
@@ -141,18 +126,11 @@ export default {
             :should-link="false"
             :exclude-components="['details']"/>
         </div>
-        <entity-form v-if="isUpdateSpec"
+        <entity-form
           :editing-object="'mainEntity'"
           :key="formTab.id"
           :is-active="true"
           :diff="previewDiff"
-          :form-data="previewData"
-          :locked="true"
-        />
-        <entity-form v-if="isDeleteSpec || isMergeSpec"
-          :editing-object="'mainEntity'"
-          :key="formTab.id"
-          :is-active="true"
           :form-data="previewData"
           :locked="true"
         />

--- a/cataloging/src/components/inspector/entity-form.vue
+++ b/cataloging/src/components/inspector/entity-form.vue
@@ -44,7 +44,7 @@ export default {
     showBulkchangeActions: {
       type: Boolean,
       default: false,
-    }
+    },
   },
   data() {
     return {

--- a/cataloging/src/components/mixins/form-mixin.vue
+++ b/cataloging/src/components/mixins/form-mixin.vue
@@ -14,6 +14,10 @@ export default {
       type: Array,
       default: () => [],
     },
+    hideTopLevelProperties: {
+      type: Array,
+      default: () => [],
+    },
   },
   data() {
     return {
@@ -116,6 +120,8 @@ export default {
       delete fItem['@id'];
       delete fItem['@reverse'];
       delete fItem._uid;
+
+      this.hideTopLevelProperties.forEach(property => { delete fItem[property]; });
 
       return fItem;
     },

--- a/cataloging/src/resources/json/combinedTemplates.json
+++ b/cataloging/src/resources/json/combinedTemplates.json
@@ -4640,6 +4640,35 @@
           }
         }
       }
+    },
+    "removeTopicSubdivision": {
+      "label": "Underindelning",
+      "description": "Radera underindelning för ämnesord",
+      "@id": "removeTopicSubdivision",
+      "value": {
+        "mainEntity": {
+          "@type": "bulk:Job",
+          "@id": "https://id.kb.se/TEMPID#it",
+          "label": "",
+          "comment": "",
+          "bulk:status": "bulk:Draft",
+          "bulk:shouldUpdateModifiedTimestamp": false,
+          "bulk:changeSpec": {
+            "@type": "bulk:Other",
+            "bulk:script": "removeTopicSubdivision",
+            "bulk:deprecate": [],
+            "bulk:keep": null
+          }
+        },
+        "quoted": {},
+        "record": {
+          "@type": "Record",
+          "@id": "https://id.kb.se/TEMPID",
+          "mainEntity": {
+            "@id": "https://id.kb.se/TEMPID#it"
+          }
+        }
+      }
     }
   }
 }

--- a/cataloging/src/resources/json/i18n.json
+++ b/cataloging/src/resources/json/i18n.json
@@ -457,6 +457,7 @@
     "Match subtypes" : "Matcha subtyper",
     "Remove records" : "Ta bort poster",
     "Create records" : "Skapa poster",
-    "Merge" : "Slå ihop"
+    "Merge" : "Slå ihop",
+    "Change" : "Ändring"
   }
 }

--- a/cataloging/src/utils/bulk.js
+++ b/cataloging/src/utils/bulk.js
@@ -28,4 +28,5 @@ export class Type {
   static Delete = 'bulk:Delete';
   static Create = 'bulk:Create';
   static Merge = 'bulk:Merge';
+  static Other = 'bulk:Other';
 }


### PR DESCRIPTION
* Add a new bulk spec type `Other`
* Add a template for removing topic subdivisions

For now it reuses the same form as Merge. We probably want to separate them? But there are many place check isMergeSpec etc.

We could pass some more stuff from the template in order to have some description of the change. Or just map some strings to the script name.