### PR TITLE
fix(lxlweb): prevent error when missing matomo-id

### DIFF
--- a/lxl-web/src/lib/components/CookieConsent.svelte
+++ b/lxl-web/src/lib/components/CookieConsent.svelte
@@ -35,17 +35,15 @@
 			}
 		},
 		onConsent: ({ cookie }) => {
-			if ($matomoTracker && cookie.categories.includes('analytics')) {
-				$matomoTracker.rememberConsentGiven();
+			if (cookie.categories.includes('analytics')) {
+				$matomoTracker?.rememberConsentGiven();
 			}
 		},
 		onChange: ({ cookie }) => {
-			if ($matomoTracker) {
-				if (cookie.categories.includes('analytics')) {
-					$matomoTracker.rememberConsentGiven();
-				} else {
-					$matomoTracker.forgetConsentGiven();
-				}
+			if (cookie.categories.includes('analytics')) {
+				$matomoTracker?.rememberConsentGiven();
+			} else {
+				$matomoTracker?.forgetConsentGiven();
 			}
 		},
 		language: {

--- a/lxl-web/src/lib/components/CookieConsent.svelte
+++ b/lxl-web/src/lib/components/CookieConsent.svelte
@@ -35,15 +35,17 @@
 			}
 		},
 		onConsent: ({ cookie }) => {
-			if (cookie.categories.includes('analytics')) {
+			if ($matomoTracker && cookie.categories.includes('analytics')) {
 				$matomoTracker.rememberConsentGiven();
 			}
 		},
 		onChange: ({ cookie }) => {
-			if (cookie.categories.includes('analytics')) {
-				$matomoTracker.rememberConsentGiven();
-			} else {
-				$matomoTracker.forgetConsentGiven();
+			if ($matomoTracker) {
+				if (cookie.categories.includes('analytics')) {
+					$matomoTracker.rememberConsentGiven();
+				} else {
+					$matomoTracker.forgetConsentGiven();
+				}
 			}
 		},
 		language: {

--- a/lxl-web/src/lib/contexts/matomo.ts
+++ b/lxl-web/src/lib/contexts/matomo.ts
@@ -5,7 +5,7 @@ import { type Writable } from 'svelte/store';
 import { type MatomoTracker } from '$lib/types/matomo';
 import { setContext, getContext } from 'svelte';
 
-const MATOMO_ID: number = +env.PUBLIC_MATOMO_ID;
+const MATOMO_ID = env.PUBLIC_MATOMO_ID && +env.PUBLIC_MATOMO_ID;
 
 const tracker = writable<MatomoTracker>();
 
@@ -30,6 +30,8 @@ export function setMatomoTracker() {
 	if (initializedMatomoTracker) {
 		tracker.set(initializedMatomoTracker);
 		console.info('Matomo tracker set');
+	} else {
+		console.info('Matomo is disabled');
 	}
 }
 

--- a/lxl-web/src/lib/contexts/matomo.ts
+++ b/lxl-web/src/lib/contexts/matomo.ts
@@ -29,9 +29,6 @@ export function setMatomoTracker() {
 	const initializedMatomoTracker = initMatomo();
 	if (initializedMatomoTracker) {
 		tracker.set(initializedMatomoTracker);
-		console.info('Matomo tracker set');
-	} else {
-		console.info('Matomo is disabled');
 	}
 }
 


### PR DESCRIPTION
## Description

### Solves

As a dev you might want to comment out `PUBLIC_MATOMO_ID` so your lousy test searches don't end up in analytics. But doing so result in console errors related to the cookie consent component. This allows us to gracefully disable the tracker.

### Summary of changes

* Add checks before running methods on `$matomoTracker`
