### PR TITLE
chore: Run husky and lint-staged from git repo root

### DIFF
--- a/.github/workflows/codemirror-lang-lxlquery.yml
+++ b/.github/workflows/codemirror-lang-lxlquery.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           node-version: 22
       - name: Install dependencies
+        env:
+          HUSKY: ${{ env.HUSKY }}
         run: npm ci
       - name: Run tests
         run: npm run test

--- a/.github/workflows/lxl-web.yml
+++ b/.github/workflows/lxl-web.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           node-version: 22
       - name: Install dependencies
+        env:
+          HUSKY: ${{ env.HUSKY }}
         run: npm ci
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/supersearch.yml
+++ b/.github/workflows/supersearch.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           node-version: 22
       - name: Install dependencies
+        env:
+          HUSKY: ${{ env.HUSKY }}
         run: npm ci
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,6 @@
+// Skip Husky install in production and CI
+if (process.env.NODE_ENV === "production" || process.env.CI === "true") {
+  process.exit(0);
+}
+const husky = (await import("husky")).default;
+console.log(husky());

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/lxl-web/.husky/pre-commit
+++ b/lxl-web/.husky/pre-commit
@@ -1,1 +1,0 @@
-cd ./lxl-web && npx lint-staged

--- a/lxl-web/.lintstagedrc
+++ b/lxl-web/.lintstagedrc
@@ -1,0 +1,7 @@
+{
+	"*.{js,ts,svelte,css,scss,postcss,md,json}": [
+		"prettier --write --plugin-search-dir=.",
+		"prettier --check --plugin-search-dir=."
+	],
+	"*.{js,ts,svelte}": "eslint"
+}

--- a/lxl-web/package.json
+++ b/lxl-web/package.json
@@ -14,15 +14,7 @@
 		"lint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
 		"test:integration": "playwright test",
-		"test:unit": "vitest",
-		"prepare": "cd .. && husky lxl-web/.husky"
-	},
-	"lint-staged": {
-		"*.{js,ts,svelte,css,scss,postcss,md,json}": [
-			"prettier --write --plugin-search-dir=.",
-			"prettier --check --plugin-search-dir=."
-		],
-		"*.{js,ts,svelte}": "eslint"
+		"test:unit": "vitest"
 	},
 	"devDependencies": {
 		"@axe-core/playwright": "^4.9.1",
@@ -43,10 +35,8 @@
 		"eslint-plugin-svelte": "^2.43.0",
 		"estree-walker": "^3.0.3",
 		"globals": "^15.9.0",
-		"husky": "^9.1.4",
 		"jmespath": "^0.16.0",
 		"js-cookie": "^3.0.5",
-		"lint-staged": "^15.2.9",
 		"lxljs": "^1.1.0",
 		"magic-string": "^0.30.11",
 		"mdsvex": "^0.12.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,11 @@
         "packages/*",
         "lxl-web",
         "lxljs"
-      ]
+      ],
+      "devDependencies": {
+        "husky": "^9.1.6",
+        "lint-staged": "^15.2.10"
+      }
     },
     "lxl-web": {
       "version": "0.0.1",
@@ -37,10 +41,8 @@
         "eslint-plugin-svelte": "^2.43.0",
         "estree-walker": "^3.0.3",
         "globals": "^15.9.0",
-        "husky": "^9.1.4",
         "jmespath": "^0.16.0",
         "js-cookie": "^3.0.5",
-        "lint-staged": "^15.2.9",
         "lxljs": "^1.1.0",
         "magic-string": "^0.30.11",
         "mdsvex": "^0.12.3",
@@ -38177,8 +38179,6 @@
         "eslint": "^9.14.0",
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.12.0",
-        "husky": "^9.1.6",
-        "lint-staged": "^15.2.10",
         "prettier": "^3.3.3",
         "rollup": "^2.60.2",
         "rollup-plugin-dts": "^4.0.1",
@@ -38288,8 +38288,6 @@
         "eslint-plugin-svelte": "^2.36.0",
         "esm-env": "^1.1.4",
         "globals": "^15.0.0",
-        "husky": "^9.1.6",
-        "lint-staged": "^15.2.10",
         "prettier": "^3.3.2",
         "prettier-plugin-css-order": "^2.1.2",
         "prettier-plugin-svelte": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -6,5 +6,12 @@
     "packages/*",
     "lxl-web",
     "lxljs"
-  ]
+  ],
+  "devDependencies": {
+    "husky": "^9.1.6",
+    "lint-staged": "^15.2.10"
+  },
+  "scripts": {
+    "prepare": "husky"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "lint-staged": "^15.2.10"
   },
   "scripts": {
-    "prepare": "husky"
+    "prepare": "node .husky/install.mjs"
   }
 }

--- a/packages/codemirror-lang-lxlquery/.husky/pre-commit
+++ b/packages/codemirror-lang-lxlquery/.husky/pre-commit
@@ -1,1 +1,0 @@
-cd ./packages/codemirror-lang-lxlquery && npx lint-staged

--- a/packages/codemirror-lang-lxlquery/.lintstagedrc
+++ b/packages/codemirror-lang-lxlquery/.lintstagedrc
@@ -1,0 +1,7 @@
+{
+	"*.{js,ts,md,json}": [
+		"prettier --write --plugin-search-dir=.",
+		"prettier --check --plugin-search-dir=."
+	],
+	"*.{js,ts}": "eslint"
+}

--- a/packages/codemirror-lang-lxlquery/package.json
+++ b/packages/codemirror-lang-lxlquery/package.json
@@ -4,16 +4,9 @@
 	"description": "Libris XL query language support for CodeMirror",
 	"scripts": {
 		"test": "vitest",
-		"prepare": "cd ../../ && husky && cd ./packages/codemirror-lang-lxlquery && rollup -c",
+		"prepare": "rollup -c",
 		"lint": "eslint . && prettier --check .",
 		"format": "prettier --write ."
-	},
-	"lint-staged": {
-		"*.{js,ts,md,json}": [
-			"prettier --write --plugin-search-dir=.",
-			"prettier --check --plugin-search-dir=."
-		],
-		"*.{js,ts}": "eslint"
 	},
 	"type": "module",
 	"main": "dist/index.cjs",
@@ -34,8 +27,6 @@
 		"eslint": "^9.14.0",
 		"eslint-config-prettier": "^9.1.0",
 		"globals": "^15.12.0",
-		"husky": "^9.1.6",
-		"lint-staged": "^15.2.10",
 		"prettier": "^3.3.3",
 		"rollup": "^2.60.2",
 		"rollup-plugin-dts": "^4.0.1",

--- a/packages/supersearch/.husky/pre-commit
+++ b/packages/supersearch/.husky/pre-commit
@@ -1,1 +1,0 @@
-cd ./packages/supersearch && npx lint-staged

--- a/packages/supersearch/.lintstagedrc
+++ b/packages/supersearch/.lintstagedrc
@@ -1,0 +1,7 @@
+{
+	"*.{js,ts,svelte,css,scss,postcss,md,json}": [
+		"prettier --write --plugin-search-dir=.",
+		"prettier --check --plugin-search-dir=."
+	],
+	"*.{js,ts,svelte}": "eslint"
+}

--- a/packages/supersearch/package.json
+++ b/packages/supersearch/package.json
@@ -14,14 +14,7 @@
 		"test:unit": "vitest",
 		"lint": "eslint . && prettier --check .",
 		"format": "prettier --write .",
-		"prepare": "cd ../../ && husky && cd ./packages/supersearch && npm run package"
-	},
-	"lint-staged": {
-		"*.{js,ts,svelte,css,scss,postcss,md,json}": [
-			"prettier --write --plugin-search-dir=.",
-			"prettier --check --plugin-search-dir=."
-		],
-		"*.{js,ts,svelte}": "eslint"
+		"prepare": "npm run package"
 	},
 	"files": [
 		"dist",
@@ -59,8 +52,6 @@
 		"eslint-plugin-svelte": "^2.36.0",
 		"esm-env": "^1.1.4",
 		"globals": "^15.0.0",
-		"husky": "^9.1.6",
-		"lint-staged": "^15.2.10",
 		"prettier": "^3.3.2",
 		"prettier-plugin-css-order": "^2.1.2",
 		"prettier-plugin-svelte": "^3.2.6",


### PR DESCRIPTION
## Description

### Solves

Runs [husky](https://typicode.github.io/husky/) and [lint-staged](https://github.com/lint-staged/lint-staged) from the git repo root instead of juggling with different command paths for the different projects. Usage of husky is removed during CI (as it's not needed there).

### Summary of changes

- Run husky and lint-staged from git repo root
- Prevent usage of husky in CI
