### PR TITLE
LXL-4560: Set matomo id using runtime config/env

### DIFF
--- a/cataloging/src/settings.js
+++ b/cataloging/src/settings.js
@@ -18,7 +18,7 @@ export default {
   mockDisplay: import.meta.env.VITE_APP_MOCK_DISPLAY_BOOL === 'true',
   mockHelp: import.meta.env.VITE_APP_MOCK_HELP_BOOL === 'true',
   scopes: 'read write',
-  matomoId: runtimeConfig.MATOMO_ID || import.meta.env.MATOMO_ID,
+  matomoId: runtimeConfig.MATOMO_ID || import.meta.env.VITE_APP_MATOMO_ID,
   appPaths: {
     '/find?': '/search/libris?',
   },

--- a/cataloging/src/settings.js
+++ b/cataloging/src/settings.js
@@ -18,7 +18,7 @@ export default {
   mockDisplay: import.meta.env.VITE_APP_MOCK_DISPLAY_BOOL === 'true',
   mockHelp: import.meta.env.VITE_APP_MOCK_HELP_BOOL === 'true',
   scopes: 'read write',
-  matomoId: 23,
+  matomoId: runtimeConfig.MATOMO_ID || import.meta.env.MATOMO_ID,
   appPaths: {
     '/find?': '/search/libris?',
   },


### PR DESCRIPTION
## Description

### Tickets involved
[LXL-4560](https://kbse.atlassian.net/browse/LXL-4560)

### Solves

Hopefully fixes missing Matomo-tracking on cataloging. We also need to ensure the correct runtime config/environment variables are set on production.

### Summary of changes
- Set matomo id using runtime config/env
