### PR TITLE
LXL-4560: use vue-matomo

### DIFF
--- a/cataloging/.env.development.in
+++ b/cataloging/.env.development.in
@@ -8,3 +8,4 @@ VITE_APP_ID_PATH=https://id-dev.kb.se
 VITE_APP_MOCK_DISPLAY_BOOL=true
 VITE_APP_MOCK_HELP_BOOL=true
 VITE_APP_SITE_ALIAS={"http://id.kb.se.localhost:5000": "https://id.kb.se"}
+VITE_APP_MATOMO_ID=""

--- a/cataloging/.env.e2e
+++ b/cataloging/.env.e2e
@@ -2,4 +2,4 @@ NODE_ENV=production
 VITE_APP_API_PATH=http://libris.kb.se.localhost:5000
 VITE_APP_AUTH_PATH=https://login.libris.kb.se/oauth/verify
 VITE_APP_ID_PATH=http://localhost:5000
-VITE_APP_MATOMO_ID=64
+VITE_APP_MATOMO_ID=""

--- a/cataloging/.env.e2e
+++ b/cataloging/.env.e2e
@@ -2,4 +2,4 @@ NODE_ENV=production
 VITE_APP_API_PATH=http://libris.kb.se.localhost:5000
 VITE_APP_AUTH_PATH=https://login.libris.kb.se/oauth/verify
 VITE_APP_ID_PATH=http://localhost:5000
-VITE_APP_MATOMO_ID=23
+VITE_APP_MATOMO_ID=64

--- a/cataloging/package.json
+++ b/cataloging/package.json
@@ -51,6 +51,7 @@
     "vite": "^5.4.6",
     "vue": "^3.4.38",
     "vue-clipboard2": "^0.3.3",
+    "vue-matomo": "^4.2.0",
     "vue-meta": "^2.4.0",
     "vue-resize": "^2.0.0-alpha.1",
     "vue-router": "^4.4.3",

--- a/cataloging/src/App.vue
+++ b/cataloging/src/App.vue
@@ -231,17 +231,6 @@ export default {
         }
       }
     },
-    injectAnalytics() {
-      // eslint-disable-next-line vue/max-len
-      const analyticsString = 'var _paq=_paq||[];_paq.push(["trackPageView"]),_paq.push(["enableLinkTracking"]),function(){var e="//analytics.kb.se/";_paq.push(["setTrackerUrl",e+"matomo.php"]),_paq.push(["setSiteId","****"]);var a=document,p=a.createElement("script"),t=a.getElementsByTagName("script")[0];p.type="text/javascript",p.async=!0,p.defer=!0,p.src=e+"matomo.js",t.parentNode.insertBefore(p,t)}();';
-      const scriptWithMatomoId = analyticsString.replace('****', this.settings.matomoId);
-      const scriptTag = document.createElement('script');
-
-      scriptTag.setAttribute('type', 'text/javascript');
-      scriptTag.text = scriptWithMatomoId;
-
-      document.head.appendChild(scriptTag);
-    },
     verifyConfig() {
       if (!this.settings.apiPath || typeof this.settings.apiPath === 'undefined') {
         throw new Error('Missing API path in app-config');
@@ -420,7 +409,6 @@ export default {
 
       window.addEventListener('keydown', LayoutUtil.handleFirstTab);
       this.updateTitle();
-      this.injectAnalytics();
     });
 
     window.addEventListener('scroll', (e) => {

--- a/cataloging/src/main.js
+++ b/cataloging/src/main.js
@@ -4,6 +4,7 @@ import { VTooltip } from 'floating-vue';
 import { FocusTrap } from 'focus-trap-vue';
 import 'floating-vue/dist/style.css';
 import VueClipboard from 'vue-clipboard2';
+import VueMatomo from 'vue-matomo'
 import store from './store';
 import router from './router';
 import App from './App.vue';
@@ -19,6 +20,11 @@ app.component('FocusTrap', FocusTrap);
 app.use(router);
 router.app = app;
 app.use(VueClipboard);
+app.use(VueMatomo, {
+  host: 'https://analytics.kb.se',
+  siteId: runtimeConfig.MATOMO_ID || import.meta.env.VITE_APP_MATOMO_ID,
+  router: router
+})
 
 app.component('entity-summary', EntitySummary).component('field', Field);
 

--- a/cataloging/src/main.js
+++ b/cataloging/src/main.js
@@ -20,9 +20,11 @@ app.component('FocusTrap', FocusTrap);
 app.use(router);
 router.app = app;
 app.use(VueClipboard);
-app.use(VueMatomo, {
+
+const matomoId = runtimeConfig.MATOMO_ID || import.meta.env.VITE_APP_MATOMO_ID;
+matomoId && app.use(VueMatomo, {
   host: 'https://analytics.kb.se',
-  siteId: runtimeConfig.MATOMO_ID || import.meta.env.VITE_APP_MATOMO_ID,
+  siteId: matomoId,
   router: router
 })
 

--- a/cataloging/src/settings.js
+++ b/cataloging/src/settings.js
@@ -18,7 +18,7 @@ export default {
   mockDisplay: import.meta.env.VITE_APP_MOCK_DISPLAY_BOOL === 'true',
   mockHelp: import.meta.env.VITE_APP_MOCK_HELP_BOOL === 'true',
   scopes: 'read write',
-  matomoId: runtimeConfig.MATOMO_ID || import.meta.env.MATOMO_ID,
+  matomoId: runtimeConfig.MATOMO_ID || import.meta.env.VITE_APP_MATOMO_ID,
   appPaths: {
     '/find?': '/search/libris?',
   },

--- a/cataloging/src/settings.js
+++ b/cataloging/src/settings.js
@@ -18,7 +18,7 @@ export default {
   mockDisplay: import.meta.env.VITE_APP_MOCK_DISPLAY_BOOL === 'true',
   mockHelp: import.meta.env.VITE_APP_MOCK_HELP_BOOL === 'true',
   scopes: 'read write',
-  matomoId: 23,
+  matomoId: runtimeConfig.MATOMO_ID || import.meta.env.MATOMO_ID,
   appPaths: {
     '/find?': '/search/libris?',
   },

--- a/cataloging/src/settings.js
+++ b/cataloging/src/settings.js
@@ -18,7 +18,6 @@ export default {
   mockDisplay: import.meta.env.VITE_APP_MOCK_DISPLAY_BOOL === 'true',
   mockHelp: import.meta.env.VITE_APP_MOCK_HELP_BOOL === 'true',
   scopes: 'read write',
-  matomoId: runtimeConfig.MATOMO_ID || import.meta.env.VITE_APP_MATOMO_ID,
   appPaths: {
     '/find?': '/search/libris?',
   },

--- a/cataloging/yarn.lock
+++ b/cataloging/yarn.lock
@@ -6693,6 +6693,11 @@ vue-eslint-parser@^9.3.2, vue-eslint-parser@^9.4.3:
     lodash "^4.17.21"
     semver "^7.3.6"
 
+vue-matomo@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/vue-matomo/-/vue-matomo-4.2.0.tgz#d65e369e4ead1d95ef790bef3627512cac3d25e9"
+  integrity sha512-m5hCw7LH3wPDcERaF4sp/ojR9sEx7Rl8TpOyH/4jjQxMF2DuY/q5pO+i9o5Dx+BXLSa9+IQ0qhAbWYRyESQXmA==
+
 vue-meta@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/vue-meta/-/vue-meta-2.4.0.tgz#a419fb4b4135ce965dab32ec641d1989c2ee4845"


### PR DESCRIPTION
## Description

### Tickets involved
[LXL-4560](https://kbse.atlassian.net/browse/LXL-4560)

### Solves

Adds [vue-matomo](https://www.npmjs.com/package/vue-matomo) package. It's a small dependency allowing us to integrate Matomo in a more 'vue-way' instead of injecting the script ourselves. It also tracks page views automatically on navigation using the router, something we'd have to do manually otherwise (and has been missing so far, only first page load is tracked now).

### Summary of changes
- Add & implemement vue-matomo
- Remove old code
