### PR TITLE
LWS-267: Expanded search dialog with synced/mirrored editor state

### DIFF
--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -40,3 +40,31 @@ three`)
 		page.locator('[data-test-id="test1"]').getByRole('textbox').first().locator('div')
 	).toHaveText('One two three');
 });
+
+test('syncs collapsed and expanded editor views', async ({ page }) => {
+	await page.locator('[data-test-id="test1"]').getByRole('textbox').locator('div').click();
+	await page
+		.locator('[data-test-id="test1"]')
+		.getByRole('dialog')
+		.getByRole('textbox')
+		.locator('div')
+		.fill('Hello world!');
+	await page
+		.locator('[data-test-id="test1"]')
+		.getByRole('dialog')
+		.getByRole('textbox')
+		.selectText();
+	await page
+		.locator('[data-test-id="test1"]')
+		.getByRole('dialog')
+		.getByRole('textbox')
+		.press('Escape');
+	await expect(
+		await page.locator('[data-test-id="test1"]').getByRole('textbox').locator('div'),
+		'contents should be synced'
+	).toHaveText('Hello world!');
+	expect(
+		await page.evaluate(() => window.getSelection()?.toString()),
+		'text selection should be synced'
+	).toBe('Hello world!');
+});

--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -29,14 +29,14 @@ test('prevents new line characters (e.g. when pasting multi-lined text', async (
 	context
 }) => {
 	await context.grantPermissions(['clipboard-read', 'clipboard-write']);
-	await page.locator('[data-test-id="test1"]').getByRole('textbox').locator('div').click();
+	await page.locator('[data-test-id="test1"]').getByRole('textbox').first().locator('div').click();
 	await page.evaluate(() =>
 		navigator.clipboard.writeText(`One
-      two
-      three`)
+two
+three`)
 	);
 	await page.keyboard.press(`ControlOrMeta+v`);
-	await expect(page.locator('[data-test-id="test1"]').getByRole('textbox').locator('div')).toHaveText(
-		'One two three'
-	);
+	await expect(
+		page.locator('[data-test-id="test1"]').getByRole('textbox').first().locator('div')
+	).toHaveText('One two three');
 });

--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -48,7 +48,7 @@ test('syncs collapsed and expanded editor views', async ({ page }) => {
 		.getByRole('dialog')
 		.getByRole('textbox')
 		.locator('div')
-		.fill('Hello world!');
+		.fill('Hello world');
 	await page
 		.locator('[data-test-id="test1"]')
 		.getByRole('dialog')
@@ -62,9 +62,14 @@ test('syncs collapsed and expanded editor views', async ({ page }) => {
 	await expect(
 		await page.locator('[data-test-id="test1"]').getByRole('textbox').locator('div'),
 		'contents should be synced'
-	).toHaveText('Hello world!');
+	).toHaveText('Hello world');
 	expect(
 		await page.evaluate(() => window.getSelection()?.toString()),
 		'text selection should be synced'
-	).toBe('Hello world!');
+	).toBe('Hello world');
+	await page.locator('[data-test-id="test1"]').getByRole('textbox').locator('div').dblclick();
+	expect(
+		await page.evaluate(() => window.getSelection()?.toString()),
+		'collapsed editor view allows double-clicking to select words'
+	).toBe('world');
 });

--- a/packages/supersearch/src/lib/components/CodeMirror.svelte
+++ b/packages/supersearch/src/lib/components/CodeMirror.svelte
@@ -14,6 +14,7 @@
 	type CodeMirrorProps = {
 		value?: string;
 		extensions?: Extension[];
+		onclick?: (event: MouseEvent) => void;
 		onchange?: (event: ChangeCodeMirrorEvent) => void;
 		editorView?: EditorView | undefined;
 	};
@@ -21,6 +22,7 @@
 	let {
 		value = '', // value isn't bindable as it can easily cause undo/redo history issues when changing the value from outside – it's preferable to dispatch changes instead
 		extensions = [],
+		onclick = () => {},
 		onchange = () => {},
 		editorView = $bindable()
 	}: CodeMirrorProps = $props();
@@ -35,8 +37,16 @@
 		}
 	});
 
+	const domEventHandler = EditorView.domEventHandlers({
+		click: (event: MouseEvent) => onclick(event)
+	});
+
 	let codemirrorContainerElement: HTMLDivElement | undefined = $state();
-	let extensionsWithBaseHandlers: Extension[] = $derived([updateHandler, ...extensions]);
+	let extensionsWithBaseHandlers: Extension[] = $derived([
+		updateHandler,
+		domEventHandler,
+		...extensions
+	]);
 	let prevExtensions: Extension[] = extensions;
 
 	function createEditorState({ doc, selection }: { doc?: string; selection?: SelectionRange }) {

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -74,6 +74,7 @@
 	}}
 	onchange={handleChangeCodeMirror}
 	bind:editorView={collapsedEditorView}
+	syncedEditorView={expandedEditorView}
 />
 <textarea {value} {name} {form} hidden readonly></textarea>
 <dialog bind:this={dialog} onclose={hideExpandedSearch} onkeydowncapture={handleKeyDown}>
@@ -82,5 +83,6 @@
 		{extensions}
 		onchange={handleChangeCodeMirror}
 		bind:editorView={expandedEditorView}
+		syncedEditorView={collapsedEditorView}
 	/>
 </dialog>

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -30,6 +30,12 @@
 		placeholderCompartment.of(placeholderExtension(placeholder))
 	];
 
+	function handleClickCollapsedEditorView() {
+		setTimeout(() => {
+			if (!dialog?.open) showExpandedSearch(); // use timeout to allow word-selection by double-clicking
+		}, 200);
+	}
+
 	function handleChangeCodeMirror(event: ChangeCodeMirrorEvent) {
 		if (!dialog?.open) {
 			showExpandedSearch();
@@ -75,9 +81,7 @@
 <CodeMirror
 	{value}
 	{extensions}
-	onclick={() => {
-		if (!dialog?.open) showExpandedSearch(); // we should maybe wait for potential double-clicks to allow the user to select whole words by double-clicking...
-	}}
+	onclick={handleClickCollapsedEditorView}
 	onchange={handleChangeCodeMirror}
 	bind:editorView={collapsedEditorView}
 	syncedEditorView={expandedEditorView}

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -38,11 +38,17 @@
 	}
 
 	function showExpandedSearch() {
+		expandedEditorView?.dispatch({
+			selection: collapsedEditorView?.state.selection.main
+		});
 		dialog?.showModal();
 		expandedEditorView?.focus();
 	}
 
 	function hideExpandedSearch() {
+		collapsedEditorView?.dispatch({
+			selection: expandedEditorView?.state.selection.main
+		});
 		dialog?.close();
 		collapsedEditorView?.focus();
 	}
@@ -70,7 +76,7 @@
 	{value}
 	{extensions}
 	onclick={() => {
-		if (!dialog?.open) showExpandedSearch();
+		if (!dialog?.open) showExpandedSearch(); // we should maybe wait for potential double-clicks to allow the user to select whole words by double-clicking...
 	}}
 	onchange={handleChangeCodeMirror}
 	bind:editorView={collapsedEditorView}

--- a/packages/supersearch/src/lib/utils/isViewUpdateFromUserInput.ts
+++ b/packages/supersearch/src/lib/utils/isViewUpdateFromUserInput.ts
@@ -1,0 +1,24 @@
+import type { ViewUpdate } from '@codemirror/view';
+import { Transaction } from '@codemirror/state';
+
+/**
+ * Check if a ViewUpdate contains User Events.
+ *
+ * By shshaw – See: https://discuss.codemirror.net/t/distinguish-user-input-updates/5052/1
+ */
+
+function isViewUpdateFromUserInput(viewUpdate: ViewUpdate) {
+	// Make sure document has changed, ensuring user events like selections don't count.
+	if (viewUpdate.docChanged) {
+		// Check transactions for any that are direct user input, not changes from Y.js or another extension.
+		for (const transaction of viewUpdate.transactions) {
+			// Not using Transaction.isUserEvent because that only checks for a specific User event type ( "input", "delete", etc.). Checking the annotation directly allows for any type of user event.
+			const userEventType = transaction.annotation(Transaction.userEvent);
+			if (userEventType) return userEventType;
+		}
+	}
+
+	return false;
+}
+
+export default isViewUpdateFromUserInput;


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-267](https://kbse.atlassian.net/browse/LWS-267)

### Solves
Adds a expanded search dialog with synced/mirrored editor state. The dialog opens up if the user clicks or types in the collapsed editor view.

The search dialog is still extremely rudimentary but will get more functionality while working on [LWS-265](https://kbse.atlassian.net/browse/LWS-265).


### Summary of changes

- Add expanded search dialog
- Add synced/mirrored editor views
- Keep selection when expanding/collapsing dialog
- Add tests
- Allow word-selection by double-clicking on collapsed editor
