### PR TITLE
feat(supersearch): Improved handling of double-click and triple-click for text selection

### DIFF
--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -72,4 +72,18 @@ test('syncs collapsed and expanded editor views', async ({ page }) => {
 		await page.evaluate(() => window.getSelection()?.toString()),
 		'collapsed editor view allows double-clicking to select words'
 	).toBe('world');
+	await page
+		.locator('[data-test-id="test1"]')
+		.getByRole('dialog')
+		.getByRole('textbox')
+		.press('Escape');
+	await page
+		.locator('[data-test-id="test1"]')
+		.getByRole('textbox')
+		.locator('div')
+		.click({ clickCount: 3 });
+	expect(
+		await page.evaluate(() => window.getSelection()?.toString()),
+		'collapsed editor view allows triple-clicking to select entire lines'
+	).toBe('Hello world');
 });


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-267](https://kbse.atlassian.net/browse/LWS-267)

### Solves
Improves the handling of text-selection when double-clicking and triple-clicking on text in the collapsed editor.

Double-clicks results in the selection of [the word at the given position](https://codemirror.net/docs/ref/#state.EditorState.wordAt) while triple-clicks selects the entire line.


### Summary of changes

- Improve handling of double-click and triple-clicks for text selection
