### PR TITLE
LWS-263: Supersearch pills

### DIFF
--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -12,8 +12,8 @@ term {
 Group { "(" term* ")" } 
 
 BooleanQuery { 
-  (freetext | Qualifier) BooleanOperator (freetext | Qualifier) 
-  (BooleanOperator (freetext | Qualifier))+?
+  (freetext | Qualifier) booleanOperator (freetext | Qualifier) 
+  (booleanOperator (freetext | Qualifier))+?
 }
 
 Qualifier {
@@ -43,7 +43,7 @@ freetext {
 
   CompareOperator { ">" | "<" | ">=" | "<=" }
 
-  BooleanOperator { "AND" | "OR" | "NOT" }
+  booleanOperator { "AND" | "OR" | "NOT" }
 
   Wildcard { "*"+ }
 
@@ -51,7 +51,7 @@ freetext {
 
   space { @whitespace+ }
 
-  @precedence {BooleanOperator, reserved, identifier}
+  @precedence {booleanOperator, reserved, identifier}
 }
 
 @detectDelim

--- a/packages/supersearch/src/lib/components/QualifierComponent.svelte
+++ b/packages/supersearch/src/lib/components/QualifierComponent.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import type { Qualifier } from '$lib/extensions/qualifier.js';
+	import type { Qualifier } from '$lib/extensions/qualifierPlugin.js';
 	import { onMount } from 'svelte';
 
 	type QualifierWidgetProps = {
@@ -47,7 +47,7 @@
 		editableElem?.removeEventListener('focusout', onFocusout)
 	}
 	
-	// take over cursor, input from codemirror
+	// take over cursor & input from codemirror
 	function focusValueInput(elem: HTMLElement) {
 		elem?.focus();
 		elem && window.getSelection()?.selectAllChildren(elem);
@@ -112,12 +112,6 @@
 		align-items: center;
 	}
 
-	/* .type > span {
-    &::first-letter {
-      text-transform: capitalize;
-    }
-  } */
-
 	.qualifier-value {
 		/* display: inline-flex;
 		align-items: center;
@@ -132,10 +126,6 @@
 	.qualifier-value:focus-visible {
 		outline: 0;
 	}
-
-	/* .value > span {
-    align-self: center;
-  } */
 
 	a {
 		display: flex;

--- a/packages/supersearch/src/lib/components/QualifierComponent.svelte
+++ b/packages/supersearch/src/lib/components/QualifierComponent.svelte
@@ -1,105 +1,105 @@
 <script lang="ts">
-  // import type { Qualifier } from '$lib/utils/supersearch/qualifiers';
-  // import IconPerson from '~icons/mdi/person-circle';
-  // import IconClose from '~icons/mdi/remove';
-  import { page } from '$app/stores';
-  import type { Qualifier } from '$lib/extensions/qualifier.js';
+	// import type { Qualifier } from '$lib/utils/supersearch/qualifiers';
+	// import IconPerson from '~icons/mdi/person-circle';
+	// import IconClose from '~icons/mdi/remove';
+	import { page } from '$app/stores';
+	import type { Qualifier } from '$lib/extensions/qualifier.js';
 
-  type QualifierWidgetProps = {
-    qualifier: Qualifier;
-    range: { from: number; to: number };
-  };
+	type QualifierWidgetProps = {
+		qualifier: Qualifier;
+		range: { from: number; to: number };
+	};
 
-  let { qualifier, range }: QualifierWidgetProps = $props();
+	let { qualifier, range }: QualifierWidgetProps = $props();
 
-  let removeUrl = $derived.by(() => {
-    const url = new URL($page.url);
-    const _q = $page.url.searchParams.get('_q');
-    if (_q) {
-      url.searchParams.set('_q', _q.slice(0, range.from) + _q.slice(range.to)); // remove qualifier part
-    }
-    return url;
-  });
+	let removeUrl = $derived.by(() => {
+		const url = new URL($page.url);
+		const _q = $page.url.searchParams.get('_q');
+		if (_q) {
+			url.searchParams.set('_q', _q.slice(0, range.from) + _q.slice(range.to)); // remove qualifier part
+		}
+		return url;
+	});
 </script>
 
 <span class="qualifier">
-  <span class="qualifier-key">
-    {qualifier.keyLabel || qualifier.key}
-  </span>
-  <span class="qualifier-operator">
-    {qualifier.operator}
-  </span>
-  <span class="qualifier-value" contenteditable="true">
-    {qualifier.valueLabel || qualifier.value}
-  </span>
-  <a href={removeUrl.toString()} tabindex="-1">
-    <!-- <IconClose style="font-size:14px;" /> -->
-    X
-  </a>
+	<span class="qualifier-key">
+		{qualifier.keyLabel || qualifier.key}
+	</span>
+	<span class="qualifier-operator">
+		{qualifier.operator}
+	</span>
+	<span class="qualifier-value" contenteditable="true">
+		{qualifier.valueLabel || qualifier.value}
+	</span>
+	<a href={removeUrl.toString()} tabindex="-1">
+		<!-- <IconClose style="font-size:14px;" /> -->
+		X
+	</a>
 </span>&nbsp;
 
 <style>
-  .qualifier {
-    display: inline-flex;
-    align-items: stretch;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    background: rgba(14, 113, 128, 0.15);
-    padding: 0;
-    max-width: 25vw;
-    overflow: hidden;
-    font-weight: 500;
-    line-height: 1;
-    white-space: nowrap;
-  }
+	.qualifier {
+		display: inline-flex;
+		align-items: stretch;
+		border: 1px solid var(--border-color);
+		border-radius: 4px;
+		background: rgba(14, 113, 128, 0.15);
+		padding: 0;
+		max-width: 25vw;
+		overflow: hidden;
+		font-weight: 500;
+		line-height: 1;
+		white-space: nowrap;
+	}
 
-  .qualifier-key {
-    display: inline-flex;
-    align-items: center;
-    padding-right: var(--padding-2xs);
-    padding-left: var(--padding-2xs);
-    font-size: var(--font-size-2xs);
-  }
+	.qualifier-key {
+		display: inline-flex;
+		align-items: center;
+		padding-right: var(--padding-2xs);
+		padding-left: var(--padding-2xs);
+		font-size: var(--font-size-2xs);
+	}
 
-  /* .type > span {
+	/* .type > span {
     &::first-letter {
       text-transform: capitalize;
     }
   } */
 
-  .qualifier-value {
-    display: inline-flex;
-    align-items: center;
-    min-width: 0;
-    overflow: hidden;
-    color: #0e7180;
-    font-size: var(--font-size-2xs);
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+	.qualifier-value {
+		display: inline-flex;
+		align-items: center;
+		min-width: 0;
+		overflow: hidden;
+		color: #0e7180;
+		font-size: var(--font-size-2xs);
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
 
-  /* .value > span {
+	/* .value > span {
     align-self: center;
   } */
 
-  .qualifier-value :global(svg) {
-    color: var(--color-link);
-    font-size: var(--font-size-sm);
-  }
+	.qualifier-value :global(svg) {
+		color: var(--color-link);
+		font-size: var(--font-size-sm);
+	}
 
-  a {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    cursor: pointer;
-    border: none;
-    padding: 1px;
-    min-width: 24px;
-    min-height: 24px;
-    color: var(--color-link);
+	a {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		cursor: pointer;
+		border: none;
+		padding: 1px;
+		min-width: 24px;
+		min-height: 24px;
+		color: var(--color-link);
 
-    &:hover {
-      background: rgba(0, 0, 0, 0.05);
-    }
-  }
+		&:hover {
+			background: rgba(0, 0, 0, 0.05);
+		}
+	}
 </style>

--- a/packages/supersearch/src/lib/components/QualifierComponent.svelte
+++ b/packages/supersearch/src/lib/components/QualifierComponent.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  // import type { Qualifier } from '$lib/utils/supersearch/qualifiers';
+  // import IconPerson from '~icons/mdi/person-circle';
+  // import IconClose from '~icons/mdi/remove';
+  import { page } from '$app/stores';
+  import type { Qualifier } from '$lib/extensions/qualifier.js';
+
+  type QualifierWidgetProps = {
+    qualifier: Qualifier;
+    range: { from: number; to: number };
+  };
+
+  let { qualifier, range }: QualifierWidgetProps = $props();
+
+  let removeUrl = $derived.by(() => {
+    const url = new URL($page.url);
+    const _q = $page.url.searchParams.get('_q');
+    if (_q) {
+      url.searchParams.set('_q', _q.slice(0, range.from) + _q.slice(range.to)); // remove qualifier part
+    }
+    return url;
+  });
+</script>
+
+<span class="qualifier">
+  <span class="qualifier-key">
+    {qualifier.keyLabel || qualifier.key}
+  </span>
+  <span class="qualifier-operator">
+    {qualifier.operator}
+  </span>
+  <span class="qualifier-value" contenteditable="true">
+    {qualifier.valueLabel || qualifier.value}
+  </span>
+  <a href={removeUrl.toString()} tabindex="-1">
+    <!-- <IconClose style="font-size:14px;" /> -->
+    X
+  </a>
+</span>&nbsp;
+
+<style>
+  .qualifier {
+    display: inline-flex;
+    align-items: stretch;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background: rgba(14, 113, 128, 0.15);
+    padding: 0;
+    max-width: 25vw;
+    overflow: hidden;
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  .qualifier-key {
+    display: inline-flex;
+    align-items: center;
+    padding-right: var(--padding-2xs);
+    padding-left: var(--padding-2xs);
+    font-size: var(--font-size-2xs);
+  }
+
+  /* .type > span {
+    &::first-letter {
+      text-transform: capitalize;
+    }
+  } */
+
+  .qualifier-value {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    overflow: hidden;
+    color: #0e7180;
+    font-size: var(--font-size-2xs);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* .value > span {
+    align-self: center;
+  } */
+
+  .qualifier-value :global(svg) {
+    color: var(--color-link);
+    font-size: var(--font-size-sm);
+  }
+
+  a {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    border: none;
+    padding: 1px;
+    min-width: 24px;
+    min-height: 24px;
+    color: var(--color-link);
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.05);
+    }
+  }
+</style>

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -5,6 +5,7 @@
 	import { type LanguageSupport } from '@codemirror/language';
 	import submitFormOnEnterKey from '$lib/extensions/submitFormOnEnterKey.js';
 	import preventNewLine from '$lib/extensions/preventNewLine.js';
+	import { qualifierPlugin } from '$lib/extensions/qualifier.js';
 
 	interface Props {
 		name: string;
@@ -32,6 +33,7 @@
 		preventNewLine({ replaceWithSpace: true }),
 		...(language ? [language] : []),
 		placeholderCompartment.of(placeholderExtension(placeholder)),
+		qualifierPlugin
 	];
 
 	function handleChangeCodeMirror(event: ChangeCodeMirrorEvent) {

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import CodeMirror, { type ChangeCodeMirrorEvent } from '$lib/components/CodeMirror.svelte';
-	import { EditorView, placeholder as placeholderExtension } from '@codemirror/view';
+	import { EditorView, placeholder as placeholderExtension, keymap } from '@codemirror/view';
 	import { Compartment, type Extension } from '@codemirror/state';
 	import { type LanguageSupport } from '@codemirror/language';
 	import submitFormOnEnterKey from '$lib/extensions/submitFormOnEnterKey.js';
 	import preventNewLine from '$lib/extensions/preventNewLine.js';
-	import { qualifierPlugin } from '$lib/extensions/qualifier.js';
+	import { qualifierPlugin } from '$lib/extensions/qualifierPlugin.js';
+	import { defaultKeymap } from "@codemirror/commands";
 
 	interface Props {
 		name: string;
@@ -29,6 +30,8 @@
 	let prevPlaceholder = placeholder;
 
 	const extensions = [
+		// For atomic ranges to work. TODO customize
+		keymap.of(defaultKeymap),
 		submitFormOnEnterKey(form),
 		preventNewLine({ replaceWithSpace: true }),
 		...(language ? [language] : []),

--- a/packages/supersearch/src/lib/extensions/qualifier.ts
+++ b/packages/supersearch/src/lib/extensions/qualifier.ts
@@ -1,0 +1,106 @@
+import {
+  Decoration,
+  EditorView,
+  ViewPlugin,
+  ViewUpdate,
+  WidgetType,
+  type DecorationSet
+} from '@codemirror/view';
+import { syntaxTree } from '@codemirror/language';
+import { mount } from 'svelte';
+import QualifierComponent from '$lib/components/QualifierComponent.svelte';
+
+export type Qualifier = {
+  key: string;
+  keyLabel?: string;
+  value: string;
+  valueLabel?: string;
+  operator: string;
+}
+
+class QualifierWidget extends WidgetType {
+  constructor(
+    readonly qualifier: Qualifier,
+    readonly range: { from: number; to: number }
+  ) {
+    super();
+  }
+
+  // eq(other: QualifierWidget) {
+  //   return (
+  //     this.qualifier.type == other.qualifier.type &&
+  //     this.qualifier.value == other.qualifier.value &&
+  //     this.range == other.range
+  //   );
+  // }
+
+  toDOM() {
+    const container = document.createElement('span');
+    container.style.cssText = `position: relative;`;
+    mount(QualifierComponent, {
+      target: container,
+      props: {
+        qualifier: this.qualifier,
+        range: this.range
+      }
+    });
+    return container;
+  }
+}
+
+function qualifiers(view: EditorView) {
+  const widgets = [];
+
+  syntaxTree(view.state).iterate({
+    enter: (node) => {
+      if (node.name === 'Qualifier') {
+        const qKeyNode = node.node.getChild('QualifierKey');
+        const qOperatorNode = qKeyNode?.nextSibling;
+        const qValueNode = node.node.getChild('QualifierValue');
+
+        const doc = view.state.doc.toString();
+
+        const qKeyText = doc.slice(qKeyNode?.from, qKeyNode?.to)
+        const qOperatorText = doc.slice(qOperatorNode?.from, qOperatorNode?.to)
+        const qValueText = doc.slice(qValueNode?.from, qValueNode?.to)
+
+        const qualifier = { key: qKeyText, value: qValueText, operator: qOperatorText };
+        const range = { from: node.from, to: node.to };
+
+        const decoration = Decoration.replace({
+          inclusiveStart: true,
+          inclusiveEnd: true,
+          widget: new QualifierWidget(qualifier, range)
+        });
+        widgets.push(decoration.range(node.from, node.to));
+      }
+    }
+  });
+  return Decoration.set(widgets);
+}
+
+export const qualifierPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    constructor(view: EditorView) {
+      this.decorations = qualifiers(view);
+    }
+
+    update(update: ViewUpdate) {
+      if (
+        update.docChanged ||
+        update.viewportChanged ||
+        syntaxTree(update.startState) != syntaxTree(update.state)
+      ) {
+        this.decorations = qualifiers(update.view);
+      }
+    }
+  },
+  {
+    decorations: (instance) => instance.decorations,
+    provide: (plugin) =>
+      EditorView.atomicRanges.of((view) => {
+        return view.plugin(plugin)?.decorations || Decoration.none;
+      })
+  }
+);

--- a/packages/supersearch/src/lib/extensions/qualifier.ts
+++ b/packages/supersearch/src/lib/extensions/qualifier.ts
@@ -12,9 +12,7 @@ import QualifierComponent from '$lib/components/QualifierComponent.svelte';
 
 export type Qualifier = {
 	key: string;
-	keyLabel?: string;
 	value: string | undefined;
-	valueLabel?: string;
 	operator: string;
 };
 
@@ -107,9 +105,9 @@ export const qualifierPlugin = ViewPlugin.fromClass(
 	},
 	{
 		decorations: (instance) => instance.decorations,
-		// provide: (plugin) =>
-		// 	EditorView.atomicRanges.of((view) => {
-		// 		return view.plugin(plugin)?.decorations || Decoration.none;
-		// 	})
+		provide: (plugin) =>
+			EditorView.atomicRanges.of((view) => {
+				return view.plugin(plugin)?.decorations || Decoration.none;
+			})
 	}
 );

--- a/packages/supersearch/src/lib/extensions/qualifier.ts
+++ b/packages/supersearch/src/lib/extensions/qualifier.ts
@@ -1,106 +1,106 @@
 import {
-  Decoration,
-  EditorView,
-  ViewPlugin,
-  ViewUpdate,
-  WidgetType,
-  type DecorationSet
+	Decoration,
+	EditorView,
+	ViewPlugin,
+	ViewUpdate,
+	WidgetType,
+	type DecorationSet
 } from '@codemirror/view';
 import { syntaxTree } from '@codemirror/language';
 import { mount } from 'svelte';
 import QualifierComponent from '$lib/components/QualifierComponent.svelte';
 
 export type Qualifier = {
-  key: string;
-  keyLabel?: string;
-  value: string;
-  valueLabel?: string;
-  operator: string;
-}
+	key: string;
+	keyLabel?: string;
+	value: string;
+	valueLabel?: string;
+	operator: string;
+};
 
 class QualifierWidget extends WidgetType {
-  constructor(
-    readonly qualifier: Qualifier,
-    readonly range: { from: number; to: number }
-  ) {
-    super();
-  }
+	constructor(
+		readonly qualifier: Qualifier,
+		readonly range: { from: number; to: number }
+	) {
+		super();
+	}
 
-  // eq(other: QualifierWidget) {
-  //   return (
-  //     this.qualifier.type == other.qualifier.type &&
-  //     this.qualifier.value == other.qualifier.value &&
-  //     this.range == other.range
-  //   );
-  // }
+	// eq(other: QualifierWidget) {
+	//   return (
+	//     this.qualifier.type == other.qualifier.type &&
+	//     this.qualifier.value == other.qualifier.value &&
+	//     this.range == other.range
+	//   );
+	// }
 
-  toDOM() {
-    const container = document.createElement('span');
-    container.style.cssText = `position: relative;`;
-    mount(QualifierComponent, {
-      target: container,
-      props: {
-        qualifier: this.qualifier,
-        range: this.range
-      }
-    });
-    return container;
-  }
+	toDOM() {
+		const container = document.createElement('span');
+		container.style.cssText = `position: relative;`;
+		mount(QualifierComponent, {
+			target: container,
+			props: {
+				qualifier: this.qualifier,
+				range: this.range
+			}
+		});
+		return container;
+	}
 }
 
 function qualifiers(view: EditorView) {
-  const widgets = [];
+	const widgets = [];
 
-  syntaxTree(view.state).iterate({
-    enter: (node) => {
-      if (node.name === 'Qualifier') {
-        const qKeyNode = node.node.getChild('QualifierKey');
-        const qOperatorNode = qKeyNode?.nextSibling;
-        const qValueNode = node.node.getChild('QualifierValue');
+	syntaxTree(view.state).iterate({
+		enter: (node) => {
+			if (node.name === 'Qualifier') {
+				const qKeyNode = node.node.getChild('QualifierKey');
+				const qOperatorNode = qKeyNode?.nextSibling;
+				const qValueNode = node.node.getChild('QualifierValue');
 
-        const doc = view.state.doc.toString();
+				const doc = view.state.doc.toString();
 
-        const qKeyText = doc.slice(qKeyNode?.from, qKeyNode?.to)
-        const qOperatorText = doc.slice(qOperatorNode?.from, qOperatorNode?.to)
-        const qValueText = doc.slice(qValueNode?.from, qValueNode?.to)
+				const qKeyText = doc.slice(qKeyNode?.from, qKeyNode?.to);
+				const qOperatorText = doc.slice(qOperatorNode?.from, qOperatorNode?.to);
+				const qValueText = doc.slice(qValueNode?.from, qValueNode?.to);
 
-        const qualifier = { key: qKeyText, value: qValueText, operator: qOperatorText };
-        const range = { from: node.from, to: node.to };
+				const qualifier = { key: qKeyText, value: qValueText, operator: qOperatorText };
+				const range = { from: node.from, to: node.to };
 
-        const decoration = Decoration.replace({
-          inclusiveStart: true,
-          inclusiveEnd: true,
-          widget: new QualifierWidget(qualifier, range)
-        });
-        widgets.push(decoration.range(node.from, node.to));
-      }
-    }
-  });
-  return Decoration.set(widgets);
+				const decoration = Decoration.replace({
+					inclusiveStart: true,
+					inclusiveEnd: true,
+					widget: new QualifierWidget(qualifier, range)
+				});
+				widgets.push(decoration.range(node.from, node.to));
+			}
+		}
+	});
+	return Decoration.set(widgets);
 }
 
 export const qualifierPlugin = ViewPlugin.fromClass(
-  class {
-    decorations: DecorationSet;
-    constructor(view: EditorView) {
-      this.decorations = qualifiers(view);
-    }
+	class {
+		decorations: DecorationSet;
+		constructor(view: EditorView) {
+			this.decorations = qualifiers(view);
+		}
 
-    update(update: ViewUpdate) {
-      if (
-        update.docChanged ||
-        update.viewportChanged ||
-        syntaxTree(update.startState) != syntaxTree(update.state)
-      ) {
-        this.decorations = qualifiers(update.view);
-      }
-    }
-  },
-  {
-    decorations: (instance) => instance.decorations,
-    provide: (plugin) =>
-      EditorView.atomicRanges.of((view) => {
-        return view.plugin(plugin)?.decorations || Decoration.none;
-      })
-  }
+		update(update: ViewUpdate) {
+			if (
+				update.docChanged ||
+				update.viewportChanged ||
+				syntaxTree(update.startState) != syntaxTree(update.state)
+			) {
+				this.decorations = qualifiers(update.view);
+			}
+		}
+	},
+	{
+		decorations: (instance) => instance.decorations,
+		provide: (plugin) =>
+			EditorView.atomicRanges.of((view) => {
+				return view.plugin(plugin)?.decorations || Decoration.none;
+			})
+	}
 );


### PR DESCRIPTION
## Description

An early draft to discuss if this could be a way to pursue or will end up in a world of pain.

I've created a plugin with widget decorations that iterates the node tree and, upon finding a `qualifier`, breaks down its parts and passes them to a svelte component (pretty much like before). 

The new thing here is that the component essentially steals the focus from codeMirror and lets us type the value from there, and then updates it back to cm.

This aims to solve for example: 
* typing inside pills
* Typing Astrid Lindgren but treating it as "Astrid Lindgren" (adding quotes that we can later hide)
* Prevent editing values that are display labels
* etc

... maybe this can all be done within codemirror, but would propbaby require many different decorations etc for different parts.

... Also, the term 'qualifier' is now being hardcoded into supersearch. Maybe it's reasonable that we require other languages to use this term?  