### PR TITLE
fix(cataloging): Some records are slow to copy

### DIFF
--- a/cataloging/src/store.js
+++ b/cataloging/src/store.js
@@ -184,12 +184,16 @@ const store = createStore({
     },
     addToQuoted(state, data) {
       const quoted = state.inspector.data.quoted ? cloneDeep(state.inspector.data.quoted) : {};
-      quoted[data['@id']] = data;
-      (data.sameAs || []).forEach((sameAs) => {
-        if (sameAs.hasOwnProperty('@id')) {
-          quoted[sameAs['@id']] = data;
-        }
-      });
+
+      const things = Array.isArray(data) ? data : [data];
+      things.forEach(thing => {
+        quoted[thing['@id']] = thing;
+        (thing.sameAs || []).forEach((sameAs) => {
+          if (sameAs.hasOwnProperty('@id')) {
+            quoted[sameAs['@id']] = thing;
+          }
+        });
+      })
 
       state.inspector.data.quoted = quoted;
     },

--- a/cataloging/src/utils/data.js
+++ b/cataloging/src/utils/data.js
@@ -189,11 +189,12 @@ export async function fetchMissingLinkedToQuoted(obj, store) {
   return Promise
     .allSettled(missingLinks.map((l) => HttpUtil.getDocument(l, undefined, embellished)))
     .then((results) => {
-      results.filter((r) => r.status === 'fulfilled').map((r) => r.value.data).forEach((doc) => {
-        if (doc) {
-          doc['@graph'].forEach((o) => store.commit('addToQuoted', o));
-        }
-      });
+      const things = results.filter((r) => r.status === 'fulfilled')
+        .map((r) => r.value.data)
+        .filter(doc => doc)
+        .flatMap(doc => doc['@graph']);
+
+      store.commit('addToQuoted', things);
     })
     .catch((e) => console.log(e));
 }


### PR DESCRIPTION
When copying a record, any missing references are fetched and added to quoted. Copying a record with many links was slow (so slow that you get a browser warning). Because each thing added to quoted would be a commit on the store and also clone the whole quoted object. Instead make it possible to pass an array of things to `addToQuoted` to be commited at once.

[LXL-4576](https://kbse.atlassian.net/browse/LXL-4576)