### PR TITLE
Fix helpdocs heading ID generation

### DIFF
--- a/cataloging/package.json
+++ b/cataloging/package.json
@@ -42,6 +42,7 @@
     "lodash-es": "^4.17.14",
     "lxljs": "link:../lxljs",
     "marked": "^14.0.0",
+    "marked-gfm-heading-id": "^4.1.1",
     "md5": "^2.2.1",
     "path": "^0.12.7",
     "portal-vue": "^3.0.0",

--- a/cataloging/src/views/Help.vue
+++ b/cataloging/src/views/Help.vue
@@ -1,11 +1,15 @@
 <script>
 import { orderBy } from 'lodash-es';
 import { marked } from 'marked';
+import { gfmHeadingId } from 'marked-gfm-heading-id';
 import DOMPurify from 'dompurify';
 import { mapGetters } from 'vuex';
 import * as StringUtil from 'lxljs/string';
 import { translatePhrase } from '@/utils/filters';
 import { formatDate, getRelativeTime } from '@/utils/datetime';
+
+marked.use(gfmHeadingId());
+
 export default {
   name: 'help-component',
   data() {

--- a/cataloging/yarn.lock
+++ b/cataloging/yarn.lock
@@ -4010,6 +4010,11 @@ git-describe@^4.0.4:
   optionalDependencies:
     semver "^5.6.0"
 
+github-slugger@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-2.0.0.tgz#52cf2f9279a21eb6c59dd385b410f0c0adda8f1a"
+  integrity sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==
+
 glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -4926,6 +4931,13 @@ map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
   integrity sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==
+
+marked-gfm-heading-id@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/marked-gfm-heading-id/-/marked-gfm-heading-id-4.1.1.tgz#c6a46a10272745f63c6b03439dc239543a8324e8"
+  integrity sha512-EeQZieAQmsI6c2tWLx0ETd0VjPwLV8qi+HT0dIsfVMERm0rCIuXfRvZXJbo1SgUi++lmuR1LVY+QzgNiLNvVpw==
+  dependencies:
+    github-slugger "^2.0.0"
 
 marked@^14.0.0:
   version "14.0.0"


### PR DESCRIPTION
The fragment links on the help pages stopped working because `marked` moved heading ID generation to a separate package: https://www.npmjs.com/package/marked-gfm-heading-id

https://kbse.atlassian.net/browse/LXL-4589