### PR TITLE
fix(cataloging): Fix fragment link scroll issue in Firefox

### DIFF
--- a/cataloging/src/router.js
+++ b/cataloging/src/router.js
@@ -12,6 +12,9 @@ const router = createRouter({
     if (savedPosition) {
       return savedPosition;
     }
+    if (to.hash) {
+      return { el: to.hash };
+    }
     return { top: 0, left: 0 };
   },
   routes: [


### PR DESCRIPTION
In Firefox if you go to e.g. https://libris-dev.kb.se/katalogisering/help/workflow-work you have to click on "Verkstyp" twice for it to actually scroll there. Not an issue in Chrome. This seems to fix it.