### PR TITLE
fix(supersearch): Allow deletion of inserted quotes

### DIFF
--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertQuotes.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertQuotes.ts
@@ -4,7 +4,6 @@ import { syntaxTree } from '@codemirror/language';
 /**
  * Moves cursor into an empty quote on falsy qualifier value
  */
-
 const insertQuotes = (tr: Transaction) => {
 	let foundEmptyQValue = false;
 	const changes: TransactionSpec = {
@@ -20,7 +19,7 @@ const insertQuotes = (tr: Transaction) => {
 		enter: (node) => {
 			if (node.name === 'Qualifier') {
 				const qValue = node.node.getChild('QualifierValue');
-				if (!qValue) {
+				if (!qValue && tr.isUserEvent('input')) {
 					foundEmptyQValue = true;
 					return true;
 				}


### PR DESCRIPTION
## Description

### Solves

Quotes are inserted when user has typed a qualifier and the value is still empty. But weirdness happens when user is trying to delete the quotes and we try to add them again. This allows deletion by only adding them on input.

(Maybe in the future we hide the quotes from the user altogether. But for now, this seems less buggy)
