### PR TITLE
fix(cataloging-bulk): retry preview on empty, non-complete or error

### DIFF
--- a/cataloging/src/components/care/bulk-changes.vue
+++ b/cataloging/src/components/care/bulk-changes.vue
@@ -495,6 +495,7 @@ export default {
         this.completePreview = !(result['_complete'] === false);
         if (!this.completePreview) {
           if (isEmptyResult) {
+            this.previewError = translatePhrase('This might take a while...')
             setTimeout(() => {
               if (this.currentPreviewUrl === fetchUrl && !this.completePreview) {
                 this.getPreviewFromUrl(fetchUrl);

--- a/cataloging/src/components/care/bulk-changes.vue
+++ b/cataloging/src/components/care/bulk-changes.vue
@@ -70,6 +70,7 @@ export default {
       fullPreview: {},
       fullPreviewData: {'@type': 'Instance'},
       fullPreviewDiff: {},
+      previewError: null,
       showOverwriteWarning: false,
       showConfirmRunModal: false,
       completePreview: true,
@@ -469,7 +470,8 @@ export default {
     },
     getPreviewFromUrl(fetchUrl) {
       this.currentPreviewUrl = fetchUrl;
-      fetch(fetchUrl).then((response) => response.json()).then((result) => {
+      HttpUtil.fetchJson(fetchUrl).then((result) => {
+        this.previewError = null;
 
         // Form preview
         if (typeof result.changeSets !== 'undefined') {
@@ -489,11 +491,22 @@ export default {
         }
         this.totalItems = result.totalItems;
 
-        if (result['_complete'] === false) {
-          this.getMinimalPreviewFromUrl(fetchUrl);
+        const isEmptyResult = this.totalItems === 0 || typeof this.totalItems === 'undefined';
+        this.completePreview = !(result['_complete'] === false);
+        if (!this.completePreview) {
+          if (isEmptyResult) {
+            setTimeout(() => {
+              if (this.currentPreviewUrl === fetchUrl && !this.completePreview) {
+                this.getPreviewFromUrl(fetchUrl);
+              }
+            }, 1000);
+            return
+          } else {
+            this.getMinimalPreviewFromUrl(fetchUrl);
+          }
         }
         
-        if (this.totalItems === 0 || typeof this.totalItems === 'undefined') {
+        if (isEmptyResult) {
           this.resetPreviewData();
           return;
         } else {
@@ -532,12 +545,18 @@ export default {
         this.loadingPreview.previous = false;
         this.initializingPreview = false;
       }, (error) => {
-        this.initializingPreview = false;
         console.error('Failed to fetch preview', error);
+        this.previewError = error;
+        setTimeout(() => {
+          if (this.currentPreviewUrl === fetchUrl) {
+            this.getPreviewFromUrl(fetchUrl);
+          }
+        }, 1000);
       });
     },
     getMinimalPreviewFromUrl(fetchUrl) {
-      fetch(fetchUrl).then((response) => response.json()).then((result) => {
+      HttpUtil.fetchJson(fetchUrl).then((result) => {
+        this.previewError = null;
         this.totalItems = result.totalItems;
         if (result['_complete'] === false) {
           this.completePreview = false;
@@ -550,8 +569,13 @@ export default {
           this.completePreview = true;
         }
       }, (error) => {
-        this.initializingPreview = false;
         console.error('Failed to fetch preview', error);
+        this.previewError = error;
+        setTimeout(() => {
+          if (this.currentPreviewUrl === fetchUrl) {
+            this.getMinimalPreviewFromUrl(fetchUrl);
+          }
+        }, 1000);
       });
     },
     async triggerRunBulkChange() {
@@ -875,6 +899,9 @@ export default {
           :initializing-preview="initializingPreview"
           @onActive="focusPreview"
         />
+        <span v-if="this.previewError">
+          <i class="fa fa-warning" /> {{ this.previewError }}
+        </span>
       </div>
       <div class="BulkChanges-result" v-if="isRunningOrFinished">
         <div>

--- a/cataloging/src/resources/json/i18n.json
+++ b/cataloging/src/resources/json/i18n.json
@@ -465,6 +465,7 @@
     "Show as bulk change" : "Visa som körning",
     "Show as record" : "Visa som post",
     "To see bulk changes you need to switch to a sigel with access.": "För att se körningar behöver du växla till ett sigel med rättigheter.",
-    "Back to create bulk change": "Tillbaka till skapa massändring"
+    "Back to create bulk change": "Tillbaka till skapa massändring",
+    "This might take a while...": "Det här verkar ta lite tid..."
   }
 }

--- a/cataloging/src/utils/http.js
+++ b/cataloging/src/utils/http.js
@@ -215,3 +215,11 @@ export function fetchPlainEtags(ids) {
     .all(ids.map((id) => getDocument(id, undefined, false)))
     .then((responses) => Object.fromEntries(responses.map((r) => [r.uri, r.ETag])));
 }
+
+export async function fetchJson (url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return await response.json();
+}


### PR DESCRIPTION
Bulk preview
* try again on response with totalItems: 0, _complete: false
* try again on connection / HTTP error + show a small error indicator

![bild](https://github.com/user-attachments/assets/ec403619-1ebc-4b62-9c9c-4131100d32fb)

### Tickets involved
[LXL-4598](https://kbse.atlassian.net/browse/LXL-4598)