### PR TITLE
fix(lxlquery): Allow groups in boolean query

### DIFF
--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -12,8 +12,8 @@ term {
 Group { "(" term* ")" } 
 
 BooleanQuery { 
-  (freetext | Qualifier) booleanOperator (freetext | Qualifier) 
-  (booleanOperator (freetext | Qualifier))+?
+  (freetext | Qualifier | Group ) booleanOperator (freetext | Qualifier | Group ) 
+  (booleanOperator (freetext | Qualifier | Group ))+?
 }
 
 Qualifier {

--- a/packages/codemirror-lang-lxlquery/test/cases.txt
+++ b/packages/codemirror-lang-lxlquery/test/cases.txt
@@ -93,6 +93,17 @@ Query(
 )
 
 
+# BooleanQuery with groups
+
+(rummet röda) OR (rummet vita)
+
+==>
+
+Query(
+  BooleanQuery(Group(...),Group(...))
+)
+
+
 # BooleanQuery - erroneous
 
 OR AND sommar


### PR DESCRIPTION
## Description

### Solves

A `BooleanQuery` can contain `Group`, which we did not specify in the grammar.

<img width="385" alt="Skärmavbild 2024-12-11 kl  14 51 32" src="https://github.com/user-attachments/assets/5cd401a5-63bc-4442-9515-abb52a182f27" />

<img width="385" alt="Skärmavbild 2024-12-11 kl  14 50 31" src="https://github.com/user-attachments/assets/6e9a8b4d-0813-4c83-99be-7d292a94db03" />

### Summary of changes

* Addition to lxlquery grammar
* Add a test