### PR TITLE
LWS-273: feat(lxl-web, supersearch): Calculate edited ranges of query using cursor position

### DIFF
--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -64,11 +64,13 @@
 			language={lxlQuery}
 			placeholder={$page.data.t('search.search')}
 			endpoint={'/api/supersearch'}
-			queryFn={(query) =>
-				new URLSearchParams({
+			queryFn={(query, cursor) => {
+				return new URLSearchParams({
 					_q: query,
-					_limit: '10'
-				})}
+					_limit: '10',
+					cursor: cursor.toString()
+				});
+			}}
 			paginationQueryFn={handlePaginationQuery}
 			extensions={[lxlQualifierPlugin]}
 		>

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
@@ -4,10 +4,19 @@ import type { RequestHandler } from './$types.ts';
 import { LxlLens } from '$lib/types/display';
 import { getSupportedLocale } from '$lib/i18n/locales.js';
 import { toString } from '$lib/utils/xl.js';
+import getEditedRanges from './getEditedRanges.js';
 
 export const GET: RequestHandler = async ({ url, params, locals }) => {
 	const displayUtil = locals.display;
 	const locale = getSupportedLocale(params?.lang);
+
+	const query = url.searchParams.get('_q');
+	const cursor = parseInt(url.searchParams.get('cursor') || '0', 10);
+
+	if (query && Number.isInteger(cursor)) {
+		const editedRanges = getEditedRanges(query, cursor);
+		console.log('editedRanges:', editedRanges, query.slice(editedRanges.from, editedRanges.to));
+	}
 
 	const findResponse = await fetch(`${env.API_URL}/find?${url.searchParams.toString()}`);
 	const data = await findResponse.json();

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedRanges.test.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedRanges.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import getEditedRanges from './getEditedRanges';
+
+describe('getEditedRanges', () => {
+	it('gets the edited range for a simple free-text query', () => {
+		const query = 'hello';
+		const editedRanges = getEditedRanges(query, 5);
+		expect(editedRanges).toEqual({ from: 0, to: 5 });
+		expect(query.slice(editedRanges.from, editedRanges.to)).toBe('hello');
+	});
+
+	it('gets the edited range (with included ranges of qualifier parts) when editing a qualifier', () => {
+		const query = 'hasTitle:"a"';
+		const editedRanges = getEditedRanges(query, 11);
+		expect(editedRanges).toEqual({
+			from: 0,
+			to: 12,
+			qualifierKey: {
+				from: 0,
+				to: 8
+			},
+			qualifierOperator: {
+				from: 8,
+				to: 9
+			},
+			qualifierValue: {
+				from: 9,
+				to: 12
+			}
+		});
+		expect(query.slice(editedRanges.from, editedRanges.to)).toBe('hasTitle:"a"');
+		expect(query.slice(editedRanges.qualifierKey?.from, editedRanges.qualifierKey?.to)).toBe(
+			'hasTitle'
+		);
+		expect(
+			query.slice(editedRanges.qualifierOperator?.from, editedRanges.qualifierOperator?.to)
+		).toBe(':');
+		expect(query.slice(editedRanges.qualifierValue?.from, editedRanges.qualifierValue?.to)).toBe(
+			'"a"'
+		);
+	});
+
+	it('gets the edited range when editing a string', () => {
+		expect(getEditedRanges('"hello"', 6)).toEqual({
+			from: 0,
+			to: 7
+		});
+	});
+
+	it('gets the edited range when editing a group', () => {
+		expect(getEditedRanges('(hello world)', 9)).toEqual({
+			from: 0,
+			to: 13
+		});
+	});
+
+	it('gets the edited range when editing a part after a qualifier', () => {
+		expect(getEditedRanges('hasTitle:"a" hello', 18)).toEqual({
+			from: 12,
+			to: 18
+		});
+	});
+
+	it('gets the edited range when editing a part after a qualifier', () => {
+		expect(getEditedRanges('hasTitle:"a" hello', 18)).toEqual({
+			from: 12,
+			to: 18
+		});
+	});
+
+	it('gets the edited range when editing a part before a qualifier', () => {
+		expect(getEditedRanges('hello hasTitle:"a"', 5)).toEqual({
+			from: 0,
+			to: 6
+		});
+	});
+
+	it('gets the edited range when editing a part surrounded by qualifiers', () => {
+		expect(getEditedRanges('hasTitle:"a" hello hasTitle:"b', 18)).toEqual({
+			from: 12,
+			to: 19
+		});
+	});
+
+	it('gets the edited range when editing a part after a group', () => {
+		expect(getEditedRanges('(hi) hello', 7)).toEqual({
+			from: 4,
+			to: 10
+		});
+	});
+
+	it('gets the edited range when editing a part before a group', () => {
+		expect(getEditedRanges('hello (hi)', 3)).toEqual({
+			from: 0,
+			to: 6
+		});
+	});
+
+	it('gets the edited range when editing a part surrounded by groups', () => {
+		expect(getEditedRanges('(hi) hello (hej)', 7)).toEqual({
+			from: 4,
+			to: 11
+		});
+	});
+});

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedRanges.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedRanges.ts
@@ -1,0 +1,85 @@
+import { lxlQuery } from 'codemirror-lang-lxlquery';
+
+type Range = {
+	from: number;
+	to: number;
+};
+
+function getEditedRanges(
+	query: string,
+	cursor: number
+): Range & {
+	qualifierKey?: Range;
+	qualifierOperator?: Range;
+	qualifierValue?: Range;
+} {
+	const tree = lxlQuery.language.parser.parse(query);
+	const innerNode = tree.resolveInner(cursor);
+
+	/**
+	 * Return `from` and `to` from qualifier parts if editing qualifier value
+	 */
+	if (innerNode.parent?.type.is('QualifierValue')) {
+		const qualifierNode = innerNode.parent.parent;
+		const qualifierKeyNode = qualifierNode?.getChild('QualifierKey');
+		const qualifierOperatorNode = qualifierNode?.getChild('QualifierOperator');
+		const qualiferValueNode = qualifierNode?.getChild('QualifierValue');
+		if (qualifierNode) {
+			return {
+				from: qualifierNode.from,
+				to: qualifierNode.to,
+				...(qualifierKeyNode && {
+					qualifierKey: { from: qualifierKeyNode.from, to: qualifierKeyNode.to }
+				}),
+				...(qualifierOperatorNode && {
+					qualifierOperator: { from: qualifierOperatorNode.from, to: qualifierOperatorNode.to }
+				}),
+				...(qualiferValueNode && {
+					qualifierValue: { from: qualiferValueNode.from, to: qualiferValueNode.to }
+				})
+			};
+		}
+	}
+
+	let from = 0;
+	let to = query.length;
+
+	/**
+	 * Adjust `from` and `to` if enclosed qualifiers or groups are found BEFORE the edited part
+	 * */
+	tree.iterate({
+		from: 0,
+		to: cursor,
+		enter(node) {
+			if (node.type.is('Qualifier') || node.type.is('Group')) {
+				if (node.to > cursor) {
+					from = node.from;
+					to = node.to;
+				} else {
+					from = node.to;
+				}
+			}
+		}
+	});
+
+	/**
+	 * Adjust `from` and `to` if enclosed qualifiers or groups are found AFTER the edited part
+	 * */
+	tree.iterate({
+		from,
+		to,
+		enter(node) {
+			if (
+				(node.type.is('Qualifier') || node.type.is('Group')) &&
+				node.from > cursor &&
+				node.from < to
+			) {
+				to = node.from;
+			}
+		}
+	});
+
+	return { from, to };
+}
+
+export default getEditedRanges;

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -46,6 +46,7 @@
 	let collapsedEditorView: EditorView | undefined = $state();
 	let expandedEditorView: EditorView | undefined = $state();
 	let dialog: HTMLDialogElement | undefined = $state();
+	let cursor: number = $state(0);
 
 	let placeholderCompartment = new Compartment();
 	let prevPlaceholder = placeholder;
@@ -59,7 +60,7 @@
 
 	$effect(() => {
 		if (value) {
-			search.debouncedFetchData(value);
+			search.debouncedFetchData(value, cursor);
 		}
 	});
 
@@ -81,6 +82,7 @@
 			showExpandedSearch();
 		}
 		value = event.value;
+		cursor = event.cursor;
 	}
 
 	function showExpandedSearch() {

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -59,7 +59,7 @@
 	});
 
 	$effect(() => {
-		if (value) {
+		if (value && value.trim()) {
 			search.debouncedFetchData(value, cursor);
 		}
 	});

--- a/packages/supersearch/src/lib/types/superSearch.ts
+++ b/packages/supersearch/src/lib/types/superSearch.ts
@@ -1,6 +1,6 @@
 import type { JSONValue } from './json.js';
 
-export type QueryFunction = (value: string) => URLSearchParams;
+export type QueryFunction = (value: string, cursor: number) => URLSearchParams;
 export type PaginationQueryFunction = (
 	searchParams: URLSearchParams,
 	data: JSONValue

--- a/packages/supersearch/src/lib/utils/useSearchRequest.svelte.ts
+++ b/packages/supersearch/src/lib/utils/useSearchRequest.svelte.ts
@@ -56,14 +56,17 @@ export function useSearchRequest({
 		}
 	}
 
-	async function fetchData(query: string) {
-		data = await _fetchData(queryFn(query));
+	async function fetchData(query: string, cursor: number) {
+		data = await _fetchData(queryFn(query, cursor));
 		if (paginationQueryFn) {
 			paginatedData = [data];
 		}
 	}
 
-	const debouncedFetchData = debounce((query: string) => fetchData(query), debouncedWait);
+	const debouncedFetchData = debounce(
+		(query: string, cursor: number) => fetchData(query, cursor),
+		debouncedWait
+	);
 
 	async function fetchMoreData() {
 		if (moreSearchParams) {


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-273](https://kbse.atlassian.net/browse/LWS-273)

### Solves

Calculates the edited ranges of a query using the cursor positon. This is done to get relevant suggestions inside the SuperSearch component.

### Summary of changes

- Get editedRanges by [parsing the syntax tree server-side](https://github.com/libris/lxlviewer/commit/fc57145f6f359041e70d9c8e52afde1cf3a64d36#diff-014b753960bf2598d1b2db3f7b82fc2b8b4589dac85d17672eaa0fc6c696ea31R17)
- Add tests
- Only do search request if trimmed value isn't empty


