### PR TITLE
chore(supersearch, lxlquery): Add watch scripts

### DIFF
--- a/packages/codemirror-lang-lxlquery/README.md
+++ b/packages/codemirror-lang-lxlquery/README.md
@@ -1,21 +1,23 @@
-# CodeMirror 6 language package template
+# LXLQuery language package
 
-This is an example repository containing a minimal [CodeMirror](https://codemirror.net/6/) language support package. The idea is to clone it, rename it, and edit it to create support for a new language.
+A [CodeMirror](https://codemirror.net/6/) language support package for the Libris XL Query language.
 
-Things you'll need to do (see the [language support example](https://codemirror.net/6/examples/lang-package/) for a more detailed tutorial):
+- `src/syntax.grammar` contains the grammar covering the language. See the [Lezer system guide](https://lezer.codemirror.net/docs/guide/#writing-a-grammar) for information on this file format.
 
-- `git grep EXAMPLE` and replace all instances with your language name.
+- `src/index.ts` adds metadata to the language parser.
 
-- Rewrite the grammar in `src/syntax.grammar` to cover your language. See the [Lezer system guide](https://lezer.codemirror.net/docs/guide/#writing-a-grammar) for information on this file format.
+- `test/cases.txt` contains the grammar tests.
 
-- Adjust the metadata in `src/index.ts` to work with your new grammar.
+## Develop
 
-- Adjust the grammar tests in `test/cases.txt`.
+`npm run watch` watches for changes in `/src` and builds the language.
 
-- Build (`npm run prepare`) and test (`npm test`).
+See the [language support example](https://codemirror.net/6/examples/lang-package/) for a detailed tutorial on development.
 
-- Rewrite this readme file.
+## Build
 
-- Optionally add a license.
+`npm run prepare`
 
-- Publish. Put your package on npm under a name like `codemirror-lang-EXAMPLE`.
+## Test
+
+`npm run test`

--- a/packages/codemirror-lang-lxlquery/package.json
+++ b/packages/codemirror-lang-lxlquery/package.json
@@ -6,7 +6,8 @@
 		"test": "vitest",
 		"prepare": "rollup -c",
 		"lint": "eslint . && prettier --check .",
-		"format": "prettier --write ."
+		"format": "prettier --write .",
+		"watch": "rollup -c --watch"
 	},
 	"type": "module",
 	"main": "dist/index.cjs",

--- a/packages/supersearch/README.md
+++ b/packages/supersearch/README.md
@@ -50,6 +50,12 @@ npm run dev -- --open
 
 Everything inside `src/lib` is part of the library, everything inside `src/routes` can be used as a showcase or preview app.
 
+To watch `src/lib` and rebuild when it changes:
+
+```bash
+npm run watch
+```
+
 ## Building
 
 To build the library:

--- a/packages/supersearch/package.json
+++ b/packages/supersearch/package.json
@@ -14,7 +14,8 @@
 		"test:unit": "vitest",
 		"lint": "eslint . && prettier --check .",
 		"format": "prettier --write .",
-		"prepare": "npm run package"
+		"prepare": "npm run package",
+		"watch": "svelte-kit sync && svelte-package -w"
 	},
 	"files": [
 		"dist",


### PR DESCRIPTION
## Description

### Solves

Running `npm run watch` in /supersearch and /codemirror-lang-lxlquery enables instant updates in lxlweb on changes.

### Summary of changes
* Add watch script
* Update readme (changed the language readme from boilerplate to something more customized)
