### PR TITLE
fix(lxlquery): Support wildcard in qualifierValue

### DIFF
--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -38,7 +38,7 @@
 	user-select: none;
 }
 
-.lxl-boolean-query {
+.lxl-boolean-operator {
 	color: rgb(128, 0, 128);
 }
 

--- a/packages/codemirror-lang-lxlquery/src/index.ts
+++ b/packages/codemirror-lang-lxlquery/src/index.ts
@@ -8,7 +8,7 @@ import { styleTags, Tag, tagHighlighter } from '@lezer/highlight';
  * for the matching syntax
  */
 const tags = {
-	BooleanQuery: Tag.define('BooleanQuery'),
+	BooleanOperator: Tag.define('BooleanOperator'),
 	Wildcard: Tag.define('Wildcard'),
 	Qualifier: Tag.define('Qualifier'),
 	QualifierKey: Tag.define('QualifierKey'),
@@ -17,12 +17,12 @@ const tags = {
 };
 
 const tagMatcher = {
-	BooleanQuery: tags.BooleanQuery,
-	Wildcard: tags.Wildcard,
+	'BooleanQuery/BooleanOperator': tags.BooleanOperator, // only highlight operator within valid query
+	'Query/Wildcard': tags.Wildcard,
 	'Qualifier/...': tags.Qualifier,
-	'QualifierKey/...': tags.QualifierKey,
-	'QualifierOperator/...': tags.QualifierOperator,
-	'QualifierValue/...': tags.QualifierValue
+	'QualifierKey!': tags.QualifierKey,
+	'QualifierOperator!': tags.QualifierOperator,
+	'QualifierValue!': tags.QualifierValue
 };
 
 export const lxlQueryLanguage = LRLanguage.define({
@@ -34,7 +34,7 @@ export const lxlQueryLanguage = LRLanguage.define({
 });
 
 const highlighter = tagHighlighter([
-	{ tag: tags.BooleanQuery, class: 'lxl-boolean-query' },
+	{ tag: tags.BooleanOperator, class: 'lxl-boolean-operator' },
 	{ tag: tags.Wildcard, class: 'lxl-wildcard' },
 	{ tag: tags.Qualifier, class: 'lxl-qualifier' },
 	{ tag: tags.QualifierKey, class: 'lxl-qualifier-key' },

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -25,7 +25,7 @@ QualifierKey {
 }
 
 QualifierValue {
-  Identifier | String | Number | Group
+  Identifier Wildcard? | String | Number | Group | Wildcard
 }
 
 QualifierOperator {
@@ -49,7 +49,7 @@ freetext {
 
   BooleanOperator { "AND" | "OR" | "NOT" }
 
-  Wildcard { "*"+ }
+  Wildcard { "*" }
 
   reserved { "includeEplikt" | "includePreliminary" }
 

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -25,7 +25,7 @@ QualifierKey {
 }
 
 QualifierValue {
-  Identifier Wildcard? | String | Number | Group | Wildcard
+  Identifier Wildcard? | String | Number Wildcard? | Group | Wildcard
 }
 
 QualifierOperator {

--- a/packages/codemirror-lang-lxlquery/test/cases.txt
+++ b/packages/codemirror-lang-lxlquery/test/cases.txt
@@ -82,6 +82,30 @@ Query(
 )
 
 
+# Qualifier with wildcard
+
+titel:kulturarv*
+
+==>
+
+Query(
+  Qualifier(QualifierKey(...), QualifierOperator(...), QualifierValue(Identifier, Wildcard))
+)
+
+# Qualifier with wildcard (invalid)
+
+subject*:vinter
+
+==>
+
+Query(
+  Identifier,
+  Wildcard,
+  ⚠(...),
+  Identifier
+)
+
+
 # BooleanQuery
 
 sommar OR vinter NOT vår
@@ -104,7 +128,7 @@ Query(
 )
 
 
-# BooleanQuery - erroneous
+# BooleanQuery (invalid)
 
 OR AND sommar
 
@@ -131,7 +155,12 @@ träd* bibliografi:"sigel:DST" NOT typ:Text
 ==>
 
 Query(
-  Identifier, Wildcard, BooleanQuery(Qualifier(QualifierKey(Identifier), QualifierOperator(EqualOperator), QualifierValue(String)), BooleanOperator, Qualifier(QualifierKey(Identifier), QualifierOperator(EqualOperator), QualifierValue(Identifier)))
+  Identifier, 
+  Wildcard, 
+  BooleanQuery(
+    Qualifier(QualifierKey(Identifier), QualifierOperator(EqualOperator), QualifierValue(String)), 
+    BooleanOperator, 
+    Qualifier(QualifierKey(Identifier), QualifierOperator(EqualOperator), QualifierValue(Identifier)))
 )
 
 
@@ -165,7 +194,11 @@ image:*
 
 ==>
 
-Query(Qualifier(...))
+Query(
+  Qualifier(
+    QualifierKey(...), QualifierOperator(...), QualifierValue(Wildcard)
+  )
+)
 
 
 # Other filters: include E-plikt


### PR DESCRIPTION
## Description
### Solves

* Support a Wildcard as sole `QualifierValue`. For example 'Endast omslagsbild' filter `image:*`
* Support a Wildcard ending QualifierValue identifier and number. For example `title:kulturarv*`
* Also fixes syntax highlighting of `BooleanOperator` within a `BooleanQuery`.

### Summary of changes

* Update grammar
* Update/add grammar test
* Update tag highlighter
* Update `lxlquery.css`
