### PR TITLE
fix(lxlweb): Provide lang to supersearch endpoint

### DIFF
--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -88,7 +88,7 @@
 			bind:value={q}
 			language={lxlQuery}
 			placeholder={$page.data.t('search.search')}
-			endpoint={'/api/supersearch'}
+			endpoint={`/api/${$page.data.locale}/supersearch`}
 			queryFn={(query, cursor) => {
 				return new URLSearchParams({
 					_q: query,


### PR DESCRIPTION
## Description

### Solves

* Supersearch labels shown in the currenly selected language.

### Summary of changes

* Provide lang to supersearch endpoint
