### PR TITLE
fix(lxlweb): Continue showing error page for _invalid when not using Supersearch

### DIFF
--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -134,7 +134,7 @@ type MappingObj = { [key in SearchOperators]: SearchMapping[] | string | FramedD
 
 export interface SearchMapping extends MappingObj {
 	alias: string;
-	property?: ObjectProperty | DatatypeProperty | PropertyChainAxiom;
+	property?: ObjectProperty | DatatypeProperty | PropertyChainAxiom | InvalidProperty;
 	object?: FramedData;
 	up: { '@id': string };
 }
@@ -146,6 +146,11 @@ interface ObjectProperty {
 export interface DatatypeProperty {
 	'@type': 'DataTypeProperty';
 	'@id': string;
+}
+
+interface InvalidProperty {
+	'@type': '_Invalid';
+	label: string;
 }
 
 interface PropertyChainAxiom {

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -96,8 +96,7 @@ export function displayMappings(
 				// when encountering an invalid property in order to provide feedback.
 				// TODO remove this when Supersearch is fully implemented.
 				const useSuperSearch = env?.PUBLIC_USE_SUPERSEARCH === 'true';
-				const _propertyType = m.property?.['@type'];
-				if (!useSuperSearch && _propertyType === '_Invalid') {
+				if (!useSuperSearch && m.property?.['@type'] === '_Invalid') {
 					error(400, {
 						message: `Invalid query, please check the documentation. Unrecognized property alias: ${m.property?.label ?? ''}`
 					});


### PR DESCRIPTION
## Description

### Solves


Frontend tests were failing because of API changes added in https://github.com/libris/librisxl/pull/1541
Basically the lack of `@id` for an invalid property caused the 500 error page to show instead of expected 400.

However, when fixing this and using 'old search' the resulting page for an invalid query is now this:
<img width="1510" alt="Skärmavbild 2024-12-20 kl  10 08 56" src="https://github.com/user-attachments/assets/294dac68-436c-4063-9e17-f35f6fdd96f4" />

We figured as long as supersearch is not fully implemented, users still want some kind of feedback when using invalid queries. Therefore manually (temporarily) showing the same error page as before. This also makes tests pass.

ping @olovy @kwahlin 

### Summary of changes

* Add interface for `InvalidProperty`
* Add `@id` check in search.ts
* In `search.ts`, when encountering an `_invalid` property, show error page with same message as before.
