### PR TITLE
feat(lxlquery): Improve grammar + lint

### DIFF
--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -34,9 +34,7 @@
 }
 
 .lxl-invalid,
-.lxl-invalid .lxl-qualifier,
-/* todo rename/remove */
-.invalid > .lxl-qualifier {
+.lxl-invalid .lxl-qualifier {
 	text-decoration: underline 1px solid;
 	text-decoration-color: rgba(255, 0, 0, 0.75);
 	text-decoration-style: wavy;

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -1,5 +1,5 @@
 .lxl-qualifier {
-	display: inline-flex;
+	display: inline-block;
 	color: rgb(0, 128, 0);
 	background: rgba(14, 113, 128, 0.1);
 	padding-top: 3px;
@@ -12,8 +12,8 @@
 	border-bottom-left-radius: 5px;
 }
 
-.lxl-qualifier-value,
-.lxl-qualifier-remove {
+.lxl-qualifier-remove,
+.lxl-qualifier-value:last-of-type {
 	padding-right: 5px;
 	border-top-right-radius: 5px;
 	border-bottom-right-radius: 5px;
@@ -28,39 +28,35 @@
 	border-radius: 0;
 }
 
-.invalid,
-.invalid > .lxl-qualifier-key {
-	text-decoration: underline 1px solid;
-	text-decoration-color: rgba(255, 0, 0, 0.75);
-	text-decoration-style: wavy;
-}
-
 .atomic {
 	background: rgba(14, 113, 128, 0.2);
 	user-select: none;
 }
 
-.lxl-boolean-operator {
-	color: rgb(128, 0, 128);
+.invalid,
+.invalid > .lxl-qualifier {
+	text-decoration: underline 1px solid;
+	text-decoration-color: rgba(255, 0, 0, 0.75);
+	text-decoration-style: wavy;
 }
 
-.invalid .lxl-boolean-operator {
+/* .invalid .lxl-boolean-operator {
 	color: inherit;
-}
+} */
 
-.lxl-wildcard {
-	color: rgb(128, 0, 128);
-}
-
-.lxl-negative .lxl-qualifier {
-	background-color: rgba(230, 172, 172, 0.5);
-	color: #523314;
-}
-
-.lxl-negative .atomic {
-	background-color: rgba(230, 172, 172, 1);
-}
-
-.lxl-negative {
+.lxl-uquery {
 	color: #cf5a5a;
+}
+
+/* .lxl-qualifier.lxl-uquery {
+	background-color: rgba(213, 0, 0, 0.15);
+	color: #523314;
+} */
+
+/* .atomic.lxl-uquery {
+	background-color: rgba(213, 0, 0, 0.3);
+} */
+
+.lxl-boolean-operator {
+	color: #5955ff;
 }

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -33,29 +33,14 @@
 	user-select: none;
 }
 
-.invalid,
+.lxl-invalid,
+.lxl-invalid .lxl-qualifier,
+/* todo rename/remove */
 .invalid > .lxl-qualifier {
 	text-decoration: underline 1px solid;
 	text-decoration-color: rgba(255, 0, 0, 0.75);
 	text-decoration-style: wavy;
 }
-
-/* .invalid .lxl-boolean-operator {
-	color: inherit;
-} */
-
-.lxl-uquery {
-	color: #cf5a5a;
-}
-
-/* .lxl-qualifier.lxl-uquery {
-	background-color: rgba(213, 0, 0, 0.15);
-	color: #523314;
-} */
-
-/* .atomic.lxl-uquery {
-	background-color: rgba(213, 0, 0, 0.3);
-} */
 
 .lxl-boolean-operator {
 	color: #5955ff;

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -40,6 +40,11 @@
 	text-decoration: underline 1px solid;
 	text-decoration-color: rgba(255, 0, 0, 0.75);
 	text-decoration-style: wavy;
+	text-underline-offset: 2px;
+}
+
+.lxl-not-term {
+	color: #b53a3a;
 }
 
 .lxl-boolean-operator {

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -28,6 +28,7 @@
 	border-radius: 0;
 }
 
+.invalid,
 .invalid > .lxl-qualifier-key {
 	text-decoration: underline 1px solid;
 	text-decoration-color: rgba(255, 0, 0, 0.75);
@@ -43,6 +44,23 @@
 	color: rgb(128, 0, 128);
 }
 
+.invalid .lxl-boolean-operator {
+	color: inherit;
+}
+
 .lxl-wildcard {
 	color: rgb(128, 0, 128);
+}
+
+.lxl-negative .lxl-qualifier {
+	background-color: rgba(230, 172, 172, 0.5);
+	color: #523314;
+}
+
+.lxl-negative .atomic {
+	background-color: rgba(230, 172, 172, 1);
+}
+
+.lxl-negative {
+	color: #cf5a5a;
 }

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedRanges.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedRanges.ts
@@ -50,7 +50,13 @@ function getEditedRanges(query: string, cursor: number): EditedRanges {
 		from: 0,
 		to: cursor,
 		enter(node) {
-			if (node.type.is('Qualifier') || node.type.is('Group') || node.type.is('BooleanOperator')) {
+			if (
+				node.type.is('Qualifier') ||
+				node.type.is('Group') ||
+				node.type.is('AndOperator') ||
+				node.type.is('OrOperator') ||
+				node.type.is('NotOperator')
+			) {
 				if (node.to > cursor) {
 					from = node.from;
 					to = node.to;
@@ -69,7 +75,11 @@ function getEditedRanges(query: string, cursor: number): EditedRanges {
 		to,
 		enter(node) {
 			if (
-				(node.type.is('Qualifier') || node.type.is('Group') || node.type.is('BooleanOperator')) &&
+				(node.type.is('Qualifier') ||
+					node.type.is('Group') ||
+					node.type.is('AndOperator') ||
+					node.type.is('OrOperator') ||
+					node.type.is('NotOperator')) &&
 				node.from > cursor &&
 				node.from < to
 			) {

--- a/packages/codemirror-lang-lxlquery/src/index.ts
+++ b/packages/codemirror-lang-lxlquery/src/index.ts
@@ -14,7 +14,7 @@ const tags = {
 	QualifierOperator: Tag.define('QualifierOperator'),
 	QualifierValue: Tag.define('QualifierValue'),
 	BooleanOperator: Tag.define('BooleanOperator'),
-	UQuery: Tag.define('UQuery')
+	UTerm: Tag.define('UTerm')
 };
 
 const tagMatcher = {
@@ -22,17 +22,9 @@ const tagMatcher = {
 	'QualifierKey!': tags.QualifierKey,
 	'QualifierOperator!': tags.QualifierOperator,
 	'QualifierValue/...': tags.QualifierValue,
-	BooleanOperator: tags.BooleanOperator,
-	'UQuery/...': tags.UQuery
+	'AndOperator OrOperator': tags.BooleanOperator,
+	'UTerm/...': tags.UTerm
 };
-
-export const lxlQueryLanguage = LRLanguage.define({
-	name: 'Libris XL query',
-	parser: parser.configure({
-		props: [styleTags(tagMatcher)]
-	}),
-	languageData: {}
-});
 
 const highlighter = tagHighlighter([
 	{ tag: tags.Qualifier, class: 'lxl-qualifier' },
@@ -40,13 +32,20 @@ const highlighter = tagHighlighter([
 	{ tag: tags.QualifierOperator, class: 'lxl-qualifier-operator' },
 	{ tag: tags.QualifierValue, class: 'lxl-qualifier-value' },
 	{ tag: tags.BooleanOperator, class: 'lxl-boolean-operator' },
-	{ tag: tags.UQuery, class: 'lxl-uquery' }
+	{ tag: tags.UTerm, class: 'lxl-not-term' }
 ]);
 
-const highlighterExtensions = [syntaxHighlighting(highlighter), lxlLinter];
+export const lxlQueryLanguage = LRLanguage.define({
+	name: 'Libris XL query',
+	parser: parser.configure({
+		props: [styleTags(tagMatcher)]
+	})
+});
+
+const extensions = [syntaxHighlighting(highlighter), lxlLinter];
 
 /**
  * Libris XL query language together with highlighter extensions
  * that adds CSS classes for certain nodes
  */
-export const lxlQuery = new LanguageSupport(lxlQueryLanguage, highlighterExtensions);
+export const lxlQuery = new LanguageSupport(lxlQueryLanguage, extensions);

--- a/packages/codemirror-lang-lxlquery/src/index.ts
+++ b/packages/codemirror-lang-lxlquery/src/index.ts
@@ -9,21 +9,21 @@ import lxlLinter from './lxlLinter';
  * for the matching syntax
  */
 const tags = {
-	BooleanOperator: Tag.define('BooleanOperator'),
-	Wildcard: Tag.define('Wildcard'),
 	Qualifier: Tag.define('Qualifier'),
 	QualifierKey: Tag.define('QualifierKey'),
 	QualifierOperator: Tag.define('QualifierOperator'),
-	QualifierValue: Tag.define('QualifierValue')
+	QualifierValue: Tag.define('QualifierValue'),
+	BooleanOperator: Tag.define('BooleanOperator'),
+	UQuery: Tag.define('UQuery')
 };
 
 const tagMatcher = {
-	'NotOperator BooleanQuery/BooleanOperator': tags.BooleanOperator, // only highlight operator within valid query
-	'Query/Wildcard': tags.Wildcard,
 	'Qualifier/...': tags.Qualifier,
 	'QualifierKey!': tags.QualifierKey,
 	'QualifierOperator!': tags.QualifierOperator,
-	'QualifierValue!': tags.QualifierValue
+	'QualifierValue/...': tags.QualifierValue,
+	BooleanOperator: tags.BooleanOperator,
+	'UQuery/...': tags.UQuery
 };
 
 export const lxlQueryLanguage = LRLanguage.define({
@@ -35,12 +35,12 @@ export const lxlQueryLanguage = LRLanguage.define({
 });
 
 const highlighter = tagHighlighter([
-	{ tag: tags.BooleanOperator, class: 'lxl-boolean-operator' },
-	{ tag: tags.Wildcard, class: 'lxl-wildcard' },
 	{ tag: tags.Qualifier, class: 'lxl-qualifier' },
 	{ tag: tags.QualifierKey, class: 'lxl-qualifier-key' },
 	{ tag: tags.QualifierOperator, class: 'lxl-qualifier-operator' },
-	{ tag: tags.QualifierValue, class: 'lxl-qualifier-value' }
+	{ tag: tags.QualifierValue, class: 'lxl-qualifier-value' },
+	{ tag: tags.BooleanOperator, class: 'lxl-boolean-operator' },
+	{ tag: tags.UQuery, class: 'lxl-uquery' }
 ]);
 
 const highlighterExtensions = [syntaxHighlighting(highlighter), lxlLinter];

--- a/packages/codemirror-lang-lxlquery/src/index.ts
+++ b/packages/codemirror-lang-lxlquery/src/index.ts
@@ -1,6 +1,7 @@
 import { parser } from './syntax.grammar';
 import { LRLanguage, LanguageSupport, syntaxHighlighting } from '@codemirror/language';
 import { styleTags, Tag, tagHighlighter } from '@lezer/highlight';
+import lxlLinter from './lxlLinter';
 
 /**
  * Custom tags attached to the language parser
@@ -17,7 +18,7 @@ const tags = {
 };
 
 const tagMatcher = {
-	'BooleanQuery/BooleanOperator': tags.BooleanOperator, // only highlight operator within valid query
+	'NotOperator BooleanQuery/BooleanOperator': tags.BooleanOperator, // only highlight operator within valid query
 	'Query/Wildcard': tags.Wildcard,
 	'Qualifier/...': tags.Qualifier,
 	'QualifierKey!': tags.QualifierKey,
@@ -42,10 +43,10 @@ const highlighter = tagHighlighter([
 	{ tag: tags.QualifierValue, class: 'lxl-qualifier-value' }
 ]);
 
-const highlighterExtension = syntaxHighlighting(highlighter);
+const highlighterExtensions = [syntaxHighlighting(highlighter), lxlLinter];
 
 /**
- * Libris XL query language together with a highlighter extension
+ * Libris XL query language together with highlighter extensions
  * that adds CSS classes for certain nodes
  */
-export const lxlQuery = new LanguageSupport(lxlQueryLanguage, highlighterExtension);
+export const lxlQuery = new LanguageSupport(lxlQueryLanguage, highlighterExtensions);

--- a/packages/codemirror-lang-lxlquery/src/lxlLinter.ts
+++ b/packages/codemirror-lang-lxlquery/src/lxlLinter.ts
@@ -1,0 +1,69 @@
+import {
+	Decoration,
+	EditorView,
+	ViewPlugin,
+	ViewUpdate,
+	type DecorationSet
+} from '@codemirror/view';
+import { type Range } from '@codemirror/state';
+import { syntaxTree } from '@codemirror/language';
+import { Prec } from '@codemirror/state';
+
+/**
+ * Adds css classes for non-qualifier stuff (error nodes, NOT operator)
+ */
+function addHighlights(view: EditorView) {
+	const widgets: Range<Decoration>[] = [];
+
+	for (const { from, to } of view.visibleRanges) {
+		syntaxTree(view.state).iterate({
+			from,
+			to,
+			enter: (node) => {
+				if (node.name === '⚠') {
+					let { from, to } = node;
+					if (node.from === node.to && node.node.parent) {
+						from = node.node.parent.from;
+						to = node.node.parent.to;
+					}
+					const invalidMark = Decoration.mark({ class: 'invalid', inclusive: true });
+					widgets.push(invalidMark.range(from, to));
+				}
+
+				if (node.name === 'NegativeQuery') {
+					const operator = node.node.getChild('NotOperator');
+					const phrase = operator?.nextSibling;
+
+					if (phrase && phrase.node.from < phrase.node.to) {
+						const invalidMark = Decoration.mark({ class: 'lxl-negative', inclusive: true });
+						widgets.push(invalidMark.range(phrase.node.from, phrase.node.to)); // Add the mark to the thing following the operator
+					}
+				}
+			}
+		});
+	}
+	return Decoration.set(widgets, true);
+}
+
+const queryLinter = ViewPlugin.fromClass(
+	class {
+		highlights: DecorationSet;
+
+		constructor(view: EditorView) {
+			this.highlights = addHighlights(view);
+		}
+
+		update(update: ViewUpdate) {
+			if (update.docChanged || syntaxTree(update.startState) != syntaxTree(update.state)) {
+				this.highlights = addHighlights(update.view);
+			}
+		}
+	},
+	{
+		decorations: (v) => v.highlights
+	}
+);
+
+const lxlLinter = Prec.low(queryLinter);
+
+export default lxlLinter;

--- a/packages/codemirror-lang-lxlquery/src/lxlLinter.ts
+++ b/packages/codemirror-lang-lxlquery/src/lxlLinter.ts
@@ -10,7 +10,7 @@ import { syntaxTree } from '@codemirror/language';
 import { Prec } from '@codemirror/state';
 
 /**
- * Adds css classes for non-qualifier stuff (error nodes, NOT operator)
+ * Adds mark decoration for error nodes or their parent if zero length
  */
 function addHighlights(view: EditorView) {
 	const widgets: Range<Decoration>[] = [];
@@ -30,15 +30,15 @@ function addHighlights(view: EditorView) {
 					widgets.push(invalidMark.range(from, to));
 				}
 
-				if (node.name === 'NegativeQuery') {
-					const operator = node.node.getChild('NotOperator');
-					const phrase = operator?.nextSibling;
+				// if (node.name === 'UQuery') {
+				// 	// const operator = node.node.getChild('UOperator');
+				// 	// const phrase = operator?.nextSibling;
 
-					if (phrase && phrase.node.from < phrase.node.to) {
-						const invalidMark = Decoration.mark({ class: 'lxl-negative', inclusive: true });
-						widgets.push(invalidMark.range(phrase.node.from, phrase.node.to)); // Add the mark to the thing following the operator
-					}
-				}
+				// 	if (node.from < node.to) {
+				// 		const invalidMark = Decoration.mark({ class: 'lxl-negative', inclusive: true });
+				// 		widgets.push(invalidMark.range(node.from, node.to)); // Add the mark to the thing following the operator
+				// 	}
+				// }
 			}
 		});
 	}

--- a/packages/codemirror-lang-lxlquery/src/lxlLinter.ts
+++ b/packages/codemirror-lang-lxlquery/src/lxlLinter.ts
@@ -20,25 +20,15 @@ function addHighlights(view: EditorView) {
 			from,
 			to,
 			enter: (node) => {
-				if (node.name === '⚠') {
+				if (node.type.isError) {
 					let { from, to } = node;
 					if (node.from === node.to && node.node.parent) {
 						from = node.node.parent.from;
 						to = node.node.parent.to;
 					}
-					const invalidMark = Decoration.mark({ class: 'invalid', inclusive: true });
+					const invalidMark = Decoration.mark({ class: 'lxl-invalid', inclusive: true });
 					widgets.push(invalidMark.range(from, to));
 				}
-
-				// if (node.name === 'UQuery') {
-				// 	// const operator = node.node.getChild('UOperator');
-				// 	// const phrase = operator?.nextSibling;
-
-				// 	if (node.from < node.to) {
-				// 		const invalidMark = Decoration.mark({ class: 'lxl-negative', inclusive: true });
-				// 		widgets.push(invalidMark.range(node.from, node.to)); // Add the mark to the thing following the operator
-				// 	}
-				// }
 			}
 		});
 	}

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -6,15 +6,23 @@ term {
   freetext |
   Qualifier |
   Group |
-  BooleanQuery
+  BooleanQuery |
+  NegativeQuery |
+  DoubleNegative
 }
 
 Group { "(" term* ")" } 
 
 BooleanQuery { 
-  (freetext | Qualifier | Group ) BooleanOperator (freetext | Qualifier | Group ) 
-  (BooleanOperator (freetext | Qualifier | Group ))+?
+  (freetext | Qualifier | Group | NegativeQuery) BooleanOperator (freetext | Qualifier | Group | NegativeQuery) 
+  (BooleanOperator (freetext | Qualifier | Group | NegativeQuery))+?
 }
+
+NegativeQuery { 
+  NotOperator (freetext | Qualifier | Group) 
+}
+
+DoubleNegative { NotOperator NotOperator }
 
 Qualifier {
   (QualifierKey QualifierOperator QualifierValue) | reserved
@@ -47,7 +55,9 @@ freetext {
 
   CompareOperator { ">" | "<" | ">=" | "<=" }
 
-  BooleanOperator { "AND" | "OR" | "NOT" }
+  BooleanOperator { "AND" | "OR" }
+
+  NotOperator { "NOT" }
 
   Wildcard { "*" }
 
@@ -55,7 +65,7 @@ freetext {
 
   space { @whitespace+ }
 
-  @precedence { BooleanOperator, reserved, Identifier }
+  @precedence { BooleanOperator, NotOperator, reserved, Identifier }
 }
 
 @detectDelim

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -7,22 +7,9 @@ term {
   Qualifier |
   Group |
   BooleanQuery |
-  NegativeQuery |
-  DoubleNegative
+  UQuery |
+  doubleNegative
 }
-
-Group { "(" term* ")" } 
-
-BooleanQuery { 
-  (freetext | Qualifier | Group | NegativeQuery) BooleanOperator (freetext | Qualifier | Group | NegativeQuery) 
-  (BooleanOperator (freetext | Qualifier | Group | NegativeQuery))+?
-}
-
-NegativeQuery { 
-  NotOperator (freetext | Qualifier | Group) 
-}
-
-DoubleNegative { NotOperator NotOperator }
 
 Qualifier {
   (QualifierKey QualifierOperator QualifierValue) | reserved
@@ -33,23 +20,44 @@ QualifierKey {
 }
 
 QualifierValue {
-  Identifier Wildcard? | String | Number Wildcard? | Group | Wildcard
+  Identifier | String | GroupInQualifier
 }
 
 QualifierOperator {
   EqualOperator | CompareOperator
 }
 
-freetext {
-  (Identifier | String | Number) Wildcard?
+Group {
+  "(" (freetext | Group | Qualifier | BooleanQuery | UQuery)+ ")"
 }
 
+BooleanQuery { 
+  (freetext | Qualifier | Group | UQuery) BooleanOperator (freetext | Qualifier | Group | UQuery) 
+  (BooleanOperator (freetext | Qualifier | Group | UQuery))+?
+}
+
+GroupInQualifier {
+  "(" (freetext | booleanQueryInQualifier | GroupInQualifier | UQuery)+ ")"
+}
+
+booleanQueryInQualifier { 
+  (freetext | GroupInQualifier | UQuery) BooleanOperator (freetext | GroupInQualifier | UQuery) 
+  (BooleanOperator (freetext | GroupInQualifier | UQuery))+?
+}
+
+UQuery { 
+  uOperator (freetext | Qualifier | Group) 
+}
+
+freetext {
+  (Identifier | String )
+}
+
+doubleNegative { uOperator uOperator (freetext | Qualifier | Group)  }
+
 @tokens {
-  Identifier { $[a-zA-ZåäöÅÄÖ]+ }
 
   String { '"' (!["\\] | "\\" _)* '"' }
-
-  Number { @digit+ }
 
   EqualOperator { ":" | "=" }
 
@@ -57,15 +65,15 @@ freetext {
 
   BooleanOperator { "AND" | "OR" }
 
-  NotOperator { "NOT" }
-
-  Wildcard { "*" }
+  uOperator { "NOT" | "!" }
 
   reserved { "includeEplikt" | "includePreliminary" }
 
   space { @whitespace+ }
 
-  @precedence { BooleanOperator, NotOperator, reserved, Identifier }
+  Identifier { ![:><=()!"\ ]+ }
+
+  @precedence { BooleanOperator, uOperator, reserved, Identifier, space }
 }
 
 @detectDelim

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -25,7 +25,7 @@ Qualifier {
   filterAliases { "includeEplikt" | "includePreliminary" }
   space { @whitespace+ }
 
-  @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, reserved, str, space}
+  @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, filterAliases, str, space}
 }
 
 @detectDelim

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -1,4 +1,4 @@
-@top Program { orcomb }
+@top Query { orcomb }
 
 @skip { space }
 
@@ -21,7 +21,7 @@ Qualifier {
   bOperator {"<" | ">" | "<=" | ">=" }
   bOperatorEq { ":" | "=" }
   strliteral { '"' (!["\\] | "\\" _)* '"' }
-  str { ![:><=()!"\ ]+ }
+  str { ![:><=()~!"\ ]+ }
   filterAliases { "includeEplikt" | "includePreliminary" }
   space { @whitespace+ }
 

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -1,79 +1,31 @@
-@top Query { term* }
+@top Program { orcomb }
 
 @skip { space }
 
-term {
-  freetext |
-  Qualifier |
-  Group |
-  BooleanQuery |
-  UQuery |
-  doubleNegative
+orcomb { andcomb ( OrOperator andcomb )* }
+andcomb { term ( AndOperator term | term )* }
+term { String | Group | UTerm | Qualifier }
+Group { "(" orcomb ")" }
+UTerm { UOperator term }
+String { strliteral | str }
+Qualifier { 
+  ( QualifierKey { String } QualifierOperator { bOperator } QualifierValue { String } ) | 
+  ( QualifierKey { String } QualifierOperator { bOperatorEq } QualifierValue { term } ) |
+  filterAliases 
 }
-
-Qualifier {
-  (QualifierKey QualifierOperator QualifierValue) | reserved
-}
-
-QualifierKey {
-  Identifier | String
-}
-
-QualifierValue {
-  Identifier | String | GroupInQualifier
-}
-
-QualifierOperator {
-  EqualOperator | CompareOperator
-}
-
-Group {
-  "(" (freetext | Group | Qualifier | BooleanQuery | UQuery)+ ")"
-}
-
-BooleanQuery { 
-  (freetext | Qualifier | Group | UQuery) BooleanOperator (freetext | Qualifier | Group | UQuery) 
-  (BooleanOperator (freetext | Qualifier | Group | UQuery))+?
-}
-
-GroupInQualifier {
-  "(" (freetext | booleanQueryInQualifier | GroupInQualifier | UQuery)+ ")"
-}
-
-booleanQueryInQualifier { 
-  (freetext | GroupInQualifier | UQuery) BooleanOperator (freetext | GroupInQualifier | UQuery) 
-  (BooleanOperator (freetext | GroupInQualifier | UQuery))+?
-}
-
-UQuery { 
-  uOperator (freetext | Qualifier | Group) 
-}
-
-freetext {
-  (Identifier | String )
-}
-
-doubleNegative { uOperator uOperator (freetext | Qualifier | Group)  }
 
 @tokens {
-
-  String { '"' (!["\\] | "\\" _)* '"' }
-
-  EqualOperator { ":" | "=" }
-
-  CompareOperator { ">" | "<" | ">=" | "<=" }
-
-  BooleanOperator { "AND" | "OR" }
-
-  uOperator { "NOT" | "!" }
-
-  reserved { "includeEplikt" | "includePreliminary" }
-
+  OrOperator { "OR" }
+  AndOperator { "AND" }
+  UOperator { "!" | "NOT" }
+  bOperator {"<" | ">" | "<=" | ">=" }
+  bOperatorEq { ":" | "=" }
+  strliteral { '"' (!["\\] | "\\" _)* '"' }
+  str { ![:><=()!"\ ]+ }
+  filterAliases { "includeEplikt" | "includePreliminary" }
   space { @whitespace+ }
 
-  Identifier { ![:><=()!"\ ]+ }
-
-  @precedence { BooleanOperator, uOperator, reserved, Identifier, space }
+  @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, reserved, str, space}
 }
 
 @detectDelim

--- a/packages/codemirror-lang-lxlquery/test/cases.txt
+++ b/packages/codemirror-lang-lxlquery/test/cases.txt
@@ -1,13 +1,339 @@
-# Freetext words
+# PARSE - normal parse
 
-Astrid lindgren
+AAA BBB AND (CCC OR DDD)
 
 ==>
 
-Query(Identifier Identifier)
+Query(String String AndOperator Group(String OrOperator String))
 
 
-# Freetext string
+# implicit and group
+
+AAA BBB (CCC OR DDD)
+
+==>
+
+Query(String String Group(String OrOperator String))
+
+
+# parse negative
+
+!AAA
+
+==>
+
+Query(UTerm (UOperator String))
+
+
+# parse negative 2
+
+NOT AAA
+
+==>
+
+Query(UTerm (UOperator String))
+
+
+# parse negative 3
+
+NOT (AAA)
+
+==>
+
+Query(UTerm (UOperator Group (String)))
+
+
+# crazy grouping
+
+AAA BBB AND (CCC OR DDD OR (EEE) AND (FFF OR GGG))
+
+==>
+
+Query(
+  String,
+  String,
+  AndOperator,
+  Group(
+    String,
+    OrOperator,
+    String,
+    OrOperator,
+    Group(
+      String
+    ),
+    AndOperator,
+    Group(
+      String,
+      OrOperator,
+      String
+    )
+  )
+)
+
+
+# fail crazy grouping with bad parens
+
+AAA BBB AND (CCC OR DDD OR (EEE) AND (FFF OR GGG)
+
+==>
+
+Query(
+  String,
+  String,
+  AndOperator,
+  Group(
+    String,
+    OrOperator,
+    String,
+    OrOperator,
+    Group(
+      String
+    ),
+    AndOperator,
+    Group(
+      String,
+      OrOperator,
+      String
+    ),
+    ⚠
+  )
+)
+
+
+# super basic parse
+
+AAA
+
+==>
+
+Query(String)
+
+
+# super basic parse 2
+
+AAA BBB
+
+==>
+
+Query(String String)
+
+
+# basic code
+
+förf:AAA
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(String)))
+
+
+# basic code 2
+
+förf=AAA
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(String)))
+
+
+# quoted code
+
+förf:"AAA"
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(String)))
+
+
+# quoted code 2
+
+förf:"förf:"
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(String)))
+
+
+# quoted code 3
+
+"förf:":"AAA"
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(String)))
+
+
+# quoted code 4
+
+"Kod: författare och annat:":("AAA" OR BBB)
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(Group(String OrOperator String))))
+
+
+# code group
+
+förf:(AAA)
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(Group(String))))
+
+
+# code group 2
+
+förf:(AAA OR BBB AND CCC)
+
+==>
+
+Query(
+  Qualifier(
+    QualifierKey(
+      String
+    ),
+    QualifierOperator,
+    QualifierValue(
+      Group(
+        String,
+        OrOperator,
+        String,
+        AndOperator,
+        String
+      )
+    )
+  )
+)
+
+
+# bad use of code
+
+förf:
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator ⚠))
+
+
+# bad use of code 2
+
+AAA OR förf:
+
+==>
+
+Query(String OrOperator Qualifier(QualifierKey(String) QualifierOperator ⚠))
+
+
+# don't parse missing or-tail
+
+AAA BBB AND (CCC OR)
+
+==>
+
+Query(String String AndOperator Group(String OrOperator ⚠))
+
+
+# don't parse missing and-tail
+
+AAA BBB AND
+
+==>
+
+Query(String String AndOperator ⚠)
+
+
+# code binop
+
+published: 2022
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(String)))
+
+
+# code binop 2
+
+published:2022
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(String)))
+
+
+# code binop 3
+
+published=2022
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(String)))
+
+
+# code binop 4
+
+published<2022
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(String)))
+
+
+# code binop 5
+
+published>=2022
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(String)))
+
+
+# fail compare with group
+
+AAA < (CCC)
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator ⚠ ) Group(String))
+
+
+# fail compare with not
+
+AAA < ! CCC
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator ⚠ ) UTerm(...))
+
+
+# fail compare with not 2
+
+AAA < NOT CCC
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator ⚠ ) UTerm(...))
+
+
+# fail compare with like
+
+AAA < ~ CCC
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator ⚠ QualifierValue(String)))
+
+
+# codes and quotes
+
+"bf:subject":"lcsh:Physics" AND "bf:subject"
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(String)) AndOperator String)
+
+
+
+# ----- freetext string
 
 "2001: A Space Odyssey"
 
@@ -16,204 +342,91 @@ Query(Identifier Identifier)
 Query(String)
 
 
-# Freetext with Wildcard
+# negative group
 
-Astrid lind*
-
-==>
-
-Query(Identifier Identifier Wildcard)
-
-
-# Qualifier with EqualOperator
-
-ÅR:2024
+!(AAAA OR BBBB)
 
 ==>
 
-Query(
-  Qualifier(QualifierKey(Identifier), QualifierOperator(EqualOperator), QualifierValue(Number))
-)
+Query(UTerm(UOperator Group(String OrOperator String)))
 
 
-# Qualifier with CompareOperator
-
-ÅR>2024
-ÅR<=2024
-
-==>
-
-Query(
-  Qualifier(QualifierKey(Identifier), QualifierOperator(CompareOperator), QualifierValue(Number))
-  Qualifier(QualifierKey(Identifier), QualifierOperator(CompareOperator), QualifierValue(Number))
-)
-
-
-# Qualifier with string key
-
-"rdf:type":Text
-
-==>
-
-Query(
-  Qualifier(QualifierKey(String),QualifierOperator(EqualOperator),QualifierValue(Identifier))
-)
-
-
-# Qualifier with string value
-
-contributor:"Astrid Lindgren"
-
-==>
-
-Query(
-  Qualifier(QualifierKey(Identifier), QualifierOperator(EqualOperator), QualifierValue(String))
-)
-
-
-# Qualifier linked
-
-contributor:"libris:fcrtpljz1qp2bdv#it"
-
-==>
-
-Query(
-  Qualifier(QualifierKey(Identifier), QualifierOperator(EqualOperator), QualifierValue(String))
-)
-
-
-# Qualifier with wildcard
-
-titel:kulturarv*
-
-==>
-
-Query(
-  Qualifier(QualifierKey(...), QualifierOperator(...), QualifierValue(Identifier, Wildcard))
-)
-
-# Qualifier with wildcard (invalid)
-
-subject*:vinter
-
-==>
-
-Query(
-  Identifier,
-  Wildcard,
-  ⚠(...),
-  Identifier
-)
-
-
-# BooleanQuery
-
-sommar OR vinter NOT vår
-
-==>
-
-Query(
-  BooleanQuery(Identifier, BooleanOperator, Identifier, BooleanOperator, Identifier)
-)
-
-
-# BooleanQuery with groups
-
-(rummet röda) OR (rummet vita)
-
-==>
-
-Query(
-  BooleanQuery(Group(...),BooleanOperator,Group(...))
-)
-
-
-# BooleanQuery (invalid)
+# fail boolean query
 
 OR AND sommar
 
 ==>
 
-Query(⚠(BooleanOperator), ⚠(BooleanOperator), Identifier)
+Query(⚠(OrOperator) ⚠(AndOperator) String)
 
 
-# Combined: Qualifier and Freetext
+# fail boolean query 2
 
-contributor:"Astrid Lindgren" Pippi Långstrump
-
-==>
-
-Query(
-  Qualifier(QualifierKey(Identifier), QualifierOperator(EqualOperator), QualifierValue(String)) Identifier Identifier
-)
-
-
-# Combined: Freetext BooleanQuery (Qualifier NOT Qualifier)
-
-träd* bibliografi:"sigel:DST" NOT typ:Text
+NOT sommar NOT OR vinter
 
 ==>
 
-Query(
-  Identifier, 
-  Wildcard, 
-  BooleanQuery(
-    Qualifier(QualifierKey(Identifier), QualifierOperator(EqualOperator), QualifierValue(String)), 
-    BooleanOperator, 
-    Qualifier(QualifierKey(Identifier), QualifierOperator(EqualOperator), QualifierValue(Identifier)))
-)
+Query(UTerm(UOperator String) UTerm(UOperator ⚠) OrOperator String)
 
 
-# Combined: Freetext Qualifier (Group with BooleanQuery) Qualifier
+# fail boolean query 3
 
-pippi långstrump språk:(engelska OR franska) ÅR>2002
+NOT
 
 ==>
 
-Query(
-  Identifier,
-  Identifier,
-  Qualifier(
-    QualifierKey(Identifier), QualifierOperator(EqualOperator), QualifierValue(
-      Group(
-        BooleanQuery(
-          Identifier,
-          BooleanOperator,
-          Identifier
-        )
-      )
-    )
-  ),
-  Qualifier(QualifierKey(Identifier), QualifierOperator(CompareOperator), QualifierValue(Number))
-)
+Query(UTerm(UOperator ⚠))
 
 
-# Other filters: cover image
+# fail unclosed quote
 
-image:*
+"Astrid Lind
 
 ==>
 
-Query(
-  Qualifier(
-    QualifierKey(...), QualifierOperator(...), QualifierValue(Wildcard)
-  )
-)
+Query(⚠ String String)
 
 
-# Other filters: include E-plikt
+# fail empty paren
+
+()
+
+==>
+
+Query(Group(String(⚠)))
+
+
+# uterm code
+
+NOT key:value
+
+==>
+
+Query(UTerm(UOperator Qualifier(QualifierKey(String) QualifierOperator QualifierValue(String))))
+
+
+# uterm code 2
+
+key:(NOT value)
+
+==>
+
+Query(Qualifier(QualifierKey(String) QualifierOperator QualifierValue(Group(UTerm(UOperator String)))))
+
+
+# other filters: include E-plikt
 
 Pippi includeEplikt
 
 ==>
 
-Query(Identifier, Qualifier)
+Query(String Qualifier)
 
 
-# Other filters: include preliminary
+# other filters: include preliminary
 
 includePreliminary Pippi
 
 ==>
 
-Query(Qualifier, Identifier)
+Query(Qualifier String)

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
@@ -121,7 +121,7 @@ function lxlQualifierPlugin(getLabelFn?: GetLabelFunction) {
 						} else if (invalid) {
 							// Add invalid key mark decoration
 							const qualifierMark = Decoration.mark({
-								class: 'invalid',
+								class: 'lxl-invalid',
 								inclusive: true
 							});
 							const invalidRangeFrom = keyNode ? keyNode.from : node.from;

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertQuotes.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertQuotes.ts
@@ -2,24 +2,28 @@ import { Transaction } from '@codemirror/state';
 import { syntaxTree } from '@codemirror/language';
 
 /**
- * Moves cursor into an empty quote on falsy qualifier value
+ * Moves cursor into an empty quote after typing the QualifierOperator
  */
 const insertQuotes = (tr: Transaction) => {
+	if (!tr.isUserEvent('input')) {
+		return tr;
+	}
 	let changes = null;
 	syntaxTree(tr.state).iterate({
 		enter: (node) => {
-			if (node.name === 'Qualifier') {
-				const qValue = node.node.getChild('QualifierValue');
-				const qKey = node.node.getChild('QualifierKey');
-				if (qKey && !qValue && tr.isUserEvent('input')) {
+			if (node.name === 'QualifierOperator') {
+				const operatorEnd = node.to;
+				const oldCursorPos = tr.startState.selection.main.head;
+				const newCursorPos = tr.state.selection.main.head;
+				if (operatorEnd - 1 === oldCursorPos) {
 					changes = {
 						changes: {
-							from: tr.state.selection.main.head,
-							to: tr.state.selection.main.head,
+							from: newCursorPos,
+							to: newCursorPos,
 							insert: '""'
 						},
 						sequential: true,
-						selection: { anchor: tr.state.selection.main.head + 1 }
+						selection: { anchor: newCursorPos + 1 }
 					};
 					return true;
 				}

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertQuotes.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertQuotes.ts
@@ -1,32 +1,32 @@
-import { Transaction, type TransactionSpec } from '@codemirror/state';
+import { Transaction } from '@codemirror/state';
 import { syntaxTree } from '@codemirror/language';
 
 /**
  * Moves cursor into an empty quote on falsy qualifier value
  */
 const insertQuotes = (tr: Transaction) => {
-	let foundEmptyQValue = false;
-	const changes: TransactionSpec = {
-		changes: {
-			from: tr.state.selection.main.head,
-			to: tr.state.selection.main.head,
-			insert: '""'
-		},
-		sequential: true,
-		selection: { anchor: tr.state.selection.main.head + 1 }
-	};
+	let changes = null;
 	syntaxTree(tr.state).iterate({
 		enter: (node) => {
 			if (node.name === 'Qualifier') {
 				const qValue = node.node.getChild('QualifierValue');
-				if (!qValue && tr.isUserEvent('input')) {
-					foundEmptyQValue = true;
+				const qKey = node.node.getChild('QualifierKey');
+				if (qKey && !qValue && tr.isUserEvent('input')) {
+					changes = {
+						changes: {
+							from: tr.state.selection.main.head,
+							to: tr.state.selection.main.head,
+							insert: '""'
+						},
+						sequential: true,
+						selection: { anchor: tr.state.selection.main.head + 1 }
+					};
 					return true;
 				}
 			}
 		}
 	});
-	return foundEmptyQValue ? [tr, changes] : tr;
+	return changes ? [tr, changes] : tr;
 };
 
 export default insertQuotes;


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-292](https://kbse.atlassian.net/browse/LWS-292)

### Solves

Upon discovering that the frontend language parsing was allowing stuff that the backend don't and vice versa, I tried to fill in the gaps in our grammar, but ended up rewriting the whole thing after inspecting the backend code.

see [source](https://github.com/libris/librisxl/blob/7990106ab2b5e5cfa49eee843c09847869e0d5b3/whelk-core/src/main/groovy/whelk/search2/parse/Parse.java#L7)

The root node now being `orcomb` (not exported), this exports pretty much the same nodes as before, but with more robust logic and less code. For example:

Used to be valid but is invalid:
`key>(sommar AND vinter)`

Used to be invalid but is valid:
`!(sommar AND vinter)`

The query language is clearly not settled (whitespace discussion), but with frontend/backend in sync, we can (must!) do parallel changes moving forward.

Instead of rewriting all of our tests, I replaced many of them with the backend tests most relevant for our use case.

#### Lint

To spot valid/invalid queries, I tried adding mark decorations to error nodes. This feels pretty useful for us and maybe for the end user too. So i ended up doing a linting extension that is now bundled with the language. This simply highlights syntax errors from the language + a couple of manual cases (next step can be to use Codemirror lint package for tooltips etc). Try some invalid queries:

`()`
`AND sommar`
`"Astrid Lindgren`
`NOT sommar NOT OR vinter`
`code:("something" and code:"whatever")`
`sommar!` (pretty strange that this is invalid, but as long as it is, the frontend should point it out)

#### NOT

The language now exports inequality term nodes, which can be used to highlight excluded terms. I added very basic styling, but this needs improvement if we want to handle double negatives (NOT NOT) for example, or style pills like we do today:

![Skärmavbild 2025-01-14 kl  10 56 31](https://github.com/user-attachments/assets/b8a5e6c8-3528-4025-a961-93fd349e8b4d)

### Summary of changes

* Rewrite grammar
* Add lxlLinter extension for language
* Update (still rudimentary) styling
* Rewrite tests
* Fixed a bug in insertQuotes that inserted quotes for 'special' qualifiers without key/value such as `includeEplikt`
