### PR TITLE
feat(lxlweb): supersearch feature flag param (LWS-275)

### DIFF
--- a/lxl-web/src/lib/components/Search.svelte
+++ b/lxl-web/src/lib/components/Search.svelte
@@ -19,7 +19,8 @@
 
 	let { placeholder, autofocus = false }: Props = $props();
 
-	const useSuperSearch = env?.PUBLIC_USE_SUPERSEARCH === 'true';
+	let useSuperSearch =
+		env?.PUBLIC_USE_SUPERSEARCH === 'true' || $page.url.searchParams.get('_x') === 'supersearch';
 	const showAdvanced = $page.url.searchParams.get('_x') === 'advanced' || useSuperSearch;
 
 	let q = $state(

--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -19,9 +19,9 @@
 	$: showEditButton =
 		$page.url.pathname === `${$page.data.base}find` &&
 		$page.url.searchParams.get('_q') !== $page.url.searchParams.get('_i');
-	$: editActive = $page.url.searchParams.get('_x') === 'advanced';
+	$: editActive = $page.url.searchParams.has('_x');
 	$: toggleEditUrl = editActive
-		? $page.url.href.replace('&_x=advanced', '')
+		? $page.url.href.replace(`&_x=${$page.url.searchParams.get('_x')}`, '')
 		: `${$page.url.href}&_x=advanced`;
 
 	function getRelationSymbol(operator: keyof typeof SearchOperators): string {

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -26,8 +26,8 @@ import { type LocaleCode as LangCode } from '$lib/i18n/locales';
 import { bestImage, bestSize, toSecure } from '$lib/utils/auxd';
 import getAtPath from '$lib/utils/getAtPath';
 import { getUriSlug } from '$lib/utils/http';
-import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
+// import { error } from '@sveltejs/kit';
+// import { env } from '$env/dynamic/public';
 
 export async function asResult(
 	view: PartialCollectionView,
@@ -95,12 +95,12 @@ export function displayMappings(
 				// Mock old behaviour for 'classic' search GUI, i.e show error page
 				// when encountering an invalid property in order to provide feedback.
 				// TODO remove this when Supersearch is fully implemented.
-				const useSuperSearch = env?.PUBLIC_USE_SUPERSEARCH === 'true';
-				if (!useSuperSearch && m.property?.['@type'] === '_Invalid') {
-					error(400, {
-						message: `Invalid query, please check the documentation. Unrecognized property alias: ${m.property?.label ?? ''}`
-					});
-				}
+				// const useSuperSearch = env?.PUBLIC_USE_SUPERSEARCH === 'true';
+				// if (!useSuperSearch && m.property?.['@type'] === '_Invalid') {
+				// 	error(400, {
+				// 		message: `Invalid query, please check the documentation. Unrecognized property alias: ${m.property?.label ?? ''}`
+				// 	});
+				// }
 
 				const property = m[operator] as FramedData;
 				return {

--- a/lxl-web/tests/error.spec.ts
+++ b/lxl-web/tests/error.spec.ts
@@ -41,17 +41,17 @@ test.describe('Missing resource page', () => {
 	});
 });
 
-test.describe('Find page with invalid query', () => {
-	test.beforeEach(async ({ page }) => {
-		await page.goto(
-			'/find?_i=geh&_q=test+unrecognizedproperty:%22https://id.kb.se/language/swe%22&_limit=20'
-		);
-	});
-	test('has expected h1', async ({ page }) => {
-		await expect(page.getByRole('heading', { name: '400' })).toBeVisible();
-	});
-	test('should not have any detectable a11y issues', async ({ page }) => {
-		const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-		expect.soft(accessibilityScanResults.violations).toEqual([]);
-	});
-});
+// test.describe('Find page with invalid query', () => {
+// 	test.beforeEach(async ({ page }) => {
+// 		await page.goto(
+// 			'/find?_i=geh&_q=test+unrecognizedproperty:%22https://id.kb.se/language/swe%22&_limit=20'
+// 		);
+// 	});
+// 	test('has expected h1', async ({ page }) => {
+// 		await expect(page.getByRole('heading', { name: '400' })).toBeVisible();
+// 	});
+// 	test('should not have any detectable a11y issues', async ({ page }) => {
+// 		const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+// 		expect.soft(accessibilityScanResults.violations).toEqual([]);
+// 	});
+// });


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-275](https://kbse.atlassian.net/browse/LWS-275)

### Solves

Easiest possible solution to toggle supersearch using a param: we borrow the `_x` param and show it when set to `_x=supersearch`.

It's good 'cause `_x` is accepted and returned by the api, meaning the facet links etc will have it too.

Explanation for the outcommented code:
The api now accepts invalid property keys. Users of the 'old' search will get no feedback that this happened (only zero results). We manually thew an error for them ([here](https://github.com/libris/lxlviewer/pull/1195)). But it's no longer working when moving away from the `.env`. So instead of building another more complicated temp solution, I suggest users will have to live with this until supersearch is fully in place.


### Summary of changes

* change `useSuperSearch` variable
* small change to the search mapping 'edit' button
* comment out manual handling of _invalid type
* comment out test failing because of 👆 

