### PR TITLE
fix(lxlweb): string check in getDefinition

### DIFF
--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -55,7 +55,9 @@ export class VocabUtil {
 	}
 
 	getDefinition(name: ClassName | PropertyName): FramedData {
-		return lxljsVocab.getTermObject(name, this.vocabIndex, this.context);
+		if (typeof name === 'string') {
+			return lxljsVocab.getTermObject(name, this.vocabIndex, this.context);
+		}
 	}
 
 	getInverseProperty(name: PropertyName): PropertyName | undefined {


### PR DESCRIPTION
## Description

### Solves

Some queries cause the app to break, which is becoming more evident with supersearch.
For example a wildcard search for genreForm:
https://beta.libris-qa.kb.se/find?_i=&_q=%22rdf:type%22:GenreForm&_limit=20&_x=advanced&_spell=true

Caused by `lxljsVocab.getTermObject` requiring a `name` string, while arrays exist as `@type` among old MARC terms.
for example
```
[
  'marc:SerialsNatureType',
  'marc:BooksContentsType',
  'marc:SerialsContentsType'
]
```
We could also call the function with `name[0]` in these cases, dunno what's better?


### Summary of changes

* string check in xl.ts `getDefinition`
