### PR TITLE
Allow locking/unlocking of listed properties

### DIFF
--- a/cataloging/src/resources/json/i18n.json
+++ b/cataloging/src/resources/json/i18n.json
@@ -466,6 +466,9 @@
     "Show as record" : "Visa som post",
     "To see bulk changes you need to switch to a sigel with access.": "För att se körningar behöver du växla till ett sigel med rättigheter.",
     "Back to create bulk change": "Tillbaka till skapa körning",
-    "This might take a while...": "Det här verkar ta lite tid..."
+    "This might take a while...": "Det här verkar ta lite tid...",
+    "Lock property": "Lås egenskap",
+    "Unlock property": "Lås upp egenskap",
+    "The property is locked for editing. Are you sure you want to unlock it?" : "Egenskapen är låst för redigering. Är du säker på att du vill låsa upp?"
   }
 }

--- a/cataloging/src/settings.js
+++ b/cataloging/src/settings.js
@@ -138,6 +138,9 @@ export default {
       },
     ],
   },
+  protectedProperties: [
+    'usageAndAccessPolicy',
+  ],
   warnOnSave: {
     'record.encodingLevel': ['marc:PrepublicationLevel', 'marc:PartialPreliminaryLevel'],
   },


### PR DESCRIPTION
Make it possible to lock and unlock properties listed in settings for editing/removal.

Works on all levels in the JSON-tree.

If the user adds a protected property, it shows up in the form unlocked.  Currently, the only protected property is `usageAndAccessPolicy`. 

Locked:

![Screenshot from 2025-02-11 14-14-12](https://github.com/user-attachments/assets/f265c6a9-ab04-419f-9542-e9fd7194863d)

Unlocked:

![Screenshot from 2025-02-11 14-14-20](https://github.com/user-attachments/assets/505c85ee-696b-4fef-a677-93ffb2e2910e)

Modal:

![Screenshot from 2025-02-11 14-14-31](https://github.com/user-attachments/assets/4703b69c-4db6-444f-93eb-32848cf4c16d)


### Tickets involved
[LXL-4178](https://kbse.atlassian.net/browse/LXL-4178)
