### PR TITLE
fix(lxlweb): iterate parents in getEditedRanges

### DIFF
--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedRanges.test.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedRanges.test.ts
@@ -40,6 +40,31 @@ describe('getEditedRanges', () => {
 		);
 	});
 
+	it('calculates the edited range when editing a qualifier value in a group', () => {
+		const query = 'hasTitle:((a))';
+		const editedRanges = getEditedRanges(query, 11);
+		expect(editedRanges).toEqual({
+			from: 0,
+			to: 14,
+			qualifierKey: {
+				from: 0,
+				to: 8
+			},
+			qualifierOperator: {
+				from: 8,
+				to: 9
+			},
+			qualifierValue: {
+				from: 9,
+				to: 14
+			}
+		});
+		expect(query.slice(editedRanges.from, editedRanges.to)).toBe('hasTitle:((a))');
+		expect(query.slice(editedRanges.qualifierValue?.from, editedRanges.qualifierValue?.to)).toBe(
+			'((a))'
+		);
+	});
+
 	it('calculates the edited range when editing a string', () => {
 		expect(getEditedRanges('"hello"', 6)).toEqual({
 			from: 0,


### PR DESCRIPTION
## Description

### Solves

Discovered a flaw in `getEditedRanges` that only recognizes editing a qualifier when the `innerNode` is a direct child of `qualifierValue`. This is however not always the case. Consider for example:

`contributor:(astrid lindgren)` that produces the tree `QualifierValue { Group { String String } }`. We're editing the `String` and the parent is `Group`.

This means we fail to narrow down the query to `_q=(astrid+lindgren)+"rdf:type":Agent` in this case.

And since the query in theory could be `contributor:(((((Astrid)))))`, we need to iterate the tree to se if the `innerNode` is located _somewhere_ inside a `qualifierValue`.   

### Summary of changes

* Iterate parents in `getEditedRanges`
* Add test to cover this use case
