### PR TITLE
fix(lxlweb): implement mapping _key _value (LWS-327)

### DIFF
--- a/lxl-web/src/lib/components/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/SuperSearchWrapper.svelte
@@ -123,7 +123,7 @@
 						<BiArrowLeft />
 					</button>
 				{/if}
-				<div class="flex-1">
+				<div class="flex-1 overflow-hidden">
 					{@render inputField()}
 				</div>
 				{#if q}

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -74,8 +74,9 @@ export interface DisplayMapping {
 	children?: DisplayMapping[];
 	label?: string;
 	operator: keyof typeof SearchOperators;
-	property?: string;
 	invalid?: string;
+	_key?: string;
+	_value?: string;
 }
 
 export interface PartialCollectionView {
@@ -139,6 +140,8 @@ export interface SearchMapping extends MappingObj {
 	property?: ObjectProperty | DatatypeProperty | PropertyChainAxiom | InvalidProperty;
 	object?: FramedData;
 	up: { '@id': string };
+	_key?: string;
+	_value?: string;
 }
 
 interface ObjectProperty {

--- a/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
+++ b/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
@@ -1,6 +1,7 @@
+import type { DisplayMapping } from '$lib/types/search';
+
 let prevSuggestMapping: DisplayMapping[] | undefined;
 
-import type { DisplayMapping } from '$lib/types/search';
 function getLabelFromMappings(
 	key: string,
 	value?: string,

--- a/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
+++ b/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
@@ -22,7 +22,7 @@ function getLabelFromMappings(
 	const removeLink = pageLabels.keyLabel ? pageLabels.removeLink : undefined;
 
 	if (suggestMapping?.length) {
-		// save latest ok labels if we should get an (empty) error response
+		// save latest mapping as fallback for error responses etc
 		prevSuggestMapping = suggestMapping;
 	}
 

--- a/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
+++ b/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
@@ -8,13 +8,9 @@ function getLabelFromMappings(
 	pageMapping?: DisplayMapping[],
 	suggestMapping?: DisplayMapping[]
 ) {
-	if (suggestMapping && suggestMapping.length) {
-		// save latest ok labels if we should get an (empty) error response
-		prevSuggestMapping = suggestMapping;
-	}
-	const bestSuggestMapping = $derived(suggestMapping?.length ? suggestMapping : prevSuggestMapping);
 	const nonQuotedKey = key.replace(/^"(.*)"$/, '$1');
 	const nonQuotedValue = value && value.replace(/^"(.*)"$/, '$1');
+	const bestSuggestMapping = $derived(suggestMapping?.length ? suggestMapping : prevSuggestMapping);
 
 	const pageLabels = iterateMapping(nonQuotedKey, nonQuotedValue, pageMapping);
 	const suggestLabels = iterateMapping(nonQuotedKey, nonQuotedValue, bestSuggestMapping);
@@ -24,6 +20,11 @@ function getLabelFromMappings(
 	const invalid = suggestLabels.invalid || pageLabels.invalid;
 	// only page data have 'up' links we can use
 	const removeLink = pageLabels.keyLabel ? pageLabels.removeLink : undefined;
+
+	if (suggestMapping?.length) {
+		// save latest ok labels if we should get an (empty) error response
+		prevSuggestMapping = suggestMapping;
+	}
 
 	return { keyLabel, valueLabel, removeLink, invalid };
 }

--- a/lxl-web/src/lib/utils/getLabelsFromMapping.test.ts
+++ b/lxl-web/src/lib/utils/getLabelsFromMapping.test.ts
@@ -65,10 +65,9 @@ const pageMapping: DisplayMapping[] = [
 				display: 'sommar',
 				displayStr: 'sommar',
 				label: 'Fritextsökning',
-				property: 'textQuery',
 				operator: 'equals',
 				up: {
-					'@id': '/find?_i=&_q=genreForm:%22saogf:Romaner%22+%C3%85R:2023&_limit=20&_spell=true'
+					'@id': '/find?_i=&_q=genreForm:%22saogf:Romaner%22&_limit=20&_spell=true'
 				}
 			},
 			{
@@ -87,22 +86,12 @@ const pageMapping: DisplayMapping[] = [
 				},
 				displayStr: 'Romaner',
 				label: 'Genre/form',
-				property: 'genreForm',
 				operator: 'equals',
 				up: {
 					'@id': '/find?_i=sommar&_q=sommar+%C3%85R:2023&_limit=20&_spell=true'
-				}
-			},
-			{
-				'@id': 'https://id.kb.se/vocab/yearPublished',
-				display: '2023',
-				displayStr: '2023',
-				label: 'Utgivningsår',
-				property: 'ÅR',
-				operator: 'equals',
-				up: {
-					'@id': '/find?_i=sommar&_q=sommar+genreForm:%22saogf:Romaner%22&_limit=20&_spell=true'
-				}
+				},
+				_key: 'genreForm',
+				_value: 'saogf:Romaner'
 			}
 		],
 		operator: 'and',
@@ -121,11 +110,10 @@ const suggestMapping: DisplayMapping[] = [
 				display: 'sommar',
 				displayStr: 'sommar',
 				label: 'Fritextsökning',
-				property: 'textQuery',
 				operator: 'equals',
 				up: {
 					'@id':
-						'/find?_i=&_q=genreForm:%22saogf:Romaner%22+%C3%85R:2023+SPR%C3%85K:%22lang:swe%22&_limit=10'
+						'/find?_i=&_q=genreForm:%22saogf:Romaner%22+%C3%85R:2023+SPR%C3%85K:%22lang:swe%22&_limit=0'
 				}
 			},
 			{
@@ -144,23 +132,25 @@ const suggestMapping: DisplayMapping[] = [
 				},
 				displayStr: 'Romaner',
 				label: 'Genre/form',
-				property: 'genreForm',
 				operator: 'equals',
 				up: {
-					'@id': '/find?_i=sommar&_q=sommar+%C3%85R:2023+SPR%C3%85K:%22lang:swe%22&_limit=10'
-				}
+					'@id': '/find?_i=sommar&_q=sommar+%C3%85R:2023+SPR%C3%85K:%22lang:swe%22&_limit=0'
+				},
+				_key: 'genreForm',
+				_value: 'saogf:Romaner'
 			},
 			{
 				'@id': 'https://id.kb.se/vocab/yearPublished',
 				display: '2023',
 				displayStr: '2023',
 				label: 'Utgivningsår',
-				property: 'ÅR',
 				operator: 'equals',
 				up: {
 					'@id':
-						'/find?_i=sommar&_q=sommar+genreForm:%22saogf:Romaner%22+SPR%C3%85K:%22lang:swe%22&_limit=10'
-				}
+						'/find?_i=sommar&_q=sommar+genreForm:%22saogf:Romaner%22+SPR%C3%85K:%22lang:swe%22&_limit=0'
+				},
+				_key: 'ÅR',
+				_value: '2023'
 			},
 			{
 				'@id': 'https://id.kb.se/vocab/language',
@@ -177,16 +167,17 @@ const suggestMapping: DisplayMapping[] = [
 				},
 				displayStr: 'Svenska',
 				label: 'Språk',
-				property: 'SPRÅK',
 				operator: 'equals',
 				up: {
-					'@id': '/find?_i=sommar&_q=sommar+genreForm:%22saogf:Romaner%22+%C3%85R:2023&_limit=10'
-				}
+					'@id': '/find?_i=sommar&_q=sommar+genreForm:%22saogf:Romaner%22+%C3%85R:2023&_limit=0'
+				},
+				_key: 'SPRÅK',
+				_value: 'lang:swe'
 			}
 		],
 		operator: 'and',
 		up: {
-			'@id': '/find?_i=&_q=*&_limit=10'
+			'@id': '/find?_i=&_q=*&_limit=0'
 		}
 	}
 ];

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -41,7 +41,7 @@ export async function asResult(
 ): Promise<SearchResult> {
 	const translate = await getTranslator(locale);
 
-	const hasDebug = view.items.length > 0 && view.items[0]._debug;
+	const hasDebug = view.items?.length > 0 && view.items?.[0]._debug;
 	const maxScores = hasDebug
 		? getMaxScores(view.items.map((i) => i._debug as ApiItemDebugInfo))
 		: {};
@@ -56,7 +56,7 @@ export async function asResult(
 		mapping: displayMappings(view, displayUtil, locale, translate, usePath),
 		first: replacePath(view.first, usePath),
 		last: replacePath(view.last, usePath),
-		items: view.items.map((i) => ({
+		items: view.items?.map((i) => ({
 			...('_debug' in i && { _debug: asItemDebugInfo(i['_debug'] as ApiItemDebugInfo, maxScores) }),
 			[JsonLd.ID]: i.meta[JsonLd.ID] as string,
 			[JsonLd.TYPE]: i[JsonLd.TYPE] as string,

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -101,33 +101,21 @@ export function displayMappings(
 			const operator = _hasOperator(m);
 
 			if ('property' in m && operator) {
-				// Mock old behaviour for 'classic' search GUI, i.e show error page
-				// when encountering an invalid property in order to provide feedback.
-				// TODO remove this when Supersearch is fully implemented.
-				// const useSuperSearch = env?.PUBLIC_USE_SUPERSEARCH === 'true';
-				// if (!useSuperSearch && m.property?.['@type'] === '_Invalid') {
-				// 	error(400, {
-				// 		message: `Invalid query, please check the documentation. Unrecognized property alias: ${m.property?.label ?? ''}`
-				// 	});
-				// }
-
 				const property = m[operator] as FramedData;
 				return {
-					...(isObject(m.property) && { '@id': m.property['@id'] }),
+					...(isObject(m.property) && { [JsonLd.ID]: m.property[JsonLd.ID] }),
 					display: displayUtil.lensAndFormat(property, LensType.Chip, locale),
 					displayStr: toString(displayUtil.lensAndFormat(property, LensType.Chip, locale)) || '',
 					label: m.alias
 						? translate(`facet.${m.alias}`)
 						: capitalize(m.property?.labelByLang?.[locale] || m.property?.label) ||
-							m.property?.['@id'] ||
+							m.property?.[JsonLd.ID] ||
 							'No label', // lensandformat?
-					property:
-						m.property?.librisQueryCode ||
-						m.property?.['@id']?.replace('https://id.kb.se/vocab/', '') ||
-						'', //TODO replace with something better
 					operator,
-					...(m.property?.['@type'] === '_Invalid' && { invalid: m.property?.label }),
-					...('up' in m && { up: replacePath(m.up as Link, usePath) })
+					...(m.property?.[JsonLd.TYPE] === '_Invalid' && { invalid: m.property?.label }),
+					...('up' in m && { up: replacePath(m.up as Link, usePath) }),
+					_key: m._key,
+					_value: m._value
 				} as DisplayMapping;
 			} else if (operator && operator in m && Array.isArray(m[operator])) {
 				const mappingArr = m[operator] as SearchMapping[];

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
@@ -39,7 +39,7 @@ export const GET: RequestHandler = async ({ url, params, locals }) => {
 
 	const [findRes, mappingRes] = await Promise.all([
 		fetch(`${env.API_URL}/find?${newSearchParams.toString()}`),
-		editedRanges?.qualifierKey && fetch(`${env.API_URL}/find?_q=${_q?.toString()}&_limit=0`) // when getting narrowed results for qualifier, we also need to send the full query to not lose all mapping labels :(
+		editedRanges?.qualifierKey && fetch(`${env.API_URL}/find?_q=${encodeURIComponent(_q)}&_limit=0`) // when getting narrowed results for qualifier, we also need to send the full query to not lose all mapping labels :(
 	]);
 
 	const data = await findRes.json();

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
@@ -44,7 +44,7 @@ export const GET: RequestHandler = async ({ url, params, locals }) => {
 
 	const data = await findRes.json();
 
-	if (mappingRes) {
+	if (mappingRes && mappingRes.ok) {
 		const mappingData = await mappingRes.json();
 		data.search.mapping = [...mappingData.search.mapping];
 	}


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-327](https://kbse.atlassian.net/browse/LWS-327)

### Solves

Frontend implementation of https://github.com/libris/librisxl/pull/1553 that lets us match a qualifier key/value with its corresponding mapping object, label & removelink.

Try for example...
To type any key that the backend understands, for example `ämne:`
To add multiple 'contributor' filters from the facets (no more mixed up labels)

### Summary of changes

* Implement search.mapping `_key` & `_value`
* Update test
* Fix bug in supersearch input field where many pills pushed away the search button 🙃 