### PR TITLE
feat(cataloging): Add KB CookieConsent

### DIFF
--- a/cataloging/package.json
+++ b/cataloging/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@babel/core": "^7.25.2",
     "@babel/polyfill": "^7.8.3",
+    "@kungbib/cookie-consent": "^0.9.1",
     "@vitejs/plugin-vue": "^5.1.2",
     "@vue/eslint-config-airbnb": "^8.0.0",
     "@vueuse/components": "^11.0.1",

--- a/cataloging/src/components/layout/footer.vue
+++ b/cataloging/src/components/layout/footer.vue
@@ -62,6 +62,9 @@ export default {
               <li>
                 <a href="https://www.kb.se/digital-tillganglighet" class="Footer-link">{{ translatePhrase("Accessibility statement") }}</a>
               </li>
+              <li>
+                <a data-cc="show-preferencesModal" href="#" aria-haspopup="dialog">{{ translatePhrase("Manage cookies") }}</a>
+              </li>
             </ul>
             <ul class="Footer-navList">
               <li>

--- a/cataloging/src/main.js
+++ b/cataloging/src/main.js
@@ -10,6 +10,7 @@ import router from './router';
 import App from './App.vue';
 import EntitySummary from './components/shared/entity-summary.vue';
 import Field from './components/inspector/field.vue';
+import KbCookieConsent from '@kungbib/cookie-consent';
 
 const app = createApp(App);
 
@@ -25,8 +26,71 @@ const matomoId = runtimeConfig.MATOMO_ID || import.meta.env.VITE_APP_MATOMO_ID;
 matomoId && app.use(VueMatomo, {
   host: 'https://analytics.kb.se',
   siteId: matomoId,
-  router: router
+  router: router,
+  requireConsent: true
 })
+
+KbCookieConsent.run({
+  categories: {
+    //necessary: {
+    //  readOnly: true,
+    //  enabled: true
+    //},
+    analytics: {
+      autoClear: {
+        cookies: [
+          {
+            // Matomo cookies
+            name: /^_pk.*/
+          }
+        ]
+      }
+    }
+  },
+  language: {
+    translations: {
+      sv: {
+        preferencesModal: {
+          sections: [
+            {
+              title: "Om användning av kakor",
+              description: "Den här tjänsten använder kakor (cookies). En kaka är en liten textfil som lagras i besökarens dator. KB:s tjänster är designade för att minska risken för spridning av dina uppgifter. Informationen som lagras via kakor kan aldrig användas av tredje part i marknadsföringssyfte."
+            },
+            //{
+            //  title: "Nödvändiga kakor",
+            //  description: "Dessa kakor krävs för att tjänsten ska vara säker och fungera som den ska. Därför går de inte att inaktivera.",
+            //  linkedCategory: "necessary", // här länkar vi samman beskrivningen med respektive kategori
+            //},
+            {
+              title: "Analytiska kakor",
+              description:
+                "Kakor som ger oss information om hur webbplatsen används som gör att vi kan underhålla, driva och förbättra användarupplevelsen.",
+              linkedCategory: "analytics"
+            },
+            {
+              title: "Mer information",
+              description: "Du kan alltid ändra dina val genom att klicka på “Hantera cookies” längst ner på sidan i sidfoten."
+            }
+          ]
+        }
+      }
+    }
+  },
+  onConsent: ({ cookie }) => {
+    if (cookie.categories.includes('analytics')) {
+      window._paq = window._paq || [];
+      window._paq.push(['rememberConsentGiven']);
+    }
+  },
+  onChange: ({ cookie }) => {
+    if (cookie.categories.includes('analytics')) {
+      window._paq = window._paq || [];
+      window._paq.push(['rememberConsentGiven']);
+    } else {
+      window._paq.push(['forgetConsentGiven']);
+    }
+  }
+});
 
 app.component('entity-summary', EntitySummary).component('field', Field);
 

--- a/cataloging/src/main.js
+++ b/cataloging/src/main.js
@@ -10,7 +10,8 @@ import router from './router';
 import App from './App.vue';
 import EntitySummary from './components/shared/entity-summary.vue';
 import Field from './components/inspector/field.vue';
-import KbCookieConsent from '@kungbib/cookie-consent';
+import CookieConsent from './plugins/cookie-consent.js'
+import settings from './settings';
 
 const app = createApp(App);
 
@@ -29,68 +30,7 @@ matomoId && app.use(VueMatomo, {
   router: router,
   requireConsent: true
 })
-
-KbCookieConsent.run({
-  categories: {
-    //necessary: {
-    //  readOnly: true,
-    //  enabled: true
-    //},
-    analytics: {
-      autoClear: {
-        cookies: [
-          {
-            // Matomo cookies
-            name: /^_pk.*/
-          }
-        ]
-      }
-    }
-  },
-  language: {
-    translations: {
-      sv: {
-        preferencesModal: {
-          sections: [
-            {
-              title: "Om användning av kakor",
-              description: "Den här tjänsten använder kakor (cookies). En kaka är en liten textfil som lagras i besökarens dator. KB:s tjänster är designade för att minska risken för spridning av dina uppgifter. Informationen som lagras via kakor kan aldrig användas av tredje part i marknadsföringssyfte."
-            },
-            //{
-            //  title: "Nödvändiga kakor",
-            //  description: "Dessa kakor krävs för att tjänsten ska vara säker och fungera som den ska. Därför går de inte att inaktivera.",
-            //  linkedCategory: "necessary", // här länkar vi samman beskrivningen med respektive kategori
-            //},
-            {
-              title: "Analytiska kakor",
-              description:
-                "Kakor som ger oss information om hur webbplatsen används som gör att vi kan underhålla, driva och förbättra användarupplevelsen.",
-              linkedCategory: "analytics"
-            },
-            {
-              title: "Mer information",
-              description: "Du kan alltid ändra dina val genom att klicka på “Hantera cookies” längst ner på sidan i sidfoten."
-            }
-          ]
-        }
-      }
-    }
-  },
-  onConsent: ({ cookie }) => {
-    if (cookie.categories.includes('analytics')) {
-      window._paq = window._paq || [];
-      window._paq.push(['rememberConsentGiven']);
-    }
-  },
-  onChange: ({ cookie }) => {
-    if (cookie.categories.includes('analytics')) {
-      window._paq = window._paq || [];
-      window._paq.push(['rememberConsentGiven']);
-    } else {
-      window._paq.push(['forgetConsentGiven']);
-    }
-  }
-});
+app.use(CookieConsent, settings.cookieConsent);
 
 app.component('entity-summary', EntitySummary).component('field', Field);
 

--- a/cataloging/src/plugins/cookie-consent.js
+++ b/cataloging/src/plugins/cookie-consent.js
@@ -1,0 +1,8 @@
+import KbCookieConsent from '@kungbib/cookie-consent';
+
+export default {
+  install: (app, pluginConfig) => {
+      app.config.globalProperties.CookieConsent = KbCookieConsent;
+      app.config.globalProperties.CookieConsent.run(pluginConfig);
+  }
+}

--- a/cataloging/src/resources/json/i18n.json
+++ b/cataloging/src/resources/json/i18n.json
@@ -469,6 +469,7 @@
     "This might take a while...": "Det här verkar ta lite tid...",
     "Lock property": "Lås egenskap",
     "Unlock property": "Lås upp egenskap",
-    "The property is locked for editing. Are you sure you want to unlock it?" : "Egenskapen är låst för redigering. Är du säker på att du vill låsa upp?"
+    "The property is locked for editing. Are you sure you want to unlock it?" : "Egenskapen är låst för redigering. Är du säker på att du vill låsa upp?",
+    "Manage cookies": "Hantera kakor"
   }
 }

--- a/cataloging/src/settings.js
+++ b/cataloging/src/settings.js
@@ -480,4 +480,56 @@ export default {
       },
     ],
   },
+  cookieConsent: {
+    categories: {
+      analytics: {
+        autoClear: {
+          cookies: [
+            {
+              // Matomo cookies
+              name: /^_pk.*/
+            }
+          ]
+        }
+      }
+    },
+    language: {
+      translations: {
+        sv: {
+          preferencesModal: {
+            sections: [
+              {
+                title: "Om användning av kakor",
+                description: "Den här tjänsten använder kakor (cookies). En kaka är en liten textfil som lagras i besökarens dator. KB:s tjänster är designade för att minska risken för spridning av dina uppgifter. Informationen som lagras via kakor kan aldrig användas av tredje part i marknadsföringssyfte."
+              },
+              {
+                title: "Analytiska kakor",
+                description:
+                  "Kakor som ger oss information om hur webbplatsen används som gör att vi kan underhålla, driva och förbättra användarupplevelsen.",
+                linkedCategory: "analytics"
+              },
+              {
+                title: "Mer information",
+                description: "Du kan alltid ändra dina val genom att klicka på “Hantera cookies” längst ner på sidan i sidfoten."
+              }
+            ]
+          }
+        }
+      }
+    },
+    onConsent: ({ cookie }) => {
+      if (cookie.categories.includes('analytics')) {
+        window._paq = window._paq || [];
+        window._paq.push(['rememberConsentGiven']);
+      }
+    },
+    onChange: ({ cookie }) => {
+      if (cookie.categories.includes('analytics')) {
+        window._paq = window._paq || [];
+        window._paq.push(['rememberConsentGiven']);
+      } else {
+        window._paq.push(['forgetConsentGiven']);
+      }
+    }
+  }
 };

--- a/cataloging/src/settings.js
+++ b/cataloging/src/settings.js
@@ -542,7 +542,7 @@ export default {
                     {
                       name: "_pk_id",
                       description: "Används för att komma ihåg besökaren genom ett unikt och slumpmässigt utformat ID.",
-                      duration: "1 år"
+                      duration: "13 månader"
                     },
                     {
                       name: "_pk_ses",

--- a/cataloging/src/settings.js
+++ b/cataloging/src/settings.js
@@ -482,6 +482,10 @@ export default {
   },
   cookieConsent: {
     categories: {
+      necessary: {
+        readOnly: true,
+        enabled: true
+      },
       analytics: {
         autoClear: {
           cookies: [
@@ -503,10 +507,60 @@ export default {
                 description: "Den här tjänsten använder kakor (cookies). En kaka är en liten textfil som lagras i besökarens dator. KB:s tjänster är designade för att minska risken för spridning av dina uppgifter. Informationen som lagras via kakor kan aldrig användas av tredje part i marknadsföringssyfte."
               },
               {
+                title: "Nödvändiga kakor",
+                description: "Dessa kakor krävs för att tjänsten ska vara säker och fungera som den ska. Därför går de inte att inaktivera.",
+                linkedCategory: "necessary",
+                cookieTable: {
+                  title: "Lista över kakor",
+                  headers: {
+                    name: "Namn",
+                    description: "Beskrivning",
+                    duration: "Varaktighet"
+                  },
+                  body: [
+                    {
+                      name: "cc_cookie",
+                      description: "Används för att spara dina kakinställningar.",
+                      duration: "6 månader"
+                    }
+                  ]
+                }
+              },
+              {
                 title: "Analytiska kakor",
                 description:
                   "Kakor som ger oss information om hur webbplatsen används som gör att vi kan underhålla, driva och förbättra användarupplevelsen.",
-                linkedCategory: "analytics"
+                linkedCategory: "analytics",
+                cookieTable: {
+                  title: "Lista över kakor",
+                  headers: {
+                    name: "Namn",
+                    description: "Beskrivning",
+                    duration: "Varaktighet"
+                  },
+                  body: [
+                    {
+                      name: "_pk_id",
+                      description: "Används för att komma ihåg besökaren genom ett unikt och slumpmässigt utformat ID.",
+                      duration: "1 år"
+                    },
+                    {
+                      name: "_pk_ses",
+                      description: "Används för att spara tillfällig data om besöket.",
+                      duration: "30 minuter"
+                    },
+                    {
+                      name: "mtm_consent",
+                      description: "Används för att spara samtycke till analytiska kakor.",
+                      duration: "400 dagar"
+                    },
+                    {
+                      name: "mtm_consent_removed",
+                      description: "Används för att spara nekat samtycke till analytiska kakor.",
+                      duration: "400 dagar"
+                    }
+                  ]
+                }
               },
               {
                 title: "Mer information",

--- a/cataloging/yarn.lock
+++ b/cataloging/yarn.lock
@@ -1381,6 +1381,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@kungbib/cookie-consent@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@kungbib/cookie-consent/-/cookie-consent-0.9.1.tgz#86586f6c013c3f667841076d0ad90f01ef2b1912"
+  integrity sha512-W63GKGWreNen+pt7up/8nHff6G+hI+XCu5XRp4981wwgKP8uIwel2x0YcnGou3Pq+OeAIj5VvnyDMvI1JaJEqA==
+
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz#dbf733a965ca47b1973177dc0bb6c889edcfb129"


### PR DESCRIPTION
### Tickets involved
[LXL-4596](https://kbse.atlassian.net/browse/LXL-4596)

### Solves

Integrates [KB CookieConsent](https://github.com/Kungbib/cookie-consent) to handle Matomo cookies. AFAIK we don't use any other cookies.

### Summary of changes

* Change VueMatomo settings to require consent before sending anything
* Add Vue plugin for KB CookieConsent and use it; trigger VueMatomo using onConsent/onChange events
* Add "Manage cookies" link to footer to display cookie settings modal

I was told this only needs to be available in Swedish.

I just guessed that `settings.js` would be an appropriate place for the cookie consent settings, alternatives being having them directly in `app.js`, or `plugins/cookie-consent.js`, or...? :shrug: 
