### PR TITLE
feat(cataloging): Set adder input type to search (LXL-4615) 

### DIFF
--- a/cataloging/src/components/inspector/field-adder.vue
+++ b/cataloging/src/components/inspector/field-adder.vue
@@ -323,7 +323,7 @@ export default {
           <div class="FieldAdderPanel-filterContainer form-group">
             <input
               id="field-adder-input"
-              type="text"
+              type="search"
               ref="input"
               class="FieldAdderPanel-filterInput customInput mousetrap"
               autocomplete="off"

--- a/cataloging/src/components/inspector/property-adder.vue
+++ b/cataloging/src/components/inspector/property-adder.vue
@@ -280,7 +280,7 @@ export default {
           <div class="PropertyAdderPanel-filterContainer form-group">
             <input
               id="field-adder-input"
-              type="text"
+              type="search"
               ref="input"
               autocomplete="off"
               class="PropertyAdderPanel-filterInput customInput mousetrap"


### PR DESCRIPTION
## Description

### Tickets involved
[LXL-4615](https://kbse.atlassian.net/browse/LXL-4615)

### Solves

The change in https://github.com/libris/lxlviewer/pull/1209 was apparently not enough to hide the autocomplete box in Chrome – hopefully changing the input type to `"search"` (instead of `"text"`) will resolve it.

### Summary of changes

- Set adder input type to search
