### PR TITLE
feat(lxlweb): add suggestion qualifiers to query

### DIFF
--- a/lxl-web/src/lib/components/SuggestionCard.svelte
+++ b/lxl-web/src/lib/components/SuggestionCard.svelte
@@ -27,11 +27,11 @@
 	let showDebugExplain = $state(false);
 </script>
 
-<article class="suggestion-card relative grid w-full gap-x-4 px-4 pb-2 pt-2 font-normal">
+<article class="suggestion-card relative grid w-full gap-x-4 px-4 py-2 font-normal">
 	<a
 		id={cellId}
 		role="gridcell"
-		class={['card-link absolute h-full w-full hover:bg-main', isFocused && 'bg-site-header/40']}
+		class={['card-link absolute h-full w-full hover:bg-main', isFocused && 'focused-cell']}
 		href={itemId}
 		aria-labelledby={titleId}
 		aria-describedby={`${footerId}`}

--- a/lxl-web/src/lib/components/SuggestionCard.svelte
+++ b/lxl-web/src/lib/components/SuggestionCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { SearchResultItem } from '$lib/types/search';
+	import type { SuperSearchResultItem } from '$lib/types/search';
 	import { LensType } from '$lib/types/xl';
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
 	import { LxlLens } from '$lib/types/display';
@@ -13,7 +13,7 @@
 	import EsExplain from '$lib/components/find/EsExplain.svelte';
 
 	type Props = {
-		item: SearchResultItem;
+		item: SuperSearchResultItem;
 		cellId: string;
 		isFocused: boolean;
 	};
@@ -27,134 +27,128 @@
 	let showDebugExplain = $state(false);
 </script>
 
-<div class="suggestion-card-container">
-	<article class="suggestion-card relative grid w-full gap-x-4 px-4 pb-2 pt-2 font-normal">
-		<a
-			id={cellId}
-			role="gridcell"
-			class={['card-link absolute h-full w-full hover:bg-main', isFocused && 'bg-site-header/40']}
-			href={itemId}
-			aria-labelledby={titleId}
-			aria-describedby={`${footerId}`}
-		></a>
-		<div class="card-image">
-			<div class="pointer-events-none relative flex">
-				{#if item.image}
+<article class="suggestion-card relative grid w-full gap-x-4 px-4 pb-2 pt-2 font-normal">
+	<a
+		id={cellId}
+		role="gridcell"
+		class={['card-link absolute h-full w-full hover:bg-main', isFocused && 'bg-site-header/40']}
+		href={itemId}
+		aria-labelledby={titleId}
+		aria-describedby={`${footerId}`}
+	></a>
+	<div class="card-image">
+		<div class="pointer-events-none relative flex">
+			{#if item.image}
+				<img
+					src={item.image.url}
+					width={item.image.widthṔx}
+					height={item.image.heightPx}
+					alt={$page.data.t('general.latestInstanceCover')}
+					class={[
+						'aspect-square object-contain object-top',
+						item['@type'] === 'Person' && 'rounded-full'
+					]}
+				/>
+				{#if item['@type'] !== 'Text' && item['@type'] !== 'Person' && getTypeIcon(item['@type'])}
+					{@const SvelteComponent = getTypeIcon(item['@type'])}
+					<div class="absolute -left-2 -top-2">
+						<div class="rounded-md bg-main/80 p-1.5">
+							<SvelteComponent class="h-3 w-3 text-icon-strong" />
+						</div>
+					</div>
+				{/if}
+			{:else}
+				<div class="flex items-center justify-center">
 					<img
-						src={item.image.url}
-						width={item.image.widthṔx}
-						height={item.image.heightPx}
-						alt={$page.data.t('general.latestInstanceCover')}
+						src={placeholder}
+						alt=""
 						class={[
-							'aspect-square object-contain object-top',
-							item['@type'] === 'Person' && 'rounded-full'
+							'object-contain object-top',
+							item['@type'] === 'Person' ? 'rounded-full' : 'rounded-sm'
 						]}
 					/>
-					{#if item['@type'] !== 'Text' && item['@type'] !== 'Person' && getTypeIcon(item['@type'])}
-						{@const SvelteComponent = getTypeIcon(item['@type'])}
-						<div class="absolute -left-2 -top-2">
-							<div class="rounded-md bg-main/80 p-1.5">
-								<SvelteComponent class="h-3 w-3 text-icon-strong" />
-							</div>
-						</div>
+					{#if getTypeIcon(item['@type'])}
+						{@const SvelteComponent_1 = getTypeIcon(item['@type'])}
+						<SvelteComponent_1 class="absolute text-lg text-icon" />
+					{/if}
+				</div>
+			{/if}
+		</div>
+	</div>
+	<div class="card-content pointer-events-none z-10 overflow-hidden">
+		<header class="card-header" id={titleId}>
+			<hgroup class="flex">
+				<h2
+					class="card-header-title flex items-baseline overflow-hidden whitespace-nowrap text-link"
+				>
+					<span class="overflow-hidden text-ellipsis text-3-cond-bold">
+						<DecoratedData data={item[LxlLens.CardHeading]} showLabels={ShowLabelsOptions.Never} />
+					</span>
+					<!-- first contributor -->
+					{#if item[LxlLens.CardBody]?._display?.[0]?.contribution}
+						<span class="divider text-2-regular">&nbsp;{'•'}&nbsp;</span>
+						<span class="flex-shrink-0 text-2-regular">
+							<DecoratedData
+								data={item[LxlLens.CardBody]?._display[0]}
+								showLabels={ShowLabelsOptions.Never}
+								allowLinks={false}
+								truncate={true}
+							/>
+						</span>
+					{/if}
+				</h2>
+			</hgroup>
+			<!-- header extra skipped -->
+		</header>
+		<footer class="card-footer mt-auto text-xs text-secondary" id={footerId}>
+			<span class="font-bold">
+				{item.typeStr}
+			</span>
+			<span class="divider">{' • '}</span>
+			{#each item[LensType.WebCardFooter]?._display as obj}
+				{#if 'hasInstance' in obj}
+					<span class="divider">{' • '}</span>
+					{@const instances = getInstanceData(obj.hasInstance)}
+					{#if instances?.years}
+						<span>
+							{#if instances.count > 1}
+								{instances?.count}
+								{$page.data.t('search.editions')}
+								{`(${instances.years})`}
+							{:else}
+								{instances.years}
+							{/if}
+						</span>
 					{/if}
 				{:else}
-					<div class="flex items-center justify-center">
-						<img
-							src={placeholder}
-							alt=""
-							class={[
-								'object-contain object-top',
-								item['@type'] === 'Person' ? 'rounded-full' : 'rounded-sm'
-							]}
-						/>
-						{#if getTypeIcon(item['@type'])}
-							{@const SvelteComponent_1 = getTypeIcon(item['@type'])}
-							<SvelteComponent_1 class="absolute text-lg text-icon" />
-						{/if}
-					</div>
+					<span>
+						<DecoratedData data={obj} showLabels={ShowLabelsOptions.Never} allowLinks={false} />
+					</span>
 				{/if}
-			</div>
-		</div>
-		<div class="card-content pointer-events-none z-10 overflow-hidden">
-			<header class="card-header" id={titleId}>
-				<hgroup class="flex">
-					<h2
-						class="card-header-title flex items-baseline overflow-hidden whitespace-nowrap text-link"
-					>
-						<span class="overflow-hidden text-ellipsis text-3-cond-bold">
-							<DecoratedData data={item['card-heading']} showLabels={ShowLabelsOptions.Never} />
-						</span>
-						<!-- first contributor -->
-						{#if item[LxlLens.CardBody]?._display?.[0]?.contribution}
-							<span class="divider text-2-regular">&nbsp;{'•'}&nbsp;</span>
-							<span class="flex-shrink-0 text-2-regular">
-								<DecoratedData
-									data={item[LxlLens.CardBody]?._display[0]}
-									showLabels={ShowLabelsOptions.Never}
-									allowLinks={false}
-									truncate={true}
-								/>
-							</span>
-						{/if}
-					</h2>
-				</hgroup>
-				<!-- header extra skipped -->
-			</header>
-			<footer class="card-footer mt-auto text-xs text-secondary" id={footerId}>
-				<span class="font-bold">
-					{item.typeStr}
-				</span>
-				<span class="divider">{' • '}</span>
-				{#each item[LensType.WebCardFooter]?._display as obj}
-					{#if 'hasInstance' in obj}
-						<span class="divider">{' • '}</span>
-						{@const instances = getInstanceData(obj.hasInstance)}
-						{#if instances?.years}
-							<span>
-								{#if instances.count > 1}
-									{instances?.count}
-									{$page.data.t('search.editions')}
-									{`(${instances.years})`}
-								{:else}
-									{instances.years}
-								{/if}
-							</span>
-						{/if}
-					{:else}
-						<span>
-							<DecoratedData data={obj} showLabels={ShowLabelsOptions.Never} allowLinks={false} />
-						</span>
-					{/if}
-				{/each}
-			</footer>
-		</div>
-		{#if item._debug}
-			{#key item._debug}
-				<button
-					type="button"
-					class="card-debug z-10 cursor-crosshair select-text self-start text-left"
-					onclick={() => {
-						showDebugExplain = !showDebugExplain;
-					}}
-				>
-					<SearchItemDebug debugInfo={item._debug} />
-				</button>
-				{#if showDebugExplain}
-					<div id="explain" class="z-10 col-span-full row-start-2 cursor-crosshair pt-4">
-						<EsExplain explain={item._debug.score.explain} />
-					</div>
-				{/if}
-			{/key}
-		{/if}
-	</article>
-</div>
+			{/each}
+		</footer>
+	</div>
+	{#if item._debug}
+		{#key item._debug}
+			<button
+				type="button"
+				class="card-debug z-10 cursor-crosshair select-text self-start text-left"
+				onclick={() => {
+					showDebugExplain = !showDebugExplain;
+				}}
+			>
+				<SearchItemDebug debugInfo={item._debug} />
+			</button>
+			{#if showDebugExplain}
+				<div id="explain" class="z-10 col-span-full row-start-2 cursor-crosshair pt-4">
+					<EsExplain explain={item._debug.score.explain} />
+				</div>
+			{/if}
+		{/key}
+	{/if}
+</article>
 
 <style scoped lang="postcss">
-	.suggestion-card-container {
-		container-type: inline-size;
-	}
-
 	.suggestion-card {
 		grid-template-areas: 'image content debug';
 		grid-template-columns: 40px 1fr auto;

--- a/lxl-web/src/lib/components/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/SuperSearchWrapper.svelte
@@ -333,7 +333,11 @@
 									href={getFullQualifierLink(qualifier._q)}
 								>
 									<span class="lxl-qualifier atomic add-qualifier">
-										<BiPlusLg class="" fill="currentColor" />
+										<BiPlusLg
+											class=""
+											fill="currentColor"
+											aria-label={$page.data.t('search.addAs')}
+										/>
 										<span class="first-letter:capitalize">{qualifier.label}</span>
 									</span>
 								</a>

--- a/lxl-web/src/lib/components/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/SuperSearchWrapper.svelte
@@ -13,7 +13,6 @@
 	import BiArrowUpLeft from '~icons/bi/arrow-up-left';
 	import BiChevronDown from '~icons/bi/chevron-down';
 	import BiChevronUp from '~icons/bi/chevron-up';
-	import BiPlusLg from '~icons/bi/plus-lg';
 	import '$lib/styles/lxlquery.css';
 
 	interface Props {
@@ -318,24 +317,24 @@
 		{/snippet}
 		{#snippet resultItemRow({ resultItem, getCellId, isFocusedCell })}
 			{#if resultItem}
-				<div class="suggestion-card-container flex">
+				<div class="suggestion-card-container flex text-xs md:text-sm">
 					<SuggestionCard item={resultItem} cellId={getCellId(0)} isFocused={isFocusedCell(0)} />
 					{#if resultItem.qualifiers.length > 0}
-						<div class="flex">
+						<div class="flex pr-2">
 							{#each resultItem.qualifiers as qualifier, index}
 								<!-- pills -->
 								<a
 									id={getCellId(index + 1)}
 									role="gridcell"
 									class={[
-										'flex items-center p-2 no-underline last-of-type:pr-4 hover:bg-main',
+										'flex items-center p-1 no-underline hover:bg-main sm:p-1.5',
 										isFocusedCell(index + 1) && 'focused-cell'
 									]}
 									onclick={() => onClickAddQualifier(qualifier.to)}
 									href={getFullQualifierLink(qualifier._q)}
 								>
 									<span class="lxl-qualifier atomic add-qualifier">
-										<BiPlusLg
+										<BiArrowUpLeft
 											class=""
 											fill="currentColor"
 											aria-label={$page.data.t('search.addAs')}
@@ -400,6 +399,18 @@
 		box-shadow: inset 0 0 0 1px rgba(105, 65, 25, 0.24);
 	}
 
+	:global(.supersearch-dialog .focused) {
+		@apply bg-site-header/24;
+	}
+
+	:global(.focused-cell) {
+		@apply bg-site-header/40;
+	}
+
+	:global(.button-primary.focused-cell) {
+		@apply before:opacity-100;
+	}
+
 	/* suggestions */
 
 	:global(.supersearch-suggestions [role='row']:last-child) {
@@ -438,13 +449,5 @@
 		padding-top: 0.6125rem;
 		padding-bottom: 0.6125rem;
 		outline: none;
-	}
-
-	.focused-cell {
-		@apply bg-site-header/40;
-	}
-
-	:global(.button-primary.focused-cell) {
-		@apply before:opacity-100;
 	}
 </style>

--- a/lxl-web/src/lib/components/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/SuperSearchWrapper.svelte
@@ -339,7 +339,7 @@
 											fill="currentColor"
 											aria-label={$page.data.t('search.addAs')}
 										/>
-										<span class="first-letter:capitalize">{qualifier.label}</span>
+										<span class="whitespace-nowrap first-letter:capitalize">{qualifier.label}</span>
 									</span>
 								</a>
 							{/each}

--- a/lxl-web/src/lib/components/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/SuperSearchWrapper.svelte
@@ -93,7 +93,7 @@
 	});
 
 	let moreFiltersRowIndex = $derived(showMoreFilters ? 7 : 4);
-	
+
 	function getFullQualifierLink(q: string) {
 		const params = new URLSearchParams($page.url.searchParams.toString());
 		params.set('_q', q);
@@ -103,7 +103,7 @@
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	function onClickAddQualifier(to: string) {
+	function onClickAddQualifier(cursor: string) {
 		// TODO set cursor position
 	}
 </script>
@@ -330,7 +330,7 @@
 										'flex items-center p-1 no-underline hover:bg-main sm:p-1.5',
 										isFocusedCell(index + 1) && 'focused-cell'
 									]}
-									onclick={() => onClickAddQualifier(qualifier.to)}
+									onclick={() => onClickAddQualifier(qualifier.cursor)}
 									href={getFullQualifierLink(qualifier._q)}
 								>
 									<span class="lxl-qualifier atomic add-qualifier">

--- a/lxl-web/src/lib/components/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/SuperSearchWrapper.svelte
@@ -327,8 +327,10 @@
 								<a
 									id={getCellId(index + 1)}
 									role="gridcell"
-									class:focused-cell={isFocusedCell(index + 1)}
-									class="flex items-center p-2 no-underline last-of-type:pr-4 hover:bg-main"
+									class={[
+										'flex items-center p-2 no-underline last-of-type:pr-4 hover:bg-main',
+										isFocusedCell(index + 1) && 'focused-cell'
+									]}
 									onclick={() => onClickAddQualifier(qualifier.to)}
 									href={getFullQualifierLink(qualifier._q)}
 								>

--- a/lxl-web/src/lib/components/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/SuperSearchWrapper.svelte
@@ -319,7 +319,7 @@
 			{#if resultItem}
 				<div class="suggestion-card-container flex text-xs md:text-sm">
 					<SuggestionCard item={resultItem} cellId={getCellId(0)} isFocused={isFocusedCell(0)} />
-					{#if resultItem.qualifiers.length > 0}
+					{#if resultItem.qualifiers.length}
 						<div class="flex pr-2">
 							{#each resultItem.qualifiers as qualifier, index}
 								<!-- pills -->

--- a/lxl-web/src/lib/components/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/SuperSearchWrapper.svelte
@@ -13,6 +13,7 @@
 	import BiArrowUpLeft from '~icons/bi/arrow-up-left';
 	import BiChevronDown from '~icons/bi/chevron-down';
 	import BiChevronUp from '~icons/bi/chevron-up';
+	import BiPlusLg from '~icons/bi/plus-lg';
 	import '$lib/styles/lxlquery.css';
 
 	interface Props {
@@ -93,6 +94,19 @@
 	});
 
 	let moreFiltersRowIndex = $derived(showMoreFilters ? 7 : 4);
+	
+	function getFullQualifierLink(q: string) {
+		const params = new URLSearchParams($page.url.searchParams.toString());
+		params.set('_q', q);
+		params.delete('_i');
+		params.set('_offset', '0');
+		return `/find?${params.toString()}`;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	function onClickAddQualifier(to: string) {
+		// TODO set cursor position
+	}
 </script>
 
 {#snippet startFilterItem({
@@ -304,7 +318,29 @@
 		{/snippet}
 		{#snippet resultItemRow({ resultItem, getCellId, isFocusedCell })}
 			{#if resultItem}
-				<SuggestionCard item={resultItem} cellId={getCellId(0)} isFocused={isFocusedCell(0)} />
+				<div class="suggestion-card-container flex">
+					<SuggestionCard item={resultItem} cellId={getCellId(0)} isFocused={isFocusedCell(0)} />
+					{#if resultItem.qualifiers.length > 0}
+						<div class="flex">
+							{#each resultItem.qualifiers as qualifier, index}
+								<!-- pills -->
+								<a
+									id={getCellId(index + 1)}
+									role="gridcell"
+									class:focused-cell={isFocusedCell(index + 1)}
+									class="flex items-center p-2 no-underline last-of-type:pr-4 hover:bg-main"
+									onclick={() => onClickAddQualifier(qualifier.to)}
+									href={getFullQualifierLink(qualifier._q)}
+								>
+									<span class="lxl-qualifier atomic add-qualifier">
+										<BiPlusLg class="" fill="currentColor" />
+										<span class="first-letter:capitalize">{qualifier.label}</span>
+									</span>
+								</a>
+							{/each}
+						</div>
+					{/if}
+				</div>
 			{/if}
 		{/snippet}
 	</SuperSearch>
@@ -318,6 +354,14 @@
 <style lang="postcss">
 	.supersearch-input {
 		@apply relative flex min-h-12 w-full cursor-text overflow-hidden rounded-md bg-cards focus-within:outline focus-within:outline-2 focus-within:outline-accent-dark/32;
+	}
+
+	.suggestion-card-container {
+		container-type: inline-size;
+	}
+
+	.add-qualifier {
+		@apply flex items-center gap-1 rounded-sm px-2 py-1;
 	}
 
 	/* dialog */

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -51,7 +51,7 @@
 	{@const facets = searchResult.facetGroups}
 	{@const numHits = searchResult.totalItems}
 	{@const filterCount = getFiltersCount(searchResult.mapping)}
-	{#if searchResult.predicates.length > 0}
+	{#if searchResult.predicates.length}
 		<nav
 			class="border-b border-primary/16 px-4 md:flex lg:px-6"
 			aria-label={$page.data.t('search.selectedFilters')}
@@ -148,7 +148,7 @@
 					{:else}
 						<span class="hits-count">{$page.data.t('search.noResults')}</span>
 					{/if}
-					{#if searchResult._spell.length > 0}
+					{#if searchResult._spell.length}
 						<span class="suggest">
 							{#each searchResult._spell as suggestion (suggestion.label)}
 								{$page.data.t('search.didYouMean')}

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -99,7 +99,7 @@ export default {
 		didYouMean: 'Did you mean',
 		showAllResults: 'Show all results',
 		supersearchStartHeader: 'Build and refine your search query',
-		addAs: 'Lägg till som'
+		addAs: 'Add as'
 	},
 	sort: {
 		sort: 'Sort',

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -98,7 +98,8 @@ export default {
 		relatedSearchLabel: 'Search the results',
 		didYouMean: 'Did you mean',
 		showAllResults: 'Show all results',
-		supersearchStartHeader: 'Build and refine your search query'
+		supersearchStartHeader: 'Build and refine your search query',
+		addAs: 'Lägg till som'
 	},
 	sort: {
 		sort: 'Sort',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -97,7 +97,8 @@ export default {
 		relatedSearchLabel: 'Sök i resultaten',
 		didYouMean: 'Menade du',
 		showAllResults: 'Visa alla sökresultat',
-		supersearchStartHeader: 'Bygg och förfina din sökning'
+		supersearchStartHeader: 'Bygg och förfina din sökning',
+		addAs: 'Lägg till som'
 	},
 	sort: {
 		sort: 'Sortera',

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -206,6 +206,5 @@ export interface SuperSearchResultItem extends SearchResultItem {
 export interface addQualifier {
 	label: string;
 	_q: string;
-	from: number;
-	to: number;
+	cursor: number;
 }

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -1,4 +1,4 @@
-import { JsonLd, type Link, type DisplayDecorated, type FramedData } from '$lib/types/xl';
+import { JsonLd, type Link, type DisplayDecorated, type FramedData, LensType } from '$lib/types/xl';
 import { type SecureImageResolution } from '$lib/types/auxd';
 import { LxlLens } from '$lib/types/display';
 
@@ -23,6 +23,8 @@ export interface SearchResultItem {
 	[JsonLd.TYPE]: string;
 	[LxlLens.CardHeading]: DisplayDecorated;
 	[LxlLens.CardBody]: DisplayDecorated;
+	[LensType.WebCardHeaderExtra]: DisplayDecorated;
+	[LensType.WebCardFooter]: DisplayDecorated;
 	image: SecureImageResolution | undefined;
 	typeStr: string;
 	_debug?: ItemDebugInfo;
@@ -190,4 +192,20 @@ export interface EsExplain {
 	description: string;
 	value: number;
 	details: EsExplain[];
+}
+
+export interface SuperSearchResult extends SearchResult {
+	[JsonLd.ID]: string;
+	items: SuperSearchResultItem[];
+}
+
+export interface SuperSearchResultItem extends SearchResultItem {
+	qualifiers: addQualifier[];
+}
+
+export interface addQualifier {
+	label: string;
+	_q: string;
+	from: number;
+	to: number;
 }

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -200,10 +200,10 @@ export interface SuperSearchResult extends SearchResult {
 }
 
 export interface SuperSearchResultItem extends SearchResultItem {
-	qualifiers: addQualifier[];
+	qualifiers: QualifierSuggestion[];
 }
 
-export interface addQualifier {
+export interface QualifierSuggestion {
 	label: string;
 	_q: string;
 	cursor: number;

--- a/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
+++ b/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
@@ -10,7 +10,7 @@ function getLabelFromMappings(
 ) {
 	const nonQuotedKey = key.replace(/^"(.*)"$/, '$1');
 	const nonQuotedValue = value && value.replace(/^"(.*)"$/, '$1');
-	const bestSuggestMapping = $derived(suggestMapping?.length ? suggestMapping : prevSuggestMapping);
+	const bestSuggestMapping = suggestMapping?.length ? suggestMapping : prevSuggestMapping;
 
 	const pageLabels = iterateMapping(nonQuotedKey, nonQuotedValue, pageMapping);
 	const suggestLabels = iterateMapping(nonQuotedKey, nonQuotedValue, bestSuggestMapping);

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -68,7 +68,7 @@ export async function asResult(
 				locale
 			),
 			[LensType.WebCardFooter]: displayUtil.lensAndFormat(i, LensType.WebCardFooter, locale),
-			image: toSecure(bestSize(bestImage(i), Width.SMALL), auxdSecret),
+			image: toSecure(bestSize(bestImage(i, locale), Width.SMALL), auxdSecret),
 			typeStr: toString(
 				displayUtil.lensAndFormat(vocabUtil.getDefinition(i[JsonLd.TYPE]), LensType.Chip, locale)
 			)

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -91,6 +91,13 @@ export class VocabUtil {
 		});
 	}
 
+	getLabelByLang(label: string, lang: string) {
+		return lxljsString.getLabelByLang(label, lang, {
+			vocab: this.vocabIndex,
+			context: this.context
+		});
+	}
+
 	private contextTerms() {
 		return this.context[1];
 	}

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
@@ -7,7 +7,7 @@ import getEditedRanges from './getEditedRanges.js';
 import { asResult } from '$lib/utils/search.js';
 import { DebugFlags } from '$lib/types/userSettings.js';
 import type { SuperSearchResult } from '$lib/types/search.js';
-import { itemAsQualifiers } from './itemAsQualifiers.js';
+import itemAsQualifiers from './itemAsQualifiers.js';
 
 /**
  * TODO:

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
@@ -56,7 +56,7 @@ export const GET: RequestHandler = async ({ url, params, locals }) => {
 	const superSearchResult: SuperSearchResult = {
 		'@id': data['@id'],
 		...searchResult,
-		items: searchResult.items.map((item, index) => {
+		items: searchResult.items?.map((item, index) => {
 			return {
 				...item,
 				qualifiers: itemAsQualifiers(data.items[index], editedRanges, _q, locale, vocabUtil)

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
@@ -6,6 +6,8 @@ import getEditedPartEntries from './getEditedPartEntries.js';
 import getEditedRanges from './getEditedRanges.js';
 import { asResult } from '$lib/utils/search.js';
 import { DebugFlags } from '$lib/types/userSettings.js';
+import type { SuperSearchResult } from '$lib/types/search.js';
+import { itemAsQualifiers } from './itemAsQualifiers.js';
 
 /**
  * TODO:
@@ -51,9 +53,16 @@ export const GET: RequestHandler = async ({ url, params, locals }) => {
 
 	const searchResult = await asResult(data, displayUtil, vocabUtil, locale, env.AUXD_SECRET);
 
-	return json({
+	const superSearchResult: SuperSearchResult = {
 		'@id': data['@id'],
-		'@context': data['@context'],
-		...searchResult
-	});
+		...searchResult,
+		items: searchResult.items.map((item, index) => {
+			return {
+				...item,
+				qualifiers: itemAsQualifiers(data.items[index], editedRanges, _q, locale, vocabUtil)
+			};
+		})
+	};
+
+	return json(superSearchResult);
 };

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.test.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.test.ts
@@ -7,7 +7,7 @@ describe('getEditedPartEntries', () => {
 	});
 	it('narrows down search query by base class for query codes', () => {
 		expect(getEditedPartEntries('astrid lindgren subject:"winter"', 27)).toEqual([
-			['_q', `"winter" "rdf:type":Subject`],
+			['_q', `"winter" "rdf:type":(Agent OR Subject)`],
 			['min-reverseLinks.totalItems', '1']
 		]);
 	});

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.ts
@@ -1,23 +1,11 @@
 import getEditedRanges, { type EditedRanges } from './getEditedRanges.js';
+import {
+	BASE_CLASS_FROM_QUALIFIER_KEY,
+	QUALIFIER_KEY_FROM_ALIAS,
+	findInMap
+} from './qualifierMappings.js';
 
 const DEFAULT_SUPERSEARCH_TYPES = ['Agent', 'Concept', 'Language', 'Work'];
-
-export const QUALIFIER_KEY_FROM_ALIAS = {
-	Contributor: ['medverkande'],
-	Language: ['språk'],
-	Subject: ['ämne'],
-	Bibliography: ['bibliografi']
-};
-
-export const BASE_CLASS_FROM_QUALIFIER_KEY = {
-	Agent: ['contributor', 'subject'], // find agents when typing 'subject:'
-	Subject: ['subject'],
-	GenreForm: ['genreForm'],
-	Language: ['language', 'translationOf.language'],
-	Library: ['itemHeldBy'],
-	Bibliography: ['bibliography']
-};
-
 const SKIP_QUALIFIERS = ['yearPublished', 'år'];
 
 /**
@@ -74,18 +62,6 @@ function queryIncludesType(q: string | undefined) {
 		return !!q.match(/"rdf:type"[:=]/g);
 	}
 	return false;
-}
-
-export function findInMap(map: Record<string, string[]>, k: string) {
-	const found = [];
-	if (k && typeof k === 'string') {
-		for (const [key, value] of Object.entries(map)) {
-			if (Array.isArray(value) && value.some((el) => el.toLowerCase() === k.toLowerCase())) {
-				found.push(key);
-			}
-		}
-	}
-	return found;
 }
 
 export default getEditedPartEntries;

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.ts
@@ -37,7 +37,7 @@ function getEditedPartEntries(
 			const keyFromAlias = findInMap(QUALIFIER_KEY_FROM_ALIAS, qualifierKey).join();
 			const baseClasses = findInMap(BASE_CLASS_FROM_QUALIFIER_KEY, keyFromAlias || qualifierKey);
 
-			if (baseClasses.length > 0) {
+			if (baseClasses.length) {
 				return [
 					['_q', `${qualifierValue} "rdf:type":(${baseClasses.join(' OR ')})`],
 					['min-reverseLinks.totalItems', '1'] // ensure results are linked/used atleast once

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.ts
@@ -2,7 +2,7 @@ import getEditedRanges, { type EditedRanges } from './getEditedRanges.js';
 
 const DEFAULT_SUPERSEARCH_TYPES = ['Agent', 'Concept', 'Language', 'Work'];
 
-const QUALIFIER_KEY_FROM_ALIAS = {
+export const QUALIFIER_KEY_FROM_ALIAS = {
 	Contributor: ['medverkande'],
 	Language: ['språk'],
 	Subject: ['ämne'],
@@ -76,7 +76,7 @@ function queryIncludesType(q: string | undefined) {
 	return false;
 }
 
-function findInMap(map: Record<string, string[]>, k: string) {
+export function findInMap(map: Record<string, string[]>, k: string) {
 	const found = [];
 	if (k && typeof k === 'string') {
 		for (const [key, value] of Object.entries(map)) {

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.test.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.test.ts
@@ -57,7 +57,7 @@ describe('itemAsQualifiers', () => {
 
 	it('returns all qualifiers in its range when not editing a qualifier', () => {
 		const _q = 'Astrid';
-		const item = { '@type': 'Person', '@id': 'https://libris-qa.kb.se/fcrtpljz1qp2bdv' };
+		const item = { '@type': 'Person', '@id': '"libris:fcrtpljz1qp2bdv"' };
 		const vocabUtil = {
 			getLabelByLang: () => 'test label',
 			getBaseClasses: () => ['Person', 'Agent']

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.test.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.test.ts
@@ -21,8 +21,8 @@ describe('itemAsQualifiers', () => {
 		const qualifiers = itemAsQualifiers(item, editedRanges, _q, 'sv', vocabUtil);
 		const result = [
 			{
-				_q: ' subject:"barn:Vintern" ',
-				cursor: 23,
+				_q: 'subject:"barn:Vintern"',
+				cursor: 22,
 				label: 'test label'
 			}
 		];
@@ -67,13 +67,13 @@ describe('itemAsQualifiers', () => {
 		const qualifiers = itemAsQualifiers(item, editedRanges, _q, 'sv', vocabUtil);
 		const result = [
 			{
-				_q: ' contributor:"libris:fcrtpljz1qp2bdv" ',
-				cursor: 37,
+				_q: 'contributor:"libris:fcrtpljz1qp2bdv"',
+				cursor: 36,
 				label: 'test label'
 			},
 			{
-				_q: ' subject:"libris:fcrtpljz1qp2bdv" ',
-				cursor: 33,
+				_q: 'subject:"libris:fcrtpljz1qp2bdv"',
+				cursor: 32,
 				label: 'test label'
 			}
 		];

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.test.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import itemAsQualifiers from './itemAsQualifiers';
+import type { VocabUtil } from '$lib/utils/xl';
+
+describe('itemAsQualifiers', () => {
+	it('produces a subject qualifier from ämne:vinter', () => {
+		const _q = 'ämne:vinter';
+		const item = { '@type': 'Topic', '@id': 'https://id.kb.se/term/barn/Vintern' };
+		const vocabUtil = {
+			getLabelByLang: () => 'test label',
+			getBaseClasses: () => ['Topic', 'Subject', 'Concept', 'Identity', 'Resource']
+		} as unknown as VocabUtil;
+		const editedRanges = {
+			from: 0,
+			to: 11,
+			qualifierKey: { from: 0, to: 4 },
+			qualifierOperator: { from: 4, to: 5 },
+			qualifierValue: { from: 5, to: 11 }
+		};
+
+		const qualifiers = itemAsQualifiers(item, editedRanges, _q, 'sv', vocabUtil);
+		const result = [
+			{
+				_q: ' subject:"barn:Vintern" ',
+				cursor: 23,
+				label: 'test label'
+			}
+		];
+		expect(qualifiers).toEqual(result);
+	});
+
+	it('correctly inserts the qualifier in the middle of _q', () => {
+		const _q = 'hej ämne:vinter hej';
+		const item = { '@type': 'Topic', '@id': 'https://id.kb.se/term/barn/Vintern' };
+		const vocabUtil = {
+			getLabelByLang: () => 'test label',
+			getBaseClasses: () => ['Topic', 'Subject', 'Concept', 'Identity', 'Resource']
+		} as unknown as VocabUtil;
+		const editedRanges = {
+			from: 4,
+			to: 15,
+			qualifierKey: { from: 4, to: 8 },
+			qualifierOperator: { from: 8, to: 9 },
+			qualifierValue: { from: 9, to: 15 }
+		};
+
+		const qualifiers = itemAsQualifiers(item, editedRanges, _q, 'sv', vocabUtil);
+		const result = [
+			{
+				_q: 'hej subject:"barn:Vintern" hej',
+				cursor: 26,
+				label: 'test label'
+			}
+		];
+		expect(qualifiers).toEqual(result);
+	});
+
+	it('returns all qualifiers in its range when not editing a qualifier', () => {
+		const _q = 'Astrid';
+		const item = { '@type': 'Person', '@id': 'https://libris-qa.kb.se/fcrtpljz1qp2bdv' };
+		const vocabUtil = {
+			getLabelByLang: () => 'test label',
+			getBaseClasses: () => ['Person', 'Agent']
+		} as unknown as VocabUtil;
+		const editedRanges = { from: 0, to: 6 };
+
+		const qualifiers = itemAsQualifiers(item, editedRanges, _q, 'sv', vocabUtil);
+		const result = [
+			{
+				_q: ' contributor:"libris:fcrtpljz1qp2bdv" ',
+				cursor: 37,
+				label: 'test label'
+			},
+			{
+				_q: ' subject:"libris:fcrtpljz1qp2bdv" ',
+				cursor: 33,
+				label: 'test label'
+			}
+		];
+		expect(qualifiers).toEqual(result);
+	});
+});

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
@@ -1,0 +1,77 @@
+import type { addQualifier } from '$lib/types/search';
+import { JsonLd, type FramedData } from '$lib/types/xl';
+import { VocabUtil } from '$lib/utils/xl';
+import { BASE_CLASS_FROM_QUALIFIER_KEY } from './getEditedPartEntries';
+import { env } from '$env/dynamic/private';
+import type { EditedRanges } from './getEditedRanges';
+import type { LocaleCode } from '$lib/i18n/locales';
+
+const PREFIXES_BY_NAMESPACE = {
+	'https://id.kb.se/vocab/': 'kbv:',
+	'http://id.loc.gov/ontologies/bibframe/': 'bf:',
+	'http://purl.org/dc/terms/': 'dc:',
+	'http://schema.org/': 'sdo:',
+	'https://id.kb.se/term/sao/': 'sao:',
+	'https://id.kb.se/marc/': 'marc:',
+	'https://id.kb.se/term/saogf/': 'saogf:',
+	'https://id.kb.se/term/barn/': 'barn:',
+	'https://id.kb.se/term/barngf/': 'barngf:',
+	'https://libris.kb.se/library/': 'sigel:',
+	'https://id.kb.se/language/': 'lang:'
+};
+
+export function itemAsQualifiers(
+	item: FramedData,
+	editedRanges: EditedRanges,
+	_q: string,
+	locale: LocaleCode,
+	vocabUtil: VocabUtil
+): addQualifier[] {
+	const itemType = item[JsonLd.TYPE] as string | string[];
+	const itemTypeBaseClasses = vocabUtil.getBaseClasses(itemType);
+	const qualifierBaseClasses = Object.keys(BASE_CLASS_FROM_QUALIFIER_KEY);
+	const itemBaseClass = itemTypeBaseClasses
+		.filter((c) => qualifierBaseClasses.includes(c))
+		.join() as keyof typeof BASE_CLASS_FROM_QUALIFIER_KEY;
+
+	const predicates = BASE_CLASS_FROM_QUALIFIER_KEY?.[itemBaseClass];
+	const qualifierValue = getQualifierValue(item[JsonLd.ID] as string);
+
+	if (predicates && Array.isArray(predicates)) {
+		return predicates.map((p) => {
+			const qualifier = `${p}:${qualifierValue}`;
+			const qWithQualifier = _q.slice(0, editedRanges.from) + qualifier + _q.slice(editedRanges.to);
+			const label: string = vocabUtil.getLabelByLang(p, locale);
+			return {
+				label: label || p,
+				_q: qWithQualifier,
+				from: editedRanges.from,
+				to: editedRanges.to
+			};
+		});
+	} else return [];
+}
+
+function getQualifierValue(id: string) {
+	const prefix = getPrefix(id);
+	const qId = id.split('/').pop();
+
+	if (prefix && qId) {
+		return '"' + prefix + qId + '"';
+	}
+	return id;
+}
+
+function getPrefix(id: string) {
+	const prefixFromNamespace = Object.entries(PREFIXES_BY_NAMESPACE).find(([ns]) =>
+		id.includes(ns)
+	)?.[1];
+
+	if (prefixFromNamespace) {
+		return prefixFromNamespace;
+	}
+	if (id.includes(env.API_URL)) {
+		return 'libris:';
+	}
+	return '';
+}

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
@@ -1,4 +1,4 @@
-import type { addQualifier } from '$lib/types/search';
+import type { QualifierSuggestion } from '$lib/types/search';
 import { JsonLd, type FramedData } from '$lib/types/xl';
 import { VocabUtil } from '$lib/utils/xl';
 import {
@@ -30,7 +30,7 @@ function itemAsQualifiers(
 	_q: string,
 	locale: LocaleCode,
 	vocabUtil: VocabUtil
-): addQualifier[] {
+): QualifierSuggestion[] {
 	const itemType = item[JsonLd.TYPE] as string | string[];
 	const itemTypeBaseClasses = vocabUtil.getBaseClasses(itemType);
 	const qualifierBaseClasses = Object.keys(BASE_CLASS_FROM_QUALIFIER_KEY);

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
@@ -24,7 +24,7 @@ const PREFIXES_BY_NAMESPACE = {
 	'https://id.kb.se/language/': 'lang:'
 };
 
-export function itemAsQualifiers(
+function itemAsQualifiers(
 	item: FramedData,
 	editedRanges: EditedRanges,
 	_q: string,
@@ -97,3 +97,5 @@ function getPrefix(id: string) {
 	}
 	return '';
 }
+
+export default itemAsQualifiers;

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
@@ -59,12 +59,13 @@ function itemAsQualifiers(
 
 	return predicates.map((p) => {
 		const qualifier = `${p}:${qualifierValue}`;
-		const qWithQualifier =
+		const qWithQualifier = (
 			_q.slice(0, editedRanges.from).trim() +
 			' ' +
 			qualifier +
 			' ' +
-			_q.slice(editedRanges.to).trim();
+			_q.slice(editedRanges.to).trim()
+		).trim();
 		const label: string = vocabUtil.getLabelByLang(p, locale);
 		return {
 			label: label || p,

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
@@ -54,11 +54,13 @@ export function itemAsQualifiers(
 			(p: string) => p.toLowerCase() === (keyFromAlias.toLowerCase() || qualifierKey.toLowerCase())
 		);
 	}
+
 	const qualifierValue = getQualifierValue(item[JsonLd.ID] as string);
 
 	return predicates.map((p) => {
-		const qualifier = `${p}:${qualifierValue}`;
-		const qWithQualifier = _q.slice(0, editedRanges.from) + qualifier + _q.slice(editedRanges.to);
+		const qualifier = ` ${p}:${qualifierValue} `;
+		const qWithQualifier =
+			_q.slice(0, editedRanges.from).trim() + qualifier + _q.slice(editedRanges.to).trim();
 		const label: string = vocabUtil.getLabelByLang(p, locale);
 		return {
 			label: label || p,

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
@@ -1,7 +1,11 @@
 import type { addQualifier } from '$lib/types/search';
 import { JsonLd, type FramedData } from '$lib/types/xl';
 import { VocabUtil } from '$lib/utils/xl';
-import { BASE_CLASS_FROM_QUALIFIER_KEY } from './getEditedPartEntries';
+import {
+	BASE_CLASS_FROM_QUALIFIER_KEY,
+	findInMap,
+	QUALIFIER_KEY_FROM_ALIAS
+} from './getEditedPartEntries';
 import { env } from '$env/dynamic/private';
 import type { EditedRanges } from './getEditedRanges';
 import type { LocaleCode } from '$lib/i18n/locales';
@@ -34,7 +38,16 @@ export function itemAsQualifiers(
 		.filter((c) => qualifierBaseClasses.includes(c))
 		.join() as keyof typeof BASE_CLASS_FROM_QUALIFIER_KEY;
 
-	const predicates = BASE_CLASS_FROM_QUALIFIER_KEY?.[itemBaseClass];
+	let predicates = BASE_CLASS_FROM_QUALIFIER_KEY?.[itemBaseClass];
+
+	// if user explicitly requested a relation ('contributor:'), only show that one
+	if (editedRanges.qualifierKey) {
+		const qualifierKey = _q.substring(editedRanges.qualifierKey.from, editedRanges.qualifierKey.to);
+		const keyFromAlias = findInMap(QUALIFIER_KEY_FROM_ALIAS, qualifierKey).join();
+		predicates = predicates.filter(
+			(p) => p === (keyFromAlias.toLowerCase() || qualifierKey.toLowerCase())
+		);
+	}
 	const qualifierValue = getQualifierValue(item[JsonLd.ID] as string);
 
 	if (predicates && Array.isArray(predicates)) {

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/itemAsQualifiers.ts
@@ -58,15 +58,18 @@ export function itemAsQualifiers(
 	const qualifierValue = getQualifierValue(item[JsonLd.ID] as string);
 
 	return predicates.map((p) => {
-		const qualifier = ` ${p}:${qualifierValue} `;
+		const qualifier = `${p}:${qualifierValue}`;
 		const qWithQualifier =
-			_q.slice(0, editedRanges.from).trim() + qualifier + _q.slice(editedRanges.to).trim();
+			_q.slice(0, editedRanges.from).trim() +
+			' ' +
+			qualifier +
+			' ' +
+			_q.slice(editedRanges.to).trim();
 		const label: string = vocabUtil.getLabelByLang(p, locale);
 		return {
 			label: label || p,
 			_q: qWithQualifier,
-			from: editedRanges.from,
-			to: editedRanges.to
+			cursor: qWithQualifier.lastIndexOf(qualifier) + qualifier.length
 		};
 	});
 }

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/qualifierMappings.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/qualifierMappings.ts
@@ -1,0 +1,27 @@
+export const QUALIFIER_KEY_FROM_ALIAS = {
+	Contributor: ['medverkande'],
+	Language: ['språk'],
+	Subject: ['ämne'],
+	Bibliography: ['bibliografi']
+};
+
+export const BASE_CLASS_FROM_QUALIFIER_KEY = {
+	Agent: ['contributor', 'subject'],
+	Subject: ['subject'],
+	GenreForm: ['genreForm'],
+	Language: ['language', 'translationOf.language'],
+	Library: ['itemHeldBy'],
+	Bibliography: ['bibliography']
+};
+
+export function findInMap(map: Record<string, string[]>, k: string) {
+	const found = [];
+	if (k && typeof k === 'string') {
+		for (const [key, value] of Object.entries(map)) {
+			if (Array.isArray(value) && value.some((el) => el.toLowerCase() === k.toLowerCase())) {
+				found.push(key);
+			}
+		}
+	}
+	return found;
+}

--- a/packages/supersearch/src/lib/types/superSearch.ts
+++ b/packages/supersearch/src/lib/types/superSearch.ts
@@ -7,6 +7,7 @@ export type PaginationQueryFunction = (
 ) => URLSearchParams | undefined;
 export type TransformFunction = (data: JSONValue) => JSONValue;
 
+// TODO update me
 export interface ResultItem {
 	'@id'?: string;
 	heading: string;


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-324](https://kbse.atlassian.net/browse/LWS-324)

### Solves

Enables adding qualifiers to the query from the result suggestions. 

This is done by extending the response from the proxy api /supersearch route with a list of possible qualifiers for each item. The qualifiers are decided by the same [mapping](https://github.com/libris/lxlviewer/blob/2fa377333f16ebf351a65b2ba778b519ae701dcf/lxl-web/src/routes/api/%5B%5Blang%3Dlang%5D%5D/supersearch/qualifierMappings.ts#L8) that decides what type to search for when editing a qualifier, but in reverse (maybe this and [the prefix mapping](https://github.com/libris/lxlviewer/blob/2fa377333f16ebf351a65b2ba778b519ae701dcf/lxl-web/src/routes/api/%5B%5Blang%3Dlang%5D%5D/supersearch/itemAsQualifiers.ts#L13) should not be done in the frontend at all. Let's continue discussing/working with @kwahlin on this). 
I.e: 

`subject:` --> Search for `Agent` and `Subject` types
Library suggestion (subclass of Agent) --> range includes `contributor`, `subject` (Agent), `itemHeldBy` (Library).

However, when editing `subject:` you're probably looking to add a subject. In that case, we only show the `subject` qualifier (let's see if this makes sense).

Next step should be to prevent 'dead ends' by not showing subject pills for persons never used as a subject, for example. The best thing would of course be that they don't show up at all when editing `subject:`

TODO: place cursor after inserted qualifier

### Summary of changes

* Extend /api/supersearch reponse using new util `itemAsQualifiers.ts` , 
* Add extended types `SuperSearchResult`, `SuperSearchResultItem`, `addQualifier`
* Enable use of lxljs function `getLabelByLang` to get qualifier key labels.
* Move shared mapping stuff to `qualifierMappings.ts`
* Update `resultItemRow` snippet with qualifier pills
* Add unit tests