### PR TITLE
feat(lxl-web): Add option to sort (works) on number of holdings

### DIFF
--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -22,7 +22,10 @@
 		{ value: `-_sortKeyByLang.${$page.data.locale}`, label: $page.data.t('sort.alphaDesc') },
 		{ value: '-@reverse.instanceOf.publication.year', label: $page.data.t('sort.publicationDesc') },
 		{ value: '@reverse.instanceOf.publication.year', label: $page.data.t('sort.publicationAsc') },
-		{ value: '-reverseLinks.totalItems', label: $page.data.t('sort.linksDesc') }
+		{
+			value: '-reverseLinks.totalItemsByRelation.itemOf.instanceOf',
+			label: $page.data.t('sort.holdingsDesc')
+		}
 	];
 
 	function handleSortChange(e: Event) {

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -107,7 +107,7 @@ export default {
 		alphaDesc: 'Z-A',
 		publicationAsc: 'Oldest first (publication year)',
 		publicationDesc: 'Newest first (publication year)',
-		linksDesc: 'Most linked',
+		holdingsDesc: 'Number of libraries',
 		hitsAsc: 'Hits asc.',
 		hitsDesc: 'Hits desc.',
 		yearAsc: 'Oldest first',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -106,7 +106,7 @@ export default {
 		alphaDesc: 'Ö-A',
 		publicationAsc: 'Äldst först (utgivningsår)',
 		publicationDesc: 'Nyast först (utgivningsår)',
-		linksDesc: 'Mest länkad',
+		holdingsDesc: 'Antal bibliotek',
 		hitsAsc: 'Minst träffar',
 		hitsDesc: 'Flest träffar',
 		yearAsc: 'Äldst först',


### PR DESCRIPTION
TODO
Doesn't take the type into account. So it is also displayed when searching for e.g. Person
But that is also the case for sort.publicationDesc/sort.publicationAsc

Depends on https://github.com/libris/librisxl/pull/1560

### Tickets involved
[LWS-169](https://kbse.atlassian.net/browse/LWS-169)