### PR TITLE
fix(xlOptimize insertQuotes

### DIFF
--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertQuotes.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertQuotes.ts
@@ -5,31 +5,25 @@ import { syntaxTree } from '@codemirror/language';
  * Moves cursor into an empty quote after typing the QualifierOperator
  */
 const insertQuotes = (tr: Transaction) => {
-	if (!tr.isUserEvent('input')) {
+	if (!tr.isUserEvent('input') || tr.isUserEvent('input.complete')) {
 		return tr;
 	}
 	let changes = null;
-	syntaxTree(tr.state).iterate({
-		enter: (node) => {
-			if (node.name === 'QualifierOperator') {
-				const operatorEnd = node.to;
-				const oldCursorPos = tr.startState.selection.main.head;
-				const newCursorPos = tr.state.selection.main.head;
-				if (operatorEnd - 1 === oldCursorPos) {
-					changes = {
-						changes: {
-							from: newCursorPos,
-							to: newCursorPos,
-							insert: '""'
-						},
-						sequential: true,
-						selection: { anchor: newCursorPos + 1 }
-					};
-					return true;
-				}
-			}
+	const nodeBefore = syntaxTree(tr.state).resolveInner(tr.state.selection.main.head, -1);
+	if (nodeBefore.name === 'QualifierOperator') {
+		const textAfter = tr.state.sliceDoc(nodeBefore.to);
+		if (!textAfter || /^\s/.test(textAfter)) {
+			changes = {
+				changes: {
+					from: tr.state.selection.main.head,
+					to: tr.state.selection.main.head,
+					insert: '""'
+				},
+				sequential: true,
+				selection: { anchor: tr.state.selection.main.head + 1 }
+			};
 		}
-	});
+	}
 	return changes ? [tr, changes] : tr;
 };
 


### PR DESCRIPTION
Removes the need to iterate through the entire syntax tree

## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-NNNN](https://kbse.atlassian.net/browse/LXL-NNNN), [LXL-NNNN](https://kbse.atlassian.net/browse/LXL-NNNN)

### Solves

Description of what this solves

### Summary of changes

Summary of changes
