### PR TITLE
Feature/lxl 4625 blank node id issue

### DIFF
--- a/cataloging/src/components/care/bulk-changes.vue
+++ b/cataloging/src/components/care/bulk-changes.vue
@@ -364,7 +364,9 @@ export default {
         // NOP
       } else {
         this.currentSpec[MATCH_FORM_KEY] = form;
-        this.currentSpec[TARGET_FORM_KEY] = form;
+        if (this.hasTargetForm) {
+          this.currentSpec[TARGET_FORM_KEY] = form;
+        }
       }
     },
     onInactiveForm() {

--- a/cataloging/src/components/care/bulk-changes.vue
+++ b/cataloging/src/components/care/bulk-changes.vue
@@ -369,7 +369,7 @@ export default {
         }
       }
     },
-    onInactiveForm() {
+    onInactiveMatchForm() {
       let form = DataUtil.appendIds(cloneDeep(this.inspector.data.mainEntity));
       if (isEqual(form, this.currentSpec[MATCH_FORM_KEY])) {
         this.setInspectorData(this.currentSpec[TARGET_FORM_KEY]);
@@ -874,7 +874,7 @@ export default {
           :form-data="formObj"
           :first-item-active="isFirstActive"
           :is-draft="isDraft"
-          @onInactive="onInactiveForm"
+          @onInactive="onInactiveMatchForm"
           @onActive="focusMatchForm"
           @removeIdList="removeIdList"
         />

--- a/cataloging/src/components/care/bulk-changes.vue
+++ b/cataloging/src/components/care/bulk-changes.vue
@@ -358,6 +358,15 @@ export default {
         addToHistory: false,
       });
     },
+    onSaveFromActiveMatchForm() {
+      let form = DataUtil.appendIds(cloneDeep(this.inspector.data.mainEntity));
+      if (isEqual(form, this.currentSpec[MATCH_FORM_KEY])) {
+        // NOP
+      } else {
+        this.currentSpec[MATCH_FORM_KEY] = form;
+        this.currentSpec[TARGET_FORM_KEY] = form;
+      }
+    },
     onInactiveForm() {
       let form = DataUtil.appendIds(cloneDeep(this.inspector.data.mainEntity));
       if (isEqual(form, this.currentSpec[MATCH_FORM_KEY])) {
@@ -451,8 +460,7 @@ export default {
       this.isSaving = true;
       this.resetLastAdded();
       if (this.isActive('form')) {
-        this.onInactiveForm();
-        this.onInactiveTargetForm();
+        this.onSaveFromActiveMatchForm();
       } else if (this.isActive('targetForm')) {
         this.onInactiveTargetForm();
       } else if (this.isActive('mergeSpec')) {

--- a/cataloging/src/components/care/bulk-changes.vue
+++ b/cataloging/src/components/care/bulk-changes.vue
@@ -114,7 +114,7 @@ export default {
       return this.mergeSpecActive ? this.inspector.data.mainEntity : this.currentBulkChange[CHANGE_SPEC_KEY];
     },
     matchFormActive() {
-      return this.isActive('form');
+      return this.isActive('matchForm');
     },
     targetFormActive() {
       return this.isActive('targetForm');
@@ -124,9 +124,9 @@ export default {
     },
     formTitle() {
       if (this.specType === Type.Delete) {
-        return `${this.steps.indexOf('form') + 1}. ${translatePhrase('Remove records')}`;
+        return `${this.steps.indexOf('matchForm') + 1}. ${translatePhrase('Remove records')}`;
       }
-      return `${this.steps.indexOf('form') + 1}. ${translatePhrase('Selection')}`;
+      return `${this.steps.indexOf('matchForm') + 1}. ${translatePhrase('Selection')}`;
     },
     mergeTitle() {
       const title = this.isOtherSpec
@@ -184,13 +184,13 @@ export default {
     },
     steps() {
       if (this.isUpdateSpec) {
-        return ['form', 'targetForm', 'preview'];
+        return ['matchForm', 'targetForm', 'preview'];
       } else if (this.isMergeSpec) {
         return ['mergeSpec', 'preview'];
       } else if (this.isCreateSpec) {
         return ['targetForm', 'preview'];
       } else if (this.isDeleteSpec) {
-        return ['form', 'preview'];
+        return ['matchForm', 'preview'];
       } else {
         return ['preview'];
       }
@@ -382,7 +382,7 @@ export default {
       } else {
         this.currentSpec[TARGET_FORM_KEY] = cloneDeep(this.inspector.data.mainEntity);
       }
-      if (this.activeStep === 'form') {
+      if (this.activeStep === 'matchForm') {
         this.setInspectorData(this.currentSpec[MATCH_FORM_KEY]);
       }
     },
@@ -459,7 +459,7 @@ export default {
     save() {
       this.isSaving = true;
       this.resetLastAdded();
-      if (this.isActive('form')) {
+      if (this.isActive('matchForm')) {
         this.onSaveFromActiveMatchForm();
       } else if (this.isActive('targetForm')) {
         this.onInactiveTargetForm();
@@ -868,7 +868,7 @@ export default {
         <form-builder
           :title="formTitle"
           tabindex="0"
-          :is-active="isActive('form') && isDraft"
+          :is-active="isActive('matchForm') && isDraft"
           :form-data="formObj"
           :first-item-active="isFirstActive"
           :is-draft="isDraft"


### PR DESCRIPTION
As described in [LXL-4625](https://kbse.atlassian.net/browse/LXL-4625) there are rare cases where the hidden ID's that are generated by the frontend differ in the `matchForm` and `targetForm` parts of the bulk change specification. This sometimes occured when saving a bulk change with the  `matchForm` part active. It was caused by unwanted sideeffects of calling `onInactiveMatchForm` (this method should only be called when actually switching between the forms).

