### PR TITLE
feat(lxl-web): Move cursor after adding qualifiers (LWS-324)

### DIFF
--- a/lxl-web/src/lib/components/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/SuperSearchWrapper.svelte
@@ -6,7 +6,7 @@
 	import addDefaultSearchParams from '$lib/utils/addDefaultSearchParams';
 	import getSortedSearchParams from '$lib/utils/getSortedSearchParams';
 	import getLabelFromMappings from '$lib/utils/getLabelsFromMapping.svelte';
-	import type { DisplayMapping } from '$lib/types/search';
+	import type { DisplayMapping, QualifierSuggestion } from '$lib/types/search';
 	import { lxlQuery } from 'codemirror-lang-lxlquery';
 	import BiXLg from '~icons/bi/x-lg';
 	import BiArrowLeft from '~icons/bi/arrow-left';
@@ -79,9 +79,18 @@
 			selection: {
 				anchor: cursor + qualifierKey?.length + 2,
 				head: cursor + qualifierKey?.length + 2
-			}
+			},
+			userEvent: 'input.complete'
 		});
 		superSearch?.hideExpandedSearch();
+	}
+
+	function addQualifier(qualifier: QualifierSuggestion) {
+		superSearch?.dispatchChange({
+			change: { from: 0, to: q.length, insert: qualifier._q },
+			selection: { anchor: qualifier.cursor, head: qualifier.cursor },
+			userEvent: 'input.complete'
+		});
 	}
 
 	let derivedLxlQualifierPlugin = $derived.by(() => {
@@ -100,11 +109,6 @@
 		params.delete('_i');
 		params.set('_offset', '0');
 		return `/find?${params.toString()}`;
-	}
-
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	function onClickAddQualifier(cursor: string) {
-		// TODO set cursor position
 	}
 </script>
 
@@ -330,7 +334,7 @@
 										'flex items-center p-1 no-underline hover:bg-main sm:p-1.5',
 										isFocusedCell(index + 1) && 'focused-cell'
 									]}
-									onclick={() => onClickAddQualifier(qualifier.cursor)}
+									onclick={() => addQualifier(qualifier)}
 									href={getFullQualifierLink(qualifier._q)}
 								>
 									<span class="lxl-qualifier atomic add-qualifier">

--- a/packages/supersearch/src/lib/components/CodeMirror.svelte
+++ b/packages/supersearch/src/lib/components/CodeMirror.svelte
@@ -9,7 +9,7 @@
 	import { DEV } from 'esm-env';
 	import { onMount } from 'svelte';
 	import { EditorView } from '@codemirror/view';
-	import { EditorState, StateEffect, type Extension, type SelectionRange } from '@codemirror/state';
+	import { EditorSelection, EditorState, StateEffect, type Extension } from '@codemirror/state';
 	import isViewUpdateFromUserInput from '$lib/utils/isViewUpdateFromUserInput.js';
 
 	type CodeMirrorProps = {
@@ -59,7 +59,7 @@
 	]);
 	let prevExtensions: Extension[] = extensions;
 
-	function createEditorState({ doc, selection }: { doc?: string; selection?: SelectionRange }) {
+	function createEditorState({ doc, selection }: { doc?: string; selection?: EditorSelection }) {
 		return EditorState.create({
 			doc,
 			selection,
@@ -67,8 +67,20 @@
 		});
 	}
 
-	export function reset(options?: { doc: string; selection?: SelectionRange }) {
-		editorView?.setState(createEditorState({ doc: options?.doc, selection: options?.selection }));
+	export function reset(options?: { doc: string; selection?: { anchor: number; head?: number } }) {
+		editorView?.setState(
+			createEditorState({
+				doc: options?.doc,
+				selection: EditorSelection.create([
+					value && options?.selection
+						? EditorSelection.range(
+								options.selection.anchor,
+								options.selection?.head || options.selection.anchor
+							)
+						: EditorSelection.range(0, 0)
+				])
+			})
+		);
 		value = options?.doc || '';
 		onchange({
 			value,

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -238,7 +238,7 @@
 		selection,
 		userEvent = 'input'
 	}: {
-		change: {
+		change?: {
 			from: number;
 			to: number;
 			insert: string;

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertQuotes.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertQuotes.ts
@@ -5,12 +5,13 @@ import { syntaxTree } from '@codemirror/language';
  * Moves cursor into an empty quote after typing the QualifierOperator
  */
 const insertQuotes = (tr: Transaction) => {
-	if (!tr.isUserEvent('input')) {
+	if (!tr.isUserEvent('input') || tr.isUserEvent('input.complete')) {
 		return tr;
 	}
 	let changes = null;
 	syntaxTree(tr.state).iterate({
 		enter: (node) => {
+			/** TODO: We can probably optimize this as it currently traverses the entire syntax tree (when it should be enough to just check the edited/added part) */
 			if (node.name === 'QualifierOperator') {
 				const operatorEnd = node.to;
 				const oldCursorPos = tr.startState.selection.main.head;

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertQuotes.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertQuotes.ts
@@ -11,7 +11,6 @@ const insertQuotes = (tr: Transaction) => {
 	let changes = null;
 	syntaxTree(tr.state).iterate({
 		enter: (node) => {
-			/** TODO: We can probably optimize this as it currently traverses the entire syntax tree (when it should be enough to just check the edited/added part) */
 			if (node.name === 'QualifierOperator') {
 				const operatorEnd = node.to;
 				const oldCursorPos = tr.startState.selection.main.head;


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-324](https://kbse.atlassian.net/browse/LWS-324)

### Solves

Moves cursor after adding qualifiers. This is done by [dispatching changes](https://github.com/libris/lxlviewer/pull/1229/files#diff-eb1ad9ef8cb971563e0b0fdc86232ded17a2a2c7224467a53d45de62547aaa09R89-R93) instead of relying on the [reset effect](https://github.com/libris/lxlviewer/blob/7540d6a9bb19d64e2585433bf1cf9d4b1c9a7e2b/packages/supersearch/src/lib/components/CodeMirror.svelte#L97-L102) (which was triggered when the value changes from outside = when the URL changes).

There is a short flash of unformatted content when adding a qualifier but this could maybe be mitigated by using the label from the qualifier suggestion instead.

### Summary of changes

- Add qualifiers using dispatchChange
- Make change param optional (to allow selection-only changes
- Fix selection param type on reset function

