### PR TITLE
feat(lxl-web): Prepare QA-release of supersearch (LWS-329)

### DIFF
--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -10,10 +10,10 @@
 	import IconSliders from '~icons/bi/sliders';
 	import BiChevronDown from '~icons/bi/chevron-down';
 	import type { SearchResult, DisplayMapping } from '$lib/types/search';
-	import { shouldShowMapping } from '$lib/utils/search';
 
 	let showFiltersModal = false;
 	export let searchResult: SearchResult;
+	export let showMapping: boolean = false;
 
 	$: sortOrder = $page.url.searchParams.get('_sort');
 	const sortOptions = [
@@ -83,7 +83,7 @@
 			</ul>
 		</nav>
 	{/if}
-	{#if shouldShowMapping(searchResult.mapping)}
+	{#if showMapping}
 		<nav
 			class="hidden md:flex md:px-6 md:pb-0 md:pt-4"
 			aria-label={$page.data.t('search.selectedFilters')}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
@@ -10,6 +10,16 @@
 </svelte:head>
 
 <article class="container-fluid my-8 max-w-3xl">
+	<div class="landing flex flex-col items-center gap-2 pb-3">
+		<h1 class="flex text-3xl font-extrabold text-primary sm:text-[5.5rem] sm:font-bold">
+			Libris
+			<sup
+				class="self-center rounded-sm bg-positive-dark/16 px-2 uppercase text-2-cond-bold sm:text-3-cond-bold"
+				>Beta</sup
+			>
+		</h1>
+	</div>
+
 	{#if $page.data.locale === 'en'}
 		<EnContent />
 	{:else}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
@@ -7,8 +7,6 @@
 	import HeaderMenu from './HeaderMenu.svelte';
 	import SuperSearchWrapper from '$lib/components/SuperSearchWrapper.svelte';
 
-	$: isLandingPage = $page.route.id === '/(app)/[[lang=lang]]';
-
 	let useSuperSearch =
 		env?.PUBLIC_USE_SUPERSEARCH === 'true' || $page.url.searchParams.get('_x') === 'supersearch';
 
@@ -19,18 +17,16 @@
 	}
 </script>
 
-<header class="bg-site-header" class:is-landing={isLandingPage}>
+<header class="bg-site-header">
 	<nav class="header-nav min-h-20 items-center px-4 py-0">
 		<div class="home md:pl-4">
-			{#if !isLandingPage}
-				<a href={$page.data.base} class="flex flex-col text-primary no-underline md:flex-row">
-					<span class="text-[1.6rem] font-extrabold leading-tight md:text-[2.1rem]"> Libris</span>
-					<sup
-						class="top-0 -rotate-6 self-baseline rounded-sm bg-positive-dark/16 px-2 uppercase text-2-cond-bold md:rotate-0"
-						>Beta</sup
-					>
-				</a>
-			{/if}
+			<a href={$page.data.base} class="flex flex-col text-primary no-underline md:flex-row">
+				<span class="text-[1.6rem] font-extrabold leading-tight md:text-[2.1rem]"> Libris</span>
+				<sup
+					class="top-0 -rotate-6 self-baseline rounded-sm bg-positive-dark/16 px-2 uppercase text-2-cond-bold md:rotate-0"
+					>Beta</sup
+				>
+			</a>
 		</div>
 		<div class="search px-4">
 			{#if useSuperSearch}
@@ -59,20 +55,6 @@
 				{/if}
 			</div>
 		</div>
-		{#if isLandingPage}
-			<div class="landing flex flex-col items-center gap-2 pb-3">
-				<h1 class="flex text-3xl font-extrabold text-primary sm:text-[5.5rem] sm:font-bold">
-					Libris
-					<sup
-						class="self-center rounded-sm bg-positive-dark/16 px-2 uppercase text-2-cond-bold sm:text-3-cond-bold"
-						>Beta</sup
-					>
-				</h1>
-				<!-- <div class="w-full max-w-3xl">
-					<Search placeholder={$page.data.t('home.searchPlaceholder')} autofocus />
-				</div> -->
-			</div>
-		{/if}
 	</nav>
 </header>
 
@@ -80,21 +62,6 @@
 	.header-nav {
 		@apply header-layout;
 		grid-template-areas: 'home search actions';
-	}
-
-	.is-landing .header-nav {
-		@apply landing-layout;
-		grid-template-areas:
-			'home . actions'
-			'. landing .'
-			'search search search';
-
-		@media screen and (min-width: theme('screens.sm')) {
-			grid-template-areas:
-				'home . actions'
-				'. landing .'
-				'. search .';
-		}
 	}
 
 	.home {
@@ -107,14 +74,6 @@
 
 	.actions {
 		grid-area: actions;
-	}
-
-	.landing {
-		grid-area: landing;
-	}
-
-	.is-landing .search {
-		@apply w-full max-w-3xl justify-self-center;
 	}
 
 	#header-menu:target {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -263,7 +263,7 @@
 		</Modal>
 	{/if}
 </article>
-<SearchResult searchResult={$page.data.searchResult} />
+<SearchResult searchResult={$page.data.searchResult} showMapping />
 
 <style lang="postcss">
 	.resource {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
+	import { env } from '$env/dynamic/public';
 	import { page } from '$app/stores';
 	import SearchResult from '$lib/components/find/SearchResult.svelte';
 	import getPageTitle from '$lib/utils/getPageTitle';
+
+	let usingSuperSearch = $derived(
+		env?.PUBLIC_USE_SUPERSEARCH === 'true' || $page.url.searchParams.get('_x') === 'supersearch'
+	);
 </script>
 
 <svelte:head>
@@ -10,5 +15,5 @@
 <h1 class="sr-only">{$page.data.t('search.searchResults')}</h1>
 <SearchResult
 	searchResult={$page.data.searchResult}
-	showMapping={$page.url.searchParams.get('_x') === 'mappings'}
+	showMapping={$page.url.searchParams.get('_x') === 'mappings' || !usingSuperSearch}
 />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -8,4 +8,7 @@
 	<title>{getPageTitle($page.url.searchParams.get('_q')?.trim())}</title>
 </svelte:head>
 <h1 class="sr-only">{$page.data.t('search.searchResults')}</h1>
-<SearchResult searchResult={$page.data.searchResult} />
+<SearchResult
+	searchResult={$page.data.searchResult}
+	showMapping={$page.url.searchParams.get('_x') === 'mappings'}
+/>


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-329](https://kbse.atlassian.net/browse/LWS-329)

### Solves

Prepares lxl-web for the first QA-release of the supersearch component.

### Summary of changes

- Fix layout on start page
- Hide mapping on find pages if supersearch is enabled (but keep them on resource pages)
- Allow mappings to be shown if `_x`  search param is set to `mappings`
