### PR TITLE
fix(supersearch): Prevent setting default row on start content (LWS-278)

### DIFF
--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -213,7 +213,7 @@
 	}
 
 	function setDefaultRowAndCols() {
-		if (value.trim().length) {
+		if (!shouldShowStartContentFn(value, cursor)) {
 			activeRowIndex = defaultResultRow;
 			if (activeRowIndex > 0) {
 				activeColIndex = defaultResultCol;


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-278](https://kbse.atlassian.net/browse/LWS-278)

### Solves

Prevent setting default row on start content

### Summary of changes

- Prevent setting default row on start content
