### PR TITLE
feat(supersearch): Add arrow key cursor handling (LWS-330)

### DIFF
--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -216,7 +216,8 @@ test('arrow key cursor handling (depending on supersearch state)', async ({ page
 	).toHaveText('Hola!!');
 	await page.keyboard.press('Escape');
 	await expect(page.getByRole('dialog')).not.toBeVisible();
-	await page.keyboard.press('ArrowUp');
+	await page.getByRole('combobox').press('ArrowRight');
+	await page.getByRole('combobox').press('ArrowUp');
 	await page.getByRole('combobox').pressSequentially('¡');
 	await expect(
 		await page.getByRole('dialog').getByRole('combobox'),

--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -159,6 +159,71 @@ test('syncs collapsed and expanded editor views', async ({ context, page }) => {
 		.toBe('Hello world');
 });
 
+test('arrow key cursor handling (depending on supersearch state)', async ({ page }) => {
+	await page.getByRole('combobox').click();
+	await page.getByRole('dialog').getByRole('combobox').fill('Hola');
+	await page.keyboard.press('ArrowUp');
+	await page.getByRole('dialog').getByRole('combobox').pressSequentially('!');
+	await expect(
+		await page.getByRole('dialog').getByRole('combobox'),
+		'prevents cursor movement by arrow up key if expanded search'
+	).toHaveText('Hola!');
+	await page.keyboard.press('ArrowLeft');
+	await page.keyboard.press('ArrowLeft');
+	await page.keyboard.press('ArrowLeft');
+	await page.keyboard.press('ArrowLeft');
+	await page.keyboard.press('ArrowLeft');
+	await page.getByRole('dialog').getByRole('combobox').pressSequentially('¡');
+	await expect(await page.getByRole('dialog').getByRole('combobox')).toHaveText('¡Hola!');
+	await page.keyboard.press('ArrowDown');
+	await page.getByRole('dialog').getByRole('combobox').pressSequentially('A');
+	await expect(
+		page.getByTestId('result-item').first(),
+		'prevents cursor movement by arrow down key if expanded search'
+	).toContainText('Heading 1 for "¡AHola!"'); // await delayed results
+	await page.getByRole('dialog').getByRole('combobox').press('ArrowDown');
+	await page.getByRole('dialog').getByRole('combobox').press('ArrowDown');
+	await page.keyboard.press('ArrowRight');
+	await page.keyboard.press('ArrowRight');
+	await page.getByRole('dialog').getByRole('combobox').pressSequentially('B');
+	await expect(
+		page.getByTestId('result-item').first(),
+		'prevents cursor movement by arrow right key if there are more than one column/cell on current row'
+	).toContainText('Heading 1 for "¡ABHola!"');
+	await page.keyboard.press('ArrowLeft');
+	await page.getByRole('dialog').getByRole('combobox').pressSequentially('C');
+	await expect(
+		page.getByTestId('result-item').first(),
+		'prevents cursor movement by arrow left key if there are more than one column/cell on current row'
+	).toContainText('Heading 1 for "¡ABCHola!"');
+	await page.keyboard.press('ArrowDown');
+	await page.keyboard.press('ArrowUp');
+	await page.keyboard.press('ArrowLeft');
+	await page.keyboard.press('ArrowLeft');
+	await page.keyboard.press('ArrowLeft');
+	await page.keyboard.press('ArrowLeft');
+	await page.keyboard.press('Delete');
+	await page.keyboard.press('Delete');
+	await page.keyboard.press('Delete');
+	await page.keyboard.press('Delete');
+	await expect(page.getByTestId('result-item').first()).toContainText('Heading 1 for "Hola!"');
+	await page.keyboard.press('Escape');
+	await page.keyboard.press('ArrowDown');
+	await page.getByRole('combobox').pressSequentially('!');
+	await expect(
+		await page.getByRole('dialog').getByRole('combobox'),
+		'arrow down triggers cursor movement if search is collapsed'
+	).toHaveText('Hola!!');
+	await page.keyboard.press('Escape');
+	await expect(page.getByRole('dialog')).not.toBeVisible();
+	await page.keyboard.press('ArrowUp');
+	await page.getByRole('combobox').pressSequentially('¡');
+	await expect(
+		await page.getByRole('dialog').getByRole('combobox'),
+		'arrow up triggers cursor movement if search is collapsed'
+	).toHaveText('¡Hola!!');
+});
+
 test('fires click events on focused cells', async ({ page }) => {
 	await page.getByRole('combobox').fill('a');
 	await expect(page.locator('#supersearch-item-1x0')).toBeVisible();

--- a/packages/supersearch/src/lib/extensions/arrowKeyCursorHandling.ts
+++ b/packages/supersearch/src/lib/extensions/arrowKeyCursorHandling.ts
@@ -1,0 +1,37 @@
+import { Prec } from '@codemirror/state';
+import { keymap } from '@codemirror/view';
+
+/**
+ * CodeMirror extension which controls if arrow key cursor handling should be enabled or not depending on passed param
+ */
+
+const arrowKeyCursorHandling = ({
+	vertical,
+	horizontal
+}: {
+	vertical: boolean;
+	horizontal: boolean;
+}) => {
+	return Prec.highest(
+		keymap.of([
+			{
+				key: 'ArrowUp',
+				run: () => !vertical // return true to prevent further commands to be tried
+			},
+			{
+				key: 'ArrowDown',
+				run: () => !vertical
+			},
+			{
+				key: 'ArrowRight',
+				run: () => !horizontal
+			},
+			{
+				key: 'ArrowLeft',
+				run: () => !horizontal
+			}
+		])
+	);
+};
+
+export default arrowKeyCursorHandling;


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-330](https://kbse.atlassian.net/browse/LWS-330)

### Solves

Adds arrow key cursor handling.

Arrow up and down to jump to the start and end of the string is prevented if the expanded search is open.
Arrow left and right cursor movement is prevented if there are more than one cell/column on the active row.

### Summary of changes

-  Add arrow key cursor handling
