### PR TITLE
fix(lxlweb): set _stats to false

### DIFF
--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -51,10 +51,11 @@
 
 <slot />
 {#if searchResult}
-	{@const facets = searchResult.facetGroups}
+	{@const facets = searchResult.facetGroups || []}
+	{@const predicates = searchResult.predicates || []}
 	{@const numHits = searchResult.totalItems}
 	{@const filterCount = getFiltersCount(searchResult.mapping)}
-	{#if searchResult.predicates.length}
+	{#if predicates.length}
 		<nav
 			class="border-b border-primary/16 px-4 md:flex lg:px-6"
 			aria-label={$page.data.t('search.selectedFilters')}
@@ -63,7 +64,7 @@
 				<li class="tab-header max-w-80 truncate font-bold">{$page.data.title}</li>
 				<span class="tab-header">{$page.data.t('search.occursAs')}</span>
 
-				{#each searchResult.predicates as p}
+				{#each predicates as p}
 					<li>
 						<a
 							class="tab"
@@ -165,7 +166,7 @@
 				</span>
 				<div class="search-related flex justify-start">
 					{#if $page.params.fnurgel}
-						{@const activePredicate = searchResult.predicates.filter((p) => p.selected)}
+						{@const activePredicate = predicates.filter((p) => p.selected)}
 						<SearchRelated view={activePredicate[0].view} />
 					{/if}
 				</div>

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -13,8 +13,8 @@ export interface SearchResult {
 	next?: Link;
 	previous?: Link;
 	items: SearchResultItem[];
-	facetGroups: FacetGroup[];
-	predicates: MultiSelectFacet[];
+	facetGroups?: FacetGroup[];
+	predicates?: MultiSelectFacet[];
 	_spell: SpellingSuggestion[] | [];
 }
 

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -73,8 +73,10 @@ export async function asResult(
 				displayUtil.lensAndFormat(vocabUtil.getDefinition(i[JsonLd.TYPE]), LensType.Chip, locale)
 			)
 		})),
-		facetGroups: displayFacetGroups(view, displayUtil, locale, translate, usePath),
-		predicates: displayPredicates(view, displayUtil, locale, usePath),
+		...('stats' in view && {
+			facetGroups: displayFacetGroups(view, displayUtil, locale, translate, usePath)
+		}),
+		...('stats' in view && { predicates: displayPredicates(view, displayUtil, locale, usePath) }),
 		_spell: view._spell
 			? view._spell.map((el) => {
 					return {
@@ -214,7 +216,7 @@ function displayFacetGroups(
 	displayUtil: DisplayUtil,
 	locale: LangCode,
 	translate: translateFn,
-	usePath: string
+	usePath?: string
 ): FacetGroup[] {
 	const slices = view.stats?.sliceByDimension || {};
 
@@ -246,7 +248,7 @@ export function displayPredicates(
 	view: PartialCollectionView,
 	displayUtil: DisplayUtil,
 	locale: LangCode,
-	usePath: string
+	usePath?: string
 ): MultiSelectFacet[] {
 	const predicates = view.stats?._predicates || [];
 
@@ -266,7 +268,7 @@ function displayBoolFilters(
 	displayUtil: DisplayUtil,
 	locale: LangCode,
 	translate: translateFn,
-	usePath: string
+	usePath?: string
 ): FacetGroup {
 	const filters = view.stats?._boolFilters || [];
 

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/+server.ts
@@ -34,6 +34,7 @@ export const GET: RequestHandler = async ({ url, params, locals }) => {
 		newSearchParams.set('_debug', 'esScore');
 	}
 
+	newSearchParams.set('_stats', 'false');
 	newSearchParams.delete('cursor');
 
 	console.log('Initial search params:', decodeURIComponent(url.searchParams.toString()));


### PR DESCRIPTION
## Description

### Solves

Frontend implementation of https://github.com/libris/librisxl/pull/1566

### Summary of changes

* Set `_stats=false` for api/supersearch requests
* omit `facetGroups` and `predicates` from response if stats is missing
* modify `SearchResult` type and component accordingly