### PR TITLE
feat(cataloging): Make locked properties handling more clear

### DIFF
--- a/cataloging/src/components/inspector/field.vue
+++ b/cataloging/src/components/inspector/field.vue
@@ -166,6 +166,13 @@ export default {
     'modal-component': ModalComponent,
   },
   watch: {
+    'inspector.event'(val) {
+      if (val.name === 'record-control') {
+        if (val.value === 'save-record' || val.value === 'save-record-done' || val.value === 'cancel') {
+          this.unlockedByUser = false;
+        }
+      }
+    },
   },
   computed: {
     diffAdded() {
@@ -563,9 +570,6 @@ export default {
     closeUnlockModal() {
       this.unlockModalOpen = false;
     },
-    lockProtected() {
-      this.unlockedByUser = false;
-    },
     removeThis() {
       let approved = true;
       if (this.warnBeforeRemove) {
@@ -790,21 +794,16 @@ export default {
             <i class="fa fa-lock fa-fw icon icon--sm"
                tabindex="0"
                role="button"
-               :aria-label="translatePhrase('Unlock property')"
+               :aria-label="translatePhrase('Edit locked property')"
                v-on:click="openUnlockModal()"
-               v-tooltip.top="translatePhrase('Unlock property')"
+               v-tooltip.top="translatePhrase('Edit locked property')"
                @keyup.enter="openUnlockModal()"
             />
           </div>
           <div class="Field-action" v-if="isProtected && unlockedByUser && !isLocked">
             <i class="fa fa-unlock-alt fa-fw icon icon--sm"
                tabindex="0"
-               role="button"
-               :aria-label="translatePhrase('Lock property')"
-               v-on:click="lockProtected()"
-               v-tooltip.top="translatePhrase('Lock property')"
-               @keyup.enter="lockProtected()"
-               />
+            />
           </div>
 
           <div
@@ -923,20 +922,15 @@ export default {
           <i class="fa fa-lock fa-fw icon icon--sm"
              tabindex="0"
              role="button"
-             :aria-label="translatePhrase('Unlock property')"
+             :aria-label="translatePhrase('Edit locked property')"
              v-on:click="openUnlockModal()"
-             v-tooltip.top="translatePhrase('Unlock property')"
+             v-tooltip.top="translatePhrase('Edit locked property')"
              @keyup.enter="openUnlockModal()"
             />
         </div>
         <div class="Field-action" v-if="isProtected && unlockedByUser && !isLocked">
           <i class="fa fa-unlock-alt fa-fw icon icon--sm"
              tabindex="0"
-             role="button"
-             :aria-label="translatePhrase('Lock property')"
-             v-on:click="lockProtected()"
-             v-tooltip.top="translatePhrase('Lock property')"
-             @keyup.enter="lockProtected()"
           />
         </div>
 

--- a/cataloging/src/resources/json/i18n.json
+++ b/cataloging/src/resources/json/i18n.json
@@ -467,8 +467,7 @@
     "To see bulk changes you need to switch to a sigel with access.": "För att se körningar behöver du växla till ett sigel med rättigheter.",
     "Back to create bulk change": "Tillbaka till skapa körning",
     "This might take a while...": "Det här verkar ta lite tid...",
-    "Lock property": "Lås egenskap",
-    "Unlock property": "Lås upp egenskap",
+    "Edit locked property": "Redigera låst egenskap",
     "The property is locked for editing. Are you sure you want to unlock it?" : "Egenskapen är låst för redigering. Är du säker på att du vill låsa upp?",
     "Manage cookies": "Hantera kakor"
   }

--- a/cataloging/src/resources/json/protectedProperties.json
+++ b/cataloging/src/resources/json/protectedProperties.json
@@ -1,6 +1,6 @@
 {
   "default": {
-    "title": "Unlock property",
+    "title": "Edit locked property",
     "infoText": "The property is locked for editing. Are you sure you want to unlock it?"
   },
   "nextShelfControlNumber": {


### PR DESCRIPTION
Make it more clear that "protected" properties are always locked, and can temporarily be unlocked for editing.

Some users thought that it was necessary to click the lock icon for a property to become locked again, and that this affected other users; hence this possibility is removed. 

Also, these properties are reset to their default locked state on save, cancel or save+done editing, for clarity.
