### PR TITLE
fix(lxlweb): Hide lone wildcard from supersearch input

### DIFF
--- a/lxl-web/src/lib/components/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/SuperSearchWrapper.svelte
@@ -43,9 +43,8 @@
 	afterNavigate(({ to }) => {
 		/** Update input value after navigation on /find route */
 		if (to?.url) {
-			q = $page.params.fnurgel
-				? ''
-				: addSpaceIfEndingQualifier(new URL(to.url).searchParams.get('_q')?.trim() || '');
+			const toQ = addSpaceIfEndingQualifier(new URL(to.url).searchParams.get('_q')?.trim() || '');
+			q = $page.params.fnurgel ? '' : toQ !== '*' ? toQ : ''; // hide wildcard in input field
 			superSearch?.hideExpandedSearch();
 		}
 	});
@@ -112,9 +111,9 @@
 	}
 
 	function removeQualifier(qualifier: string) {
-		const newQ = q.replace(qualifier, '').trim() || '*';
+		const newQ = q.replace(qualifier, '').trim();
 		const newUrl = new URLSearchParams(params);
-		newUrl.set('_q', newQ);
+		newUrl.set('_q', newQ || '*');
 
 		superSearch?.dispatchChange({
 			change: { from: 0, to: q.length, insert: addSpaceIfEndingQualifier(newQ) },

--- a/lxl-web/src/lib/components/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/SuperSearchWrapper.svelte
@@ -111,13 +111,15 @@
 	}
 
 	function removeQualifier(qualifier: string) {
-		const newQ = q.replace(qualifier, '').trim();
+		const newQ = addSpaceIfEndingQualifier(q.replace(qualifier, '').trim());
+		const insertCursor = Math.min(q.indexOf(qualifier), newQ.length);
 		const newUrl = new URLSearchParams(params);
-		newUrl.set('_q', newQ || '*');
+		newUrl.set('_q', newQ.trim() ? newQ : '*');
 
 		superSearch?.dispatchChange({
-			change: { from: 0, to: q.length, insert: addSpaceIfEndingQualifier(newQ) },
-			userEvent: 'input.complete'
+			change: { from: 0, to: q.length, insert: newQ },
+			selection: { anchor: insertCursor, head: insertCursor },
+			userEvent: 'delete'
 		});
 		goto('/find?' + newUrl.toString());
 	}

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertSpaceAroundQualifier.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertSpaceAroundQualifier.ts
@@ -10,87 +10,91 @@ const insertSpaceAroundQualifier = (getRanges: () => RangeSet<RangeValue>) => {
 		const isDelete = tr.isUserEvent('delete');
 		const isInput = tr.isUserEvent('input');
 
-		if (!isInput && !isDelete) {
-			// return non-user transactions (triggered by this filter)
+		if (!tr.docChanged || (!isInput && !isDelete)) {
+			// return transactions triggered by this filter
 			return tr;
 		}
 
+		let insert: TransactionSpec | TransactionSpec[] = [tr];
 		const inputLength = tr.changes.desc.newLength - tr.changes.desc.length;
 		const newCursorPos = tr.state.selection.main.head;
 		const oldCursorPos = newCursorPos - inputLength;
-
-		if (!tr.docChanged || (isDelete && newCursorPos === 0)) {
-			return tr;
-		}
-		let insert: TransactionSpec | TransactionSpec[] = [tr];
 		const atomicRanges = getRanges();
 
-		atomicRanges.between(
-			Math.min(oldCursorPos, newCursorPos),
-			Math.max(oldCursorPos, newCursorPos),
-			(atomicStart, atomicEnd) => {
-				const input = tr.newDoc.slice(oldCursorPos, newCursorPos).toString().trim();
+		const inputRangeMin = Math.min(oldCursorPos, newCursorPos);
+		const inputRangeMax = Math.max(oldCursorPos, newCursorPos);
 
-				if (oldCursorPos === atomicStart) {
-					// input touches atomic range start
+		atomicRanges.between(inputRangeMin, inputRangeMax, (atomicStart, atomicEnd) => {
+			const input = tr.newDoc.slice(oldCursorPos, newCursorPos).toString().trim();
+			const prevChar = tr.newDoc
+				.slice(inputRangeMin - 1, inputRangeMin)
+				.toString()
+				.trim();
+			const nextChar = tr.newDoc
+				.slice(inputRangeMax - 1, inputRangeMax)
+				.toString()
+				.trim();
+
+			if (oldCursorPos === atomicStart && (input || (isDelete && prevChar))) {
+				// input touches atomic range start, insert space after input
+				insert = [
+					tr,
+					{
+						changes: {
+							from: newCursorPos,
+							to: newCursorPos,
+							insert: ' '
+						},
+						sequential: true,
+						selection: { anchor: newCursorPos }
+					}
+				];
+			} else if (
+				oldCursorPos >= atomicStart &&
+				oldCursorPos <= atomicEnd &&
+				newCursorPos !== atomicStart
+			) {
+				const node = syntaxTree(tr.startState).resolveInner(oldCursorPos, -1);
+				if (node.parent?.name == 'QualifierValue') {
+					// input touches qualifier value, insert space before input after range
 					insert = [
+						// we need to pass the original transaction, or we get a sync error for some reason.
+						// Undo it before applying changes
 						tr,
 						{
-							...((!!input || isDelete) && {
-								// don't insert space if input is space
-								changes: {
-									from: newCursorPos,
-									to: newCursorPos,
-									insert: ' '
-								}
-							}),
-							sequential: true,
-							selection: { anchor: !!input || isDelete ? newCursorPos : oldCursorPos }
+							changes: {
+								from: inputRangeMin,
+								to: inputRangeMax,
+								insert: ''
+							},
+							sequential: true
+						},
+						{
+							changes: {
+								from: atomicEnd,
+								insert: ` ${input}`
+							},
+							selection: { anchor: input ? atomicEnd + inputLength + 1 : atomicEnd + 1 }
 						}
 					];
-				} else if (oldCursorPos >= atomicStart && oldCursorPos <= atomicEnd) {
-					const node = syntaxTree(tr.state).resolveInner(oldCursorPos, -1);
-					if (node.parent?.name == 'QualifierValue') {
-						// input touches atomic range up until end
-						insert = [
-							// we need to pass the original transaction, or we get a sync error for some reason.
-							// Undo the changes, move cursor out and apply changes.
-							tr,
-							{
-								changes: {
-									from: Math.min(oldCursorPos, newCursorPos),
-									to: Math.max(oldCursorPos, newCursorPos),
-									insert: ''
-								},
-								sequential: true
-							},
-							{
-								changes: {
-									from: atomicEnd,
-									insert: ` ${input}`
-								},
-								selection: { anchor: input ? atomicEnd + inputLength + 1 : atomicEnd + 1 }
-							}
-						];
-					}
-				} else if (newCursorPos === atomicEnd && inputLength < 0) {
-					const node = syntaxTree(tr.state).resolveInner(newCursorPos, -1);
-					if (node.parent?.name == 'QualifierValue') {
-						// deletion touches qualifierValue end, preserve space
-						insert = [
-							{
-								changes: {
-									from: atomicEnd,
-									insert: ' '
-								}
-							},
-							tr
-						];
-					}
 				}
-				return false;
+			} else if (newCursorPos === atomicEnd && isDelete && nextChar) {
+				const node = syntaxTree(tr.startState).resolveInner(newCursorPos, -1);
+				if (node.parent?.name == 'QualifierValue') {
+					// deletion touches qualifierValue end, insert space after input
+					insert = [
+						{
+							changes: {
+								from: atomicEnd,
+								insert: ' '
+							}
+						},
+						tr
+					];
+				}
 			}
-		);
+			return false;
+		});
 		return insert;
 	});
 };


### PR DESCRIPTION
## Description

Hide the fallback wildcard that appears when removing all filter pills.
It's especially annoying because of all the weird suggestions it brings up...

![Skärmavbild 2025-03-05 kl  13 08 01](https://github.com/user-attachments/assets/d0b94e03-4eff-4b10-93aa-77b3e9f85157)


### Summary of changes

* Don't dispatch '*' when removing qualifier
* Don't set `q` to '*' when syncing after route change
