### PR TITLE
fix(lxlweb): Reduce debouceWait, disable loading indicator

### DIFF
--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -201,11 +201,12 @@
 		comboboxAriaLabel={$page.data.t('search.search')}
 		defaultInputCol={2}
 		loadMoreLabel={$page.data.t('search.showMore')}
+		debouncedWait={100}
 	>
 		{#snippet loadingIndicator()}
-			<div class="flex min-h-11 w-full items-center px-4 text-left">
+			<!-- <div class="flex min-h-11 w-full items-center px-4 text-left">
 				{$page.data.t('search.loading')}
-			</div>
+			</div> -->
 		{/snippet}
 		{#snippet inputRow({
 			expanded,


### PR DESCRIPTION
### Solves

Minor stuff to improve supersearch user experience

### Summary of changes

* Reduce `debounceWait` from 300 to 100 ms
* comment out 'loading' snippet
