### PR TITLE
fix(lxlweb): SuperSearchWrapper bugs

### DIFF
--- a/lxl-web/src/lib/components/supersearch/Suggestion.svelte
+++ b/lxl-web/src/lib/components/supersearch/Suggestion.svelte
@@ -74,7 +74,7 @@
 					{item.typeStr}
 				</strong>
 				<span class="text-xs">
-					{#if item.typeStr.length}
+					{#if item.typeStr?.length}
 						<span class="divider">{' • '}</span>
 					{/if}
 					{#each item?.[LensType.WebCardFooter]?._display as obj}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -38,8 +38,6 @@
 		p.delete('_p');
 		return p;
 	});
-
-	const paramsArr = $derived(Array.from(pageParams));
 	let suggestMapping: DisplayMapping[] | undefined = $state();
 
 	afterNavigate(({ to }) => {
@@ -345,7 +343,7 @@
 			{/if}
 		{/snippet}
 	</SuperSearch>
-	{#each paramsArr as [name, value]}
+	{#each Array.from(pageParams) as [name, value]}
 		{#if name !== '_q'}
 			<input type="hidden" {name} {value} />
 		{/if}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -29,14 +29,17 @@
 	let superSearch = $state<ReturnType<typeof SuperSearch>>();
 	let showMoreFilters = $state(false);
 
-	let params = getSortedSearchParams(addDefaultSearchParams($page.url.searchParams));
-	// Always reset these params on new search
-	params.set('_offset', '0');
-	params.delete('_i');
-	params.delete('_o');
-	params.delete('_p');
-	const searchParams = Array.from(params);
+	let pageParams = $derived.by(() => {
+		let p = getSortedSearchParams(addDefaultSearchParams($page.url.searchParams));
+		// Always reset these params on new search
+		p.set('_offset', '0');
+		p.delete('_i');
+		p.delete('_o');
+		p.delete('_p');
+		return p;
+	});
 
+	const paramsArr = $derived(Array.from(pageParams));
 	let suggestMapping: DisplayMapping[] | undefined = $state();
 
 	afterNavigate(({ to }) => {
@@ -113,7 +116,7 @@
 	function removeQualifier(qualifier: string) {
 		const newQ = addSpaceIfEndingQualifier(q.replace(qualifier, '').trim());
 		const insertCursor = Math.min(q.indexOf(qualifier), newQ.length);
-		const newUrl = new URLSearchParams(params);
+		const newUrl = new URLSearchParams(pageParams);
 		newUrl.set('_q', newQ.trim() ? newQ : '*');
 
 		superSearch?.dispatchChange({
@@ -135,11 +138,9 @@
 	let moreFiltersRowIndex = $derived(showMoreFilters ? 7 : 4);
 
 	function getFullQualifierLink(q: string) {
-		const params = new URLSearchParams($page.url.searchParams.toString());
-		params.set('_q', q);
-		params.delete('_i');
-		params.set('_offset', '0');
-		return `/find?${params.toString()}`;
+		const newParams = new URLSearchParams(pageParams);
+		newParams.set('_q', q);
+		return `/find?${newParams.toString()}`;
 	}
 </script>
 
@@ -344,7 +345,7 @@
 			{/if}
 		{/snippet}
 	</SuperSearch>
-	{#each searchParams as [name, value]}
+	{#each paramsArr as [name, value]}
 		{#if name !== '_q'}
 			<input type="hidden" {name} {value} />
 		{/if}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -114,15 +114,15 @@
 	function removeQualifier(qualifier: string) {
 		const newQ = addSpaceIfEndingQualifier(q.replace(qualifier, '').trim());
 		const insertCursor = Math.min(q.indexOf(qualifier), newQ.length);
-		const newUrl = new URLSearchParams(pageParams);
-		newUrl.set('_q', newQ.trim() ? newQ : '*');
+		const newSearchParams = new URLSearchParams(pageParams);
+		newSearchParams.set('_q', newQ.trim() ? newQ : '*');
 
 		superSearch?.dispatchChange({
 			change: { from: 0, to: q.length, insert: newQ },
 			selection: { anchor: insertCursor, head: insertCursor },
 			userEvent: 'delete'
 		});
-		goto('/find?' + newUrl.toString());
+		goto('/find?' + newSearchParams.toString());
 	}
 
 	let derivedLxlQualifierPlugin = $derived.by(() => {


### PR DESCRIPTION
## Description
### Solves
**Bug:** Typing 'a' in the supersearch input does not generate suggestions (but a console error)
**Fix:** `typStr` check

**Bug:** From the start screen, type `språk:svenska` and add Svenska. The following result page shows 200 hits.
**Fix:** make `getFullQualifierLink` function use the groomed `pageParams` value (fixed below)

**Bug:** Type `språk:svenska` and add Svenska. Change the sorting to something else. Click qualifier remove btn. The sorting is now reverted back.
**Fix:** `removeQualifier` relied on the `params` variable which is set on page load and not reactive (to client side navigations like sort changes). Make it derived by search params state. Also rename `params`/`searchParams` since the component contain many (other) variables of the same name.

### Summary of changes

* `item.typeStr` check
* Make wrapper params variable reactive
