### PR TITLE
fix(lxl-web): Unquote qualifier values (LWS-346)

### DIFF
--- a/lxl-web/src/lib/components/supersearch/Suggestion.svelte
+++ b/lxl-web/src/lib/components/supersearch/Suggestion.svelte
@@ -74,7 +74,7 @@
 					{item.typeStr}
 				</strong>
 				<span class="text-xs">
-					{#if item.typeStr.length}
+					{#if item.typeStr?.length}
 						<span class="divider">{' • '}</span>
 					{/if}
 					{#each item?.[LensType.WebCardFooter]?._display as obj}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -38,8 +38,6 @@
 		p.delete('_p');
 		return p;
 	});
-
-	const paramsArr = $derived(Array.from(pageParams));
 	let suggestMapping: DisplayMapping[] | undefined = $state();
 
 	afterNavigate(({ to }) => {
@@ -345,7 +343,7 @@
 			{/if}
 		{/snippet}
 	</SuperSearch>
-	{#each paramsArr as [name, value]}
+	{#each Array.from(pageParams) as [name, value]}
 		{#if name !== '_q'}
 			<input type="hidden" {name} {value} />
 		{/if}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -29,14 +29,17 @@
 	let superSearch = $state<ReturnType<typeof SuperSearch>>();
 	let showMoreFilters = $state(false);
 
-	let params = getSortedSearchParams(addDefaultSearchParams($page.url.searchParams));
-	// Always reset these params on new search
-	params.set('_offset', '0');
-	params.delete('_i');
-	params.delete('_o');
-	params.delete('_p');
-	const searchParams = Array.from(params);
+	let pageParams = $derived.by(() => {
+		let p = getSortedSearchParams(addDefaultSearchParams($page.url.searchParams));
+		// Always reset these params on new search
+		p.set('_offset', '0');
+		p.delete('_i');
+		p.delete('_o');
+		p.delete('_p');
+		return p;
+	});
 
+	const paramsArr = $derived(Array.from(pageParams));
 	let suggestMapping: DisplayMapping[] | undefined = $state();
 
 	afterNavigate(({ to }) => {
@@ -113,7 +116,7 @@
 	function removeQualifier(qualifier: string) {
 		const newQ = addSpaceIfEndingQualifier(q.replace(qualifier, '').trim());
 		const insertCursor = Math.min(q.indexOf(qualifier), newQ.length);
-		const newUrl = new URLSearchParams(params);
+		const newUrl = new URLSearchParams(pageParams);
 		newUrl.set('_q', newQ.trim() ? newQ : '*');
 
 		superSearch?.dispatchChange({
@@ -135,11 +138,9 @@
 	let moreFiltersRowIndex = $derived(showMoreFilters ? 7 : 4);
 
 	function getFullQualifierLink(q: string) {
-		const params = new URLSearchParams($page.url.searchParams.toString());
-		params.set('_q', q);
-		params.delete('_i');
-		params.set('_offset', '0');
-		return `/find?${params.toString()}`;
+		const newParams = new URLSearchParams(pageParams);
+		newParams.set('_q', q);
+		return `/find?${newParams.toString()}`;
 	}
 </script>
 
@@ -344,7 +345,7 @@
 			{/if}
 		{/snippet}
 	</SuperSearch>
-	{#each searchParams as [name, value]}
+	{#each paramsArr as [name, value]}
 		{#if name !== '_q'}
 			<input type="hidden" {name} {value} />
 		{/if}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -114,15 +114,15 @@
 	function removeQualifier(qualifier: string) {
 		const newQ = addSpaceIfEndingQualifier(q.replace(qualifier, '').trim());
 		const insertCursor = Math.min(q.indexOf(qualifier), newQ.length);
-		const newUrl = new URLSearchParams(pageParams);
-		newUrl.set('_q', newQ.trim() ? newQ : '*');
+		const newSearchParams = new URLSearchParams(pageParams);
+		newSearchParams.set('_q', newQ.trim() ? newQ : '*');
 
 		superSearch?.dispatchChange({
 			change: { from: 0, to: q.length, insert: newQ },
 			selection: { anchor: insertCursor, head: insertCursor },
 			userEvent: 'delete'
 		});
-		goto('/find?' + newUrl.toString());
+		goto('/find?' + newSearchParams.toString());
 	}
 
 	let derivedLxlQualifierPlugin = $derived.by(() => {

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.ts
@@ -38,8 +38,9 @@ function getEditedPartEntries(
 			const baseClasses = findInMap(BASE_CLASS_FROM_QUALIFIER_KEY, keyFromAlias || qualifierKey);
 
 			if (baseClasses.length) {
+				const unquotedQualifierValue = qualifierValue.replaceAll(/(^")?("$)?/g, '');
 				return [
-					['_q', `${qualifierValue} "rdf:type":(${baseClasses.join(' OR ')})`],
+					['_q', `${unquotedQualifierValue} "rdf:type":(${baseClasses.join(' OR ')})`], // Use unquoted value as a temporary work-around for the issue where contributor:"Astrid Lindgren" didn't give any results (as the search index uses last name + first name)
 					['min-reverseLinks.totalItems', '1'] // ensure results are linked/used atleast once
 				];
 			}


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-346](https://kbse.atlassian.net/browse/LWS-346)

### Solves
Show results for `contributor:"Astrid Lindgren"` by unquoting the qualifier value (the search index uses _last name + first name_ instead of _first name + last name_).

This should only be seen as a temporary work-around as it's probably better to replace the automatically inserted quotes with (hidden?) parenthesis.

### Summary of changes

- Unquote qualifier values
