### PR TITLE
fix(lxl-web): Unquote qualifier values (LWS-346)

### DIFF
--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.test.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.test.ts
@@ -7,7 +7,7 @@ describe('getEditedPartEntries', () => {
 	});
 	it('narrows down search query by base class for query codes', () => {
 		expect(getEditedPartEntries('astrid lindgren subject:"winter"', 27)).toEqual([
-			['_q', `"winter" "rdf:type":(Agent OR Subject)`],
+			['_q', `winter "rdf:type":(Agent OR Subject)`],
 			['min-reverseLinks.totalItems', '1']
 		]);
 	});

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.ts
@@ -38,8 +38,9 @@ function getEditedPartEntries(
 			const baseClasses = findInMap(BASE_CLASS_FROM_QUALIFIER_KEY, keyFromAlias || qualifierKey);
 
 			if (baseClasses.length) {
+				const unquotedQualifierValue = qualifierValue.replaceAll(/(^")?("$)?/g, '');
 				return [
-					['_q', `${qualifierValue} "rdf:type":(${baseClasses.join(' OR ')})`],
+					['_q', `${unquotedQualifierValue} "rdf:type":(${baseClasses.join(' OR ')})`], // Use unquoted value as a temporary work-around for the issue where contributor:"Astrid Lindgren" didn't give any results (as the search index uses last name + first name)
 					['min-reverseLinks.totalItems', '1'] // ensure results are linked/used atleast once
 				];
 			}


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-346](https://kbse.atlassian.net/browse/LWS-346)

### Solves
Adds a work-around so results for e.g. `contributor:"Astrid Lindgren"` are shown.

This is done by unquoting the qualifier value so it is treated as _Astrid AND Lindgren_ instead of the exact phrase _"Astrid Lindgren"_ (the latter doesn't give any results as the search index uses _last name + first name_ instead of _first name + last name_).

This should only be seen as a temporary work-around as it's probably better to replace the automatically inserted quotes with (hidden?) parenthesis.

### Summary of changes

- Unquote qualifier values
