### PR TITLE
feat(lxl-web): Add wildcard when searching for qualifiers (LWS-335)

### DIFF
--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.test.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.test.ts
@@ -7,7 +7,7 @@ describe('getEditedPartEntries', () => {
 	});
 	it('narrows down search query by base class for query codes', () => {
 		expect(getEditedPartEntries('astrid lindgren subject:"winter"', 27)).toEqual([
-			['_q', `winter "rdf:type":(Agent OR Subject)`],
+			['_q', `winter* "rdf:type":(Agent OR Subject)`],
 			['min-reverseLinks.totalItems', '1']
 		]);
 	});

--- a/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/supersearch/getEditedPartEntries.ts
@@ -38,9 +38,12 @@ function getEditedPartEntries(
 			const baseClasses = findInMap(BASE_CLASS_FROM_QUALIFIER_KEY, keyFromAlias || qualifierKey);
 
 			if (baseClasses.length) {
-				const unquotedQualifierValue = qualifierValue.replaceAll(/(^")?("$)?/g, '');
+				const unquotedQualifierValue = qualifierValue.replaceAll(/(^")?("$)?/g, ''); // Use unquoted value as a temporary work-around for the issue where contributor:"Astrid Lindgren" didn't give any results (as the search index uses last name + first name)
+				const wildcardQualifierValue =
+					unquotedQualifierValue + (unquotedQualifierValue.match(/[^*]$/) ? '*' : ''); // Add trailing wildcard asterisk when searching for qualifiers
+
 				return [
-					['_q', `${unquotedQualifierValue} "rdf:type":(${baseClasses.join(' OR ')})`], // Use unquoted value as a temporary work-around for the issue where contributor:"Astrid Lindgren" didn't give any results (as the search index uses last name + first name)
+					['_q', `${wildcardQualifierValue} "rdf:type":(${baseClasses.join(' OR ')})`],
 					['min-reverseLinks.totalItems', '1'] // ensure results are linked/used atleast once
 				];
 			}


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-335](https://kbse.atlassian.net/browse/LWS-335)

### Solves

Adds wildcard when searching for qualifiers (solves issue with `contributor:"astrid lindgr"` not giving relevant results).

### Summary of changes

- Add trailing wildcard asterisk when searching for qualifiers
