### PR TITLE
feat(supersearch): Add select event handler 

### DIFF
--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { afterNavigate, goto } from '$app/navigation';
-	import { SuperSearch, lxlQualifierPlugin } from 'supersearch';
+	import { SuperSearch, lxlQualifierPlugin, type Selection } from 'supersearch';
 	import Suggestion from './Suggestion.svelte';
 	import addDefaultSearchParams from '$lib/utils/addDefaultSearchParams';
 	import getSortedSearchParams from '$lib/utils/getSortedSearchParams';
@@ -25,7 +25,9 @@
 			? ''
 			: addSpaceIfEndingQualifier($page.url.searchParams.get('_q')?.trim() || '')
 	);
-	let cursor: number = $state(0);
+	let selection: Selection | undefined = $state();
+	let cursor = $derived(selection?.head || 0);
+
 	let superSearch = $state<ReturnType<typeof SuperSearch>>();
 	let showMoreFilters = $state(false);
 
@@ -69,13 +71,15 @@
 		return undefined;
 	}
 
-	function handleShouldShowStartContent(value: string, cursor: number) {
-		const tree = lxlQuery.language.parser.parse(value);
-		const node = tree.resolveInner(cursor, -1);
+	function handleShouldShowStartContent(value: string, selection?: Selection) {
+		if (selection && selection.anchor == selection.head) {
+			const tree = lxlQuery.language.parser.parse(value);
+			const node = tree.resolveInner(selection.head, -1);
 
-		/** Start content should be shown when the cursor isn't placed inside a qualifier or edited string part */
-		if (!node.parent?.name) {
-			return true;
+			/** Start content should be shown when the cursor isn't placed inside a qualifier or edited string part */
+			if (!node.parent?.name) {
+				return true;
+			}
 		}
 
 		return false;
@@ -181,7 +185,7 @@
 		name="_q"
 		bind:this={superSearch}
 		bind:value={q}
-		bind:cursor
+		bind:selection
 		language={lxlQuery}
 		{placeholder}
 		endpoint={`/api/${$page.data.locale}/supersearch`}
@@ -343,7 +347,7 @@
 			{/if}
 		{/snippet}
 	</SuperSearch>
-	{#each Array.from(pageParams) as [name, value]}
+	{#each Array.from(pageParams) as [name, value] (name)}
 		{#if name !== '_q'}
 			<input type="hidden" {name} {value} />
 		{/if}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -74,10 +74,11 @@
 	function handleShouldShowStartContent(value: string, selection?: Selection) {
 		if (selection && selection.anchor == selection.head) {
 			const tree = lxlQuery.language.parser.parse(value);
-			const node = tree.resolveInner(selection.head, -1);
+			const nodeLeft = tree.resolveInner(selection.head, -1);
+			const nodeRight = tree.resolveInner(selection.head, 1);
 
 			/** Start content should be shown when the cursor isn't placed inside a qualifier or edited string part */
-			if (!node.parent?.name) {
+			if (!nodeLeft.parent?.name && !nodeRight.parent?.name) {
 				return true;
 			}
 		}

--- a/packages/supersearch/src/lib/components/CodeMirror.svelte
+++ b/packages/supersearch/src/lib/components/CodeMirror.svelte
@@ -8,7 +8,6 @@
 
 	export type ChangeCodeMirrorEvent = {
 		value: string;
-		cursor: number;
 		selection: Selection;
 	};
 
@@ -54,7 +53,6 @@
 				value = update.state.doc.toString();
 				onchange({
 					value,
-					cursor: update.state.selection.main.anchor,
 					selection: {
 						from: update.state.selection.main.from,
 						to: update.state.selection.main.to,
@@ -113,7 +111,6 @@
 		value = options?.doc || '';
 		onchange({
 			value,
-			cursor: options?.selection?.anchor || 0,
 			selection: {
 				from: selection.main.from,
 				to: selection.main.to,

--- a/packages/supersearch/src/lib/components/CodeMirror.svelte
+++ b/packages/supersearch/src/lib/components/CodeMirror.svelte
@@ -1,8 +1,18 @@
 <script lang="ts" module>
+	export type Selection = {
+		from: number;
+		to: number;
+		anchor: number;
+		head: number;
+	};
+
 	export type ChangeCodeMirrorEvent = {
 		value: string;
 		cursor: number;
+		selection: Selection;
 	};
+
+	export type SelectCodeMirrorEvent = Selection;
 </script>
 
 <script lang="ts">
@@ -11,11 +21,13 @@
 	import { EditorView } from '@codemirror/view';
 	import { EditorSelection, EditorState, StateEffect, type Extension } from '@codemirror/state';
 	import isViewUpdateFromUserInput from '$lib/utils/isViewUpdateFromUserInput.js';
+	import isViewUpdateOfUserEvent from '$lib/utils/isViewUpdateOfUserEvent.js';
 
 	type CodeMirrorProps = {
 		value?: string;
 		extensions?: Extension[];
 		onclick?: (event: MouseEvent) => void;
+		onselect?: (event: SelectCodeMirrorEvent) => void;
 		onchange?: (event: ChangeCodeMirrorEvent) => void;
 		editorView?: EditorView | undefined;
 		syncedEditorView?: EditorView | undefined;
@@ -25,6 +37,7 @@
 		value = '', // value isn't bindable as it can easily cause undo/redo history issues when changing the value from outside – it's preferable to dispatch changes instead
 		extensions = [],
 		onclick = () => {},
+		onselect = () => {},
 		onchange = () => {},
 		editorView = $bindable(),
 		syncedEditorView
@@ -41,9 +54,27 @@
 				value = update.state.doc.toString();
 				onchange({
 					value,
-					cursor: update.state.selection.main.anchor
+					cursor: update.state.selection.main.anchor,
+					selection: {
+						from: update.state.selection.main.from,
+						to: update.state.selection.main.to,
+						anchor: update.state.selection.main.anchor,
+						head: update.state.selection.main.head
+					}
 				});
 			}
+		}
+
+		if (isViewUpdateOfUserEvent(update, 'select')) {
+			syncedEditorView?.dispatch({
+				selection: update.state.selection
+			});
+			onselect({
+				from: update.state.selection.main.from,
+				to: update.state.selection.main.to,
+				anchor: update.state.selection.main.anchor,
+				head: update.state.selection.main.head
+			});
 		}
 	});
 
@@ -67,24 +98,28 @@
 		});
 	}
 
-	export function reset(options?: { doc: string; selection?: { anchor: number; head?: number } }) {
+	export function reset(options?: { doc: string; selection?: { anchor: number; head: number } }) {
+		const selection = EditorSelection.create([
+			options?.selection
+				? EditorSelection.range(options.selection.anchor, options.selection.head)
+				: EditorSelection.range(0, 0)
+		]);
 		editorView?.setState(
 			createEditorState({
 				doc: options?.doc,
-				selection: EditorSelection.create([
-					value && options?.selection
-						? EditorSelection.range(
-								options.selection.anchor,
-								options.selection?.head || options.selection.anchor
-							)
-						: EditorSelection.range(0, 0)
-				])
+				selection
 			})
 		);
 		value = options?.doc || '';
 		onchange({
 			value,
-			cursor: options?.selection?.anchor || 0
+			cursor: options?.selection?.anchor || 0,
+			selection: {
+				from: selection.main.from,
+				to: selection.main.to,
+				anchor: selection.main.anchor,
+				head: selection.main.head
+			}
 		});
 	}
 

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -310,9 +310,6 @@
 	}
 
 	function handleCloseExpandedSearch() {
-		collapsedEditorView?.dispatch({
-			selection: expandedEditorView?.state.selection.main
-		});
 		collapsedEditorView?.focus();
 		expanded = false;
 		allowArrowKeyCursorHandling = { vertical: true, horizontal: true };

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -650,30 +650,32 @@
 							})}
 						</div>
 					{/if}
-					{#if search.data}
-						{@const resultItemRows =
-							(Array.isArray(search.paginatedData) &&
-								search.paginatedData.map((page) => page.items).flat()) ||
-							search.data?.items}
-						{#each resultItemRows as resultItem, index (index)}
-							{@const rowIndex = persistentResultItemRow ? index + 2 : index + 1}
-							<div role="row" class:focused={activeRowIndex === rowIndex}>
-								{@render resultItemRow?.({
-									resultItem,
-									getCellId: (colIndex: number) => `${id}-item-${rowIndex}x${colIndex}`,
-									isFocusedCell: (colIndex: number) =>
-										activeRowIndex === rowIndex && colIndex === activeColIndex,
-									rowIndex
-								})}
-							</div>
-						{/each}
-					{/if}
-					{#if search.isLoading}
-						{@render loadingIndicator?.()}
-					{:else if search.hasMorePaginatedData}
-						<button type="button" class="supersearch-show-more" onclick={search.fetchMoreData}>
-							{loadMoreLabel}
-						</button>
+					{#if selection?.anchor === selection?.head}
+						{#if search.data}
+							{@const resultItemRows =
+								(Array.isArray(search.paginatedData) &&
+									search.paginatedData.map((page) => page.items).flat()) ||
+								search.data?.items}
+							{#each resultItemRows as resultItem, index (index)}
+								{@const rowIndex = persistentResultItemRow ? index + 2 : index + 1}
+								<div role="row" class:focused={activeRowIndex === rowIndex}>
+									{@render resultItemRow?.({
+										resultItem,
+										getCellId: (colIndex: number) => `${id}-item-${rowIndex}x${colIndex}`,
+										isFocusedCell: (colIndex: number) =>
+											activeRowIndex === rowIndex && colIndex === activeColIndex,
+										rowIndex
+									})}
+								</div>
+							{/each}
+						{/if}
+						{#if search.isLoading}
+							{@render loadingIndicator?.()}
+						{:else if search.hasMorePaginatedData}
+							<button type="button" class="supersearch-show-more" onclick={search.fetchMoreData}>
+								{loadMoreLabel}
+							</button>
+						{/if}
 					{/if}
 				{/if}
 			</nav>

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -3,7 +3,8 @@
 	import { BROWSER } from 'esm-env';
 	import CodeMirror, {
 		type ChangeCodeMirrorEvent,
-		type SelectCodeMirrorEvent
+		type SelectCodeMirrorEvent,
+		type Selection
 	} from '$lib/components/CodeMirror.svelte';
 	import { EditorView, placeholder as placeholderExtension, keymap } from '@codemirror/view';
 	import { Compartment, StateEffect, type Extension } from '@codemirror/state';
@@ -77,7 +78,7 @@
 		defaultResultCol?: number;
 		toggleWithKeyboardShortcut?: boolean;
 		debouncedWait?: number;
-		cursor?: number;
+		selection?: Selection;
 		isLoading?: boolean;
 		hasData?: boolean;
 		loadMoreLabel?: string;
@@ -107,7 +108,7 @@
 		defaultResultRow = 0,
 		defaultResultCol = 0,
 		debouncedWait = 300,
-		cursor = $bindable(0), // should be treated as readonly
+		selection = $bindable(),
 		isLoading = $bindable(), // should be treated as readonly
 		hasData = $bindable(), // should be treated as readonly
 		loadMoreLabel = 'Load more'
@@ -218,7 +219,7 @@
 	}
 
 	function setDefaultRowAndCols() {
-		if (!shouldShowStartContentFn(value, cursor)) {
+		if (!shouldShowStartContentFn(value, selection)) {
 			activeRowIndex = defaultResultRow;
 			if (activeRowIndex > 0) {
 				activeColIndex = defaultResultCol;
@@ -236,12 +237,12 @@
 			showExpandedSearch();
 		}
 		value = event.value;
-		cursor = event.selection.head;
+		selection = event.selection;
 		setDefaultRowAndCols();
 
 		if (value.trim() && value.trim() !== prevValue.trim()) {
 			prevValue = value;
-			search.debouncedFetchData(value, cursor);
+			search.debouncedFetchData(value, selection.head);
 		}
 
 		if (!value.trim()) {
@@ -251,8 +252,7 @@
 	}
 
 	function handleSelectCodeMirror(event: SelectCodeMirrorEvent) {
-		console.log('select event:', event);
-		cursor = event.head;
+		selection = event;
 	}
 
 	export function dispatchChange({
@@ -298,7 +298,6 @@
 		expandedEditorView?.dispatch({
 			selection: collapsedEditorView?.state.selection.main
 		});
-		cursor = collapsedEditorView?.state.selection.main.head || cursor;
 		dialog?.showModal();
 		expandedEditorView?.focus();
 		setDefaultRowAndCols();
@@ -637,7 +636,7 @@
 				})}
 			</div>
 			<nav class="supersearch-suggestions" role="rowgroup">
-				{#if startContent && shouldShowStartContentFn(value, cursor)}
+				{#if startContent && shouldShowStartContentFn(value, selection)}
 					{@render startContent({
 						getCellId: (rowIndex: number, colIndex: number) => `${id}-item-${rowIndex}x${colIndex}`,
 						isFocusedCell: (rowIndex: number, colIndex: number) =>
@@ -659,7 +658,7 @@
 							(Array.isArray(search.paginatedData) &&
 								search.paginatedData.map((page) => page.items).flat()) ||
 							search.data?.items}
-						{#each resultItemRows as resultItem, index}
+						{#each resultItemRows as resultItem, index (index)}
 							{@const rowIndex = persistentResultItemRow ? index + 2 : index + 1}
 							<div role="row" class:focused={activeRowIndex === rowIndex}>
 								{@render resultItemRow?.({

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -236,7 +236,7 @@
 			showExpandedSearch();
 		}
 		value = event.value;
-		cursor = event.cursor;
+		cursor = event.selection.head;
 		setDefaultRowAndCols();
 
 		if (value.trim() && value.trim() !== prevValue.trim()) {
@@ -252,6 +252,7 @@
 
 	function handleSelectCodeMirror(event: SelectCodeMirrorEvent) {
 		console.log('select event:', event);
+		cursor = event.head;
 	}
 
 	export function dispatchChange({
@@ -297,7 +298,7 @@
 		expandedEditorView?.dispatch({
 			selection: collapsedEditorView?.state.selection.main
 		});
-		cursor = collapsedEditorView?.state.selection.main.anchor || cursor;
+		cursor = collapsedEditorView?.state.selection.main.head || cursor;
 		dialog?.showModal();
 		expandedEditorView?.focus();
 		setDefaultRowAndCols();

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import { onMount, onDestroy, type Snippet } from 'svelte';
 	import { BROWSER } from 'esm-env';
-	import CodeMirror, { type ChangeCodeMirrorEvent } from '$lib/components/CodeMirror.svelte';
+	import CodeMirror, {
+		type ChangeCodeMirrorEvent,
+		type SelectCodeMirrorEvent
+	} from '$lib/components/CodeMirror.svelte';
 	import { EditorView, placeholder as placeholderExtension, keymap } from '@codemirror/view';
 	import { Compartment, StateEffect, type Extension } from '@codemirror/state';
 	import { type LanguageSupport } from '@codemirror/language';
@@ -245,6 +248,10 @@
 			prevValue = value;
 			if (search.data) search.resetData();
 		}
+	}
+
+	function handleSelectCodeMirror(event: SelectCodeMirrorEvent) {
+		console.log('select event:', event);
 	}
 
 	export function dispatchChange({
@@ -578,6 +585,7 @@
 		extensions={collapsedExtensions}
 		onclick={handleClickCollapsed}
 		onchange={handleChangeCodeMirror}
+		onselect={handleSelectCodeMirror}
 		bind:editorView={collapsedEditorView}
 		syncedEditorView={expandedEditorView}
 	/>
@@ -588,6 +596,7 @@
 		{value}
 		extensions={expandedExtensions}
 		onchange={handleChangeCodeMirror}
+		onselect={handleSelectCodeMirror}
 		bind:editorView={expandedEditorView}
 		syncedEditorView={collapsedEditorView}
 	/>

--- a/packages/supersearch/src/lib/index.ts
+++ b/packages/supersearch/src/lib/index.ts
@@ -1,6 +1,7 @@
 import SuperSearch from '$lib/components/SuperSearch.svelte';
+import type { Selection } from './components/CodeMirror.svelte';
 import lxlQualifierPlugin from '$lib/extensions/lxlQualifierPlugin/index.js';
 import type { ResultItem } from './types/superSearch.js';
 import useSearchRequest from './utils/useSearchRequest.svelte';
 
-export { SuperSearch, lxlQualifierPlugin, type ResultItem, useSearchRequest };
+export { SuperSearch, lxlQualifierPlugin, useSearchRequest, type ResultItem, type Selection };

--- a/packages/supersearch/src/lib/types/superSearch.ts
+++ b/packages/supersearch/src/lib/types/superSearch.ts
@@ -1,4 +1,5 @@
 import type { JSONValue } from './json.js';
+import type { Selection } from '$lib/components/CodeMirror.svelte';
 
 export type QueryFunction = (value: string, cursor: number) => URLSearchParams;
 export type PaginationQueryFunction = (
@@ -6,7 +7,7 @@ export type PaginationQueryFunction = (
 	data: JSONValue
 ) => URLSearchParams | undefined;
 export type TransformFunction = (data: JSONValue) => JSONValue;
-export type ShouldShowStartContentFunction = (value: string, cursor: number) => boolean;
+export type ShouldShowStartContentFunction = (value: string, selection?: Selection) => boolean;
 
 // TODO update me
 export interface ResultItem {

--- a/packages/supersearch/src/lib/utils/isViewUpdateOfUserEvent.ts
+++ b/packages/supersearch/src/lib/utils/isViewUpdateOfUserEvent.ts
@@ -1,0 +1,35 @@
+import type { ViewUpdate } from '@codemirror/view';
+
+/**
+ * Check if a ViewUpdate contains a specific user event type
+ */
+
+function isViewUpdateOfUserEvent(
+	viewUpdate: ViewUpdate,
+	userEvent:
+		| 'input'
+		| 'input.type'
+		| 'input.paste'
+		| 'input.drop'
+		| 'input.complete'
+		| 'delete'
+		| 'delete.selection'
+		| 'delete.forward'
+		| 'delete.backward'
+		| 'delete.cut'
+		| 'move'
+		| 'move.drop'
+		| 'select'
+		| 'select.pointer'
+		| 'undo'
+		| 'redo' // see: https://codemirror.net/docs/ref/#state.Transaction%5EuserEvent
+) {
+	for (const transaction of viewUpdate.transactions) {
+		const userEventType = transaction.isUserEvent(userEvent);
+		if (userEventType) return true;
+	}
+
+	return false;
+}
+
+export default isViewUpdateOfUserEvent;


### PR DESCRIPTION
### Solves

Replaces bindable cursor prop with a selection event handler

### Summary of changes

- Add select event handler
- Use selection head instead of anchor for cursor
- Replace bindable cursor prop
- Use selection inside handleShouldShowStartContent
- Skip redundant selection sync
- Hide result items when text is selected
- Look both left and right when deciding if editing a part of query
