### PR TITLE
fix(idkbse): encode single quote char in requests to backend

### DIFF
--- a/idkbse/src/plugins/env.js
+++ b/idkbse/src/plugins/env.js
@@ -28,7 +28,8 @@ export function encodeSpecialChars(path) {
     .replace(/\(/g, '%28')
     .replace(/\)/g, '%29')
     .replace(/&/g, '%26')
-    .replace(/,/g, '%2C');
+    .replace(/,/g, '%2C')
+    .replace(/'/g, '%27');
 }
 
 export function activeSite(xForwardedHost, siteAlias, siteConfig, defaultSite) {


### PR DESCRIPTION
Terms with a `'` in their prefLabel 404, for example:

* https://id.kb.se/term/gmgpc/swe/%C3%89preuves%20d'artiste
* https://id.kb.se/term/saogf/Rock'n'roll

Looking with tcpflow, the idkbse app sends a request to the backend for `https://id.kb.se/term/saogf/Rock'n'roll` rather than (the correct) `https://id.kb.se/term/saogf/Rock%27n%27roll`. So, this should fix it.