### PR TITLE
fix(lxlweb): catch parsing error, fix failing test

### DIFF
--- a/lxl-web/src/lib/components/Error.svelte
+++ b/lxl-web/src/lib/components/Error.svelte
@@ -1,14 +1,14 @@
 <script>
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import getPageTitle from '$lib/utils/getPageTitle';
 
 	export let showHeader = false;
 
 	function getErrorPageTitle() {
-		if ($page.status === 404) {
-			return getPageTitle($page.data.t('errors.notFound'));
+		if (page.status === 404) {
+			return getPageTitle(page.data.t('errors.notFound'));
 		}
-		return getPageTitle($page.data.t('errors.somethingWentWrong'));
+		return getPageTitle(page.data.t('errors.somethingWentWrong'));
 	}
 </script>
 
@@ -23,25 +23,24 @@
 	</header>
 {/if}
 <div class="m-auto flex flex-col p-8 text-center">
-	<h1 class="text-6-cond-extrabold">{$page.status}</h1>
-	{#if $page.status === 404}
-		<h2 class="pb-4">{$page.data.t('errors.notFound')}</h2>
-		<p>{$page.data.t('errors.wrongLink')}</p>
+	<h1 class="text-6-cond-extrabold">{page.status}</h1>
+	{#if page.status === 404}
+		<h2 class="pb-4">{page.data.t('errors.notFound')}</h2>
+		<p>{page.data.t('errors.wrongLink')}</p>
 		<p>
-			{$page.data.t('errors.sendEmail')}
+			{page.data.t('errors.sendEmail')}
 			<a
 				href="mailto:libris@kb.se?subject={encodeURIComponent(
-					$page.data.t('errors.mailSubject')
-				)}&body={encodeURIComponent($page.data.t('errors.mailBody'))} {$page.url.href}"
-				>{$page.data.t('errors.customerService')}</a
-			>{$page.data.t('errors.followUp')}
+					page.data.t('errors.mailSubject')
+				)}&body={encodeURIComponent(page.data.t('errors.mailBody'))} {page.url.href}"
+				>{page.data.t('errors.customerService')}</a
+			>{page.data.t('errors.followUp')}
 		</p>
 		<p class="pt-4">
-			<a href={$page.data.locale === 'en' ? '/en' : '/'}>{$page.data.t('errors.backToStartPage')}</a
-			>
+			<a href={page.data.locale === 'en' ? '/en' : '/'}>{page.data.t('errors.backToStartPage')}</a>
 		</p>
-	{:else if $page.error?.message}
-		<h2 class="pb-4">{$page.data.t('errors.somethingWentWrong')}</h2>
-		<p class="text-secondary">{$page.error.message}</p>
+	{:else if page.error?.message}
+		<h2 class="pb-4">{page.data.t('errors.somethingWentWrong')}</h2>
+		<p class="text-secondary">{page.error.message}</p>
 	{/if}
 </div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -40,8 +40,13 @@ export const load = async ({ params, url, locals, fetch }) => {
 	}
 
 	if (!resourceRes.ok) {
-		const err = (await resourceRes.json()) as ApiError;
-		throw error(err.status_code, { message: err.message, status: err.status });
+		try {
+			const err = (await resourceRes.json()) as ApiError;
+			throw error(err.status_code, { message: err.message, status: err.status });
+		} catch (e) {
+			console.warn(e);
+			throw error(resourceRes?.status, { message: resourceRes?.statusText });
+		}
 	}
 
 	const resource = await resourceRes.json();

--- a/lxl-web/tests/error.spec.ts
+++ b/lxl-web/tests/error.spec.ts
@@ -30,7 +30,7 @@ test.describe('English 404 page', () => {
 
 test.describe('Missing resource page', () => {
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/aaaaaaaaaaaaaaaa');
+		await page.goto('/5nxb2lhk30q35zdb');
 	});
 	test('has expected h1', async ({ page }) => {
 		await expect(page.getByRole('heading', { name: '404' })).toBeVisible();


### PR DESCRIPTION
## Description

### Solves

e2e-test failing now because we expect a 404-page at https://beta.libris-qa.kb.se/aaaaaaaaaaaaaaa, but for some reason getting a [502 html page](https://libris-qa.kb.se/aaaaaaaaaaaaaaa?framed=true) that we fail to parse as json, resulting in a 500 internal error page...

Changing the cursed /aaaaaaaaaaaaaaa route in the test, because any other non-existent fnurgel seems to result in 404 as expected.

### Summary of changes

* Change 404 route in test
* try/catch the error parsing to be able to display the actual error
* Replace deprecated app/stores `$page` in Error component 