### PR TITLE
feat(lxlweb, supersearch, lxlquery): Handle filter alias in supersearch

### DIFF
--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -11,6 +11,10 @@
 	border-bottom-left-radius: 5px;
 }
 
+.lxl-filter-alias {
+	padding-right: 5px;
+}
+
 .lxl-qualifier-remove,
 .lxl-qualifier-value:not(:has(+ .lxl-qualifier-value)) {
 	padding-right: 5px;

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -4,7 +4,8 @@
 	background: rgba(14, 113, 128, 0.1);
 }
 
-.lxl-qualifier-key {
+.lxl-qualifier-key,
+.lxl-filter-alias {
 	padding-left: 5px;
 	border-top-left-radius: 5px;
 	border-bottom-left-radius: 5px;

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -149,6 +149,7 @@ export interface SearchMapping extends MappingObj {
 	alias: string;
 	property?: ObjectProperty | DatatypeProperty | PropertyChainAxiom | InvalidProperty;
 	object?: FramedData;
+	value?: string;
 	up: { '@id': string };
 	_key?: string;
 	_value?: string;

--- a/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
+++ b/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
@@ -54,6 +54,9 @@ function iterateMapping(
 						// only use atomic ranges for linked values
 						valueLabel = el.displayStr;
 					}
+				} else if (!key && value === el?._value && el?.displayStr) {
+					// ...unless a filter alias (no key, only value)
+					valueLabel = el.displayStr;
 				}
 			});
 		}

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -138,9 +138,13 @@ export function displayMappings(
 						LensType.Chip,
 						locale
 					),
+					displayStr: toString(
+						displayUtil.lensAndFormat({ ...defaultType, ...m.object }, LensType.Chip, locale)
+					),
 					label: '',
 					operator,
-					...('up' in m && { up: replacePath(m.up as Link, usePath) })
+					...('up' in m && { up: replacePath(m.up as Link, usePath) }),
+					_value: m?.value
 				} as DisplayMapping;
 			} else {
 				return {

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -11,7 +11,7 @@ String { strliteral | str }
 Qualifier { 
   ( QualifierKey { String } QualifierOperator { bOperator } QualifierValue { String } ) | 
   ( QualifierKey { String } QualifierOperator { bOperatorEq } QualifierValue { term } ) |
-  filterAliases 
+  QualifierValue { filterAlias }
 }
 
 @tokens {
@@ -22,10 +22,10 @@ Qualifier {
   bOperatorEq { ":" | "=" }
   strliteral { '"' (!["\\] | "\\" _)* '"' }
   str { ![:><=()~!"\ ]+ }
-  filterAliases { "includeEplikt" | "includePreliminary" }
+  filterAlias { "includeEplikt" | "includePreliminary" }
   space { @whitespace+ }
 
-  @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, filterAliases, str, space}
+  @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, filterAlias, str, space}
 }
 
 @detectDelim

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -11,7 +11,7 @@ String { strliteral | str }
 Qualifier { 
   ( QualifierKey { String } QualifierOperator { bOperator } QualifierValue { String } ) | 
   ( QualifierKey { String } QualifierOperator { bOperatorEq } QualifierValue { term } ) |
-  QualifierValue { filterAlias }
+  QualifierValue { FilterAlias { filterAlias } }
 }
 
 @tokens {

--- a/packages/codemirror-lang-lxlquery/test/cases.txt
+++ b/packages/codemirror-lang-lxlquery/test/cases.txt
@@ -420,7 +420,7 @@ Pippi includeEplikt
 
 ==>
 
-Query(String Qualifier)
+Query(String Qualifier(QualifierValue))
 
 
 # other filters: include preliminary
@@ -429,4 +429,4 @@ includePreliminary Pippi
 
 ==>
 
-Query(Qualifier String)
+Query(Qualifier(QualifierValue) String)

--- a/packages/codemirror-lang-lxlquery/test/cases.txt
+++ b/packages/codemirror-lang-lxlquery/test/cases.txt
@@ -420,7 +420,7 @@ Pippi includeEplikt
 
 ==>
 
-Query(String Qualifier(QualifierValue))
+Query(String Qualifier(QualifierValue(FilterAlias)))
 
 
 # other filters: include preliminary
@@ -429,4 +429,4 @@ includePreliminary Pippi
 
 ==>
 
-Query(Qualifier(QualifierValue) String)
+Query(Qualifier(QualifierValue(FilterAlias)) String)

--- a/packages/supersearch/README.md
+++ b/packages/supersearch/README.md
@@ -47,9 +47,9 @@ To use `supersearch` in a non-Svelte project ...
 | `hasData` | `boolean` | A bindable prop telling if the component has data (the prop should be treated as readonly) | `undefined` |
 
 &nbsp;
-Supersearch also exports a `lxlQualifierPlugin` that can be used (passed to the extensions prop) if you want atomic, stylable, removable, labeled pills from some key-value pairs in your editor. This requires:
+Supersearch also exports a `lxlQualifierPlugin` that can be used (passed to the extensions prop) if you want atomic, stylable, removable, labeled pills in your editor from some key-value pair or reserved word. This requires:
 
-- Your language exporting `Qualifier` nodes consisting of `QualifierKey`, `QualifierOperator` and `QualifierValue` (i.e `key:value`).
+- Your language exporting `Qualifier` nodes that can consist of `QualifierKey`, `QualifierOperator` and `QualifierValue` (i.e `key:value`).
 - Passing a function of type `GetLabelFunction`, that should return readable labels in order for the pill to turn atomic (non-editable) together with an optional `invalid` flag that enables styling of invalid queries.
 - Optionally passing a `RemoveQualifierFunction` that will be called with the qualifier when user clicks the remove button.
 

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/QualifierComponent.svelte
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/QualifierComponent.svelte
@@ -14,20 +14,37 @@
 	}
 
 	const { key, keyLabel, operator, value, valueLabel, removeQualifierFn }: Props = $props();
+
+	const hasRemoveBtn = $derived(
+		((keyLabel && operator && valueLabel) ||
+			// filter alias
+			(!keyLabel && !operator && valueLabel)) &&
+			removeQualifierFn
+	);
 </script>
 
-<span class="lxl-qualifier lxl-qualifier-key atomic" data-qualifier-key={key}>
-	{keyLabel}
-</span>
-<span class="lxl-qualifier lxl-qualifier-operator atomic" data-qualifier-operator={operator}>
-	{operator}
-</span>
+{#if keyLabel}
+	<span class="lxl-qualifier lxl-qualifier-key atomic" data-qualifier-key={key}>
+		{keyLabel}
+	</span>
+{/if}
+{#if operator}
+	<span class="lxl-qualifier lxl-qualifier-operator atomic" data-qualifier-operator={operator}>
+		{operator}
+	</span>
+{/if}
 {#if valueLabel}
-	<span class="lxl-qualifier lxl-qualifier-value atomic" data-qualifier-value={value}>
+	<span
+		class={[
+			'lxl-qualifier atomic',
+			keyLabel && operator ? 'lxl-qualifier-value' : 'lxl-filter-alias'
+		]}
+		data-qualifier-value={value}
+	>
 		{valueLabel}
 	</span>
 {/if}
-{#if keyLabel && operator && valueLabel && removeQualifierFn}
+{#if hasRemoveBtn}
 	<button
 		type="button"
 		onclick={() => removeQualifierFn?.(key + operator + value)}

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
@@ -110,7 +110,7 @@ function lxlQualifierPlugin(
 						const { keyLabel, valueLabel, invalid } = getLabelFn?.(key, value) || {};
 
 						// Add qualifier widget
-						if (keyLabel) {
+						if (keyLabel || valueLabel) {
 							const qualifierDecoration = Decoration.replace({
 								widget: new QualifierWidget(
 									key,

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertSpaceAroundQualifier.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/insertSpaceAroundQualifier.ts
@@ -78,7 +78,7 @@ const insertSpaceAroundQualifier = (getRanges: () => RangeSet<RangeValue>) => {
 						// At qualifier end, insert space before input
 						insert = [{ changes: { from: atomicEnd, insert: ' ' } }, tr];
 					}
-				} else if (rightNode.parent?.name === 'QualifierKey') {
+				} else if (rightNode.parent?.name === 'QualifierKey' || rightNode.name === 'FilterAlias') {
 					if ((input && inputRangeMin === atomicStart) || (isDelete && prevChar)) {
 						// At qualifier start, insert space after input
 						insert = [tr, { changes: { from: atomicStart, insert: ' ' } }];


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-347](https://kbse.atlassian.net/browse/LWS-347), [LWS-313](https://kbse.atlassian.net/browse/LWS-313)

### Solves

Handle filter aliases in supersearch like so:

<img width="745" alt="Skärmavbild 2025-04-10 kl  09 51 07" src="https://github.com/user-attachments/assets/8064eb96-0138-4868-bbde-e7b188b4594a" />

When myLibs is available as a filter alias, we should be able to just add it to the grammar file.

### Summary of changes

* `Search.ts`: return `displayStr` and `_value` properties for `mapping.object`s
* `syntax.grammar`: define `filterAlias` as a type of `QualifierValue`. Update tests.
* `getLabelsFromMappings`:  can now return only a value label.
*  `lxlQualifierPlugin`: now creates an atomic decoration from just the value label.
* `QualifierComponent`: Enable rendering a value label only.