### PR TITLE
chore(lxl-web): Format code after tailwind v4 migration

### DIFF
--- a/lxl-web/eslint.config.js
+++ b/lxl-web/eslint.config.js
@@ -29,13 +29,5 @@ export default [
 	},
 	{
 		ignores: ['build/', '.svelte-kit/', 'dist/']
-	},
-	{
-		rules: {
-			// Temporarily disable errors while formatting old code
-			'svelte/require-each-key': 'warn',
-			'svelte/no-useless-mustaches': 'warn',
-			'svelte/no-unused-svelte-ignore': 'warn'
-		}
 	}
 ];

--- a/lxl-web/eslint.config.js
+++ b/lxl-web/eslint.config.js
@@ -29,5 +29,13 @@ export default [
 	},
 	{
 		ignores: ['build/', '.svelte-kit/', 'dist/']
+	},
+	{
+		rules: {
+			// Temporarily disable errors while formatting old code
+			'svelte/require-each-key': 'warn',
+			'svelte/no-useless-mustaches': 'warn',
+			'svelte/no-unused-svelte-ignore': 'warn'
+		}
 	}
 ];

--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -63,9 +63,9 @@
 	--text-4xl--line-height: var(--leading-tight);
 	--text-5xl--line-height: var(--leading-tight);
 
-	--font-sans: "Roboto Flex", "sans-serif";
-	--font-condensed: "Roboto Flex", "sans-serif";
-	--font-condensed--font-variation-settings: "wdth" 60;
+	--font-sans: 'Roboto Flex', 'sans-serif';
+	--font-condensed: 'Roboto Flex', 'sans-serif';
+	--font-condensed--font-variation-settings: 'wdth' 60;
 
 	--breakpoint-xs: 375px;
 	--breakpoint-sm: 640px;
@@ -146,15 +146,15 @@
 }
 
 @utility text-1-cond {
-	@apply text-xs font-condensed;
+	@apply font-condensed text-xs;
 }
 
 @utility text-1-cond-bold {
-	@apply text-xs font-condensed font-bold;
+	@apply font-condensed text-xs font-bold;
 }
 
 @utility text-1-cond-caps {
-	@apply text-xs font-condensed font-normal uppercase tracking-wide;
+	@apply font-condensed text-xs font-normal tracking-wide uppercase;
 }
 
 @utility text-2-regular {
@@ -162,11 +162,11 @@
 }
 
 @utility text-2-cond {
-	@apply text-sm font-condensed;
+	@apply font-condensed text-sm;
 }
 
 @utility text-2-cond-bold {
-	@apply text-sm font-condensed font-bold;
+	@apply font-condensed text-sm font-bold;
 }
 
 @utility text-3-regular {
@@ -174,11 +174,11 @@
 }
 
 @utility text-3-cond {
-	@apply text-base font-condensed;
+	@apply font-condensed text-base;
 }
 
 @utility text-3-cond-bold {
-	@apply text-base font-condensed font-bold
+	@apply font-condensed text-base font-bold;
 }
 
 @utility text-4-regular {
@@ -186,23 +186,23 @@
 }
 
 @utility text-4-cond {
-	@apply text-lg font-condensed;
+	@apply font-condensed text-lg;
 }
 
 @utility text-4-cond-bold {
-	@apply text-lg font-condensed font-bold;
+	@apply font-condensed text-lg font-bold;
 }
 
 @utility text-5-cond-extrabold {
-	@apply text-xl font-condensed font-extrabold;
+	@apply font-condensed text-xl font-extrabold;
 }
 
 @utility text-6-cond-extrabold {
-	@apply text-2xl md:text-3xl font-condensed font-extrabold;
+	@apply font-condensed text-2xl font-extrabold md:text-3xl;
 }
 
 @utility text-7-cond-extrabold {
-	@apply text-3xl md:text-4xl lg:text-5xl font-condensed font-extrabold;
+	@apply font-condensed text-3xl font-extrabold md:text-4xl lg:text-5xl;
 }
 
 /* shadow */
@@ -212,7 +212,9 @@
 }
 
 @utility shadow-btn-primary {
-	box-shadow: 0px 1px 0px 0px --alpha(var(--color-primary) / 16%), inset 0px 1px 0px 0px --alpha(var(--color-highlight) / 24%);
+	box-shadow:
+		0px 1px 0px 0px --alpha(var(--color-primary) / 16%),
+		inset 0px 1px 0px 0px --alpha(var(--color-highlight) / 24%);
 }
 
 /* gradient */
@@ -236,7 +238,7 @@
 }
 
 @utility find-layout {
-	@apply flex flex-col gap-4 md:grid md:grid-cols-find md:gap-8;
+	@apply md:grid-cols-find flex flex-col gap-4 md:grid md:gap-8;
 }
 
 @utility header-layout-md {
@@ -245,7 +247,7 @@
 
 @utility header-layout {
 	grid-template-columns: 70px minmax(0, 8fr) 1fr;
-	@apply grid gap-x-8 px-4 md:px-2 sm:px-6 md:header-layout-md;
+	@apply md:header-layout-md grid gap-x-8 px-4 sm:px-6 md:px-2;
 
 	/* why is this not working?? */
 	/* @media screen and (min-width: var(--breakpoint-md)) {
@@ -287,7 +289,7 @@
 	}
 
 	input {
-		@apply shadow-input bg-white text-3-regular rounded-md px-4 py-2 text-ellipsis;
+		@apply shadow-input text-3-regular rounded-md bg-white px-4 py-2 text-ellipsis;
 	}
 
 	select {
@@ -332,7 +334,7 @@
 	.button-ghost {
 		@apply border-primary/16 text-secondary text-3-cond-bold flex h-10 items-center justify-center gap-2 rounded-md border-2 px-4 py-2 whitespace-nowrap no-underline transition-colors;
 
-		@apply hover:border-positive-dark/32 hover:bg-positive/32 hover:text-positive-dark outline-transparent hover:outline-positive-dark/8 focus:border-positive-dark/32 focus:bg-positive/32 focus:text-positive-dark hover:outline-4;
+		@apply hover:border-positive-dark/32 hover:bg-positive/32 hover:text-positive-dark hover:outline-positive-dark/8 focus:border-positive-dark/32 focus:bg-positive/32 focus:text-positive-dark outline-transparent hover:outline-4;
 
 		&:not(:hover):not(:focus) svg {
 			@apply text-primary/40;
@@ -361,6 +363,6 @@
 	}
 
 	.icon-button {
-		@apply w-11 h-11 flex items-center justify-center rounded-full hover:bg-cards focus:bg-cards transition-colors relative;
+		@apply hover:bg-cards focus:bg-cards relative flex h-11 w-11 items-center justify-center rounded-full transition-colors;
 	}
 }

--- a/lxl-web/src/lib/actions/dropDownMenu/DropDownMenu.svelte
+++ b/lxl-web/src/lib/actions/dropDownMenu/DropDownMenu.svelte
@@ -71,7 +71,7 @@
 	Note that `DropDownMenu.svelte` isn't intended to be used directly in page templates – use the `use:dropDownMenu` instead (see `$lib/actions/dropDownMenu`).
 -->
 <div
-	class="drop-down-menu absolute top-0 left-0 z-100 w-max-content max-w-sm bg-cards border border-primary/32 rounded-sm text-sm shadow-xl"
+	class="drop-down-menu w-max-content bg-cards border-primary/32 absolute top-0 left-0 z-100 max-w-sm rounded-sm border text-sm shadow-xl"
 	role="complementary"
 	bind:this={dropDownMenuElement}
 	{onmouseover}
@@ -82,7 +82,13 @@
 	<nav class="menu-items">
 		<ul>
 			{#each menuItems as item}
-				<li><button type="button" class="flex items-center text-left px-4 w-full min-h-[44px] cursor-pointer hover:bg-main" onclick={item.action}>{item.label}</button></li>
+				<li>
+					<button
+						type="button"
+						class="hover:bg-main flex min-h-[44px] w-full cursor-pointer items-center px-4 text-left"
+						onclick={item.action}>{item.label}</button
+					>
+				</li>
 			{/each}
 		</ul>
 	</nav>

--- a/lxl-web/src/lib/actions/popover/Popover.svelte
+++ b/lxl-web/src/lib/actions/popover/Popover.svelte
@@ -67,7 +67,7 @@
 	Note that `Popover.svelte` isn't intended to be used directly in page templates – use the `use:popover` instead (see `$lib/actions/popover`).
 -->
 <div
-	class="absolute left-0 top-0 z-50 w-max max-w-sm rounded-md border border-primary/16 bg-cards text-sm shadow-xl"
+	class="border-primary/16 bg-cards absolute top-0 left-0 z-50 w-max max-w-sm rounded-md border text-sm shadow-xl"
 	role="complementary"
 	bind:this={popoverElement}
 	on:mouseover={onMouseOver}

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -267,7 +267,7 @@
 	}
 
 	.pill {
-		@apply mb-1 mr-1 inline-block rounded-full border border-primary/8 px-3 py-1 no-underline;
+		@apply border-primary/8 mr-1 mb-1 inline-block rounded-full border px-3 py-1 no-underline;
 	}
 
 	a.pill {
@@ -275,7 +275,7 @@
 	}
 
 	.remainder {
-		@apply ml-2 whitespace-nowrap rounded-full bg-primary/8 px-2 py-0.5 text-secondary;
+		@apply bg-primary/8 text-secondary ml-2 rounded-full px-2 py-0.5 whitespace-nowrap;
 	}
 
 	.block {

--- a/lxl-web/src/lib/components/Error.svelte
+++ b/lxl-web/src/lib/components/Error.svelte
@@ -18,7 +18,7 @@
 {#if showHeader}
 	<header class="flex justify-center pt-8">
 		<a href="/" class="inline-block no-underline">
-			<h1 class="text-3xl font-bold text-primary">Libris</h1>
+			<h1 class="text-primary text-3xl font-bold">Libris</h1>
 		</a>
 	</header>
 {/if}

--- a/lxl-web/src/lib/components/MarkdownContent.svelte
+++ b/lxl-web/src/lib/components/MarkdownContent.svelte
@@ -4,18 +4,18 @@
 
 <style lang="postcss">
 	@reference "../../app.css";
-	
+
 	div {
 		& :global(h1) {
 			@apply text-6-cond-extrabold;
 		}
 
 		& :global(h2) {
-			@apply mt-6 text-5-cond-extrabold;
+			@apply text-5-cond-extrabold mt-6;
 		}
 
 		& :global(h3) {
-			@apply mt-6 text-3-cond-bold;
+			@apply text-3-cond-bold mt-6;
 		}
 
 		& :global(p) {

--- a/lxl-web/src/lib/components/Modal.svelte
+++ b/lxl-web/src/lib/components/Modal.svelte
@@ -56,13 +56,13 @@
 </script>
 
 <div
-	class="pointer-events-none fixed left-0 top-0 z-10 h-full w-full bg-backdrop"
+	class="bg-backdrop pointer-events-none fixed top-0 left-0 z-10 h-full w-full"
 	transition:fade={{ duration: 300 }}
 ></div>
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <dialog
-	class="fixed left-0 top-0 flex h-screen max-h-full w-screen max-w-full"
+	class="fixed top-0 left-0 flex h-screen max-h-full w-screen max-w-full"
 	tabindex="-1"
 	on:click|self={handleBackdropClick}
 	on:close={handleClose}
@@ -76,7 +76,7 @@
 	}}
 >
 	<div
-		class="absolute right-0 top-0 flex w-full bg-main shadow-2xl md:max-w-[480px] xl:max-w-[640px] {position ===
+		class="bg-main absolute top-0 right-0 flex w-full shadow-2xl md:max-w-[480px] xl:max-w-[640px] {position ===
 		'top'
 			? 'h-auto'
 			: 'h-full'}"
@@ -85,7 +85,7 @@
 	>
 		<div class="flex flex-1 flex-col gap-4 overflow-y-auto pb-4">
 			<header
-				class="sticky top-0 z-10 flex min-h-14 items-center justify-between border-b border-b-primary/16 bg-main px-4"
+				class="border-b-primary/16 bg-main sticky top-0 z-10 flex min-h-14 items-center justify-between border-b px-4"
 			>
 				<h1 class="text-3-cond-bold"><slot name="title" /></h1>
 				<!-- svelte-ignore a11y-autofocus -->

--- a/lxl-web/src/lib/components/MyLibsHoldingIndicator.svelte
+++ b/lxl-web/src/lib/components/MyLibsHoldingIndicator.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <span
-	class="relative p-2 text-positive-dark text-lg md:text-xl"
+	class="text-positive-dark relative p-2 text-lg md:text-xl"
 	use:popover={{
 		title: `${page.data.t('holdings.availableAt')}: ${librariesString}`
 	}}

--- a/lxl-web/src/lib/components/ResourceImage.svelte
+++ b/lxl-web/src/lib/components/ResourceImage.svelte
@@ -51,7 +51,7 @@
 		{/if}
 		{#if image?.usageAndAccessPolicy}
 			<figcaption
-				class="mt-1 table-caption caption-bottom overflow-hidden text-[10px] text-tertiary"
+				class="text-tertiary mt-1 table-caption caption-bottom overflow-hidden text-[10px]"
 				class:text-center={geometry === 'circle'}
 			>
 				{#if image.attribution}
@@ -103,7 +103,7 @@
 			class:rounded-full={geometry === 'circle'}
 		/>
 		{#if getTypeIcon(type)}
-			<svelte:component this={getTypeIcon(type)} class="absolute text-2xl text-icon" />
+			<svelte:component this={getTypeIcon(type)} class="text-icon absolute text-2xl" />
 		{/if}
 	</div>
 {/if}

--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -100,7 +100,7 @@
 </script>
 
 <li
-	class="border-b border-primary/16 first:border-t"
+	class="border-primary/16 border-b first:border-t"
 	class:hidden={searchPhrase && !hasHits}
 	class:has-hits={hasHits}
 	data-dimension={group.dimension}
@@ -116,11 +116,11 @@
 			<span class="flex-1 whitespace-nowrap">{group.label}</span>
 		</summary>
 		<!-- sorting -->
-		<div class="facet-sort absolute right-0 top-2 hidden" data-testid="facet-sort">
+		<div class="facet-sort absolute top-2 right-0 hidden" data-testid="facet-sort">
 			<select
 				bind:value={currentSort}
 				onchange={saveUserSort}
-				class="appearance-none px-6 py-1 text-2-regular"
+				class="text-2-regular appearance-none px-6 py-1"
 				aria-label={page.data.t('sort.sort') + ' ' + page.data.t('search.filters')}
 			>
 				{#each sortOptions as option (option.value)}
@@ -128,9 +128,9 @@
 					>
 				{/each}
 			</select>
-			<BiSortDown class="pointer-events-none absolute top-0 m-1.5 text-icon-strong" />
+			<BiSortDown class="text-icon-strong pointer-events-none absolute top-0 m-1.5" />
 			<BiChevronRight
-				class="pointer-events-none absolute right-0 top-0 m-1.5 w-3 rotate-90 text-icon-strong"
+				class="text-icon-strong pointer-events-none absolute top-0 right-0 m-1.5 w-3 rotate-90"
 			/>
 		</div>
 		<div class="text-md mb-4 md:text-sm">
@@ -139,7 +139,7 @@
 				<FacetRange search={group.search} />
 			{/if}
 			<ol
-				class="flex max-h-72 flex-col gap-1 overflow-y-auto overflow-x-clip pl-6 pr-0.5 sm:max-h-[437px]"
+				class="flex max-h-72 flex-col gap-1 overflow-x-clip overflow-y-auto pr-0.5 pl-6 sm:max-h-[437px]"
 				data-testid="facet-list"
 			>
 				{#each shownItems as facet (facet.view['@id'])}
@@ -165,13 +165,13 @@
 								<span>
 									<DecoratedData data={facet.object} showLabels={ShowLabelsOptions.Never} />
 									{#if facet.discriminator}
-										<span class="text-sm text-secondary">({facet.discriminator})</span>
+										<span class="text-secondary text-sm">({facet.discriminator})</span>
 									{/if}
 								</span>
 							</span>
 							{#if facet.totalItems > 0}
 								<span
-									class="facet-total mb-px rounded-sm bg-primary/4 px-1 text-sm text-secondary md:text-xs"
+									class="facet-total bg-primary/4 text-secondary mb-px rounded-sm px-1 text-sm md:text-xs"
 									aria-label="{facet.totalItems} {page.data.t('search.hits')}"
 									>{facet.totalItems.toLocaleString(locale)}</span
 								>
@@ -184,7 +184,7 @@
 				<!-- 'show more' btn -->
 				{#if canShowMoreItems || canShowFewerItems}
 					<button
-						class="ml-6 mt-4 underline"
+						class="mt-4 ml-6 underline"
 						onclick={() =>
 							canShowMoreItems
 								? (defaultItemsShown = totalItems)
@@ -195,9 +195,9 @@
 				{/if}
 				<!-- limit reached info -->
 				{#if maxItemsReached && (canShowFewerItems || (!canShowMoreItems && searchPhrase))}
-					<div class="ml-auto mt-4">
+					<div class="mt-4 ml-auto">
 						<button
-							class="flex items-center gap-1 rounded-sm bg-primary/4 px-2 py-1 text-xs text-error"
+							class="bg-primary/4 text-error flex items-center gap-1 rounded-sm px-2 py-1 text-xs"
 							use:popover={{
 								title: page.data.t('facet.limitText'),
 								placeAsSibling: true

--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -45,7 +45,7 @@
 				class="w-full pl-8"
 				type="search"
 			/>
-			<BiSearch class="absolute left-2.5 top-3 text-sm text-icon" />
+			<BiSearch class="text-icon absolute top-3 left-2.5 text-sm" />
 			<MyLibrariesFilter />
 			<ol>
 				{#each facets as group (group.dimension)}

--- a/lxl-web/src/lib/components/find/MyLibrariesFilter.svelte
+++ b/lxl-web/src/lib/components/find/MyLibrariesFilter.svelte
@@ -57,14 +57,14 @@
 	</div>
 {/snippet}
 
-<div class="flex w-full gap-2 rounded-sm bg-positive/40 p-3 md:flex-col md:gap-1">
+<div class="bg-positive/40 flex w-full gap-2 rounded-sm p-3 md:flex-col md:gap-1">
 	{#if libraryValues.length}
 		<a class="no-underline" href={isFilterActive ? removeFilterUrl : applyFilterUrl}>
 			{@render filterContent()}
 		</a>
 	{:else}
 		<div
-			class="cursor-not-allowed text-secondary"
+			class="text-secondary cursor-not-allowed"
 			use:popover={{
 				title: page.data.t('search.noAddedLibrariesText'),
 				placeAsSibling: true
@@ -73,7 +73,7 @@
 			{@render filterContent()}
 		</div>
 	{/if}
-	<a class="self-end text-secondary text-2-regular" href="/my-pages"
+	<a class="text-secondary text-2-regular self-end" href="/my-pages"
 		>{libraryValues.length
 			? page.data.t('search.changeLibraries')
 			: page.data.t('search.addLibraries')}</a

--- a/lxl-web/src/lib/components/find/Pagination.svelte
+++ b/lxl-web/src/lib/components/find/Pagination.svelte
@@ -52,7 +52,7 @@
 
 {#if showPagination}
 	<nav aria-label={$page.data.t('search.pagination')} data-testid="pagination">
-		<ul class="flex justify-center overflow-hidden page-padding">
+		<ul class="page-padding flex justify-center overflow-hidden">
 			<!-- prev -->
 			{#if previous}
 				<li>
@@ -73,7 +73,7 @@
 				>
 			</li>
 			{#if pageSequence[0].page > 2}
-				<li class="hidden items-end text-3-cond-bold sm:flex"><span>...</span></li>
+				<li class="text-3-cond-bold hidden items-end sm:flex"><span>...</span></li>
 			{/if}
 			<!-- page sequence -->
 			{#each pageSequence as p}
@@ -92,7 +92,7 @@
 				{/if}
 			{/each}
 			{#if lastPage - pageSequence[pageSequence.length - 1].page > 1}
-				<li class="hidden items-end text-3-cond-bold sm:flex"><span>...</span></li>
+				<li class="text-3-cond-bold hidden items-end sm:flex"><span>...</span></li>
 			{/if}
 			<!-- last -->
 			<li>

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -47,11 +47,11 @@
 							: 'aspect-square'}"
 					/>
 					{#if item['@type'] !== 'Text' && item['@type'] !== 'Person' && getTypeIcon(item['@type'])}
-						<div class="absolute -left-4 -top-4">
-							<div class="rounded-md bg-cards p-1.5">
+						<div class="absolute -top-4 -left-4">
+							<div class="bg-cards rounded-md p-1.5">
 								<svelte:component
 									this={getTypeIcon(item['@type'])}
-									class="h-6 w-6 text-icon-strong"
+									class="text-icon-strong h-6 w-6"
 								/>
 							</div>
 						</div>
@@ -68,7 +68,7 @@
 						{#if getTypeIcon(item['@type'])}
 							<svelte:component
 								this={getTypeIcon(item['@type'])}
-								class="absolute text-lg text-icon"
+								class="text-icon absolute text-lg"
 							/>
 						{/if}
 					</div>
@@ -133,7 +133,7 @@
 		</div>
 		{#if item._debug}
 			{#key item._debug}
-				<div class="card-debug z-20 select-text self-start text-left">
+				<div class="card-debug z-20 self-start text-left select-text">
 					<SearchItemDebug debugInfo={item._debug} />
 					<button
 						type="button"
@@ -182,7 +182,7 @@
 	}
 
 	.search-card {
-		@apply relative grid w-full gap-x-4 rounded-md border-b border-b-primary/16 bg-cards px-4 pb-3 pt-3 font-normal transition-shadow;
+		@apply border-b-primary/16 bg-cards relative grid w-full gap-x-4 rounded-md border-b px-4 pt-3 pb-3 font-normal transition-shadow;
 
 		grid-template-areas: 'image content debug libraries';
 		grid-template-columns: 64px 1fr auto auto;
@@ -197,7 +197,7 @@
 		}
 
 		@container (min-width: 768px) {
-			@apply gap-x-6 px-6 pb-6 pt-4;
+			@apply gap-x-6 px-6 pt-4 pb-6;
 			grid-template-columns: 72px 1fr;
 		}
 	}
@@ -268,7 +268,7 @@
 	.card-header-extra,
 	.card-footer,
 	.card-header :global([data-property='_script']) {
-		@apply text-xs text-secondary;
+		@apply text-secondary text-xs;
 		@container (min-width: 768px) {
 			@apply text-sm;
 		}

--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -61,10 +61,10 @@
 			{:else if m.operator === 'existence' || m.operator === 'notExistence'}
 				{@const symbol = getRelationSymbol(m.operator)}
 				<span class="pill-relation">{symbol}</span>
-				<div class="pill-label inline text-2-regular">{m.label}</div>
+				<div class="pill-label text-2-regular inline">{m.label}</div>
 			{:else if 'label' in m && 'display' in m}
 				{@const symbol = getRelationSymbol(m.operator)}
-				<div class="pill-label inline text-2-regular">{m.label}</div>
+				<div class="pill-label text-2-regular inline">{m.label}</div>
 				<span class="pill-relation">{symbol}</span>
 				<span class="pill-value">
 					<DecoratedData data={m.display} showLabels={ShowLabelsOptions['Never']} />
@@ -117,7 +117,7 @@
 	@reference "../../../app.css";
 
 	.mapping-item {
-		@apply rounded-md px-4 py-2 brightness-100 text-3-cond-bold;
+		@apply text-3-cond-bold rounded-md px-4 py-2 brightness-100;
 		transition: filter 0.1s ease;
 	}
 
@@ -155,7 +155,7 @@
 	}
 
 	.pill-group {
-		@apply flex items-center gap-2 bg-primary/8 p-0 pr-4;
+		@apply bg-primary/8 flex items-center gap-2 p-0 pr-4;
 
 		&.outer {
 			@apply bg-transparent;
@@ -164,7 +164,7 @@
 
 	.pill-between,
 	.pill-relation {
-		@apply uppercase text-primary text-2-regular;
+		@apply text-primary text-2-regular uppercase;
 	}
 
 	.pill-between-and,

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -57,7 +57,7 @@
 	{@const filterCount = getFiltersCount(searchResult.mapping)}
 	{#if predicates.length}
 		<nav
-			class="border-b border-primary/16 px-4 md:flex lg:px-6"
+			class="border-primary/16 border-b px-4 md:flex lg:px-6"
 			aria-label={$page.data.t('search.selectedFilters')}
 		>
 			<ul class="flex flex-wrap items-center gap-2">
@@ -75,7 +75,7 @@
 						>
 							{p.str}
 							<span
-								class="mb-px rounded-sm bg-primary/4 px-1 text-sm text-secondary md:text-xs lg:text-sm"
+								class="bg-primary/4 text-secondary mb-px rounded-sm px-1 text-sm md:text-xs lg:text-sm"
 								aria-label="{p.totalItems} {$page.data.t('search.hits')}">{p.totalItems}</span
 							>
 						</a>
@@ -86,13 +86,13 @@
 	{/if}
 	{#if showMapping}
 		<nav
-			class="hidden md:flex md:px-6 md:pb-0 md:pt-4"
+			class="hidden md:flex md:px-6 md:pt-4 md:pb-0"
 			aria-label={$page.data.t('search.selectedFilters')}
 		>
 			<SearchMapping mapping={searchResult.mapping} />
 		</nav>
 	{/if}
-	<div class="relative gap-y-4 find-layout md:page-padding">
+	<div class="find-layout md:page-padding relative gap-y-4">
 		{#if showFiltersModal}
 			<Modal position="left" close={toggleFiltersModal}>
 				<span slot="title">
@@ -108,7 +108,7 @@
 
 		<div class="results max-w-content">
 			<div
-				class="toolbar flex min-h-14 items-center justify-between page-padding md:min-h-fit md:p-0 md:pb-4"
+				class="toolbar page-padding flex min-h-14 items-center justify-between md:min-h-fit md:p-0 md:pb-4"
 				class:has-search={$page.params.fnurgel}
 			>
 				<a
@@ -121,13 +121,13 @@
 					{$page.data.t('search.filters')}
 					{#if filterCount}
 						<span
-							class="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-xs font-bold leading-none text-primary-inv"
+							class="bg-primary text-primary-inv flex h-5 w-5 items-center justify-center rounded-full text-xs leading-none font-bold"
 						>
 							{filterCount}
 						</span>
 					{/if}
 				</a>
-				<span class="hits pt-4 text-secondary md:pt-0" role="status" data-testid="result-info">
+				<span class="hits text-secondary pt-4 md:pt-0" role="status" data-testid="result-info">
 					{#if numHits && numHits > 0}
 						<span class="hits-count">
 							{#if numHits > searchResult.itemsPerPage}
@@ -175,7 +175,7 @@
 						class="sort-select flex flex-col items-end justify-self-end"
 						data-testid="sort-select"
 					>
-						<label class="pr-6 text-secondary text-2-regular" for="search-sort">
+						<label class="text-secondary text-2-regular pr-6" for="search-sort">
 							{$page.data.t('sort.sort')}
 						</label>
 						<div class="relative">
@@ -186,7 +186,7 @@
 									>
 								{/each}
 							</select>
-							<span class="pointer-events-none absolute right-0 top-[5px]">
+							<span class="pointer-events-none absolute top-[5px] right-0">
 								<BiChevronDown aria-hidden="true" class="text-icon" />
 							</span>
 						</div>
@@ -285,13 +285,13 @@
 				'hits sort-select';
 		}
 	}
-	
+
 	.tab-header {
 		@apply block py-4;
 	}
 
 	.tab {
-		@apply block py-4 pl-4 pr-3.5 lowercase no-underline;
+		@apply block py-4 pr-3.5 pl-4 lowercase no-underline;
 		transition: filter 0.1s ease;
 	}
 

--- a/lxl-web/src/lib/components/my-pages/Libraries.svelte
+++ b/lxl-web/src/lib/components/my-pages/Libraries.svelte
@@ -28,16 +28,16 @@
 	}
 </script>
 
-<div class="container-fluid mb-12 mt-8 w-screen max-w-full page-padding md:max-w-5xl">
-	<h1 class="mb-4 pl-2 text-6-cond-extrabold">{page.data.t('myPages.myPages')}</h1>
-	<h1 class="mb-2 pl-2 text-3-cond-bold">{page.data.t('myPages.libraries')}</h1>
+<div class="container-fluid page-padding mt-8 mb-12 w-screen max-w-full md:max-w-5xl">
+	<h1 class="text-6-cond-extrabold mb-4 pl-2">{page.data.t('myPages.myPages')}</h1>
+	<h1 class="text-3-cond-bold mb-2 pl-2">{page.data.t('myPages.libraries')}</h1>
 	<div
-		class="flex w-screen max-w-full flex-col justify-between rounded-md bg-primary/4 page-padding md:container md:max-w-5xl md:flex-row"
+		class="bg-primary/4 page-padding flex w-screen max-w-full flex-col justify-between rounded-md md:container md:max-w-5xl md:flex-row"
 	>
 		<div class="md:w-3/5">
 			{page.data.t('myPages.findAndAdd')}
 			<div class="relative">
-				<BiSearch class="absolute left-2.5 top-6 text-sm text-icon" />
+				<BiSearch class="text-icon absolute top-6 left-2.5 text-sm" />
 				<input
 					bind:value={searchPhrase}
 					placeholder={page.data.t('myPages.findLibrary')}
@@ -61,10 +61,10 @@
 							</div>
 						{/if}
 						{#if searchResult?.items && searchResult?.items.length !== 0}
-							<div class="my-3 rounded-md bg-cards py-2">
+							<div class="bg-cards my-3 rounded-md py-2">
 								{#each searchResult.items as resultItem (resultItem['@id'])}
 									<div
-										class="flex min-h-12 w-full items-center justify-between bg-cards hover:bg-main"
+										class="bg-cards hover:bg-main flex min-h-12 w-full items-center justify-between"
 									>
 										<div class="truncate py-1 pl-3" title={resultItem.label}>
 											{resultItem.label}

--- a/lxl-web/src/lib/components/supersearch/Suggestion.svelte
+++ b/lxl-web/src/lib/components/supersearch/Suggestion.svelte
@@ -34,7 +34,7 @@
 {#snippet resourceSnippet(item: SuperSearchResultItem)}
 	{#if item.qualifiers.length}
 		<span
-			class="order-1 ml-auto hidden whitespace-nowrap rounded-sm bg-positive px-1.5 py-0.5 text-xs text-positive-dark sm:inline md:text-sm"
+			class="bg-positive text-positive-dark order-1 ml-auto hidden rounded-sm px-1.5 py-0.5 text-xs whitespace-nowrap sm:inline md:text-sm"
 		>
 			{$page.data.t('search.add')}
 
@@ -49,7 +49,9 @@
 		<SuggestionImage {item} />
 		<div class="resource-content">
 			<hgroup class="resource-heading">
-				<h2 class="inline overflow-hidden text-ellipsis text-secondary text-3-cond-bold md:max-w-[33vw]">
+				<h2
+					class="text-secondary text-3-cond-bold inline overflow-hidden text-ellipsis md:max-w-[33vw]"
+				>
 					<DecoratedData
 						data={item[LxlLens.CardHeading]}
 						showLabels={ShowLabelsOptions.Never}
@@ -58,7 +60,7 @@
 					/>
 				</h2>
 				{#if item[LxlLens.CardBody]?._display?.[0]}
-					<p class="inline overflow-hidden text-ellipsis text-sm text-secondary">
+					<p class="text-secondary inline overflow-hidden text-sm text-ellipsis">
 						<span class="divider">{' • '}</span>
 						<DecoratedData
 							data={item[LxlLens.CardBody]?._display[0]}
@@ -70,7 +72,7 @@
 				{/if}
 			</hgroup>
 			<div class="resource-footer">
-				<strong class="text-xs text-secondary">
+				<strong class="text-secondary text-xs">
 					{item.typeStr}
 				</strong>
 				<span class="text-xs">
@@ -119,7 +121,12 @@
 		>
 			{@render resourceSnippet(item)}
 		</button>
-		<button type="button" class="more text-secondary" id={getCellId(1)} class:focused-cell={isFocusedCell(1)}>
+		<button
+			type="button"
+			class="more text-secondary"
+			id={getCellId(1)}
+			class:focused-cell={isFocusedCell(1)}
+		>
 			{#key item.qualifiers}
 				<span
 					class="more-icon-container rounded-full"

--- a/lxl-web/src/lib/components/supersearch/SuggestionImage.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuggestionImage.svelte
@@ -25,9 +25,9 @@
 		/>
 		{#if item['@type'] !== 'Text' && item['@type'] !== 'Person' && getTypeIcon(item['@type'])}
 			{@const SvelteComponent = getTypeIcon(item['@type'])}
-			<div class="absolute -left-2 -top-2">
-				<div class="rounded-md bg-main p-1.5">
-					<SvelteComponent class="h-3 w-3 text-icon-strong" />
+			<div class="absolute -top-2 -left-2">
+				<div class="bg-main rounded-md p-1.5">
+					<SvelteComponent class="text-icon-strong h-3 w-3" />
 				</div>
 			</div>
 		{/if}
@@ -43,7 +43,7 @@
 			/>
 			{#if getTypeIcon(item['@type'])}
 				{@const SvelteComponent_1 = getTypeIcon(item['@type'])}
-				<SvelteComponent_1 class="absolute text-lg text-icon" />
+				<SvelteComponent_1 class="text-icon absolute text-lg" />
 			{/if}
 		</div>
 	{/if}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -164,13 +164,13 @@
 			type="button"
 			role="gridcell"
 			id={getCellId(rowIndex, 0)}
-			class="flex min-h-12 w-full items-center px-4 hover:bg-main"
+			class="hover:bg-main flex min-h-12 w-full items-center px-4"
 			class:focused-cell={isFocusedCell(rowIndex, 0)}
 			onclick={() => addQualifierKey(qualifierKey)}
 		>
 			<span class="overflow-hidden text-ellipsis whitespace-nowrap">
 				<strong class="text-secondary text-3-cond-bold">{qualifierLabel}:</strong>
-				<span class="text-sm italic text-tertiary">{qualifierPlaceholder}</span>
+				<span class="text-tertiary text-sm italic">{qualifierPlaceholder}</span>
 			</span>
 		</button>
 	</div>
@@ -223,7 +223,7 @@
 						id={getCellId(0)}
 						class:focused-cell={isFocusedCell(0)}
 						aria-label={$page.data.t('general.close')}
-						class="button-ghost min-h-12 min-w-11 rounded-none border-none hover:bg-main sm:hidden"
+						class="button-ghost hover:bg-main min-h-12 min-w-11 rounded-none border-none sm:hidden"
 						onclick={onclickClose}
 					>
 						<BiArrowLeft />
@@ -237,7 +237,7 @@
 						type="reset"
 						id={getCellId(1)}
 						class:focused-cell={isFocusedCell(1)}
-						class="button-ghost min-h-12 rounded-none border-none hover:bg-main"
+						class="button-ghost hover:bg-main min-h-12 rounded-none border-none"
 						aria-label={$page.data.t('search.clearFilters')}
 						onclick={onclickClear}
 					>
@@ -258,7 +258,7 @@
 		{/snippet}
 		{#snippet startContent({ getCellId, isFocusedCell, isFocusedRow })}
 			<div role="rowgroup">
-				<div class="flex w-full items-center px-4 py-2 text-2-cond-bold">
+				<div class="text-2-cond-bold flex w-full items-center px-4 py-2">
 					{$page.data.t('search.supersearchStartHeader')}
 				</div>
 				{@render startFilterItem({
@@ -322,7 +322,7 @@
 						type="button"
 						role="gridcell"
 						id={getCellId(moreFiltersRowIndex, 0)}
-						class="flex min-h-11 w-full items-center px-4 text-secondary hover:bg-main"
+						class="text-secondary hover:bg-main flex min-h-11 w-full items-center px-4"
 						class:focused-cell={isFocusedCell(moreFiltersRowIndex, 0)}
 						onclick={() => (showMoreFilters = !showMoreFilters)}
 					>
@@ -354,7 +354,7 @@
 	@reference "../../../app.css";
 
 	.supersearch-input {
-		@apply relative flex min-h-12 w-full cursor-text overflow-hidden rounded-md bg-cards focus-within:outline-2 focus-within:outline-positive-dark/32;
+		@apply bg-cards focus-within:outline-positive-dark/32 relative flex min-h-12 w-full cursor-text overflow-hidden rounded-md focus-within:outline-2;
 	}
 
 	/* dialog */
@@ -364,7 +364,7 @@
 	}
 
 	:global(.supersearch-dialog-wrapper) {
-		@apply pointer-events-none header-layout;
+		@apply header-layout pointer-events-none;
 		grid-template-areas: 'supersearch-content supersearch-content supersearch-content';
 
 		@variant sm {
@@ -373,13 +373,13 @@
 	}
 
 	:global(.supersearch-dialog-content) {
-		@apply pointer-events-auto max-h-screen overflow-hidden overflow-y-scroll rounded-md bg-cards drop-shadow-md;
+		@apply bg-cards pointer-events-auto max-h-screen overflow-hidden overflow-y-scroll rounded-md drop-shadow-md;
 		grid-area: supersearch-content;
 		scrollbar-width: none;
 	}
 
 	:global(.supersearch-dialog .supersearch-combobox) {
-		@apply sticky top-0 z-20 items-stretch bg-cards px-4 pb-2 pt-4;
+		@apply bg-cards sticky top-0 z-20 items-stretch px-4 pt-4 pb-2;
 	}
 
 	:global(.supersearch-suggestions) {
@@ -407,13 +407,13 @@
 
 	:global(.supersearch-suggestions [role='row']:last-child) {
 		/* border-bottom: 1px solid rgb(var(--color-primary) / 0.12); */
-		@apply border-b border-b-primary/16;
+		@apply border-b-primary/16 border-b;
 	}
 
 	/* snippets elements */
 
 	:global(.supersearch-show-more) {
-		@apply flex min-h-11 w-full items-center px-4 text-left hover:bg-main;
+		@apply hover:bg-main flex min-h-11 w-full items-center px-4 text-left;
 	}
 
 	/* codemirror elements */
@@ -423,7 +423,7 @@
 	}
 
 	:global(.codemirror-container .cm-scroller) {
-		@apply min-h-12 font-sans outline-hidden text-3-regular;
+		@apply text-3-regular min-h-12 font-sans outline-hidden;
 		scrollbar-width: none;
 	}
 

--- a/lxl-web/src/lib/styles/nprogress.css
+++ b/lxl-web/src/lib/styles/nprogress.css
@@ -2,31 +2,33 @@
 @reference "../../app.css";
 
 #nprogress {
-  pointer-events: none;
+	pointer-events: none;
 }
 
 #nprogress .bar {
-  @apply bg-positive-dark;
+	@apply bg-positive-dark;
 
-  position: fixed;
-  z-index: 1031;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 2px;
+	position: fixed;
+	z-index: 1031;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 2px;
 }
 
 /* Fancy blur effect */
 #nprogress .peg {
-  display: block;
-  position: absolute;
-  right: 0px;
-  width: 100px;
-  height: 100%;
-  box-shadow: 0 0 10px #6e6e6e, 0 0 5px #6e6e6e;
-  opacity: 1.0;
+	display: block;
+	position: absolute;
+	right: 0px;
+	width: 100px;
+	height: 100%;
+	box-shadow:
+		0 0 10px #6e6e6e,
+		0 0 5px #6e6e6e;
+	opacity: 1;
 
-  -webkit-transform: rotate(3deg) translate(0px, -4px);
-      -ms-transform: rotate(3deg) translate(0px, -4px);
-          transform: rotate(3deg) translate(0px, -4px);
+	-webkit-transform: rotate(3deg) translate(0px, -4px);
+	-ms-transform: rotate(3deg) translate(0px, -4px);
+	transform: rotate(3deg) translate(0px, -4px);
 }

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
@@ -11,12 +11,13 @@
 
 <article class="container-fluid my-8 max-w-3xl">
 	<div class="landing flex flex-col items-center gap-2 pb-3">
-		<h1 class="flex text-3xl/tight font-extrabold text-primary sm:text-[5.5rem] sm:font-bold">
+		<h1 class="text-primary flex text-3xl/tight font-extrabold sm:text-[5.5rem] sm:font-bold">
 			Libris
 			<div
-				class="self-center rounded-sm bg-positive-dark/16 px-2 uppercase text-2-cond-bold sm:text-3-cond-bold"
-				>Beta</div
+				class="bg-positive-dark/16 text-2-cond-bold sm:text-3-cond-bold self-center rounded-sm px-2 uppercase"
 			>
+				Beta
+			</div>
 		</h1>
 	</div>
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/HeaderMenu.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/HeaderMenu.svelte
@@ -15,11 +15,11 @@
 			: `/${otherLangCode}${$page.url.pathname}`) + $page.url.search;
 </script>
 
-<div class="[&_a]:no-underline py-4 lg:py-0">
-	<ol class="flex flex-col items-center gap-4 text-secondary lg:flex-row lg:text-2-regular">
+<div class="py-4 lg:py-0 [&_a]:no-underline">
+	<ol class="text-secondary lg:text-2-regular flex flex-col items-center gap-4 lg:flex-row">
 		<li>
 			<a class="flex items-center gap-2 lg:flex-col lg:gap-1" href="help">
-				<BiQuestionCircle class="h-4 w-4 text-icon" />
+				<BiQuestionCircle class="text-icon h-4 w-4" />
 				<span>
 					{$page.data.t('header.help')}
 				</span>
@@ -27,7 +27,7 @@
 		</li>
 		<li>
 			<a class="flex items-center gap-2 lg:flex-col lg:gap-1" href="my-pages">
-				<BiPerson class="h-4 w-4 text-icon" />
+				<BiPerson class="text-icon h-4 w-4" />
 				<div class="text-nowrap">
 					{$page.data.t('header.myPages')}
 				</div>
@@ -41,7 +41,7 @@
 				data-sveltekit-reload
 				data-testid="current-lang"
 			>
-				<BiGlobeAmericas class="h-4 w-4 text-icon" />
+				<BiGlobeAmericas class="text-icon h-4 w-4" />
 				<span>{otherLangLabel}</span>
 			</a>
 		</li>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteFooter.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteFooter.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <footer
-	class="mt-auto flex flex-col justify-between gap-8 bg-primary/4 p-8 text-secondary text-3-regular sm:flex-row lg:p-16"
+	class="bg-primary/4 text-secondary text-3-regular mt-auto flex flex-col justify-between gap-8 p-8 sm:flex-row lg:p-16"
 >
 	<div class="flex flex-col gap-8 sm:flex-row sm:gap-16">
 		<nav class="flex flex-col gap-4" aria-labelledby="nav-info">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
@@ -22,19 +22,23 @@
 <header class="bg-site-header">
 	<nav class="header-nav header-layout min-h-20 items-center py-0">
 		<div class="home md:pl-4">
-			<a href={page.data.base} class="flex flex-col text-primary no-underline md:flex-row">
-				<span class="text-[1.6rem] font-extrabold leading-tight md:text-[2.1rem]"> Libris</span>
+			<a href={page.data.base} class="text-primary flex flex-col no-underline md:flex-row">
+				<span class="text-[1.6rem] leading-tight font-extrabold md:text-[2.1rem]"> Libris</span>
 				<div
-					class="top-0 -rotate-6 self-baseline rounded-sm bg-positive-dark/16 px-2 uppercase text-2-cond-bold md:rotate-0"
-					>Beta</div
+					class="bg-positive-dark/16 text-2-cond-bold top-0 -rotate-6 self-baseline rounded-sm px-2 uppercase md:rotate-0"
 				>
+					Beta
+				</div>
 			</a>
 		</div>
 		<div class="search pb-4 sm:px-4 sm:pb-0">
 			<SuperSearchWrapper placeholder={page.data.t('header.searchPlaceholder')} />
 		</div>
 		<div class="actions flex min-h-20 items-center justify-end md:pr-4">
-			<div id="header-menu" class="hidden items-center lg:flex target:absolute target:left-0 target:block target:w-full target:bg-main">
+			<div
+				id="header-menu"
+				class="target:bg-main hidden items-center target:absolute target:left-0 target:block target:w-full lg:flex"
+			>
 				<HeaderMenu />
 			</div>
 			<div class="lg:hidden">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -104,9 +104,9 @@
 	<title>{getPageTitle(data.title)}</title>
 </svelte:head>
 <article>
-	<div class="resource gap-8 find-layout page-padding" class:bg-header={shouldShowHeaderBackground}>
+	<div class="resource find-layout page-padding gap-8" class:bg-header={shouldShowHeaderBackground}>
 		<div
-			class="image mb-2 mt-4 flex w-full justify-center self-center object-center md:mx-auto md:self-start md:px-2 xl:px-0"
+			class="image mt-4 mb-2 flex w-full justify-center self-center object-center md:mx-auto md:self-start md:px-2 xl:px-0"
 			class:hidden={!$page.data.images?.length}
 		>
 			{#if data.images.length}
@@ -120,7 +120,7 @@
 			{/if}
 		</div>
 		<div
-			class="content flex max-w-content flex-col gap-4 pt-2 md:flex-row"
+			class="content max-w-content flex flex-col gap-4 pt-2 md:flex-row"
 			class:pb-4={shouldShowHeaderBackground}
 		>
 			<div class="flex flex-col gap-4">
@@ -178,8 +178,8 @@
 		</div>
 	</div>
 	{#if data.instances?.length}
-		<div class="instances pt-2! find-layout page-padding">
-			<div class="instances-list max-w-content border-t border-t-primary/16 pt-6">
+		<div class="instances find-layout page-padding pt-2!">
+			<div class="instances-list max-w-content border-t-primary/16 border-t pt-6">
 				<InstancesList
 					data={data.instances}
 					columns={[
@@ -196,7 +196,7 @@
 			<span slot="title">{data.t('holdings.findAtYourNearestLibrary')}</span>
 			<div class="flex flex-col">
 				<div
-					class="relative mb-4 flex w-full flex-col gap-x-4 rounded-md border-b border-b-primary/16 bg-cards p-5 text-sm transition-shadow"
+					class="border-b-primary/16 bg-cards relative mb-4 flex w-full flex-col gap-x-4 rounded-md border-b p-5 text-sm transition-shadow"
 				>
 					<div
 						id="instance-details"
@@ -259,7 +259,7 @@
 								: data.t('holdings.libraries')}
 						{/if}
 					</h2>
-					<div class="relative mb-4 mt-2">
+					<div class="relative mt-2 mb-4">
 						<input
 							bind:value={searchPhrase}
 							placeholder={$page.data.t('holdings.findLibrary')}
@@ -267,7 +267,7 @@
 							class="w-full pl-8"
 							type="search"
 						/>
-						<BiSearch class="absolute left-2.5 top-3 text-sm text-icon" />
+						<BiSearch class="text-icon absolute top-3 left-2.5 text-sm" />
 					</div>
 					<ul class="w-full text-sm">
 						{#each filteredHolders as holder, i (holder.sigel || i)}
@@ -347,7 +347,11 @@
 		bottom: 0;
 		left: 0;
 		pointer-events: none;
-		background: linear-gradient(to bottom, --alpha(var(--color-cards) / 0%), --alpha(var(--color-cards) / 100%));
+		background: linear-gradient(
+			to bottom,
+			--alpha(var(--color-cards) / 0%),
+			--alpha(var(--color-cards) / 100%)
+		);
 		overflow: hidden;
 	}
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingStatus.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingStatus.svelte
@@ -209,7 +209,7 @@
 	}
 
 	.status-container {
-		@apply max-w-md rounded-sm border border-primary/16 p-2;
+		@apply border-primary/16 max-w-md rounded-sm border p-2;
 
 		&:has(p.error) {
 			@apply bg-negative;

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/InstancesList.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/InstancesList.svelte
@@ -72,7 +72,7 @@
 <div>
 	{#if Array.isArray(data) && data.length > 1}
 		<div class="flex items-center justify-between pb-4">
-			<h2 class="capitalize text-4-cond-bold">{$page.data.t('search.editions')}</h2>
+			<h2 class="text-4-cond-bold capitalize">{$page.data.t('search.editions')}</h2>
 			<a
 				href={getCollapseAllUrl($page.url)}
 				data-sveltekit-preload-data="false"
@@ -98,7 +98,7 @@
 		<ul bind:this={instancesList}>
 			{#each data as item (item['@id'])}
 				{@const id = relativizeUrl(getResourceId(item))}
-				<li {id} class="border-t border-t-primary/16">
+				<li {id} class="border-t-primary/16 border-t">
 					<details
 						open={$page.state.expandedInstances?.includes(id) ||
 							$page.url.searchParams.getAll('expanded').includes(id) ||
@@ -106,7 +106,7 @@
 						on:toggle={() => handleToggleDetails($page.state)}
 					>
 						<summary
-							class="grid min-h-11 items-center gap-2 align-middle text-sm hover:bg-primary/16 md:text-base"
+							class="hover:bg-primary/16 grid min-h-11 items-center gap-2 align-middle text-sm md:text-base"
 							on:keydown={handleSummaryKeydown}
 						>
 							<span class="arrow w-4">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/InstancesListContent.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/InstancesListContent.svelte
@@ -92,6 +92,6 @@
 	}
 
 	.oneOfMany {
-		@apply grid grid-cols-1 gap-4 py-8 sm:grid-cols-instance-list sm:gap-2;
+		@apply sm:grid-cols-instance-list grid grid-cols-1 gap-4 py-8 sm:gap-2;
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/frontpage.sv.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/frontpage.sv.md
@@ -4,6 +4,6 @@ Här kommer du kunna följa arbetet med att utveckla nya Libris sök. Bidra gär
 
 För att läsa mer om vilka funktioner som finns att testa, eller planeras framöver, se [versionsinformationen](/help). Fler funktioner kommer att läggas till allt eftersom de blir färdiga.
 
-Läs gärna [svar på vanligt förekommande frågor](https://www.kb.se/samverkan-och-utveckling/libris/fragor-och-svar-om-libris-nya-soktjanst.html). 
+Läs gärna [svar på vanligt förekommande frågor](https://www.kb.se/samverkan-och-utveckling/libris/fragor-och-svar-om-libris-nya-soktjanst.html).
 
 Observera att betaversionen innehåller en kopia av Libris-katalogen som togs i mars 2024. Ofullständig information och fel kan därför förekomma i innehållet.

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/+page.svelte
@@ -11,7 +11,7 @@
 	<title>{getPageTitle($page.data.t('header.help'))}</title>
 </svelte:head>
 
-<article class="container-fluid mb-12 mt-8 max-w-3xl page-padding">
+<article class="container-fluid page-padding mt-8 mb-12 max-w-3xl">
 	{#if data.locale === 'en'}
 		<EnContent />
 	{:else}


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-361](https://kbse.atlassian.net/browse/LWS-351)

### Solves
Runs `npm run format` on all code in `lxl-web` after migration to Tailwind 4.0 (done in https://github.com/libris/lxlviewer/pull/1274).

This would be good to do before further development as the formatting changes would otherwise clutter future PRs.

### Summary of changes

- Temporarily disable `svelte/require-each-key`, `svelte/no-useless-mustaches` and `svelte/no-unused-svelte-ignore` compiler errors  while formatting code so we are able to commit formatted code without having to resolve them all beforehand.
- Format code
- Remove temporarily disabled rules changes.

