### PR TITLE
feat(lxlweb, lxlquery): Implement alias-myLibraries in frontend (LWS-313)

### DIFF
--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -46,7 +46,9 @@
 				type="search"
 			/>
 			<BiSearch class="text-icon absolute top-3 left-2.5 text-sm" />
-			<MyLibrariesFilter />
+			{#if page.url.pathname === '/find'}
+				<MyLibrariesFilter {facets} />
+			{/if}
 			<ol>
 				{#each facets as group (group.dimension)}
 					<FacetGroup {group} locale={page.data.locale} {searchPhrase} />

--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -46,7 +46,7 @@
 				type="search"
 			/>
 			<BiSearch class="text-icon absolute top-3 left-2.5 text-sm" />
-			{#if page.url.pathname === '/find'}
+			{#if page.route.id === '/(app)/[[lang=lang]]/find'}
 				<MyLibrariesFilter {facets} />
 			{/if}
 			<ol>

--- a/lxl-web/src/lib/components/find/MyLibrariesFilter.svelte
+++ b/lxl-web/src/lib/components/find/MyLibrariesFilter.svelte
@@ -22,7 +22,7 @@
 
 	const applyFilterUrl = $derived.by(() => {
 		const paramsCopy = new URLSearchParams(page.url.searchParams);
-		let q = paramsCopy.get('_q')?.replaceAll(MY_LIBRARIES_FILTER_ALIAS, '');
+		let q = paramsCopy.get('_q');
 		q = q === '*' ? '' : q;
 		paramsCopy.set('_q', `${q?.trim()} ${MY_LIBRARIES_FILTER_ALIAS}`);
 		return 'find?' + paramsCopy.toString();

--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-	import { ShowLabelsOptions } from '$lib/types/decoratedData';
 	import type { DisplayMapping, SearchOperators } from '$lib/types/search';
 
 	import { page } from '$app/stores';
-	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import { getModalContext } from '$lib/contexts/modal';
 	import BiXLg from '~icons/bi/x-lg';
 	import BiPencil from '~icons/bi/pencil';
@@ -49,7 +47,7 @@
 </script>
 
 <ul class="flex flex-wrap items-center gap-2">
-	{#each mapping as m}
+	{#each mapping as m (m['@id'])}
 		<li
 			class="mapping-item {m.children ? 'pill-group' : 'pill'} pill-{m.operator}"
 			class:wildcard={m.operator === 'equals' && m.display === '*'}
@@ -67,7 +65,7 @@
 				<div class="pill-label text-2-regular inline">{m.label}</div>
 				<span class="pill-relation">{symbol}</span>
 				<span class="pill-value">
-					<DecoratedData data={m.display} showLabels={ShowLabelsOptions['Never']} />
+					{m.displayStr}
 				</span>
 			{/if}
 			{#if 'up' in m && (!m.children || depth > 0)}

--- a/lxl-web/src/lib/constants/facets.ts
+++ b/lxl-web/src/lib/constants/facets.ts
@@ -4,3 +4,4 @@ export const CUSTOM_FACET_SORT = {
 	bibliography: 'alpha.asc',
 	itemHeldBy: 'alpha.asc'
 };
+export const MY_LIBRARIES_FILTER_ALIAS = 'alias-myLibraries';

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -13,7 +13,7 @@ export default {
 	myPages: {
 		myPages: 'My pages',
 		libraries: 'Libraries',
-		favouriteLibraries: 'My favourite libraries',
+		favouriteLibraries: 'My libraries',
 		findLibrary: 'Search for libraries',
 		findAndAdd: 'Find and add favourite libraries',
 		noResultsFor: 'No results for',

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -194,5 +194,8 @@ export default {
 		available: 'Available',
 		unavailable: 'Not available',
 		map: 'map'
+	},
+	filterAlias: {
+		'alias-myLibraries': 'My Libraries'
 	}
 };

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -12,7 +12,7 @@ export default {
 	myPages: {
 		myPages: 'Mina sidor',
 		libraries: 'Bibliotek',
-		favouriteLibraries: 'Mina favoritbibliotek',
+		favouriteLibraries: 'Mina bibliotek',
 		findLibrary: 'Sök efter bibliotek',
 		findAndAdd: 'Hitta och lägg till favoritbibliotek',
 		noResultsFor: 'Inga sökträffar för',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -193,5 +193,8 @@ export default {
 		available: 'Tillgänglig',
 		unavailable: 'Ej tillgänglig',
 		map: 'karta'
+	},
+	filterAlias: {
+		'alias-myLibraries': 'Mina bibliotek'
 	}
 };

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -68,6 +68,7 @@ export interface Facet {
 
 export interface MultiSelectFacet extends Facet {
 	selected: boolean;
+	alias?: string;
 }
 
 interface SpellingSuggestion {

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -138,9 +138,10 @@ export function displayMappings(
 						LensType.Chip,
 						locale
 					),
-					displayStr: toString(
-						displayUtil.lensAndFormat({ ...defaultType, ...m.object }, LensType.Chip, locale)
-					),
+					displayStr:
+						toString(
+							displayUtil.lensAndFormat({ ...defaultType, ...m.object }, LensType.Chip, locale)
+						) || translate(`filterAlias.${m.object?.alias}`), // Allow frontend-defined displayStr for custom filter aliases
 					label: '',
 					operator,
 					...('up' in m && { up: replacePath(m.up as Link, usePath) }),
@@ -297,7 +298,8 @@ function displayBoolFilters(
 			view: replacePath(o.view, usePath),
 			object: displayUtil.lensAndFormat(o.object, LensType.Chip, locale),
 			str: toString(displayUtil.lensAndFormat(o.object, LensType.Chip, locale)) || '',
-			discriminator: ''
+			discriminator: '',
+			alias: o.object.alias
 		};
 	});
 

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -22,7 +22,7 @@ Qualifier {
   bOperatorEq { ":" | "=" }
   strliteral { '"' (!["\\] | "\\" _)* '"' }
   str { ![:><=()~!"\ ]+ }
-  filterAlias { "includeEplikt" | "includePreliminary" }
+  filterAlias { "includeEplikt" | "includePreliminary" | "existsImage" | "alias-myLibraries" }
   space { @whitespace+ }
 
   @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, filterAlias, str, space}


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-313](https://kbse.atlassian.net/browse/LWS-313)

### Solves

Frontend implementation of filter alias API feature (https://github.com/libris/librisxl/pull/1581), also a continuation of https://github.com/libris/lxlviewer/pull/1273.

1. If `alias-myLibraries` is present in `_q`, append myLibraries cookie values to secret param before fetch to search api: `_alias-myLibraries=(itemHeldBy:"sigel:X" OR itemHeldBy:"sigel:Y")`.

2. The response then includes the alias in search mapping, but has no label since it is a custom filter that's not hardcoded into the backend. Allow `displayStr` to look for the value label in the frontend translation files.

3. Add `alias-myLibraries` as a reserved qualifier term in lxlquery grammar. It will then pick up the label from search mapping:
<img width="426" alt="Skärmavbild 2025-04-24 kl  10 14 03" src="https://github.com/user-attachments/assets/c8858685-73d0-4500-9529-e1788d932357" />

<img width="426" alt="Skärmavbild 2025-04-24 kl  10 14 44" src="https://github.com/user-attachments/assets/24554b99-339e-4267-aa08-7783fef02767" />

4. Modify `MyLibrariesFilter` to recieve the facets as prop, and use the filter alias's `checked` prop and `view['@id']` as remove link.

### NOTES
* the MyLibraries filter is now currently disabled for the fnurgel pages related search. Implementing it there will be more challenging - and since the page will be redesigned, this seemed unnecessary. Do you agree?

* In the case that `alias-myLibraries` is in `_q`, _but libraries cookie is missing or empty_ - we still append `_alias-myLibraries=""` or the filter alias won't "activate" and is treated as free text search, right @lrosenstrom ?