### PR TITLE
Support new filter for free digital material

### DIFF
--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -116,7 +116,7 @@ export function displayMappings(
 						? translate(`facet.${m.alias}`)
 						: capitalize(m.property?.labelByLang?.[locale] || m.property?.label) ||
 							m.property?.[JsonLd.ID] ||
-							'No label', // lensandformat?
+							m._key,
 					operator,
 					...(m.property?.[JsonLd.TYPE] === '_Invalid' && { invalid: m.property?.label }),
 					...('up' in m && { up: replacePath(m.up as Link, usePath) }),

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -22,7 +22,7 @@ Qualifier {
   bOperatorEq { ":" | "=" }
   strliteral { '"' (!["\\] | "\\" _)* '"' }
   str { ![:><=()~!"\ ]+ }
-  filterAlias { "includeEplikt" | "includePreliminary" | "existsImage" | "alias-myLibraries" | "freeDigital"}
+  filterAlias { "includeEplikt" | "includePreliminary" | "existsImage" | "alias-myLibraries" | "freeOnline"}
   space { @whitespace+ }
 
   @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, filterAlias, str, space}

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -22,7 +22,7 @@ Qualifier {
   bOperatorEq { ":" | "=" }
   strliteral { '"' (!["\\] | "\\" _)* '"' }
   str { ![:><=()~!"\ ]+ }
-  filterAlias { "includeEplikt" | "includePreliminary" | "existsImage" | "alias-myLibraries" }
+  filterAlias { "includeEplikt" | "includePreliminary" | "existsImage" | "alias-myLibraries" | "freeDigital"}
   space { @whitespace+ }
 
   @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, filterAlias, str, space}


### PR DESCRIPTION
### Tickets involved
[LWS-242](https://kbse.atlassian.net/browse/LWS-242)

### Solves
Frontend support for free e-resource filter defined in https://github.com/libris/definitions/pull/525. Other suggestions for a descriptive name of the filter are welcome.  

### Summary of changes

* Add `freeDigital` filter to grammar 

![Screenshot from 2025-04-29 13-53-25](https://github.com/user-attachments/assets/2333e54d-b1ed-4acf-ad99-3e6d1626dffb)

![Screenshot from 2025-04-29 13-53-07](https://github.com/user-attachments/assets/dbb4c483-161b-4790-b093-5c0ca1100eb7)

