### PR TITLE
feat(lxlweb): Redesign theme - adjust breakpoints

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -48,7 +48,6 @@
 }
 
 @theme inline {
-	--breakpoint-2xl: 90rem; /* 1440px */
 	--breakpoint-3xl: 110rem; /* 1760px */
 
 	--font-sans: 'Inter', var(--font-fallback);

--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -294,7 +294,7 @@
 	grid-template-columns: 70px minmax(0, 8fr) 1fr;
 	@apply grid gap-x-8 px-4 sm:px-6;
 
-	@variant md {
+	@variant lg {
 		grid-template-columns: minmax(240px, 1fr) minmax(0, 4fr) minmax(160px, 1fr);
 		padding-inline: calc(var(--spacing) * 2);
 	}

--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -48,11 +48,8 @@
 }
 
 @theme inline {
-	/* TODO: remove the old breakpoints (use tw defaults) when reworking layout */
-	--breakpoint-md: 64rem; /* 1024px */
-	--breakpoint-lg: 90rem; /* 1440px */
-	--breakpoint-xl: 110rem; /* 1760px */
-	/* ---- */
+	--breakpoint-2xl: 90rem; /* 1440px */
+	--breakpoint-3xl: 110rem; /* 1760px */
 
 	--font-sans: 'Inter', var(--font-fallback);
 	--font-body: var(--font-sans);
@@ -290,7 +287,7 @@
 }
 
 @utility find-layout {
-	@apply md:grid-cols-find flex flex-col gap-4 md:grid md:gap-8;
+	@apply lg:grid-cols-find flex flex-col gap-4 lg:grid lg:gap-8;
 }
 
 @utility header-layout {

--- a/lxl-web/src/lib/components/Modal.svelte
+++ b/lxl-web/src/lib/components/Modal.svelte
@@ -76,7 +76,7 @@
 	}}
 >
 	<div
-		class="absolute top-0 right-0 flex w-full bg-neutral-50 shadow-2xl md:max-w-[480px] xl:max-w-[640px] {position ===
+		class="3xl:max-w-[640px] absolute top-0 right-0 flex w-full bg-neutral-50 shadow-2xl lg:max-w-[480px] {position ===
 		'top'
 			? 'h-auto'
 			: 'h-full'}"

--- a/lxl-web/src/lib/components/MyLibsHoldingIndicator.svelte
+++ b/lxl-web/src/lib/components/MyLibsHoldingIndicator.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <span
-	class="text-primary-700 relative p-2 text-lg md:text-xl"
+	class="text-primary-700 relative p-2 text-lg lg:text-xl"
 	use:popover={{
 		title: `${page.data.t('holdings.availableAt')}: ${librariesString}`
 	}}

--- a/lxl-web/src/lib/components/ResourceImage.svelte
+++ b/lxl-web/src/lib/components/ResourceImage.svelte
@@ -24,7 +24,7 @@
 </script>
 
 {#if image && thumb}
-	<figure class="table aspect-square h-64 overflow-hidden md:h-56 xl:h-64">
+	<figure class="3xl:h-64 table aspect-square h-64 overflow-hidden lg:h-56">
 		{#if linkToFull && full}
 			<a href={full.url} target="_blank" class="object-[inherit]">
 				<img

--- a/lxl-web/src/lib/components/find/MyLibrariesFilter.svelte
+++ b/lxl-web/src/lib/components/find/MyLibrariesFilter.svelte
@@ -49,7 +49,7 @@
 {/snippet}
 
 <div
-	class="text-2xs bg-accent/10 border-neutral flex w-full gap-2 rounded-sm border-b p-3 md:flex-col md:gap-1"
+	class="text-2xs bg-accent/10 border-neutral flex w-full gap-2 rounded-sm border-b p-3 lg:flex-col lg:gap-1"
 >
 	{#if myLibrariesValues.length}
 		<a class="no-underline" href={isFilterActive ? removeFilterUrl : applyFilterUrl}>

--- a/lxl-web/src/lib/components/find/SearchRelated.svelte
+++ b/lxl-web/src/lib/components/find/SearchRelated.svelte
@@ -25,7 +25,7 @@
 	});
 </script>
 
-<form action="" on:submit={handleSubmit} class="relative flex w-full gap-2 md:max-w-2xl">
+<form action="" on:submit={handleSubmit} class="relative flex w-full gap-2 lg:max-w-2xl">
 	<label for="search-related" class="sr-only">{$page.data.t('search.relatedSearchLabel')}</label>
 	<input
 		class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-xs"

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -291,7 +291,7 @@
 		}
 	}
 
-	@variant md {
+	@variant lg {
 		.filters {
 			display: block;
 		}

--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -58,7 +58,7 @@
 	{@const filterCount = getFiltersCount(searchResult.mapping)}
 	{#if predicates.length}
 		<nav
-			class="border-neutral border-b px-4 md:flex lg:px-6"
+			class="border-neutral border-b px-4 lg:flex 2xl:px-6"
 			aria-label={$page.data.t('search.selectedFilters')}
 		>
 			<ul class="flex flex-wrap items-center gap-2">
@@ -88,7 +88,7 @@
 	{/if}
 	{#if showMapping}
 		<nav
-			class="hidden md:flex md:px-6 md:pt-4 md:pb-0"
+			class="hidden lg:flex lg:px-6 lg:pt-4 lg:pb-0"
 			aria-label={$page.data.t('search.selectedFilters')}
 		>
 			<SearchMapping mapping={searchResult.mapping} />
@@ -104,7 +104,7 @@
 				<Filters {facets} mapping={searchResult.mapping} />
 			</Modal>
 		{/if}
-		<div class="filters hidden md:block" id="filters">
+		<div class="filters hidden lg:block" id="filters">
 			<Filters {facets} mapping={searchResult.mapping} />
 		</div>
 
@@ -115,7 +115,7 @@
 			>
 				<a
 					href={`${$page.url.pathname}?${$page.url.searchParams.toString()}#filters`}
-					class="filter-modal-toggle btn btn-primary md:hidden"
+					class="filter-modal-toggle btn btn-primary lg:hidden"
 					aria-label={$page.data.t('search.filters')}
 					on:click|preventDefault={toggleFiltersModal}
 				>
@@ -127,7 +127,7 @@
 						</span>
 					{/if}
 				</a>
-				<span class="hits text-2xs pt-4 md:pt-0" role="status" data-testid="result-info">
+				<span class="hits text-2xs pt-4 lg:pt-0" role="status" data-testid="result-info">
 					{#if numHits && numHits > 0}
 						<span class="hits-count">
 							{#if numHits > searchResult.itemsPerPage}
@@ -204,7 +204,7 @@
 					</div>
 				{/if}
 			</div>
-			<ol class="flex flex-col gap-0.5 md:px-0">
+			<ol class="flex flex-col gap-0.5 lg:px-0">
 				{#each searchResult.items as item (item['@id'])}
 					<li>
 						<SearchCard {item} />

--- a/lxl-web/src/lib/components/my-pages/Libraries.svelte
+++ b/lxl-web/src/lib/components/my-pages/Libraries.svelte
@@ -29,8 +29,8 @@
 </script>
 
 <h2 class="mt-6 text-lg font-medium">{page.data.t('myPages.libraries')}</h2>
-<div class="flex flex-col justify-between gap-6 py-4 md:flex-row">
-	<div class="w-full shrink-0 md:w-1/2">
+<div class="flex flex-col justify-between gap-6 py-4 lg:flex-row">
+	<div class="w-full shrink-0 lg:w-1/2">
 		<label for="my-libraries-search" class="text-sm font-medium"
 			>{page.data.t('myPages.findAndAdd')}</label
 		>
@@ -80,7 +80,7 @@
 			{/if}
 		{/if}
 	</div>
-	<div class="w-full shrink-0 md:w-1/2">
+	<div class="w-full shrink-0 lg:w-1/2">
 		<span id="my-libraries" class="mb-2 block text-sm font-medium"
 			>{page.data.t('myPages.favouriteLibraries')}</span
 		>

--- a/lxl-web/src/lib/components/supersearch/Suggestion.svelte
+++ b/lxl-web/src/lib/components/supersearch/Suggestion.svelte
@@ -38,7 +38,7 @@
 		>
 			{$page.data.t('search.add')}
 
-			<span class="hidden lowercase md:inline">
+			<span class="hidden lowercase lg:inline">
 				{item.qualifiers[0].label}
 			</span>
 		</span>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/HeaderMenu.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/HeaderMenu.svelte
@@ -15,12 +15,12 @@
 			: `/${otherLangCode}${$page.url.pathname}`) + $page.url.search;
 </script>
 
-<div class="py-4 lg:py-0 [&_a]:no-underline">
+<div class="py-4 2xl:py-0 [&_a]:no-underline">
 	<ol
-		class="text-subtle [&_svg]:text-body flex flex-col items-center gap-4 font-medium lg:flex-row [&_svg]:text-lg"
+		class="text-subtle [&_svg]:text-body flex flex-col items-center gap-4 font-medium 2xl:flex-row [&_svg]:text-lg"
 	>
 		<li>
-			<a class="flex items-center gap-2 lg:flex-col lg:gap-1" href="help">
+			<a class="flex items-center gap-2 2xl:flex-col 2xl:gap-1" href="help">
 				<BiQuestionCircle />
 				<span>
 					{$page.data.t('header.help')}
@@ -28,7 +28,7 @@
 			</a>
 		</li>
 		<li>
-			<a class="flex items-center gap-2 lg:flex-col lg:gap-1" href="my-pages">
+			<a class="flex items-center gap-2 2xl:flex-col 2xl:gap-1" href="my-pages">
 				<BiPerson />
 				<div class="text-nowrap">
 					{$page.data.t('header.myPages')}
@@ -37,7 +37,7 @@
 		</li>
 		<li>
 			<a
-				class="flex items-center gap-2 whitespace-nowrap lg:flex-col lg:gap-1"
+				class="flex items-center gap-2 whitespace-nowrap 2xl:flex-col 2xl:gap-1"
 				href={otherLangUrl}
 				hreflang={otherLangCode}
 				data-sveltekit-reload

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteFooter.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteFooter.svelte
@@ -4,7 +4,7 @@
 	import * as CookieConsent from 'vanilla-cookieconsent';
 </script>
 
-<footer class="mt-auto flex flex-col justify-between gap-8 bg-neutral-100 p-8 sm:flex-row lg:p-10">
+<footer class="mt-auto flex flex-col justify-between gap-8 bg-neutral-100 p-8 sm:flex-row 2xl:p-10">
 	<div class="flex flex-col gap-4 sm:flex-row sm:gap-16 [&_li>*]:text-sm [&_p]:font-medium">
 		<nav class="flex flex-col gap-2" aria-labelledby="nav-info">
 			<p id="nav-info">
@@ -37,6 +37,6 @@
 		</nav>
 	</div>
 	<div class="flex items-end">
-		<img class="h-20 w-auto md:h-20 lg:h-24" alt={$page.data.t('footer.logo')} src={KbLogo} />
+		<img class="h-20 w-auto lg:h-20 2xl:h-24" alt={$page.data.t('footer.logo')} src={KbLogo} />
 	</div>
 </footer>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
@@ -21,11 +21,11 @@
 
 <header class="bg-app-header border-b-primary-200 border-b">
 	<nav class="header-nav header-layout min-h-20 items-center py-0">
-		<div class="home md:pl-4">
-			<a href={page.data.base} class="flex flex-col no-underline md:flex-row">
-				<span class="text-2xl font-[600] md:text-3xl"> Libris</span>
+		<div class="home lg:pl-4">
+			<a href={page.data.base} class="flex flex-col no-underline lg:flex-row">
+				<span class="text-2xl font-[600] lg:text-3xl"> Libris</span>
 				<div
-					class="bg-primary-200 top-0 -rotate-6 self-baseline rounded-sm px-2 text-sm uppercase md:rotate-0"
+					class="bg-primary-200 top-0 -rotate-6 self-baseline rounded-sm px-2 text-sm uppercase lg:rotate-0"
 				>
 					Beta
 				</div>
@@ -34,14 +34,14 @@
 		<div class="search pb-4 sm:px-4 sm:pb-0">
 			<SuperSearchWrapper placeholder={page.data.t('header.searchPlaceholder')} />
 		</div>
-		<div class="actions flex min-h-20 items-center justify-end md:pr-4">
+		<div class="actions flex min-h-20 items-center justify-end lg:pr-4">
 			<div
 				id="header-menu"
-				class="text-3xs hidden items-center target:absolute target:left-0 target:block target:w-full lg:flex"
+				class="text-3xs hidden items-center target:absolute target:left-0 target:block target:w-full 2xl:flex"
 			>
 				<HeaderMenu />
 			</div>
-			<div class="lg:hidden">
+			<div class="2xl:hidden">
 				<a
 					aria-label={page.data.t('header.openMenu')}
 					class="text-subtle flex items-center p-4"

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -126,7 +126,7 @@
 <article class="resource-page text-base">
 	<div class="resource find-layout gap-8 p-4 sm:px-6">
 		<div
-			class="image mt-4 mb-2 flex w-full justify-center self-center object-center md:mx-auto md:self-start md:px-2 xl:px-0"
+			class="image mt-4 mb-2 flex w-full justify-center self-center object-center lg:mx-auto lg:self-start lg:px-2 xl:px-0"
 			class:hidden={!page.data.images?.length}
 		>
 			{#if data.images.length}
@@ -140,7 +140,7 @@
 			{/if}
 		</div>
 		<div
-			class="content flex flex-col gap-4 pt-2 md:flex-row"
+			class="content flex flex-col gap-4 pt-2 lg:flex-row"
 			class:pb-4={shouldShowHeaderBackground}
 		>
 			<div class="flex flex-col gap-4">
@@ -149,7 +149,7 @@
 						<DecoratedData data={data.heading} showLabels={ShowLabelsOptions.Never} />
 					</h1>
 				</header>
-				<div class="flex flex-col-reverse gap-4 md:flex-row">
+				<div class="flex flex-col-reverse gap-4 lg:flex-row">
 					<div class="overview flex-1 gap-6">
 						<DecoratedData data={data.overview} block />
 						{#if Object.keys(data.holdersByType).length}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/InstancesList.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/InstancesList.svelte
@@ -108,7 +108,7 @@
 						ontoggle={() => handleToggleDetails(page.state)}
 					>
 						<summary
-							class="hover:bg-primary/10 grid min-h-11 items-center gap-2 align-middle text-sm md:text-base"
+							class="hover:bg-primary/10 grid min-h-11 items-center gap-2 align-middle text-sm lg:text-base"
 							onkeydown={handleSummaryKeydown}
 						>
 							<span class="arrow text-subtle w-4 origin-center rotate-0 transition-transform">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/InstancesListContent.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/InstancesListContent.svelte
@@ -82,7 +82,7 @@
 	@reference "../../../../app.css";
 
 	:global(.columns > div) {
-		@apply gap-2 lg:columns-2 lg:gap-x-8;
+		@apply gap-2 2xl:columns-2 2xl:gap-x-8;
 	}
 
 	:global(.columns > div > *) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/my-pages/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/my-pages/+page.svelte
@@ -8,7 +8,7 @@
 	<title>{getPageTitle(page.data.t('header.myPages'))}</title>
 </svelte:head>
 
-<div class="mx-auto mt-8 max-w-screen p-4 sm:px-6 md:max-w-5xl">
+<div class="mx-auto mt-8 max-w-screen p-4 sm:px-6 lg:max-w-5xl">
 	<h1 class="font-heading text-3xl font-medium">{page.data.t('myPages.myPages')}</h1>
 	<Libraries />
 </div>


### PR DESCRIPTION
Follow-up PR to https://github.com/libris/lxlviewer/pull/1285.

### Solves

Adjusts custom breakpoints so they are more inline with the Tailwind defaults.

### Summary of changes

- Custom `--breakpoint-md` has been removed in favour of default `lg` which had the same value (64rem / 1024px)
- Custom `--breakpoint-lg` has become `--breakpoint-2xl` so we can keep the default lg value.
- Custom `--breakpoint-xl` has become newly added `--breakpoint-3xl` so we can keep the default xl value.

So the available breakpoint prefixes are now:
 
| Breakpoint prefix | Minimum width |
| ------------- | ------------- |
| `sm`| `40 rem (640px)`|
| `md`| `48rem (768px)`|
| `lg`| `64rem (1024px)`|
| `xl`| `80rem (1280px)`|
| `2xl`| `90rem (1440px)` – overriding the default 1536px|
| `3xl`| `110rem (1760px)`|