### PR TITLE
feat(lxlweb): Use consistent property styles

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -582,7 +582,7 @@
 			"@id": "contribution-format",
 			"@type": "fresnel:Format",
 			"fresnel:propertyFormatDomain": ["contribution"],
-			"fresnel:propertyStyle": ["nolabel"]
+			"fresnel:propertyStyle": ["contribution nolabel"]
 		},
 		"genreForm-format": {
 			"@id": "genreForm-format",
@@ -658,6 +658,7 @@
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Agent"],
 			"fresnel:propertyFormatDomain": ["seeAlso"],
+			"fresnel:propertyStyle": ["see-also"],
 			"fresnel:valueFormat": {
 				"fresnel:contentBefore": "",
 				"fresnel:contentFirst": ""
@@ -678,6 +679,13 @@
 				"fresnel:contentBefore": "; ",
 				"fresnel:contentFirst": ""
 			}
+		},
+		"Agent-lifeSpan-format": {
+			"@id": "Agent-lifeSpan-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Agent"],
+			"fresnel:propertyFormatDomain": ["lifeSpan"],
+			"fresnel:propertyStyle": ["agent-lifespan"]
 		},
 		"Role-format": {
 			"@id": "Role-format",
@@ -736,7 +744,7 @@
 			"@id": "Transliteration-format",
 			"@type": "fresnel:Format",
 			"fresnel:propertyFormatDomain": ["_script"],
-			"fresnel:propertyStyle": ["italic", "block", "transliteration"],
+			"fresnel:propertyStyle": ["transliteration", "block"],
 			"fresnel:propertyFormat": {
 				"fresnel:contentBefore": " ",
 				"fresnel:contentFirst": ""
@@ -798,7 +806,7 @@
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Collection"],
 			"fresnel:propertyFormatDomain": ["sigel"],
-			"fresnel:propertyStyle": ["text-subtle"],
+			"fresnel:propertyStyle": ["sigel"],
 			"fresnel:propertyFormat": {
 				"fresnel:contentBefore": " (",
 				"fresnel:contentFirst": "(",

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -276,4 +276,13 @@
 	.block {
 		display: block;
 	}
+
+	/* property-specific styles */
+	.transliteration {
+		font-style: italic;
+	}
+
+	.sigel {
+		color: var(--color-subtle);
+	}
 </style>

--- a/lxl-web/src/lib/components/supersearch/Suggestion.svelte
+++ b/lxl-web/src/lib/components/supersearch/Suggestion.svelte
@@ -154,12 +154,8 @@
 <style lang="postcss">
 	@reference "tailwindcss";
 
-	.suggestion {
-		& :global([data-property='role']),
-		& :global(._contentBefore:has(+ [data-property='role'])),
-		& :global([data-property='role'] + ._contentAfter) {
-			display: none;
-		}
+	.suggestion :global(.contribution-role) {
+		display: none;
 	}
 
 	.suggestion:has(:global(*:hover)) h2,
@@ -199,7 +195,7 @@
 			display: none;
 		}
 
-		& :global(span[data-property='lifeSpan']) {
+		& :global(.agent-lifespan) {
 			color: var(--color-subtle);
 		}
 	}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -351,7 +351,7 @@
 			font-size: var(--text-2xl);
 		}
 
-		& :global(header span[data-property='lifeSpan']) {
+		& header :global(.agent-lifespan) {
 			color: var(--color-subtle);
 		}
 	}
@@ -377,17 +377,17 @@
 			margin-bottom: 0.8rem;
 		}
 
-		& :global([data-property='contribution'] > ._contentBefore),
-		:global([data-property='contribution'] > ._contentAfter) {
+		& :global(.contribution > ._contentBefore),
+		:global(.contribution > ._contentAfter) {
 			display: none;
 		}
 
-		& :global([data-property='contribution'] > *) {
+		& :global(.contribution > *) {
 			display: block;
 			white-space: nowrap;
 		}
 
-		& :global([data-property='seeAlso'] > *) {
+		& :global(.see-also > *) {
 			display: block;
 			width: fit-content;
 			white-space: nowrap;


### PR DESCRIPTION
## Description

### Solves

In relation to https://github.com/libris/lxlviewer/pull/1285#issuecomment-2858742288 - trying to move away from adding 'style-specific' classes directly in display-web, towards more descriptive classes that can then be styled either globally in DecoratedData or individual contexts/components etc.

### Summary of changes

* Add `contribution` class that's styled in fnurgel pages `overview`
* Add `see-also` class that's styled in fnurgel pages `overview`
* Add `agent-lifespan` class that's styled here & there
* Remove `italic` class -> `transliteration` now styled as italic globally in `DecoratedData`
* Swap `text-subtle` for `sigel` class, styled as color-subtle globally in `DecoratedData`
