### PR TITLE
Display links to things in local systems

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -245,6 +245,15 @@
 		}
 	}
 
+	.btn-outlined {
+		color: var(--color-link);
+		font-size: var(--text-xs);
+		padding: calc(var(--spacing) * 1.5) calc(var(--spacing) * 6);
+		height: calc(var(--spacing) * 10);
+		border-radius: calc(infinity * 1px);
+		border: 1px solid var(--color-link);
+	}
+
 	.badge {
 		display: flex;
 		align-items: center;

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -835,6 +835,26 @@
 				"fresnel:contentBefore": ""
 			}
 		},
+		"bibdb:PostalAddress-format": {
+			"@id": "bibdb:PostalAddress-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["bibdb:PostalAddress"],
+			"fresnel:propertyFormatDomain": ["bibdb:streetAddress", "bibdb:postalCode", "bibdb:email"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": "\n",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"bibdb:PostalAddress-format2": {
+			"@id": "bibdb:PostalAddress-format2",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["bibdb:PostalAddress"],
+			"fresnel:propertyFormatDomain": ["bibdb:addressLocality"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": " ",
+				"fresnel:contentFirst": ""
+			}
+		},
 		"default-separators": {
 			"@id": "default-separators",
 			"@type": "fresnel:Format",

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -234,6 +234,18 @@
 				}
 			}
 		},
+		"tokens": {
+			"@id": "tokens",
+			"@type": "fresnel:Group",
+			"lenses": {
+				"Publication": {
+					"@id": "Publication-tokens",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "Publication",
+					"showProperties": ["agent", "year"]
+				}
+			}
+		},
 		"web-chips": {
 			"@id": "web-chips",
 			"@type": "fresnel:Group",

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -193,7 +193,10 @@ export default {
 		loanStatusFailed: 'Failed to get loan status',
 		available: 'Available',
 		unavailable: 'Not available',
-		map: 'map'
+		map: 'map',
+		linkToLocal: 'Show in local catalog',
+		linkToLibrary: 'Library website',
+		openingHoursEtc: 'Opening hours, address etc'
 	},
 	filterAlias: {
 		'alias-myLibraries': 'My Libraries'

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -194,8 +194,9 @@ export default {
 		available: 'Available',
 		unavailable: 'Not available',
 		map: 'map',
-		linkToLocal: 'Show in local catalog',
-		linkToLibrary: 'Library website',
+		linkToLocal: 'Show in local library catalog',
+		linkToCatalog: 'Local library catalog',
+		linkToSite: 'Library website',
 		openingHoursEtc: 'Opening hours, address etc'
 	},
 	filterAlias: {

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -195,6 +195,7 @@ export default {
 		unavailable: 'Not available',
 		map: 'map',
 		linkToLocal: 'Show in local library catalog',
+		loanReserveLink: 'Loan/reserve',
 		linkToCatalog: 'Local library catalog',
 		linkToSite: 'Library website',
 		openingHoursEtc: 'Opening hours, address etc'

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -194,9 +194,10 @@ export default {
 		unavailable: 'Ej tillgänglig',
 		map: 'karta',
 		linkToLocal: 'Visa i bibliotekets katalog',
+		loanReserveLink: 'Låna/reservera',
 		linkToCatalog: 'Bibliotekets lokala katalog',
 		linkToSite: 'Bibliotekets webbplats',
-		openingHoursEtc: 'Öppettider, adress mm'
+		openingHoursEtc: 'Öppettider, adress m.m.'
 	},
 	filterAlias: {
 		'alias-myLibraries': 'Mina bibliotek'

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -194,7 +194,8 @@ export default {
 		unavailable: 'Ej tillgänglig',
 		map: 'karta',
 		linkToLocal: 'Visa i bibliotekets katalog',
-		linkToLibrary: 'Bibliotekets webbplats',
+		linkToCatalog: 'Bibliotekets lokala katalog',
+		linkToSite: 'Bibliotekets webbplats',
 		openingHoursEtc: 'Öppettider, adress mm'
 	},
 	filterAlias: {

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -192,7 +192,10 @@ export default {
 		loanStatusFailed: 'Lånestatus kunde inte hämtas',
 		available: 'Tillgänglig',
 		unavailable: 'Ej tillgänglig',
-		map: 'karta'
+		map: 'karta',
+		linkToLocal: 'Visa i bibliotekets katalog',
+		linkToLibrary: 'Bibliotekets webbplats',
+		openingHoursEtc: 'Öppettider, adress mm'
 	},
 	filterAlias: {
 		'alias-myLibraries': 'Mina bibliotek'

--- a/lxl-web/src/lib/types/holdings.ts
+++ b/lxl-web/src/lib/types/holdings.ts
@@ -36,7 +36,7 @@ export type FullHolderBySigel = {
 };
 
 export type ItemLinksForHolder = {
-	[sigel: string]: { [linkType: string]: string[] }; //links
+	[sigel: string]: { [linkType: string]: string[] };
 };
 
 export type ItemLinksByBibId = {

--- a/lxl-web/src/lib/types/holdings.ts
+++ b/lxl-web/src/lib/types/holdings.ts
@@ -38,6 +38,6 @@ export type ItemLinksForHolder = {
 	[sigel: string]: { [linkType: string]: string[] }; //links
 };
 
-export type ItemLinksByInstanceId = {
+export type ItemLinksByBibId = {
 	[id: string]: ItemLinksForHolder;
 };

--- a/lxl-web/src/lib/types/holdings.ts
+++ b/lxl-web/src/lib/types/holdings.ts
@@ -7,6 +7,7 @@ export type BibIdObj = {
 	onr: string | null;
 	isbn: string[];
 	issn: string[];
+	str: string;
 };
 
 export type HoldingsByInstanceId = {

--- a/lxl-web/src/lib/types/holdings.ts
+++ b/lxl-web/src/lib/types/holdings.ts
@@ -35,7 +35,7 @@ export type FullHolderBySigel = {
 };
 
 export type ItemLinksForHolder = {
-	[sigel: string]: string[]; //links
+	[sigel: string]: { [linkType: string]: string[] }; //links
 };
 
 export type ItemLinksByInstanceId = {

--- a/lxl-web/src/lib/types/holdings.ts
+++ b/lxl-web/src/lib/types/holdings.ts
@@ -1,4 +1,4 @@
-import type { DisplayDecorated } from './xl';
+import type { DisplayDecorated, FramedData } from './xl';
 
 export type BibIdObj = {
 	bibId: string;
@@ -28,4 +28,16 @@ export type DecoratedHolder = {
 	obj: DisplayDecorated;
 	sigel: string;
 	str: string;
+};
+
+export type FullHolderBySigel = {
+	[sigel: string]: FramedData;
+};
+
+export type ItemLinksForHolder = {
+	[sigel: string]: string[]; //links
+};
+
+export type ItemLinksByInstanceId = {
+	[id: string]: ItemLinksForHolder;
 };

--- a/lxl-web/src/lib/types/xl.ts
+++ b/lxl-web/src/lib/types/xl.ts
@@ -46,6 +46,28 @@ export enum Platform {
 	meta = 'meta'
 }
 
+export enum BibDb {
+	ils = 'bibdb:ils',
+	lopac = 'bibdb:lopac',
+	bibIdSearchUriByLang = 'bibdb:bibIdSearchUriByLang',
+	bibIdSearchUri = 'bibdb:bibIdSearchUri',
+	isbnSearchUri = 'bibdb:isbnSearchUri',
+	issnSearchUri = 'bibdb:issnSearchUri',
+	eodUri = 'bibdb:eodUri',
+	itemStatusUri = 'bibdb:itemStatusUri',
+	openingHours = 'bibdb:openingHours',
+	address = 'bibdb:address',
+	postalAddress = 'bibdb:PostalAddress',
+	visitingAddress = 'bibdb:VisitingAddress',
+	LinksToCatalog = 'linksToCatalog',
+	LinksToSite = 'linksToSite',
+	LinksToItem = 'linksToItem',
+	Address = 'address',
+	ItemStatus = 'itemStatus',
+	OpeningHours = 'openingHours',
+	LoanReserveLink = 'loanReserveLink'
+}
+
 export type ClassName = string;
 export type PropertyName = string;
 export type LangCode = string;

--- a/lxl-web/src/lib/utils/holdersCache.svelte.ts
+++ b/lxl-web/src/lib/utils/holdersCache.svelte.ts
@@ -1,6 +1,6 @@
 import type { FullHolderBySigel } from '$lib/types/holdings';
 
 type Cache = {
-	holders: undefined | FullHolderBySigel;
+	holders: FullHolderBySigel;
 };
-export const holdersCache: Cache = $state({ holders: undefined });
+export const holdersCache: Cache = $state({ holders: {} });

--- a/lxl-web/src/lib/utils/holdersCache.svelte.ts
+++ b/lxl-web/src/lib/utils/holdersCache.svelte.ts
@@ -1,0 +1,6 @@
+import type { FullHolderBySigel } from '$lib/types/holdings';
+
+type Cache = {
+	holders: undefined | FullHolderBySigel;
+};
+export const holdersCache: Cache = $state({ holders: undefined });

--- a/lxl-web/src/lib/utils/holdings.test.ts
+++ b/lxl-web/src/lib/utils/holdings.test.ts
@@ -6,14 +6,18 @@ import { UserSettings } from './userSettings.svelte';
 
 describe('getBibIdsByInstanceId', () => {
 	it('Returns a correctly mapped object (bibId, type & holders)', () => {
-		expect(getBibIdsByInstanceId(mainEntity, record)).toStrictEqual({
+		const instanceTokenStr = 'Natur och kultur, 2018';
+		const DisplayUtil = { lensAndFormat: () => instanceTokenStr };
+
+		expect(getBibIdsByInstanceId(mainEntity, DisplayUtil, record, 'sv')).toStrictEqual({
 			'0h96fs3b0c49qkt': {
 				bibId: '7654300',
 				'@type': 'Instance',
 				holders: ['S', 'H', 'U', 'Um', 'Umdp', 'La', 'Q', 'L', 'Sbi', 'NB'],
 				onr: '9176423484',
 				isbn: ['9176423484'],
-				issn: []
+				issn: [],
+				str: instanceTokenStr
 			}
 		});
 	});

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -224,7 +224,8 @@ export async function getFullHolderData(allHolders: DecoratedHolder[]): Promise<
 export function getItemLinksByBibId(
 	holderBySigel: FullHolderBySigel,
 	bibIdsByInstanceId: Record<string, BibIdObj>,
-	locale: LocaleCode
+	locale: LocaleCode,
+	displayUtil: DisplayUtil
 ): ItemLinksByBibId {
 	const linksByInstanceId: ItemLinksByBibId = {};
 	for (const bibIdObj of Object.values(bibIdsByInstanceId)) {
@@ -278,8 +279,18 @@ export function getItemLinksByBibId(
 			const visitingAddress = address.find((a) => a[JsonLd.TYPE] === 'bibdb:VisitingAddress');
 
 			if (address && address.length !== 0) {
-				addresses.push(postalAddress);
-				addresses.push(visitingAddress);
+				console.log(
+					'lensed and formatted',
+					displayUtil.lensAndFormat(postalAddress, LensType.Card, locale)
+				);
+				console.log('postal address', postalAddress as FramedData);
+				addresses.push(
+					toString(displayUtil.lensAndFormat(postalAddress as FramedData, LensType.Card, locale)) ||
+						''
+				);
+				addresses.push(
+					toString(displayUtil.lensAndFormat(visitingAddress, LensType.Card, locale)) || ''
+				);
 				allLinks['address'] = addresses;
 			}
 

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -246,9 +246,23 @@ export function getItemLinksByInstanceId(
 				linksToItem = [linkTemplateEod.replace(/%BIBID%/, bibIdObj.bibId), ...linksToItem];
 			}
 
+			const allLinks: { [linkType: string]: string[] } = {};
+
+			const linksToSite: string[] = [];
+			const linkToSite = getAtPath(fullHolderData, ['bibdb:ils', 'url'], undefined);
+			if (linkToSite && linkToSite.length !== 0) {
+				linksToSite.push(linkToSite);
+				//TODO: formalize keys
+				allLinks['linksToSite'] = linksToSite;
+			}
+
 			if (linksToItem.length !== 0) {
-				//TODO: formalize linksToItem
 				linksForHolder[sigel] = { linksToItem: linksToItem };
+				allLinks['linksToItem'] = linksToItem;
+			}
+
+			if (Object.keys(allLinks).length !== 0) {
+				linksForHolder[sigel] = allLinks;
 			}
 		});
 		linksByInstanceId[id] = linksForHolder;

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -279,17 +279,11 @@ export function getItemLinksByBibId(
 			const visitingAddress = address.find((a) => a[JsonLd.TYPE] === 'bibdb:VisitingAddress');
 
 			if (address && address.length !== 0) {
-				console.log(
-					'lensed and formatted',
-					displayUtil.lensAndFormat(postalAddress, LensType.Card, locale)
-				);
-				console.log('postal address', postalAddress as FramedData);
-				addresses.push(
-					toString(displayUtil.lensAndFormat(postalAddress as FramedData, LensType.Card, locale)) ||
-						''
-				);
 				addresses.push(
 					toString(displayUtil.lensAndFormat(visitingAddress, LensType.Card, locale)) || ''
+				);
+				addresses.push(
+					toString(displayUtil.lensAndFormat(postalAddress, LensType.Card, locale)) || ''
 				);
 				allLinks['address'] = addresses;
 			}

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -249,7 +249,15 @@ export function getItemLinksByBibId(
 				linksToItem = [linkTemplateEod.replace(/%BIB_*ID%/, bibIdObj.bibId), ...linksToItem];
 			}
 
+			//TODO: rename
 			const allLinks: { [linkType: string]: string[] } = {};
+
+			const hasItemStatus = getAtPath(fullHolderData, ['bibdb:ils', 'bibdb:itemStatusUri'], []);
+
+			//TODO: don't just support list of strings
+			if (hasItemStatus) {
+				allLinks['hasItemStatus'] = ['true'];
+			}
 
 			const linksToCatalog: string[] = [];
 			const linkToCatalog = getAtPath(fullHolderData, ['bibdb:ils', 'url'], undefined);

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -331,17 +331,17 @@ function getLinksToItemFor(
 		const linkTemplate = getAtPath(fullHolderData, path, []);
 		if (linkTemplate && linkTemplate.length !== 0) {
 			if (path.includes(BibDb.bibIdSearchUriByLang) && bibIdObj.bibId !== '') {
-				linksToItem = [linkTemplate[locale].replace(/%BIB_*ID%/, bibIdObj.bibId), ...linksToItem];
+				linksToItem = [linkTemplate[locale].replace(/%BIB_*ID%/g, bibIdObj.bibId), ...linksToItem];
 			}
 			if (path.includes(BibDb.bibIdSearchUri) && bibIdObj.bibId !== '') {
 				// forms in the wild %BIB_ID%, %BIBID%, more???
-				linksToItem = [linkTemplate.replace(/%BIB_*ID%/, bibIdObj.bibId), ...linksToItem];
+				linksToItem = [linkTemplate.replace(/%BIB_*ID%/g, bibIdObj.bibId), ...linksToItem];
 			}
 			if (path.includes(BibDb.isbnSearchUri) && bibIdObj.isbn.length !== 0) {
-				linksToItem = [linkTemplate.replace(/%ISBN%/, bibIdObj.isbn), ...linksToItem];
+				linksToItem = [linkTemplate.replace(/%ISBN%/g, bibIdObj.isbn), ...linksToItem];
 			}
 			if (path.includes(BibDb.issnSearchUri) && bibIdObj.issn.length !== 0) {
-				linksToItem = [linkTemplate.replace(/%ISSN%/, bibIdObj.issn), ...linksToItem];
+				linksToItem = [linkTemplate.replace(/%ISSN%/g, bibIdObj.issn), ...linksToItem];
 			}
 		}
 	}

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -229,13 +229,17 @@ export async function fetchHoldersIfAbsent(holdersByType: HoldersByType) {
 		const id = h.obj?.['@id'];
 
 		if (h.sigel && cachedHolders && !cachedHolders[h.sigel]) {
-			const libraryRes = await fetch(`${id}?framed=true`, {
+			const response = await fetch(`${id}?framed=true`, {
 				headers: { Accept: 'application/ld+json' }
 			});
-			const resJson = await libraryRes.json();
-			const libraryMainEntity = resJson['mainEntity'] as FramedData;
-			if (libraryMainEntity) {
-				cachedHolders[h.sigel] = libraryMainEntity;
+			if (response.ok) {
+				const resJson = await response.json();
+				const libraryMainEntity = resJson['mainEntity'] as FramedData;
+				if (libraryMainEntity) {
+					cachedHolders[h.sigel] = libraryMainEntity;
+				}
+			} else {
+				console.error(`Could not fetch holder data for ${id}`);
 			}
 		}
 	}

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -92,8 +92,12 @@ export function getBibIdsByInstanceId(
 		const bibId = instance.meta?.controlNumber || record?.controlNumber;
 		const type = instance['@type'];
 		const holders = instance['@reverse']?.itemOf?.map((i) => i?.heldBy?.sigel);
-		const str =
-			toString(displayUtil.lensAndFormat(instance.publication[0], LensType.Token, locale)) || '';
+		const publication = instance.publication;
+		let str = '';
+		if (publication) {
+			str =
+				toString(displayUtil.lensAndFormat(instance.publication[0], LensType.Token, locale)) || '';
+		}
 
 		// add Legacy Libris III system number for ONR param
 		let onr = null;

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -243,7 +243,7 @@ export function getItemLinksByInstanceId(
 			}
 			const linkTemplateEod = getAtPath(fullHolderData, ['bibdb:eodUri'], []);
 			if (linkTemplateEod) {
-				linksToItem = [linkTemplateEod.replace(/%BIBID%/, bibIdObj.bibId), ...linksToItem];
+				linksToItem = [linkTemplateEod.replace(/%BIB_*ID%/, bibIdObj.bibId), ...linksToItem];
 			}
 
 			const allLinks: { [linkType: string]: string[] } = {};

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -95,7 +95,7 @@ export function getBibIdsByInstanceId(
 		const holders = instance['@reverse']?.itemOf?.map((i) => i?.heldBy?.sigel);
 		const str =
 			toString(displayUtil.lensAndFormat(instance.publication[0], LensType.Token, locale)) || '';
-		console.log('str', str);
+
 		// add Legacy Libris III system number for ONR param
 		let onr = null;
 		record?.identifiedBy?.forEach((el: { '@type': string; value: string }) => {
@@ -127,7 +127,8 @@ export function getBibIdsByInstanceId(
 				holders,
 				onr,
 				isbn,
-				issn
+				issn,
+				str
 			}
 		};
 	}, {});
@@ -287,7 +288,6 @@ export function getItemLinksByBibId(
 			}
 
 			if (lopacLinksItem.length !== 0) {
-				console.log('lopacLinksItem', lopacLinksItem);
 				allLinks['loanReserveLink'] = lopacLinksItem;
 			}
 

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -249,7 +249,8 @@ export function getItemLinksByBibId(
 	const linksByInstanceId: ItemLinksByBibId = {};
 	for (const bibIdObj of Object.values(bibIdsByInstanceId)) {
 		const linksForHolder: ItemLinksForHolder = {};
-		bibIdObj.holders.forEach((sigel) => {
+		console.log('bibIdObj', bibIdObj);
+		bibIdObj.holders?.forEach((sigel) => {
 			if (holdersCache.holders) {
 				const fullHolderData = holdersCache.holders[sigel];
 

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -2,8 +2,6 @@ import { pushState } from '$app/navigation';
 import isFnurgel from '$lib/utils/isFnurgel';
 import type {
 	BibIdObj,
-	DecoratedHolder,
-	FullHolderBySigel,
 	HoldersByType,
 	HoldingsByInstanceId,
 	ItemLinksByBibId,
@@ -202,24 +200,6 @@ export function getMyLibsFromHoldings(
 		}
 	}
 	return Object.values(result);
-}
-
-export async function getFullHolderData(allHolders: DecoratedHolder[]): Promise<FullHolderBySigel> {
-	const holderBySigel: FullHolderBySigel = {};
-
-	for (const h of allHolders) {
-		const id = h.obj?.['@id'];
-		const libraryRes = await fetch(`${id}?framed=true`, {
-			headers: { Accept: 'application/ld+json' }
-		});
-		const resJson = await libraryRes.json();
-		const libraryMainEntity = resJson['mainEntity'] as FramedData;
-
-		if (libraryMainEntity) {
-			holderBySigel[h.sigel] = libraryMainEntity;
-		}
-	}
-	return holderBySigel;
 }
 
 export async function fetchHoldersIfAbsent(holdersByType: HoldersByType) {

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -247,9 +247,8 @@ export function getItemLinksByBibId(
 	displayUtil: DisplayUtil
 ): ItemLinksByBibId {
 	const linksByInstanceId: ItemLinksByBibId = {};
-	for (const bibIdObj of Object.values(bibIdsByInstanceId)) {
+	for (const bibIdObj of Object.values(bibIdsByInstanceId || [])) {
 		const linksForHolder: ItemLinksForHolder = {};
-		console.log('bibIdObj', bibIdObj);
 		bibIdObj.holders?.forEach((sigel) => {
 			if (holdersCache.holders) {
 				const fullHolderData = holdersCache.holders[sigel];

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -19,7 +19,7 @@ import {
 	getHoldingsByType,
 	getHoldersByType,
 	getBibIdsByInstanceId,
-	getItemLinksByInstanceId,
+	getItemLinksByBibId,
 	getFullHolderData
 } from '$lib/utils/holdings.js';
 import { DebugFlags } from '$lib/types/userSettings';
@@ -76,7 +76,7 @@ export const load = async ({ params, url, locals, fetch }) => {
 
 	//TODO: cache this
 	const fullHolderByHolderId = await getFullHolderData(Object.values(holdersByType).flat());
-	const itemLinksByInstanceId = getItemLinksByInstanceId(fullHolderByHolderId, bibIdsByInstanceId);
+	const itemLinksByBibId = getItemLinksByBibId(fullHolderByHolderId, bibIdsByInstanceId);
 
 	return {
 		type: mainEntity[JsonLd.TYPE],
@@ -88,7 +88,7 @@ export const load = async ({ params, url, locals, fetch }) => {
 		holdingsByInstanceId,
 		bibIdsByInstanceId,
 		holdersByType,
-		itemLinksByInstanceId,
+		itemLinksByBibId: itemLinksByBibId,
 		full: overview,
 		images,
 		searchResult: searchPromise ? await searchPromise : null

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -70,13 +70,13 @@ export const load = async ({ params, url, locals, fetch }) => {
 
 	const images = getImages(mainEntity, locale).map((i) => toSecure(i, env.AUXD_SECRET));
 	const holdingsByInstanceId = getHoldingsByInstanceId(mainEntity, displayUtil, locale);
-	const bibIdsByInstanceId = getBibIdsByInstanceId(mainEntity, resource);
+	const bibIdsByInstanceId = getBibIdsByInstanceId(mainEntity, displayUtil, resource, locale);
 	const holdingsByType = getHoldingsByType(mainEntity);
 	const holdersByType = getHoldersByType(holdingsByType, displayUtil, locale);
 
 	//TODO: cache this
 	const fullHolderByHolderId = await getFullHolderData(Object.values(holdersByType).flat());
-	const itemLinksByBibId = getItemLinksByBibId(fullHolderByHolderId, bibIdsByInstanceId);
+	const itemLinksByBibId = getItemLinksByBibId(fullHolderByHolderId, bibIdsByInstanceId, locale);
 
 	return {
 		type: mainEntity[JsonLd.TYPE],

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -18,7 +18,9 @@ import {
 	getHoldingsByInstanceId,
 	getHoldingsByType,
 	getHoldersByType,
-	getBibIdsByInstanceId
+	getBibIdsByInstanceId,
+	getItemLinksByInstanceId,
+	getFullHolderData
 } from '$lib/utils/holdings.js';
 import { DebugFlags } from '$lib/types/userSettings';
 
@@ -72,6 +74,10 @@ export const load = async ({ params, url, locals, fetch }) => {
 	const holdingsByType = getHoldingsByType(mainEntity);
 	const holdersByType = getHoldersByType(holdingsByType, displayUtil, locale);
 
+	//TODO: cache this
+	const fullHolderByHolderId = await getFullHolderData(Object.values(holdersByType).flat());
+	const itemLinksByInstanceId = getItemLinksByInstanceId(fullHolderByHolderId, bibIdsByInstanceId);
+
 	return {
 		type: mainEntity[JsonLd.TYPE],
 		title: toString(heading),
@@ -82,6 +88,7 @@ export const load = async ({ params, url, locals, fetch }) => {
 		holdingsByInstanceId,
 		bibIdsByInstanceId,
 		holdersByType,
+		itemLinksByInstanceId,
 		full: overview,
 		images,
 		searchResult: searchPromise ? await searchPromise : null

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -20,9 +20,10 @@ import {
 	getHoldersByType,
 	getBibIdsByInstanceId,
 	getItemLinksByBibId,
-	getFullHolderData
+	fetchHoldersIfAbsent
 } from '$lib/utils/holdings.js';
 import { DebugFlags } from '$lib/types/userSettings';
+import { holdersCache } from '$lib/utils/holdersCache.svelte.js';
 
 export const load = async ({ params, url, locals, fetch }) => {
 	const displayUtil = locals.display;
@@ -74,14 +75,13 @@ export const load = async ({ params, url, locals, fetch }) => {
 	const holdingsByType = getHoldingsByType(mainEntity);
 	const holdersByType = getHoldersByType(holdingsByType, displayUtil, locale);
 
-	//TODO: cache this
-	const fullHolderByHolderId = await getFullHolderData(Object.values(holdersByType).flat());
-	const itemLinksByBibId = getItemLinksByBibId(
-		fullHolderByHolderId,
-		bibIdsByInstanceId,
-		locale,
-		displayUtil
-	);
+	await fetchHoldersIfAbsent(holdersByType);
+
+	if (holdersCache.holders) {
+		console.log('Current number of cached holders:', Object.keys(holdersCache.holders).length);
+	}
+
+	const itemLinksByBibId = getItemLinksByBibId(bibIdsByInstanceId, locale, displayUtil);
 
 	return {
 		type: mainEntity[JsonLd.TYPE],

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -76,7 +76,12 @@ export const load = async ({ params, url, locals, fetch }) => {
 
 	//TODO: cache this
 	const fullHolderByHolderId = await getFullHolderData(Object.values(holdersByType).flat());
-	const itemLinksByBibId = getItemLinksByBibId(fullHolderByHolderId, bibIdsByInstanceId, locale);
+	const itemLinksByBibId = getItemLinksByBibId(
+		fullHolderByHolderId,
+		bibIdsByInstanceId,
+		locale,
+		displayUtil
+	);
 
 	return {
 		type: mainEntity[JsonLd.TYPE],

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -308,6 +308,12 @@
 					<ul class="w-full">
 						{#each filteredHolders as holder, i (holder.sigel || i)}
 							<HoldingStatus {holder} {holdingUrl} />
+							<!-- TODO: confusing that holdingUrl is actually the instanceId/fnurgel!! -->
+							{#if isFnurgel(holdingUrl) && data.itemLinksByInstanceId[holdingUrl][holder.sigel]}
+								<a href={data.itemLinksByInstanceId[holdingUrl][holder.sigel]?.at(0)}>
+									-> Titeln i bibliotekets lokala katalog
+								</a>
+							{/if}
 						{/each}
 						{#if filteredHolders.length === 0}
 							<li class="m-3">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -14,7 +14,7 @@
 	import { getResourceId } from '$lib/utils/resourceData';
 
 	import InstancesList from './InstancesList.svelte';
-	import HoldingStatus from './HoldingStatus.svelte';
+	import HoldingInfo from './HoldingInfo.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import ResourceImage from '$lib/components/ResourceImage.svelte';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
@@ -290,7 +290,7 @@
 							</h3>
 							<ul class="w-full">
 								{#each myLibsHolders as holder, i (holder.sigel || i)}
-									<HoldingStatus
+									<HoldingInfo
 										{holder}
 										{holdingUrl}
 										linksByInstanceId={data.itemLinksByInstanceId}
@@ -311,7 +311,7 @@
 					</div>
 					<ul class="w-full">
 						{#each filteredHolders as holder, i (holder.sigel || i)}
-							<HoldingStatus {holder} {holdingUrl} linksByInstanceId={data.itemLinksByInstanceId} />
+							<HoldingInfo {holder} {holdingUrl} linksByInstanceId={data.itemLinksByInstanceId} />
 						{/each}
 						{#if filteredHolders.length === 0}
 							<li class="m-3">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -290,11 +290,7 @@
 							</h3>
 							<ul class="w-full">
 								{#each myLibsHolders as holder, i (holder.sigel || i)}
-									<HoldingInfo
-										{holder}
-										{holdingUrl}
-										linksByInstanceId={data.itemLinksByInstanceId}
-									/>
+									<HoldingInfo {holder} {holdingUrl} linksByBibId={data.itemLinksByBibId} />
 								{/each}
 							</ul>
 						</div>
@@ -311,7 +307,7 @@
 					</div>
 					<ul class="w-full">
 						{#each filteredHolders as holder, i (holder.sigel || i)}
-							<HoldingInfo {holder} {holdingUrl} linksByInstanceId={data.itemLinksByInstanceId} />
+							<HoldingInfo {holder} {holdingUrl} linksByBibId={data.itemLinksByBibId} />
 						{/each}
 						{#if filteredHolders.length === 0}
 							<li class="m-3">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -290,7 +290,11 @@
 							</h3>
 							<ul class="w-full">
 								{#each myLibsHolders as holder, i (holder.sigel || i)}
-									<HoldingStatus {holder} {holdingUrl} />
+									<HoldingStatus
+										{holder}
+										{holdingUrl}
+										linksByInstanceId={data.itemLinksByInstanceId}
+									/>
 								{/each}
 							</ul>
 						</div>
@@ -307,13 +311,7 @@
 					</div>
 					<ul class="w-full">
 						{#each filteredHolders as holder, i (holder.sigel || i)}
-							<HoldingStatus {holder} {holdingUrl} />
-							<!-- TODO: confusing that holdingUrl is actually the instanceId/fnurgel!! -->
-							{#if isFnurgel(holdingUrl) && data.itemLinksByInstanceId[holdingUrl][holder.sigel]}
-								<a href={data.itemLinksByInstanceId[holdingUrl][holder.sigel]?.at(0)}>
-									-> Titeln i bibliotekets lokala katalog
-								</a>
-							{/if}
+							<HoldingStatus {holder} {holdingUrl} linksByInstanceId={data.itemLinksByInstanceId} />
 						{/each}
 						{#if filteredHolders.length === 0}
 							<li class="m-3">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingAvailability.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingAvailability.svelte
@@ -1,0 +1,237 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { type HoldingStatus } from '$lib/types/api';
+	import type { BibIdObj, DecoratedHolder } from '$lib/types/holdings';
+	import BiChevronRight from '~icons/bi/chevron-right';
+
+	type HoldingAvailabilityProps = {
+		holder: DecoratedHolder;
+		bibId: BibIdObj;
+	};
+
+	const { holder, bibId }: HoldingAvailabilityProps = $props();
+
+	const sigel = holder?.sigel;
+	let loading = $state(false);
+	let statusData: HoldingStatus[] | undefined = $state();
+	let error: string | undefined = $state();
+	let bibIds: BibIdObj[] = [bibId];
+
+	async function fetchHoldingStatus(ids: BibIdObj[]) {
+		const promises = ids.map((id) => {
+			if (id) {
+				const searchParams = new URLSearchParams();
+				searchParams.set('bib_id', id.bibId);
+				searchParams.set('sigel', sigel);
+				if (id.onr) {
+					searchParams.set('onr', id.onr);
+				}
+				id.isbn.forEach((i: string) => {
+					searchParams.set('isbn', i);
+				});
+				id.issn.forEach((i: string) => {
+					searchParams.set('issn', i);
+				});
+				return fetch(`/api/holdingstatus?${searchParams.toString()}`);
+			}
+		});
+
+		const responses = await Promise.all(promises);
+		const data = await Promise.all(
+			responses.map((response) => {
+				if (response && response.ok) {
+					return response.json();
+				} else {
+					error = `${page.data.t('holdings.loanStatusFailed')}: ${response?.status} ${response?.statusText}`;
+				}
+			})
+		);
+		return data;
+	}
+
+	async function getHoldingStatus() {
+		if (!sigel || !bibIds || bibIds.length < 1) {
+			error = page.data.t('holdings.loanStatusFailed');
+		} else if (!statusData) {
+			loading = true;
+
+			fetchHoldingStatus(bibIds)
+				.then((data) => {
+					statusData = data;
+					loading = false;
+				})
+				.catch((err) => {
+					error = `${page.data.t('holdings.loanStatusFailed')}: ${err}`;
+					loading = false;
+				});
+		}
+	}
+
+	function getIndicator(status: string) {
+		if (status && typeof status === 'string') {
+			switch (status.toLowerCase()) {
+				case 'tillgänglig':
+				case 'ej utlånad':
+				case 'available':
+					return 'available';
+				case 'ej tillgänglig':
+				case 'utlånad':
+				case 'on loan':
+				case 'not available':
+					return 'unavailable';
+				default:
+					return false;
+			}
+		}
+		return false;
+	}
+
+	function urlNotDefinedError(err: string | undefined) {
+		if (
+			err &&
+			err === `URL till lånestatus för ${sigel} ej definierad i LIBRIS biblioteksdatabas!`
+		) {
+			return true;
+		}
+		return false;
+	}
+</script>
+
+<div class="my-2">
+	<details ontoggle={getHoldingStatus}>
+		<summary class="flex cursor-pointer items-baseline">
+			<span class="arrow text-subtle mr-2 h-3 origin-center rotate-0 transition-transform">
+				<BiChevronRight />
+			</span>
+			Tillgänglighet
+		</summary>
+		<div class="mb-4 flex flex-col gap-2">
+			{#if loading}
+				<p>{page.data.t('search.loading')}</p>
+			{/if}
+			{#if error}
+				<div class="status-container border-neutral bg-page mt-2 max-w-md rounded-sm border p-2">
+					<p class="error" role="alert">{error}</p>
+				</div>
+			{/if}
+			{#if statusData && statusData.length > 0}
+				{#each statusData as instance, index (index)}
+					{#if instance?.item_information}
+						{@const items = instance.item_information}
+						<div
+							class="status-container border-neutral bg-page mt-2 flex max-w-md flex-col gap-4 rounded-sm border p-2"
+						>
+							{#if items.error || items.count === 0}
+								{#if urlNotDefinedError(items.error)}
+									<p class="library-unavailable">{page.data.t('holdings.libraryUnvaliable')}</p>
+								{:else}
+									<p class="error" role="alert">{page.data.t('holdings.loanStatusFailed')}</p>
+								{/if}
+							{/if}
+							{#each items.items as item, index (index)}
+								{@const indicator = getIndicator(item.Status)}
+								<table>
+									<tbody class="text-xs leading-relaxed">
+										<tr>
+											<th>{page.data.t('holdings.location')}</th>
+											<td>{item.Location}</td>
+										</tr>
+										<tr>
+											<th>{page.data.t('holdings.shelf')}</th>
+											<td>
+												{item.Call_No}
+												<!-- show map link only if absolute url -->
+												{#if item.Map && (item.Map.startsWith('http://') || item.Map.startsWith('https://'))}
+													(<a href={item.Map} target="_blank" class="ext-link">
+														{page.data.t('holdings.map')}</a
+													>)
+												{/if}
+											</td>
+										</tr>
+										<tr>
+											<th>{page.data.t('holdings.loanPolicy')}</th>
+											<td>{item.Loan_Policy}</td>
+										</tr>
+										<tr>
+											<th>{page.data.t('holdings.status')}</th>
+											<td>
+												{#if indicator}
+													<span class={`indicator ${indicator}`}></span>
+													{page.data.t(`holdings.${indicator}`)}
+												{:else}
+													{item.Status}
+												{/if}
+											</td>
+										</tr>
+										{#if item.Status_Date}
+											<tr>
+												<th>{page.data.t('holdings.date')}</th>
+												<td>{item?.Status_Date_Description} {item.Status_Date}</td>
+											</tr>
+										{/if}
+									</tbody>
+								</table>
+							{/each}
+						</div>
+					{/if}
+				{/each}
+			{/if}
+		</div>
+	</details>
+</div>
+
+<style lang="postcss">
+	@reference "../../../../app.css";
+
+	details[open] {
+		& .arrow {
+			@apply rotate-90;
+		}
+
+		& .holder-label {
+			white-space: normal;
+		}
+	}
+
+	.holder-label {
+		@apply flex-1 overflow-hidden text-ellipsis whitespace-nowrap;
+		font-weight: bold;
+	}
+
+	.status-container {
+		&:has(p.error) {
+			background-color: var(--color-warning-100);
+		}
+
+		/* don't repeat the library-unavailable message for every instance */
+		&:has(p.library-unavailable):not(:first-of-type) {
+			display: none;
+		}
+	}
+
+	table th {
+		font-weight: var(--font-weight-medium);
+		width: calc(var(--spacing) * 24);
+		padding-right: calc(var(--spacing) * 4);
+		vertical-align: baseline;
+	}
+
+	table td {
+		width: auto;
+	}
+
+	.instance-token {
+		color: var(--color-subtle);
+	}
+
+	.indicator {
+		@apply mb-0.5 inline-block h-2.5 w-2.5 rounded-full align-middle;
+
+		&.unavailable {
+			background-color: var(--color-severe-500);
+		}
+		&.available {
+			background-color: var(--color-success);
+		}
+	}
+</style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -184,87 +184,90 @@
 				</div>
 			{/if}
 		</ul>
-
-		<details ontoggle={getHoldingStatus}>
-			<summary class="mt-3 flex cursor-pointer items-baseline">
-				<span class="arrow text-subtle mr-2 h-3 origin-center rotate-0 transition-transform">
-					<BiChevronRight />
-				</span>
-				Visa tillgänglighet
-			</summary>
-			<div class="mb-4 flex flex-col gap-2">
-				{#if loading}
-					<p>{page.data.t('search.loading')}</p>
-				{/if}
-				{#if error}
-					<div class="status-container border-neutral bg-page mt-2 max-w-md rounded-sm border p-2">
-						<p class="error" role="alert">{error}</p>
-					</div>
-				{/if}
-				{#if statusData && statusData.length > 0}
-					{#each statusData as instance, index (index)}
-						{#if instance?.item_information}
-							{@const items = instance.item_information}
-							<div
-								class="status-container border-neutral bg-page mt-4 flex max-w-md flex-col gap-4 rounded-sm border p-2"
-							>
-								{#if items.error || items.count === 0}
-									{#if urlNotDefinedError(items.error)}
-										<p class="library-unavailable">{page.data.t('holdings.libraryUnvaliable')}</p>
-									{:else}
-										<p class="error" role="alert">{page.data.t('holdings.loanStatusFailed')}</p>
+		{#if linksByBibId[bibIds.at(0).bibId]?.[holder.sigel]?.['hasItemStatus']}
+			<details ontoggle={getHoldingStatus}>
+				<summary class="mt-3 flex cursor-pointer items-baseline">
+					<span class="arrow text-subtle mr-2 h-3 origin-center rotate-0 transition-transform">
+						<BiChevronRight />
+					</span>
+					Visa tillgänglighet
+				</summary>
+				<div class="mb-4 flex flex-col gap-2">
+					{#if loading}
+						<p>{page.data.t('search.loading')}</p>
+					{/if}
+					{#if error}
+						<div
+							class="status-container border-neutral bg-page mt-2 max-w-md rounded-sm border p-2"
+						>
+							<p class="error" role="alert">{error}</p>
+						</div>
+					{/if}
+					{#if statusData && statusData.length > 0}
+						{#each statusData as instance, index (index)}
+							{#if instance?.item_information}
+								{@const items = instance.item_information}
+								<div
+									class="status-container border-neutral bg-page mt-4 flex max-w-md flex-col gap-4 rounded-sm border p-2"
+								>
+									{#if items.error || items.count === 0}
+										{#if urlNotDefinedError(items.error)}
+											<p class="library-unavailable">{page.data.t('holdings.libraryUnvaliable')}</p>
+										{:else}
+											<p class="error" role="alert">{page.data.t('holdings.loanStatusFailed')}</p>
+										{/if}
 									{/if}
-								{/if}
-								{#each items.items as item, index (index)}
-									{@const indicator = getIndicator(item.Status)}
-									<table>
-										<tbody class="text-xs leading-relaxed">
-											<tr>
-												<th>{page.data.t('holdings.location')}</th>
-												<td>{item.Location}</td>
-											</tr>
-											<tr>
-												<th>{page.data.t('holdings.shelf')}</th>
-												<td>
-													{item.Call_No}
-													<!-- show map link only if absolute url -->
-													{#if item.Map && (item.Map.startsWith('http://') || item.Map.startsWith('https://'))}
-														(<a href={item.Map} target="_blank" class="ext-link">
-															{page.data.t('holdings.map')}</a
-														>)
-													{/if}
-												</td>
-											</tr>
-											<tr>
-												<th>{page.data.t('holdings.loanPolicy')}</th>
-												<td>{item.Loan_Policy}</td>
-											</tr>
-											<tr>
-												<th>{page.data.t('holdings.status')}</th>
-												<td>
-													{#if indicator}
-														<span class={`indicator ${indicator}`}></span>
-														{page.data.t(`holdings.${indicator}`)}
-													{:else}
-														{item.Status}
-													{/if}
-												</td>
-											</tr>
-											{#if item.Status_Date}
+									{#each items.items as item, index (index)}
+										{@const indicator = getIndicator(item.Status)}
+										<table>
+											<tbody class="text-xs leading-relaxed">
 												<tr>
-													<th>{page.data.t('holdings.date')}</th>
-													<td>{item?.Status_Date_Description} {item.Status_Date}</td>
+													<th>{page.data.t('holdings.location')}</th>
+													<td>{item.Location}</td>
 												</tr>
-											{/if}
-										</tbody>
-									</table>
-								{/each}
-							</div>
-						{/if}
-					{/each}
-				{/if}
-			</div>
-		</details>
+												<tr>
+													<th>{page.data.t('holdings.shelf')}</th>
+													<td>
+														{item.Call_No}
+														<!-- show map link only if absolute url -->
+														{#if item.Map && (item.Map.startsWith('http://') || item.Map.startsWith('https://'))}
+															(<a href={item.Map} target="_blank" class="ext-link">
+																{page.data.t('holdings.map')}</a
+															>)
+														{/if}
+													</td>
+												</tr>
+												<tr>
+													<th>{page.data.t('holdings.loanPolicy')}</th>
+													<td>{item.Loan_Policy}</td>
+												</tr>
+												<tr>
+													<th>{page.data.t('holdings.status')}</th>
+													<td>
+														{#if indicator}
+															<span class={`indicator ${indicator}`}></span>
+															{page.data.t(`holdings.${indicator}`)}
+														{:else}
+															{item.Status}
+														{/if}
+													</td>
+												</tr>
+												{#if item.Status_Date}
+													<tr>
+														<th>{page.data.t('holdings.date')}</th>
+														<td>{item?.Status_Date_Description} {item.Status_Date}</td>
+													</tr>
+												{/if}
+											</tbody>
+										</table>
+									{/each}
+								</div>
+							{/if}
+						{/each}
+					{/if}
+				</div>
+			</details>
+		{/if}
 	</div>
 	<details>
 		<summary class="my-3 flex cursor-pointer items-baseline">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -111,119 +111,122 @@
 </script>
 
 <li class="border-neutral text-xs not-last:border-b">
-	<details ontoggle={getHoldingStatus}>
-		<summary class="my-3 flex cursor-pointer items-baseline">
-			<span class="arrow text-subtle mr-2 h-3 origin-center rotate-0 transition-transform">
-				<BiChevronRight />
-			</span>
-			<span class="holder-label">
-				<DecoratedData data={holder.obj} showLabels={ShowLabelsOptions['Never']} />
-			</span>
-		</summary>
-		<div class="mb-4 flex flex-col gap-2">
-			{#if loading}
-				<p>{page.data.t('search.loading')}</p>
-			{/if}
-			{#if error}
-				<div class="status-container border-neutral bg-page max-w-md rounded-sm border p-2">
-					<p class="error" role="alert">{error}</p>
-				</div>
-			{/if}
-			{#if statusData && statusData.length > 0}
-				{#each statusData as instance, index (index)}
-					{#if instance?.item_information}
-						{@const items = instance.item_information}
-						<div
-							class="status-container border-neutral bg-page flex max-w-md flex-col gap-4 rounded-sm border p-2"
-						>
-							{#if items.error || items.count === 0}
-								{#if urlNotDefinedError(items.error)}
-									<p class="library-unavailable">{page.data.t('holdings.libraryUnvaliable')}</p>
-								{:else}
-									<p class="error" role="alert">{page.data.t('holdings.loanStatusFailed')}</p>
+	<div class="my-3">
+		<span class="holder-label">
+			<DecoratedData data={holder.obj} showLabels={ShowLabelsOptions['Never']} />
+		</span>
+		<details ontoggle={getHoldingStatus}>
+			<summary class="my-3 flex cursor-pointer items-baseline">
+				<span class="arrow text-subtle mr-2 h-3 origin-center rotate-0 transition-transform">
+					<BiChevronRight />
+				</span>
+				Visa tillgänglighet
+			</summary>
+			<div class="mb-4 flex flex-col gap-2">
+				{#if loading}
+					<p>{page.data.t('search.loading')}</p>
+				{/if}
+				{#if error}
+					<div class="status-container border-neutral bg-page max-w-md rounded-sm border p-2">
+						<p class="error" role="alert">{error}</p>
+					</div>
+				{/if}
+				{#if statusData && statusData.length > 0}
+					{#each statusData as instance, index (index)}
+						{#if instance?.item_information}
+							{@const items = instance.item_information}
+							<div
+								class="status-container border-neutral bg-page flex max-w-md flex-col gap-4 rounded-sm border p-2"
+							>
+								{#if items.error || items.count === 0}
+									{#if urlNotDefinedError(items.error)}
+										<p class="library-unavailable">{page.data.t('holdings.libraryUnvaliable')}</p>
+									{:else}
+										<p class="error" role="alert">{page.data.t('holdings.loanStatusFailed')}</p>
+									{/if}
 								{/if}
-							{/if}
-							{#each items.items as item, index (index)}
-								{@const indicator = getIndicator(item.Status)}
-								<table>
-									<tbody class="text-xs leading-relaxed">
-										<tr>
-											<th>{page.data.t('holdings.location')}</th>
-											<td>{item.Location}</td>
-										</tr>
-										<tr>
-											<th>{page.data.t('holdings.shelf')}</th>
-											<td>
-												{item.Call_No}
-												<!-- show map link only if absolute url -->
-												{#if item.Map && (item.Map.startsWith('http://') || item.Map.startsWith('https://'))}
-													(<a href={item.Map} target="_blank" class="ext-link">
-														{page.data.t('holdings.map')}</a
-													>)
-												{/if}
-											</td>
-										</tr>
-										<tr>
-											<th>{page.data.t('holdings.loanPolicy')}</th>
-											<td>{item.Loan_Policy}</td>
-										</tr>
-										<tr>
-											<th>{page.data.t('holdings.status')}</th>
-											<td>
-												{#if indicator}
-													<span class={`indicator ${indicator}`}></span>
-													{page.data.t(`holdings.${indicator}`)}
-												{:else}
-													{item.Status}
-												{/if}
-											</td>
-										</tr>
-										{#if item.Status_Date}
+								{#each items.items as item, index (index)}
+									{@const indicator = getIndicator(item.Status)}
+									<table>
+										<tbody class="text-xs leading-relaxed">
 											<tr>
-												<th>{page.data.t('holdings.date')}</th>
-												<td>{item?.Status_Date_Description} {item.Status_Date}</td>
+												<th>{page.data.t('holdings.location')}</th>
+												<td>{item.Location}</td>
 											</tr>
-										{/if}
-									</tbody>
-								</table>
-							{/each}
-						</div>
-					{/if}
-				{/each}
-			{/if}
-		</div>
-	</details>
+											<tr>
+												<th>{page.data.t('holdings.shelf')}</th>
+												<td>
+													{item.Call_No}
+													<!-- show map link only if absolute url -->
+													{#if item.Map && (item.Map.startsWith('http://') || item.Map.startsWith('https://'))}
+														(<a href={item.Map} target="_blank" class="ext-link">
+															{page.data.t('holdings.map')}</a
+														>)
+													{/if}
+												</td>
+											</tr>
+											<tr>
+												<th>{page.data.t('holdings.loanPolicy')}</th>
+												<td>{item.Loan_Policy}</td>
+											</tr>
+											<tr>
+												<th>{page.data.t('holdings.status')}</th>
+												<td>
+													{#if indicator}
+														<span class={`indicator ${indicator}`}></span>
+														{page.data.t(`holdings.${indicator}`)}
+													{:else}
+														{item.Status}
+													{/if}
+												</td>
+											</tr>
+											{#if item.Status_Date}
+												<tr>
+													<th>{page.data.t('holdings.date')}</th>
+													<td>{item?.Status_Date_Description} {item.Status_Date}</td>
+												</tr>
+											{/if}
+										</tbody>
+									</table>
+								{/each}
+							</div>
+						{/if}
+					{/each}
+				{/if}
+			</div>
+		</details>
 
-	<ul>
-		{#each bibIds as id (id.bibId)}
-			{#if linksByInstanceId[id.bibId]?.[holder.sigel]}
-				<div class="mb-3">
-					{#if linksByInstanceId[id.bibId]?.[holder.sigel]['linksToItem']}
-						<li>
-							<a
-								href={linksByInstanceId[id.bibId][holder.sigel]['linksToItem'].at(0)}
-								target="_blank"
-								class="btn btn-outlined ext-link h-9"
-							>
-								{page.data.t('holdings.linkToLocal')}
-							</a>
-						</li>
-					{/if}
-					{#if linksByInstanceId[id.bibId]?.[holder.sigel]['linksToSite'] && !linksByInstanceId[id.bibId][holder.sigel]['linksToItem']}
-						<li>
-							<a
-								href={linksByInstanceId[id.bibId][holder.sigel]['linksToSite'].at(0)}
-								target="_blank"
-								class="ext-link"
-							>
-								{page.data.t('holdings.linkToLibrary')}
-							</a>
-						</li>
-					{/if}
-				</div>
-			{/if}
-		{/each}
-	</ul>
+		<ul>
+			{#each bibIds as id (id.bibId)}
+				{#if linksByInstanceId[id.bibId]?.[holder.sigel]}
+					<div class="mb-3">
+						{#if linksByInstanceId[id.bibId]?.[holder.sigel]['linksToItem']}
+							<li>
+								<a
+									href={linksByInstanceId[id.bibId][holder.sigel]['linksToItem'].at(0)}
+									target="_blank"
+									class="btn btn-outlined ext-link h-9"
+								>
+									{page.data.t('holdings.linkToLocal')}
+								</a>
+							</li>
+						{/if}
+						{#if linksByInstanceId[id.bibId]?.[holder.sigel]['linksToSite'] && !linksByInstanceId[id.bibId][holder.sigel]['linksToItem']}
+							<li>
+								<a
+									href={linksByInstanceId[id.bibId][holder.sigel]['linksToSite'].at(0)}
+									target="_blank"
+									class="ext-link"
+								>
+									{page.data.t('holdings.linkToLibrary')}
+								</a>
+							</li>
+						{/if}
+					</div>
+				{/if}
+			{/each}
+		</ul>
+	</div>
 </li>
 
 <style lang="postcss">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -6,13 +6,13 @@
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import BiChevronRight from '~icons/bi/chevron-right';
 
-	type HoldingStatusProps = {
+	type HoldingInfoProps = {
 		holder: DecoratedHolder;
 		holdingUrl: string;
 		linksByInstanceId: ItemLinksByInstanceId;
 	};
 
-	const { holder, holdingUrl, linksByInstanceId }: HoldingStatusProps = $props();
+	const { holder, holdingUrl, linksByInstanceId }: HoldingInfoProps = $props();
 
 	const sigel = holder?.sigel;
 	let loading = $state(false);

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -280,6 +280,16 @@
 							{linksByBibId[firstBibId][holder.sigel]['openingHours'].at(0)}
 						</li>
 					{/if}
+					<!--{#if linksByBibId[firstBibId]?.[holder.sigel]?.['address']}-->
+					<!--	<li class="my-2">-->
+					<!--		{#each linksByBibId[firstBibId][holder.sigel]['address'] as address}-->
+					<!--			{#if address['@type'] === 'bibdb:VisitingAddress' && address['bibdb:streetAddress']}-->
+					<!--				<h1>{page.data.t('holdings.streetAddress')}</h1>-->
+					<!--				{address['bibdb:streetAddress']}-->
+					<!--			{/if}-->
+					<!--		{/each}-->
+					<!--	</li>-->
+					<!--{/if}-->
 				</div>
 			{/if}
 		</span>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -276,20 +276,20 @@
 		<span>
 			{#if bibIds.at(0)}
 				{@const firstBibId = bibIds.at(0).bibId}
-				<div class="my-2">
+				<ul class="my-2" style="white-space: pre-line">
 					{#if linksByBibId[firstBibId]?.[holder.sigel]?.['openingHours']}
 						<li>
 							{linksByBibId[firstBibId][holder.sigel]['openingHours'].at(0)}
 						</li>
 					{/if}
-					<!--{#if linksByBibId[firstBibId]?.[holder.sigel]?.['address']}-->
-					<!--	<li class="my-2">-->
-					<!--		{#each linksByBibId[firstBibId][holder.sigel]['address'] as address}-->
-					<!--			{address}-->
-					<!--		{/each}-->
-					<!--	</li>-->
-					<!--{/if}-->
-				</div>
+					{#if linksByBibId[firstBibId]?.[holder.sigel]?.['address']}
+						{#each linksByBibId[firstBibId][holder.sigel]['address'] as address (address)}
+							<li class="my-2">
+								{address}
+							</li>
+						{/each}
+					{/if}
+				</ul>
 			{/if}
 		</span>
 	</details>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -138,7 +138,7 @@
 								<a
 									href={linksByBibId[id.bibId][holder.sigel]['loanReserveLink'].at(0)}
 									target="_blank"
-									class="btn btn-outlined ext-link h-9"
+									class="btn btn-outlined ext-link h-9 max-w-sm"
 								>
 									{page.data.t('holdings.loanReserveLink')}
 								</a>
@@ -149,7 +149,7 @@
 								<a
 									href={linksByBibId[id.bibId][holder.sigel][BibDb.LinksToItem].at(0)}
 									target="_blank"
-									class="btn btn-outlined ext-link h-9"
+									class="btn btn-outlined ext-link h-9 max-w-sm"
 								>
 									{page.data.t('holdings.linkToLocal')}
 								</a>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { type HoldingStatus } from '$lib/types/api';
-	import type { BibIdObj, DecoratedHolder, ItemLinksByBibId } from '$lib/types/holdings';
+	import type { DecoratedHolder, ItemLinksByBibId } from '$lib/types/holdings';
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import BiChevronRight from '~icons/bi/chevron-right';
 	import { BibDb } from '$lib/types/xl';
+	import HoldingAvailability from './HoldingAvailability.svelte';
 
 	type HoldingInfoProps = {
 		holder: DecoratedHolder;
@@ -16,9 +16,6 @@
 	const { holder, holdingUrl, linksByBibId }: HoldingInfoProps = $props();
 
 	const sigel = holder?.sigel;
-	let loading = $state(false);
-	let statusData: HoldingStatus[] | undefined = $state();
-	let error: string | undefined = $state();
 
 	// if holdingUrl is an instance fnurgel, add its mapped bibId object into arr,
 	// else add all ids of current type with holdings for current sigel
@@ -31,85 +28,6 @@
 					.map((i) => page.data.bibIdsByInstanceId[i]);
 	});
 
-	async function fetchHoldingStatus(ids: BibIdObj[]) {
-		const promises = ids.map((id) => {
-			if (id) {
-				const searchParams = new URLSearchParams();
-				searchParams.set('bib_id', id.bibId);
-				searchParams.set('sigel', sigel);
-				if (id.onr) {
-					searchParams.set('onr', id.onr);
-				}
-				id.isbn.forEach((i: string) => {
-					searchParams.set('isbn', i);
-				});
-				id.issn.forEach((i: string) => {
-					searchParams.set('issn', i);
-				});
-				return fetch(`/api/holdingstatus?${searchParams.toString()}`);
-			}
-		});
-
-		const responses = await Promise.all(promises);
-		const data = await Promise.all(
-			responses.map((response) => {
-				if (response && response.ok) {
-					return response.json();
-				} else {
-					error = `${page.data.t('holdings.loanStatusFailed')}: ${response?.status} ${response?.statusText}`;
-				}
-			})
-		);
-		return data;
-	}
-
-	async function getHoldingStatus() {
-		if (!sigel || !bibIds || bibIds.length < 1) {
-			error = page.data.t('holdings.loanStatusFailed');
-		} else if (!statusData) {
-			loading = true;
-
-			fetchHoldingStatus(bibIds)
-				.then((data) => {
-					statusData = data;
-					loading = false;
-				})
-				.catch((err) => {
-					error = `${page.data.t('holdings.loanStatusFailed')}: ${err}`;
-					loading = false;
-				});
-		}
-	}
-
-	function getIndicator(status: string) {
-		if (status && typeof status === 'string') {
-			switch (status.toLowerCase()) {
-				case 'tillgänglig':
-				case 'ej utlånad':
-				case 'available':
-					return 'available';
-				case 'ej tillgänglig':
-				case 'utlånad':
-				case 'on loan':
-				case 'not available':
-					return 'unavailable';
-				default:
-					return false;
-			}
-		}
-		return false;
-	}
-
-	function urlNotDefinedError(err: string | undefined) {
-		if (
-			err &&
-			err === `URL till lånestatus för ${sigel} ej definierad i LIBRIS biblioteksdatabas!`
-		) {
-			return true;
-		}
-		return false;
-	}
-
 	function hasLinksToItem(id: string) {
 		return linksByBibId[id]?.[holder.sigel]?.[BibDb.LinksToItem];
 	}
@@ -121,182 +39,115 @@
 	function missingAtLeastOneLinkToItem() {
 		return bibIds.find((id) => !hasLinksToItem(id.bibId) && !hasLoanReserveLink(id.bibId));
 	}
+
+	function hasStatusLink(id: string) {
+		return linksByBibId[id][holder.sigel][BibDb.ItemStatus];
+	}
+
+	function hasInstanceContent(id: string) {
+		return hasLoanReserveLink(id) || hasLinksToItem(id) || hasStatusLink(id);
+	}
 </script>
 
 <li class="border-neutral text-xs not-last:border-b">
-	<div class="my-3">
-		<span class="holder-label">
-			<DecoratedData data={holder.obj} showLabels={ShowLabelsOptions['Never']} />
-		</span>
-		<ul>
-			{#each bibIds as id (id.bibId)}
-				{#if linksByBibId[id.bibId]?.[holder.sigel]}
-					<div class="my-1">
-						{#if hasLoanReserveLink(id.bibId)}
+	<div class="holder-label mt-4">
+		<DecoratedData data={holder.obj} showLabels={ShowLabelsOptions['Never']} />
+	</div>
+	<div class="ml-3">
+		<div class="my-3">
+			<ul>
+				{#each bibIds as id (id.bibId)}
+					{#if linksByBibId[id.bibId]?.[holder.sigel]}
+						{@const linksForHolder = linksByBibId[id.bibId][holder.sigel]}
+						{#if hasInstanceContent(id.bibId)}
+							<div class="instance-token mt-4 mb-1">{id.str}</div>
+							{#if hasStatusLink(id.bibId)}
+								<HoldingAvailability {holder} bibId={id}></HoldingAvailability>
+							{/if}
+							<div class="mb-3">
+								{#if hasLoanReserveLink(id.bibId)}
+									<li>
+										<a
+											href={linksForHolder['loanReserveLink'].at(0)}
+											target="_blank"
+											class="btn btn-outlined ext-link h-9 max-w-sm"
+										>
+											{page.data.t('holdings.loanReserveLink')}
+										</a>
+									</li>
+								{:else if hasLinksToItem(id.bibId)}
+									<li>
+										<a
+											href={linksForHolder[BibDb.LinksToItem].at(0)}
+											target="_blank"
+											class="btn btn-outlined ext-link h-9 max-w-sm"
+										>
+											{page.data.t('holdings.linkToLocal')}
+										</a>
+									</li>
+								{/if}
+							</div>
+						{/if}
+					{/if}
+				{/each}
+				{#if bibIds.at(0) && missingAtLeastOneLinkToItem()}
+					{@const firstBibId = bibIds.at(0).bibId}
+					<div class="mt-2">
+						{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.LinksToCatalog]}
 							<li>
-								<div class="instance-token mt-2 mb-1">{id.str}</div>
 								<a
-									href={linksByBibId[id.bibId][holder.sigel]['loanReserveLink'].at(0)}
+									href={linksByBibId[firstBibId][holder.sigel][BibDb.LinksToCatalog].at(0)}
 									target="_blank"
-									class="btn btn-outlined ext-link h-9 max-w-sm"
+									class="ext-link"
 								>
-									{page.data.t('holdings.loanReserveLink')}
+									{page.data.t('holdings.linkToCatalog')}
 								</a>
 							</li>
-						{:else if hasLinksToItem(id.bibId)}
+						{:else if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.LinksToSite]}
 							<li>
-								<div class="instance-token mt-2 mb-1">{id.str}</div>
 								<a
-									href={linksByBibId[id.bibId][holder.sigel][BibDb.LinksToItem].at(0)}
+									href={linksByBibId[firstBibId][holder.sigel][BibDb.LinksToSite].at(0)}
 									target="_blank"
-									class="btn btn-outlined ext-link h-9 max-w-sm"
+									class="ext-link"
 								>
-									{page.data.t('holdings.linkToLocal')}
+									{page.data.t('holdings.linkToSite')}
 								</a>
 							</li>
 						{/if}
 					</div>
 				{/if}
-			{/each}
-			{#if bibIds.at(0) && missingAtLeastOneLinkToItem()}
-				{@const firstBibId = bibIds.at(0).bibId}
-				<div class="mt-2">
-					{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.LinksToCatalog]}
-						<li>
-							<a
-								href={linksByBibId[firstBibId][holder.sigel][BibDb.LinksToCatalog].at(0)}
-								target="_blank"
-								class="ext-link"
-							>
-								{page.data.t('holdings.linkToCatalog')}
-							</a>
-						</li>
-					{:else if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.LinksToSite]}
-						<li>
-							<a
-								href={linksByBibId[firstBibId][holder.sigel][BibDb.LinksToSite].at(0)}
-								target="_blank"
-								class="ext-link"
-							>
-								{page.data.t('holdings.linkToSite')}
-							</a>
-						</li>
-					{/if}
-				</div>
-			{/if}
-		</ul>
-		{#if bibIds.at(0) && linksByBibId[bibIds.at(0).bibId]?.[holder.sigel]?.[BibDb.ItemStatus]}
-			<details ontoggle={getHoldingStatus}>
-				<summary class="mt-3 flex cursor-pointer items-baseline">
-					<span class="arrow text-subtle mr-2 h-3 origin-center rotate-0 transition-transform">
-						<BiChevronRight />
-					</span>
-					Visa tillgänglighet
-				</summary>
-				<div class="mb-4 flex flex-col gap-2">
-					{#if loading}
-						<p>{page.data.t('search.loading')}</p>
-					{/if}
-					{#if error}
-						<div
-							class="status-container border-neutral bg-page mt-2 max-w-md rounded-sm border p-2"
-						>
-							<p class="error" role="alert">{error}</p>
-						</div>
-					{/if}
-					{#if statusData && statusData.length > 0}
-						{#each statusData as instance, index (index)}
-							{#if instance?.item_information}
-								{@const items = instance.item_information}
-								<div
-									class="status-container border-neutral bg-page mt-4 flex max-w-md flex-col gap-4 rounded-sm border p-2"
-								>
-									{#if items.error || items.count === 0}
-										{#if urlNotDefinedError(items.error)}
-											<p class="library-unavailable">{page.data.t('holdings.libraryUnvaliable')}</p>
-										{:else}
-											<p class="error" role="alert">{page.data.t('holdings.loanStatusFailed')}</p>
-										{/if}
-									{/if}
-									{#each items.items as item, index (index)}
-										{@const indicator = getIndicator(item.Status)}
-										<table>
-											<tbody class="text-xs leading-relaxed">
-												<tr>
-													<th>{page.data.t('holdings.location')}</th>
-													<td>{item.Location}</td>
-												</tr>
-												<tr>
-													<th>{page.data.t('holdings.shelf')}</th>
-													<td>
-														{item.Call_No}
-														<!-- show map link only if absolute url -->
-														{#if item.Map && (item.Map.startsWith('http://') || item.Map.startsWith('https://'))}
-															(<a href={item.Map} target="_blank" class="ext-link">
-																{page.data.t('holdings.map')}</a
-															>)
-														{/if}
-													</td>
-												</tr>
-												<tr>
-													<th>{page.data.t('holdings.loanPolicy')}</th>
-													<td>{item.Loan_Policy}</td>
-												</tr>
-												<tr>
-													<th>{page.data.t('holdings.status')}</th>
-													<td>
-														{#if indicator}
-															<span class={`indicator ${indicator}`}></span>
-															{page.data.t(`holdings.${indicator}`)}
-														{:else}
-															{item.Status}
-														{/if}
-													</td>
-												</tr>
-												{#if item.Status_Date}
-													<tr>
-														<th>{page.data.t('holdings.date')}</th>
-														<td>{item?.Status_Date_Description} {item.Status_Date}</td>
-													</tr>
-												{/if}
-											</tbody>
-										</table>
-									{/each}
-								</div>
+			</ul>
+		</div>
+		<details>
+			<summary class="my-4 flex cursor-pointer items-baseline">
+				<span class="arrow text-subtle mr-2 h-3 origin-center rotate-0 transition-transform">
+					<BiChevronRight />
+				</span>
+				{page.data.t('holdings.openingHoursEtc')}
+			</summary>
+			<div class="status-container border-neutral bg-page my-3 max-w-md rounded-sm border p-2">
+				<span>
+					{#if bibIds.at(0)}
+						{@const firstBibId = bibIds.at(0).bibId}
+						<ul style="white-space: pre-line">
+							{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.OpeningHours]}
+								<li>
+									{linksByBibId[firstBibId][holder.sigel][BibDb.OpeningHours].at(0)}
+								</li>
 							{/if}
-						{/each}
+							{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.Address]}
+								{#each linksByBibId[firstBibId][holder.sigel][BibDb.Address] as address, index (index)}
+									<li class="my-2">
+										{address}
+									</li>
+								{/each}
+							{/if}
+						</ul>
 					{/if}
-				</div>
-			</details>
-		{/if}
+				</span>
+			</div>
+		</details>
 	</div>
-	<details>
-		<summary class="my-3 flex cursor-pointer items-baseline">
-			<span class="arrow text-subtle mr-2 h-3 origin-center rotate-0 transition-transform">
-				<BiChevronRight />
-			</span>
-			{page.data.t('holdings.openingHoursEtc')}
-		</summary>
-		<span>
-			{#if bibIds.at(0)}
-				{@const firstBibId = bibIds.at(0).bibId}
-				<ul class="my-2" style="white-space: pre-line">
-					{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.OpeningHours]}
-						<li>
-							{linksByBibId[firstBibId][holder.sigel][BibDb.OpeningHours].at(0)}
-						</li>
-					{/if}
-					{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.Address]}
-						{#each linksByBibId[firstBibId][holder.sigel][BibDb.Address] as address, index (index)}
-							<li class="my-2">
-								{address}
-							</li>
-						{/each}
-					{/if}
-				</ul>
-			{/if}
-		</span>
-	</details>
 </li>
 
 <style lang="postcss">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -287,7 +287,7 @@
 						</li>
 					{/if}
 					{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.Address]}
-						{#each linksByBibId[firstBibId][holder.sigel][BibDb.Address] as address (address)}
+						{#each linksByBibId[firstBibId][holder.sigel][BibDb.Address] as address, index (index)}
 							<li class="my-2">
 								{address}
 							</li>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -113,8 +113,12 @@
 		return linksByBibId[id]?.[holder.sigel]?.['linksToItem'];
 	}
 
+	function hasLoanReserveLink(id: string) {
+		return linksByBibId[id]?.[holder.sigel]?.['loanReserveLink'];
+	}
+
 	function missingAtLeastOneLinkToItem() {
-		return bibIds.find((id) => !hasLinksToItem(id.bibId));
+		return bibIds.find((id) => !hasLinksToItem(id.bibId) && !hasLoanReserveLink(id.bibId));
 	}
 </script>
 
@@ -127,7 +131,17 @@
 			{#each bibIds as id (id.bibId)}
 				{#if linksByBibId[id.bibId]?.[holder.sigel]}
 					<div class="mt-2">
-						{#if hasLinksToItem(id.bibId)}
+						{#if hasLoanReserveLink(id.bibId)}
+							<li>
+								<a
+									href={linksByBibId[id.bibId][holder.sigel]['loanReserveLink'].at(0)}
+									target="_blank"
+									class="btn btn-outlined ext-link h-9"
+								>
+									{page.data.t('holdings.loanReserveLink')}
+								</a>
+							</li>
+						{:else if hasLinksToItem(id.bibId)}
 							<li>
 								<a
 									href={linksByBibId[id.bibId][holder.sigel]['linksToItem'].at(0)}
@@ -257,6 +271,18 @@
 			</span>
 			{page.data.t('holdings.openingHoursEtc')}
 		</summary>
+		<span>
+			{#if bibIds.at(0)}
+				{@const firstBibId = bibIds.at(0).bibId}
+				<div class="my-2">
+					{#if linksByBibId[firstBibId]?.[holder.sigel]?.['openingHours']}
+						<li>
+							{linksByBibId[firstBibId][holder.sigel]['openingHours'].at(0)}
+						</li>
+					{/if}
+				</div>
+			{/if}
+		</span>
 	</details>
 </li>
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -116,7 +116,7 @@
 			<DecoratedData data={holder.obj} showLabels={ShowLabelsOptions['Never']} />
 		</span>
 		<details ontoggle={getHoldingStatus}>
-			<summary class="my-3 flex cursor-pointer items-baseline">
+			<summary class="mt-3 flex cursor-pointer items-baseline">
 				<span class="arrow text-subtle mr-2 h-3 origin-center rotate-0 transition-transform">
 					<BiChevronRight />
 				</span>
@@ -127,7 +127,7 @@
 					<p>{page.data.t('search.loading')}</p>
 				{/if}
 				{#if error}
-					<div class="status-container border-neutral bg-page max-w-md rounded-sm border p-2">
+					<div class="status-container border-neutral bg-page mt-2 max-w-md rounded-sm border p-2">
 						<p class="error" role="alert">{error}</p>
 					</div>
 				{/if}
@@ -136,7 +136,7 @@
 						{#if instance?.item_information}
 							{@const items = instance.item_information}
 							<div
-								class="status-container border-neutral bg-page flex max-w-md flex-col gap-4 rounded-sm border p-2"
+								class="status-container border-neutral bg-page mt-4 flex max-w-md flex-col gap-4 rounded-sm border p-2"
 							>
 								{#if items.error || items.count === 0}
 									{#if urlNotDefinedError(items.error)}
@@ -199,7 +199,7 @@
 		<ul>
 			{#each bibIds as id (id.bibId)}
 				{#if linksByInstanceId[id.bibId]?.[holder.sigel]}
-					<div class="mb-3">
+					<div class="mt-3">
 						{#if linksByInstanceId[id.bibId]?.[holder.sigel]['linksToItem']}
 							<li>
 								<a
@@ -227,6 +227,14 @@
 			{/each}
 		</ul>
 	</div>
+	<details>
+		<summary class="my-3 flex cursor-pointer items-baseline">
+			<span class="arrow text-subtle mr-2 h-3 origin-center rotate-0 transition-transform">
+				<BiChevronRight />
+			</span>
+			{page.data.t('holdings.openingHoursEtc')}
+		</summary>
+	</details>
 </li>
 
 <style lang="postcss">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -130,9 +130,10 @@
 		<ul>
 			{#each bibIds as id (id.bibId)}
 				{#if linksByBibId[id.bibId]?.[holder.sigel]}
-					<div class="mt-2">
+					<div class="my-1">
 						{#if hasLoanReserveLink(id.bibId)}
 							<li>
+								<div class="instance-token mt-2 mb-1">{id.str}</div>
 								<a
 									href={linksByBibId[id.bibId][holder.sigel]['loanReserveLink'].at(0)}
 									target="_blank"
@@ -143,6 +144,7 @@
 							</li>
 						{:else if hasLinksToItem(id.bibId)}
 							<li>
+								<div class="instance-token mt-2 mb-1">{id.str}</div>
 								<a
 									href={linksByBibId[id.bibId][holder.sigel]['linksToItem'].at(0)}
 									target="_blank"
@@ -280,16 +282,13 @@
 							{linksByBibId[firstBibId][holder.sigel]['openingHours'].at(0)}
 						</li>
 					{/if}
-					<!--{#if linksByBibId[firstBibId]?.[holder.sigel]?.['address']}-->
-					<!--	<li class="my-2">-->
-					<!--		{#each linksByBibId[firstBibId][holder.sigel]['address'] as address}-->
-					<!--			{#if address['@type'] === 'bibdb:VisitingAddress' && address['bibdb:streetAddress']}-->
-					<!--				<h1>{page.data.t('holdings.streetAddress')}</h1>-->
-					<!--				{address['bibdb:streetAddress']}-->
-					<!--			{/if}-->
-					<!--		{/each}-->
-					<!--	</li>-->
-					<!--{/if}-->
+					{#if linksByBibId[firstBibId]?.[holder.sigel]?.['address']}
+						<li class="my-2">
+							<!--{#each linksByBibId[firstBibId][holder.sigel]['address'] as address}-->
+							<!--	<DecoratedData data={address} showLabels={ShowLabelsOptions.Never} />-->
+							<!--{/each}-->
+						</li>
+					{/if}
 				</div>
 			{/if}
 		</span>
@@ -311,6 +310,7 @@
 
 	.holder-label {
 		@apply flex-1 overflow-hidden text-ellipsis whitespace-nowrap;
+		font-weight: bold;
 	}
 
 	.status-container {
@@ -333,6 +333,10 @@
 
 	table td {
 		width: auto;
+	}
+
+	.instance-token {
+		color: var(--color-subtle);
 	}
 
 	.indicator {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -185,7 +185,7 @@
 				</div>
 			{/if}
 		</ul>
-		{#if linksByBibId[bibIds.at(0).bibId]?.[holder.sigel]?.[BibDb.ItemStatus]}
+		{#if bibIds.at(0) && linksByBibId[bibIds.at(0).bibId]?.[holder.sigel]?.[BibDb.ItemStatus]}
 			<details ontoggle={getHoldingStatus}>
 				<summary class="mt-3 flex cursor-pointer items-baseline">
 					<span class="arrow text-subtle mr-2 h-3 origin-center rotate-0 transition-transform">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -60,7 +60,7 @@
 					{#if linksByBibId[id.bibId]?.[holder.sigel]}
 						{@const linksForHolder = linksByBibId[id.bibId][holder.sigel]}
 						{#if hasInstanceContent(id.bibId)}
-							<div class="instance-token mt-4 mb-1">{id.str}</div>
+							<div class="instance-token mt-4 mb-1">{id.str || '-'}</div>
 							{#if hasStatusLink(id.bibId)}
 								<HoldingAvailability {holder} bibId={id}></HoldingAvailability>
 							{/if}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -5,6 +5,7 @@
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import BiChevronRight from '~icons/bi/chevron-right';
+	import { BibDb } from '$lib/types/xl';
 
 	type HoldingInfoProps = {
 		holder: DecoratedHolder;
@@ -110,11 +111,11 @@
 	}
 
 	function hasLinksToItem(id: string) {
-		return linksByBibId[id]?.[holder.sigel]?.['linksToItem'];
+		return linksByBibId[id]?.[holder.sigel]?.[BibDb.LinksToItem];
 	}
 
 	function hasLoanReserveLink(id: string) {
-		return linksByBibId[id]?.[holder.sigel]?.['loanReserveLink'];
+		return linksByBibId[id]?.[holder.sigel]?.[BibDb.LoanReserveLink];
 	}
 
 	function missingAtLeastOneLinkToItem() {
@@ -146,7 +147,7 @@
 							<li>
 								<div class="instance-token mt-2 mb-1">{id.str}</div>
 								<a
-									href={linksByBibId[id.bibId][holder.sigel]['linksToItem'].at(0)}
+									href={linksByBibId[id.bibId][holder.sigel][BibDb.LinksToItem].at(0)}
 									target="_blank"
 									class="btn btn-outlined ext-link h-9"
 								>
@@ -160,20 +161,20 @@
 			{#if bibIds.at(0) && missingAtLeastOneLinkToItem()}
 				{@const firstBibId = bibIds.at(0).bibId}
 				<div class="mt-2">
-					{#if linksByBibId[firstBibId]?.[holder.sigel]?.['linksToCatalog']}
+					{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.LinksToCatalog]}
 						<li>
 							<a
-								href={linksByBibId[firstBibId][holder.sigel]['linksToCatalog'].at(0)}
+								href={linksByBibId[firstBibId][holder.sigel][BibDb.LinksToCatalog].at(0)}
 								target="_blank"
 								class="ext-link"
 							>
 								{page.data.t('holdings.linkToCatalog')}
 							</a>
 						</li>
-					{:else if linksByBibId[firstBibId]?.[holder.sigel]?.['linksToSite']}
+					{:else if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.LinksToSite]}
 						<li>
 							<a
-								href={linksByBibId[firstBibId][holder.sigel]['linksToSite'].at(0)}
+								href={linksByBibId[firstBibId][holder.sigel][BibDb.LinksToSite].at(0)}
 								target="_blank"
 								class="ext-link"
 							>
@@ -184,7 +185,7 @@
 				</div>
 			{/if}
 		</ul>
-		{#if linksByBibId[bibIds.at(0).bibId]?.[holder.sigel]?.['hasItemStatus']}
+		{#if linksByBibId[bibIds.at(0).bibId]?.[holder.sigel]?.[BibDb.ItemStatus]}
 			<details ontoggle={getHoldingStatus}>
 				<summary class="mt-3 flex cursor-pointer items-baseline">
 					<span class="arrow text-subtle mr-2 h-3 origin-center rotate-0 transition-transform">
@@ -280,13 +281,13 @@
 			{#if bibIds.at(0)}
 				{@const firstBibId = bibIds.at(0).bibId}
 				<ul class="my-2" style="white-space: pre-line">
-					{#if linksByBibId[firstBibId]?.[holder.sigel]?.['openingHours']}
+					{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.OpeningHours]}
 						<li>
-							{linksByBibId[firstBibId][holder.sigel]['openingHours'].at(0)}
+							{linksByBibId[firstBibId][holder.sigel][BibDb.OpeningHours].at(0)}
 						</li>
 					{/if}
-					{#if linksByBibId[firstBibId]?.[holder.sigel]?.['address']}
-						{#each linksByBibId[firstBibId][holder.sigel]['address'] as address (address)}
+					{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.Address]}
+						{#each linksByBibId[firstBibId][holder.sigel][BibDb.Address] as address (address)}
 							<li class="my-2">
 								{address}
 							</li>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -282,13 +282,13 @@
 							{linksByBibId[firstBibId][holder.sigel]['openingHours'].at(0)}
 						</li>
 					{/if}
-					{#if linksByBibId[firstBibId]?.[holder.sigel]?.['address']}
-						<li class="my-2">
-							<!--{#each linksByBibId[firstBibId][holder.sigel]['address'] as address}-->
-							<!--	<DecoratedData data={address} showLabels={ShowLabelsOptions.Never} />-->
-							<!--{/each}-->
-						</li>
-					{/if}
+					<!--{#if linksByBibId[firstBibId]?.[holder.sigel]?.['address']}-->
+					<!--	<li class="my-2">-->
+					<!--		{#each linksByBibId[firstBibId][holder.sigel]['address'] as address}-->
+					<!--			{address}-->
+					<!--		{/each}-->
+					<!--	</li>-->
+					<!--{/if}-->
 				</div>
 			{/if}
 		</span>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingStatus.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingStatus.svelte
@@ -199,7 +199,7 @@
 			{#if linksByInstanceId[id.bibId]?.[holder.sigel]}
 				<div class="mb-4">
 					<li>
-						<a href={linksByInstanceId[id.bibId][holder.sigel]?.at(0)}>
+						<a href={linksByInstanceId[id.bibId][holder.sigel]?.['linksToItem'].at(0)}>
 							-> Titeln i bibliotekets lokala katalog
 						</a>
 					</li>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingStatus.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingStatus.svelte
@@ -197,18 +197,26 @@
 	<ul>
 		{#each bibIds as id (id.bibId)}
 			{#if linksByInstanceId[id.bibId]?.[holder.sigel]}
-				<div class="mb-4">
+				<div class="mb-3">
 					{#if linksByInstanceId[id.bibId]?.[holder.sigel]['linksToItem']}
 						<li>
-							<a href={linksByInstanceId[id.bibId][holder.sigel]['linksToItem'].at(0)}>
-								-> Titeln i bibliotekets lokala katalog
+							<a
+								href={linksByInstanceId[id.bibId][holder.sigel]['linksToItem'].at(0)}
+								target="_blank"
+								class="btn btn-outlined ext-link h-9"
+							>
+								{page.data.t('holdings.linkToLocal')}
 							</a>
 						</li>
 					{/if}
-					{#if linksByInstanceId[id.bibId]?.[holder.sigel]['linksToSite']}
+					{#if linksByInstanceId[id.bibId]?.[holder.sigel]['linksToSite'] && !linksByInstanceId[id.bibId][holder.sigel]['linksToItem']}
 						<li>
-							<a href={linksByInstanceId[id.bibId][holder.sigel]['linksToSite'].at(0)}>
-								-> Bibliotekets hemsida
+							<a
+								href={linksByInstanceId[id.bibId][holder.sigel]['linksToSite'].at(0)}
+								target="_blank"
+								class="ext-link"
+							>
+								{page.data.t('holdings.linkToLibrary')}
 							</a>
 						</li>
 					{/if}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingStatus.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingStatus.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { type HoldingStatus } from '$lib/types/api';
-	import type { BibIdObj, DecoratedHolder } from '$lib/types/holdings';
+	import type { BibIdObj, DecoratedHolder, ItemLinksByInstanceId } from '$lib/types/holdings';
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import BiChevronRight from '~icons/bi/chevron-right';
@@ -9,9 +9,10 @@
 	type HoldingStatusProps = {
 		holder: DecoratedHolder;
 		holdingUrl: string;
+		linksByInstanceId: ItemLinksByInstanceId;
 	};
 
-	const { holder, holdingUrl }: HoldingStatusProps = $props();
+	const { holder, holdingUrl, linksByInstanceId }: HoldingStatusProps = $props();
 
 	const sigel = holder?.sigel;
 	let loading = $state(false);
@@ -192,6 +193,20 @@
 			{/if}
 		</div>
 	</details>
+
+	<ul>
+		{#each bibIds as id (id.bibId)}
+			{#if linksByInstanceId[id.bibId]?.[holder.sigel]}
+				<div class="mb-4">
+					<li>
+						<a href={linksByInstanceId[id.bibId][holder.sigel]?.at(0)}>
+							-> Titeln i bibliotekets lokala katalog
+						</a>
+					</li>
+				</div>
+			{/if}
+		{/each}
+	</ul>
 </li>
 
 <style lang="postcss">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingStatus.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingStatus.svelte
@@ -198,11 +198,20 @@
 		{#each bibIds as id (id.bibId)}
 			{#if linksByInstanceId[id.bibId]?.[holder.sigel]}
 				<div class="mb-4">
-					<li>
-						<a href={linksByInstanceId[id.bibId][holder.sigel]?.['linksToItem'].at(0)}>
-							-> Titeln i bibliotekets lokala katalog
-						</a>
-					</li>
+					{#if linksByInstanceId[id.bibId]?.[holder.sigel]['linksToItem']}
+						<li>
+							<a href={linksByInstanceId[id.bibId][holder.sigel]['linksToItem'].at(0)}>
+								-> Titeln i bibliotekets lokala katalog
+							</a>
+						</li>
+					{/if}
+					{#if linksByInstanceId[id.bibId]?.[holder.sigel]['linksToSite']}
+						<li>
+							<a href={linksByInstanceId[id.bibId][holder.sigel]['linksToSite'].at(0)}>
+								-> Bibliotekets hemsida
+							</a>
+						</li>
+					{/if}
 				</div>
 			{/if}
 		{/each}


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-249](https://kbse.atlassian.net/browse/LWS-249)

### Solves

The goal is to provide access to items in the local library catalog as well as additional library info such as address, opening hours etc. This is currently presented in the holding panel:

![Screenshot from 2025-05-22 09-17-55](https://github.com/user-attachments/assets/4b39964a-bceb-44d6-8397-0fd55da0e5c2)


### Summary of changes

* Construct a mapping for library code (sigel) to the links/info on fnurgel page load 
* Tried to keep close to the Figma sketches for the frontend part
* Add a basic server side caching mechanism for full holder/library data. There is plenty of information about caching in the browser in a SvelteKit context but not so much about caching on the server. The approach used in this PR comes from https://www.loopwerk.io/articles/2025/svelte-5-stores/, which should be fine since the data we are caching is not tied to a specific user/session/browser. I think introducing an in-memory database such as Redis is overkill for this, but that's what most people seem to be suggesting in the forums.






