### PR TITLE
fix(lxlweb): Hide webkit details marker

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -155,6 +155,14 @@
 	[role='button']:not(:disabled) {
 		cursor: pointer;
 	}
+
+	summary {
+		list-style-type: none;
+	}
+
+	summary::-webkit-details-marker {
+		display: none;
+	}
 }
 
 @layer components {


### PR DESCRIPTION
## Description

Forgot to add this to new theme. Hopfully hides default summary chevron in old IOS Safari.

<img src="https://github.com/user-attachments/assets/64f8731b-1d7d-43ef-b5fb-4bbad96d6f0c" width="300">

