### PR TITLE
chore(lxl-web, supersearch): Remove redundant vite override

### DIFF
--- a/lxl-web/package.json
+++ b/lxl-web/package.json
@@ -59,10 +59,5 @@
 	},
 	"dependencies": {
 		"dotenv": "^16.4.7"
-	},
-	"overrides": {
-		"vite": {
-			"esbuild": "^0.25.0"
-		}
 	}
 }

--- a/packages/supersearch/package.json
+++ b/packages/supersearch/package.json
@@ -65,10 +65,5 @@
 		"typescript-eslint": "^8.26.1",
 		"vite": "^6.2.7",
 		"vitest": "^3.0.8"
-	},
-	"overrides": {
-		"vite": {
-			"esbuild": "^0.25.0"
-		}
 	}
 }


### PR DESCRIPTION
## Description

### Solves

Removes redundant vite override as it seems to work as intended without it?

The esbuild dependency in vite was bumped in february (see: https://github.com/vitejs/vite/pull/19389).

### Summary of changes

- Remove redundant vite override
