### PR TITLE
fix(lxlweb): Show search icon, remove dialog margin (LWS-366, LWS-367)

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -151,6 +151,10 @@
 		color: var(--color-body);
 	}
 
+	body:has(dialog[open]) {
+		overflow: hidden;
+	}
+
 	button:not(:disabled),
 	[role='button']:not(:disabled) {
 		cursor: pointer;

--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -42,8 +42,6 @@
 
 :root {
 	--font-fallback: ui-sans-serif, system-ui, sans-serif;
-	--color-black: #000;
-	--color-white: #fff;
 	--color-success: #2ab061;
 }
 
@@ -61,6 +59,9 @@
 	--text-3xl: 1.75rem; /* 28px */
 
 	--color-*: initial;
+
+	--color-black: #000;
+	--color-white: #fff;
 
 	--color-primary-50: oklch(97.93% 0.014 124.55);
 	--color-primary-100: oklch(95.92% 0.029 121.98);

--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -60,9 +60,6 @@
 
 	--color-*: initial;
 
-	--color-black: #000;
-	--color-white: #fff;
-
 	--color-primary-50: oklch(97.93% 0.014 124.55);
 	--color-primary-100: oklch(95.92% 0.029 121.98);
 	--color-primary-200: oklch(90.73% 0.063 123.24);
@@ -128,7 +125,10 @@
 	--color-severe-950: oklch(14.45% 0.031 21.73);
 	--color-severe: var(--color-severe-500);
 
-	--color-page: #fff;
+	--color-black: #000;
+	--color-white: #fff;
+
+	--color-page: var(--color-white);
 	--color-body: var(--color-neutral-800);
 	--color-subtle: var(--color-neutral-600);
 	--color-link: var(--color-accent);

--- a/lxl-web/src/lib/components/Modal.svelte
+++ b/lxl-web/src/lib/components/Modal.svelte
@@ -4,7 +4,6 @@
 	import { onDestroy, onMount } from 'svelte';
 	import { fade, fly } from 'svelte/transition';
 	import { cubicInOut } from 'svelte/easing';
-	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
 	import IconClose from '~icons/bi/x-lg';
 	import { setModalContext } from '$lib/contexts/modal';
@@ -13,20 +12,13 @@
 	export let close: ((event: Event) => void) | undefined = undefined;
 	export let position: 'left' | 'right' | 'top' = 'right';
 
-	let prevBodyOverflow: string | undefined = undefined;
-
 	setModalContext();
 
 	onMount(() => {
 		dialog?.showModal();
-		disableBodyScroll();
 	});
 
-	onDestroy(() => {
-		if (browser) {
-			enableBodyScroll();
-		}
-	});
+	onDestroy(() => {});
 
 	function handleClose(event: MouseEvent | Event) {
 		// Use close method from prop if available
@@ -44,23 +36,12 @@
 			handleClose(event);
 		}
 	}
-
-	function disableBodyScroll() {
-		prevBodyOverflow = document.body.style.overflow;
-		document.body.style.overflow = 'hidden';
-	}
-
-	function enableBodyScroll() {
-		document.body.style.overflow = prevBodyOverflow || '';
-	}
 </script>
 
 <div
 	class="bg-backdrop pointer-events-none fixed top-0 left-0 z-10 h-full w-full"
 	transition:fade={{ duration: 300 }}
 ></div>
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <dialog
 	class="fixed top-0 left-0 flex h-screen max-h-full w-screen max-w-full"
 	tabindex="-1"

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { afterNavigate, goto } from '$app/navigation';
 	import { SuperSearch, lxlQualifierPlugin, type Selection } from 'supersearch';
 	import Suggestion from './Suggestion.svelte';
@@ -22,9 +22,9 @@
 
 	let { placeholder = '' }: Props = $props();
 	let q = $state(
-		$page.params.fnurgel
+		page.params.fnurgel
 			? ''
-			: addSpaceIfEndingQualifier($page.url.searchParams.get('_q')?.trim() || '')
+			: addSpaceIfEndingQualifier(page.url.searchParams.get('_q')?.trim() || '')
 	);
 	let selection: Selection | undefined = $state();
 	let cursor = $derived(selection?.head || 0);
@@ -33,7 +33,7 @@
 	let showMoreFilters = $state(false);
 
 	let pageParams = $derived.by(() => {
-		let p = getSortedSearchParams(addDefaultSearchParams($page.url.searchParams));
+		let p = getSortedSearchParams(addDefaultSearchParams(page.url.searchParams));
 		// Always reset these params on new search
 		p.set('_offset', '0');
 		p.delete('_i');
@@ -47,7 +47,7 @@
 		/** Update input value after navigation on /find route */
 		if (to?.url) {
 			const toQ = addSpaceIfEndingQualifier(new URL(to.url).searchParams.get('_q')?.trim() || '');
-			q = $page.params.fnurgel ? '' : toQ !== '*' ? toQ : ''; // hide wildcard in input field
+			q = page.params.fnurgel ? '' : toQ !== '*' ? toQ : ''; // hide wildcard in input field
 			superSearch?.hideExpandedSearch();
 		}
 	});
@@ -133,7 +133,7 @@
 
 	let derivedLxlQualifierPlugin = $derived.by(() => {
 		function getLabels(key: string, value?: string) {
-			let pageMapping = $page.data.searchResult?.mapping;
+			let pageMapping = page.data.searchResult?.mapping;
 			return getLabelFromMappings(key, value, pageMapping, suggestMapping);
 		}
 		return lxlQualifierPlugin(getLabels, removeQualifier);
@@ -145,6 +145,10 @@
 		const newParams = new URLSearchParams(pageParams);
 		newParams.set('_q', q);
 		return `/find?${newParams.toString()}`;
+	}
+
+	export function showExpandedSearch() {
+		superSearch?.showExpandedSearch();
 	}
 </script>
 
@@ -190,7 +194,7 @@
 		bind:selection
 		language={lxlQuery}
 		{placeholder}
-		endpoint={`/api/${$page.data.locale}/supersearch`}
+		endpoint={`/api/${page.data.locale}/supersearch`}
 		queryFn={(query, cursor) => {
 			return new URLSearchParams({
 				_q: query,
@@ -203,9 +207,9 @@
 		shouldShowStartContentFn={handleShouldShowStartContent}
 		extensions={[derivedLxlQualifierPlugin]}
 		toggleWithKeyboardShortcut
-		comboboxAriaLabel={$page.data.t('search.search')}
+		comboboxAriaLabel={page.data.t('search.search')}
 		defaultInputCol={2}
-		loadMoreLabel={$page.data.t('search.showMore')}
+		loadMoreLabel={page.data.t('search.showMore')}
 		debouncedWait={100}
 	>
 		{#snippet loadingIndicator()}
@@ -230,7 +234,7 @@
 						type="button"
 						id={getCellId(0)}
 						class:focused-cell={isFocusedCell(0)}
-						aria-label={$page.data.t('general.close')}
+						aria-label={page.data.t('general.close')}
 						class="p-4 sm:hidden"
 						onclick={onclickClose}
 					>
@@ -249,7 +253,7 @@
 						id={getCellId(1)}
 						class:focused-cell={isFocusedCell(1)}
 						class="text-subtle p-4"
-						aria-label={$page.data.t('search.clearFilters')}
+						aria-label={page.data.t('search.clearFilters')}
 						onclick={onclickClear}
 					>
 						<BiXLg />
@@ -270,30 +274,30 @@
 		{#snippet startContent({ getCellId, isFocusedCell, isFocusedRow })}
 			<div role="rowgroup">
 				<div class="text-2xs text-subtle flex w-full items-center px-4 py-2 font-medium">
-					{$page.data.t('search.supersearchStartHeader')}
+					{page.data.t('search.supersearchStartHeader')}
 				</div>
 				{@render startFilterItem({
-					qualifierKey: $page.data.t('qualifiers.contributorKey'),
-					qualifierLabel: $page.data.t('qualifiers.contributorLabel'),
-					qualifierPlaceholder: $page.data.t('qualifiers.contributorPlaceholder'),
+					qualifierKey: page.data.t('qualifiers.contributorKey'),
+					qualifierLabel: page.data.t('qualifiers.contributorLabel'),
+					qualifierPlaceholder: page.data.t('qualifiers.contributorPlaceholder'),
 					getCellId,
 					isFocusedCell,
 					isFocusedRow,
 					rowIndex: 1
 				})}
 				{@render startFilterItem({
-					qualifierKey: $page.data.t('qualifiers.titleKey'),
-					qualifierLabel: $page.data.t('qualifiers.titleLabel'),
-					qualifierPlaceholder: $page.data.t('qualifiers.titlePlaceholder'),
+					qualifierKey: page.data.t('qualifiers.titleKey'),
+					qualifierLabel: page.data.t('qualifiers.titleLabel'),
+					qualifierPlaceholder: page.data.t('qualifiers.titlePlaceholder'),
 					getCellId,
 					isFocusedCell,
 					isFocusedRow,
 					rowIndex: 2
 				})}
 				{@render startFilterItem({
-					qualifierKey: $page.data.t('qualifiers.languageKey'),
-					qualifierLabel: $page.data.t('qualifiers.languageLabel'),
-					qualifierPlaceholder: $page.data.t('qualifiers.languagePlaceholder'),
+					qualifierKey: page.data.t('qualifiers.languageKey'),
+					qualifierLabel: page.data.t('qualifiers.languageLabel'),
+					qualifierPlaceholder: page.data.t('qualifiers.languagePlaceholder'),
 					getCellId,
 					isFocusedCell,
 					isFocusedRow,
@@ -301,27 +305,27 @@
 				})}
 				{#if showMoreFilters}
 					{@render startFilterItem({
-						qualifierKey: $page.data.t('qualifiers.subjectKey'),
-						qualifierLabel: $page.data.t('qualifiers.subjectLabel'),
-						qualifierPlaceholder: $page.data.t('qualifiers.subjectPlaceholder'),
+						qualifierKey: page.data.t('qualifiers.subjectKey'),
+						qualifierLabel: page.data.t('qualifiers.subjectLabel'),
+						qualifierPlaceholder: page.data.t('qualifiers.subjectPlaceholder'),
 						getCellId,
 						isFocusedCell,
 						isFocusedRow,
 						rowIndex: 4
 					})}
 					{@render startFilterItem({
-						qualifierKey: $page.data.t('qualifiers.yearKey'),
-						qualifierLabel: $page.data.t('qualifiers.yearLabel'),
-						qualifierPlaceholder: $page.data.t('qualifiers.yearPlaceholder'),
+						qualifierKey: page.data.t('qualifiers.yearKey'),
+						qualifierLabel: page.data.t('qualifiers.yearLabel'),
+						qualifierPlaceholder: page.data.t('qualifiers.yearPlaceholder'),
 						getCellId,
 						isFocusedCell,
 						isFocusedRow,
 						rowIndex: 5
 					})}
 					{@render startFilterItem({
-						qualifierKey: $page.data.t('qualifiers.genreFormKey'),
-						qualifierLabel: $page.data.t('qualifiers.genreFormLabel'),
-						qualifierPlaceholder: $page.data.t('qualifiers.genreFormPlaceholder'),
+						qualifierKey: page.data.t('qualifiers.genreFormKey'),
+						qualifierLabel: page.data.t('qualifiers.genreFormLabel'),
+						qualifierPlaceholder: page.data.t('qualifiers.genreFormPlaceholder'),
 						getCellId,
 						isFocusedCell,
 						isFocusedRow,
@@ -339,10 +343,10 @@
 					>
 						{#if showMoreFilters}
 							<BiChevronUp class="text-subtle mr-2" />
-							{$page.data.t('search.showFewer')}
+							{page.data.t('search.showFewer')}
 						{:else}
 							<BiChevronDown class="text-subtle mr-2" />
-							{$page.data.t('search.showMore')}
+							{page.data.t('search.showMore')}
 						{/if}
 					</button>
 				</div>
@@ -364,6 +368,14 @@
 <style lang="postcss">
 	@reference "../../../app.css";
 
+	/* search */
+	:global(#supersearch) {
+		display: none;
+		@variant sm {
+			display: block;
+		}
+	}
+
 	/* dialog */
 
 	:global(.supersearch-dialog) {
@@ -372,7 +384,7 @@
 	}
 
 	:global(.supersearch-dialog-wrapper) {
-		@apply header-layout pointer-events-none;
+		@apply header-layout pointer-events-none px-0 sm:px-6 lg:px-2;
 		grid-template-areas: 'supersearch-content supersearch-content supersearch-content';
 
 		@variant sm {
@@ -388,7 +400,7 @@
 	}
 
 	:global(.supersearch-dialog .supersearch-combobox) {
-		@apply sticky top-0 z-20 items-stretch px-4 pt-4 pb-2;
+		@apply sticky top-0 z-20 items-stretch px-4 pt-3 pb-2;
 		background-color: var(--color-page);
 	}
 

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -84,6 +84,10 @@
 			}
 		}
 
+		if (!value) {
+			return true;
+		}
+
 		return false;
 	}
 

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -93,6 +93,7 @@
 	}
 
 	function addQualifierKey(qualifierKey: string) {
+		superSearch?.showExpandedSearch(); // keep dialog open (since 'regular' search is hidden on mobile)
 		superSearch?.dispatchChange({
 			change: {
 				from: cursor,
@@ -105,7 +106,6 @@
 			},
 			userEvent: 'input.complete'
 		});
-		superSearch?.hideExpandedSearch();
 	}
 
 	function addQualifier(qualifier: QualifierSuggestion) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
@@ -33,7 +33,7 @@
 		bind:offsetHeight={bannerOffsetHeight}
 	>
 		<span class="flex items-center gap-2">
-			<span class="text-2xs rounded-sm bg-[#000] px-1.5 py-0.5 tracking-wide text-[#fff] uppercase">
+			<span class="text-2xs rounded-sm bg-black px-1.5 py-0.5 tracking-wide text-white uppercase">
 				Beta
 			</span>
 			<span>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
+	import type { SvelteComponent } from 'svelte';
 	import { page } from '$app/state';
 	import { beforeNavigate } from '$app/navigation';
 	import Modal from '$lib/components/Modal.svelte';
 	import HeaderMenu from './HeaderMenu.svelte';
 	import SuperSearchWrapper from '$lib/components/supersearch/SuperSearchWrapper.svelte';
 	import BiList from '~icons/bi/list';
+	import BiSearch from '~icons/bi/search';
 
 	let showHeaderMenu = false;
 	let bannerOffsetHeight: number | undefined = $state();
+	let superSearchWrapperComponent: SvelteComponent;
 
 	function toggleHeaderMenu() {
 		showHeaderMenu = !showHeaderMenu;
@@ -18,6 +21,10 @@
 			showHeaderMenu = false;
 		}
 	});
+
+	function onClickExpandSearch() {
+		superSearchWrapperComponent.showExpandedSearch();
+	}
 </script>
 
 <header class="bg-app-header">
@@ -45,19 +52,27 @@
 			{/if}
 		</a>
 	</div>
-	<nav class="header-nav header-layout min-h-20 items-center py-0">
+	<nav class="header-nav header-layout min-h-18 items-center py-0">
 		<div class="home lg:pl-4">
-			<a href={page.data.base} class="flex flex-col no-underline lg:flex-row">
-				<span class="font-heading text-2xl font-[600] lg:text-3xl"> Libris</span>
+			<a href={page.data.base} class="flex no-underline">
+				<span class="font-heading text-2xl font-[600] lg:text-3xl">Libris</span>
 			</a>
 		</div>
-		<div class="search pb-4 sm:px-4 sm:pb-0">
+		<div class="search sm:px-4">
 			<SuperSearchWrapper
 				placeholder={page.data.t('header.searchPlaceholder')}
 				--offset-top={`${bannerOffsetHeight}px`}
+				bind:this={superSearchWrapperComponent}
 			/>
 		</div>
-		<div class="actions flex min-h-20 items-center justify-end lg:pr-4">
+		<div class="actions flex items-center justify-end lg:pr-4">
+			<button
+				aria-label={page.data.t('search.search')}
+				class="text-subtle p-4 sm:hidden"
+				onclick={() => onClickExpandSearch()}
+			>
+				<BiSearch />
+			</button>
 			<div
 				id="header-menu"
 				class="text-3xs hidden items-center target:absolute target:left-0 target:block target:w-full 2xl:flex"
@@ -69,7 +84,10 @@
 					aria-label={page.data.t('header.openMenu')}
 					class="text-subtle flex items-center p-4"
 					href={`${page.url.pathname}?${page.url.search}#header-menu`}
-					on:click|preventDefault={toggleHeaderMenu}
+					onclick={(e) => {
+						e.preventDefault();
+						toggleHeaderMenu();
+					}}
 				>
 					<BiList width={20} height={20} aria-hidden="true" />
 				</a>
@@ -87,13 +105,7 @@
 	@reference "../../../app.css";
 
 	.header-nav {
-		grid-template-areas:
-			'home . actions'
-			'search search search';
-
-		@variant sm {
-			grid-template-areas: 'home search actions';
-		}
+		grid-template-areas: 'home search actions';
 	}
 
 	.home {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
@@ -8,7 +8,7 @@
 	import BiList from '~icons/bi/list';
 	import BiSearch from '~icons/bi/search';
 
-	let showHeaderMenu = false;
+	let showHeaderMenu = $state(false);
 	let bannerOffsetHeight: number | undefined = $state();
 	let superSearchWrapperComponent: SvelteComponent;
 

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -599,7 +599,7 @@
 	/>
 {/snippet}
 
-<div role="presentation" onkeydown={handleCollapsedKeyDown}>
+<div role="presentation" onkeydown={handleCollapsedKeyDown} {id}>
 	<div class="supersearch-combobox">
 		{@render inputRow?.({
 			expanded: false,


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-366](https://kbse.atlassian.net/browse/LWS-366), [LWS-367](https://kbse.atlassian.net/browse/LWS-367)

### Solves

Hides the regular input < sm, adds an icon button that opens expanded search instead.
Remove page padding for supersearch dialog < sm, using the whole width.

### Notes

The `SiteHeader` component including the old theme layout styles (`.header-layout`) is really a confusing patchwork of old styles to keep supersearch-dialog in place. It should soon be completely rewritten based on the new design.

With input now hidden < sm, expanded search must remain open after selecting from the start menu. This does however display search results from a wildcard search on the chosen type. 

Maybe nice in his case
![Skärmavbild 2025-05-19 kl  17 25 15](https://github.com/user-attachments/assets/330354db-5eab-4a4b-be9a-8b9a56cf2d74)

Weird in this case 🤔 
![Skärmavbild 2025-05-19 kl  17 25 55](https://github.com/user-attachments/assets/eb12f111-667c-4f1b-8288-2738f03b3c2d)


### Summary of changes

* Add id `{id}` to the outer (non-dialog) supersearch element. Use it to hide the input < sm. Render an icon button in header < sm.
* export `showExpandedSearch` function from `SuperSearchWrapper` and use it for the icon button.
* Remove padding for `.supersearch-dialog-wrapper` < sm.
* Keep expanded search open when choosing something from the start menu
* Decrease `SiteHeader` height (without the input, it takes up unnecessary vertical space)
* Upgrade `SuperSearchWrapper` component to Svelte 5 syntax

