### PR TITLE
fix(lxlweb): Adjust padding & overflow (LWS-368, 371)

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -182,6 +182,10 @@
 		}
 	}
 
+	.ext-link {
+		word-break: break-word;
+	}
+
 	a.ext-link::after {
 		background-color: var(--color-link);
 		content: '';

--- a/lxl-web/src/lib/components/Modal.svelte
+++ b/lxl-web/src/lib/components/Modal.svelte
@@ -64,7 +64,7 @@
 		class:left-0={position === 'left'}
 		class:right-0={position === 'right'}
 	>
-		<div class="flex flex-1 flex-col gap-4 overflow-y-auto pb-4">
+		<div class="flex flex-1 flex-col gap-4 overflow-x-hidden overflow-y-auto pb-4">
 			<header
 				class="border-neutral sticky top-0 z-10 flex min-h-14 items-center justify-between border-b bg-neutral-50 px-4"
 			>

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -26,7 +26,10 @@
 </script>
 
 <div class="search-card-container">
-	<article class="search-card" data-testid="search-card">
+	<article
+		class="search-card border-neutral relative grid w-full gap-x-4 border-t px-0 py-3 font-normal transition-shadow md:px-4"
+		data-testid="search-card"
+	>
 		<div class="card-image">
 			<a
 				href={id}
@@ -182,8 +185,6 @@
 	}
 
 	.search-card {
-		@apply border-neutral relative grid w-full gap-x-4 border-t px-4 py-3 font-normal transition-shadow;
-
 		grid-template-areas: 'image content debug libraries';
 		grid-template-columns: 64px 1fr auto auto;
 

--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -25,7 +25,7 @@
 	function getRelationSymbol(operator: keyof typeof SearchOperators): string {
 		switch (operator) {
 			case 'equals':
-				return '';
+				return ':';
 			case 'notEquals':
 				return '≠';
 			case 'greaterThan':
@@ -46,10 +46,12 @@
 	}
 </script>
 
-<ul class="flex flex-wrap items-center gap-2">
+<ul class="flex flex-wrap items-center gap-2 overflow-hidden">
 	{#each mapping as m, index (`${m['@id']}-${index}`)}
 		<li
-			class="mapping-item {m.children ? 'pill-group' : 'btn btn-accent'} pill-{m.operator}"
+			class="mapping-item overflow-hidden {m.children
+				? 'pill-group'
+				: 'btn btn-accent'} pill-{m.operator}"
 			class:wildcard={m.operator === 'equals' && m.display === '*'}
 			class:outer={depth === 0}
 			class:free-text={m?.['@id'] === 'https://id.kb.se/vocab/textQuery'}
@@ -59,12 +61,12 @@
 			{:else if m.operator === 'existence' || m.operator === 'notExistence'}
 				{@const symbol = getRelationSymbol(m.operator)}
 				<span class="pill-relation">{symbol}</span>
-				<div class="pill-label inline">{m.label}</div>
+				<div class="pill-label inline whitespace-nowrap">{m.label}</div>
 			{:else if 'label' in m && 'display' in m}
 				{@const symbol = getRelationSymbol(m.operator)}
-				<div class="pill-label inline">{m.label}</div>
+				<div class="pill-label inline whitespace-nowrap">{m.label}</div>
 				<span class="pill-relation">{symbol}</span>
-				<span class="pill-value">
+				<span class="pill-value truncate">
 					{m.displayStr}
 				</span>
 			{/if}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -383,7 +383,6 @@
 
 		& :global(.contribution > *) {
 			display: block;
-			white-space: nowrap;
 		}
 
 		& :global(.see-also > *) {


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-368(https://kbse.atlassian.net/browse/LWS-368), [LWS-371](https://kbse.atlassian.net/browse/LWS-71)

### Summary of changes

* Remove left and right padding on search cards for small screens
* Prevent modal from scrolling horizontally
* Truncate mapping pills if overflowing (in filter panel on mobile)
* Allow long ext-links to break [bad mobile example](https://beta.libris.kb.se/l3z7f4j1jbz1hxbv#work-record)
* Allow contributors to wrap in overview [bad mobile example](https://beta.libris-qa.kb.se/6pzc3mjl4gzdxqrt)
