### PR TITLE
fix(lxlweb): use progress bar with modals (LWS-369)

### DIFF
--- a/lxl-web/src/lib/components/find/SearchResult.svelte
+++ b/lxl-web/src/lib/components/find/SearchResult.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
+	import { beforeNavigate, goto } from '$app/navigation';
 	import Modal from '$lib/components/Modal.svelte';
 	import SearchMapping from './SearchMapping.svelte';
 	import SearchCard from './SearchCard.svelte';
@@ -48,6 +48,10 @@
 			(filterItem) => !(filterItem.display === '*' && filterItem.operator === 'equals') // TODO: probably best to do wildcard-filtering in an earlier step (in search.ts)?
 		).length;
 	}
+
+	beforeNavigate(() => {
+		showFiltersModal = false;
+	});
 </script>
 
 <slot />
@@ -66,7 +70,7 @@
 					<span class="font-medium">{$page.data.title}</span>
 				</li>
 				<li>{$page.data.t('search.occursAs')}</li>
-				{#each predicates as p}
+				{#each predicates as p, index (index)}
 					<li>
 						<a
 							class="flex flex-nowrap items-center gap-1 py-4 pr-3.5 pl-4 lowercase no-underline"
@@ -191,7 +195,7 @@
 								form="main-search"
 								on:change={handleSortChange}
 							>
-								{#each sortOptions as option}
+								{#each sortOptions as option (option.value)}
 									<option value={option.value} selected={option.value === sortOrder}
 										>{option.label}</option
 									>


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-369](https://kbse.atlassian.net/browse/LWS-369)

### Solves

The original case for this ticket has since resolved, i.e after searching from the expanded supersearch it now closes, revealing the progress bar under it. 

But there's another case that doesn't give any loading feedback. Adding/removing filters from the filter modal gives no loading indication since the progress bar is hidden behind it.

And placing nprogress on top of it seems impossible since the dialog sits at the `#top-layer` that is not affected by z-index etc.

So if we want to achieve this, there's basically these workarounds:

1) Close the modal after adding/removing a filter. This PR does this. Seems reasonable?
2) Adding another nprogress inside full screen modals
3) Somehow rework the modal to add it to the document flow. For example by using `show()` instead of `showModal()` (which has downsides). Anyway, the fact that we can't stack anything on top of our modals it worth keeping in mind when we start working with the panels.

### Summary of changes

* Close filter modal beforeNagivate in search results
* Add keys to each blocks
