### PR TITLE
fix(supersearch): Get virtual search keyboard (LWS-370)

### DIFF
--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -168,7 +168,7 @@
 	let collapsedContentAttributes = $derived(
 		EditorView.contentAttributes.of({
 			role: 'combobox',
-			inputmode: 'search',
+			enterkeyhint: 'search',
 			...(comboboxAriaLabel && {
 				'aria-label': comboboxAriaLabel
 			}),
@@ -184,7 +184,7 @@
 		EditorView.contentAttributes.of({
 			id: `${id}-content`,
 			role: 'combobox', // identifies the element as a combobox
-			inputmode: 'search',
+			enterkeyhint: 'search',
 			...(comboboxAriaLabel && {
 				'aria-label': comboboxAriaLabel
 			}),


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-370](https://kbse.atlassian.net/browse/LWS-370)

### Solves

Swapping inputmode for [enterkeyhint](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/enterkeyhint) seems to be the only way to get a 'search' btn for a contenteditable div in IOS at least 🤷‍♂️ 
