### PR TITLE
fix(lxlweb): Hide link popovers for touch devices (LWS-376)

### DIFF
--- a/lxl-web/src/lib/actions/popover/Popover.svelte
+++ b/lxl-web/src/lib/actions/popover/Popover.svelte
@@ -67,7 +67,10 @@
 	Note that `Popover.svelte` isn't intended to be used directly in page templates – use the `use:popover` instead (see `$lib/actions/popover`).
 -->
 <div
-	class="popover bg-page text-2xs border-neutral absolute top-0 left-0 z-50 w-max max-w-sm rounded-md border shadow-xl"
+	class={[
+		'popover bg-page text-2xs border-neutral absolute top-0 left-0 z-50 w-max max-w-sm rounded-md border shadow-xl',
+		referenceElement.getAttribute('href') && 'link-popover'
+	]}
 	role="complementary"
 	bind:this={popoverElement}
 	on:mouseover={onMouseOver}
@@ -93,3 +96,12 @@
 		</svg>
 	</div>
 </div>
+
+<style>
+	/* prevent popover from flashing before navigating away on touch devices */
+	@media (hover: none) {
+		.link-popover {
+			display: none;
+		}
+	}
+</style>


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-376](https://kbse.atlassian.net/browse/LWS-376)

### Solves

Hide link popovers for touch devices since they're of no use anyway.
(We also use popovers for buttons (focus-triggered), but they work on mobile since they don't trigger navigations)

### Summary of changes

Add a class if popover is attached to a link. Hide those popovers for devices where hover is unsupported.
