### PR TITLE
feat(lxlweb, supersearch): Supersearch loading spinner

### DIFF
--- a/lxl-web/src/lib/components/Spinner.svelte
+++ b/lxl-web/src/lib/components/Spinner.svelte
@@ -1,0 +1,67 @@
+<span class="spinner-2"></span>
+
+<style>
+	.spinner {
+		display: block;
+		height: 100%;
+		width: 100%;
+		border-radius: 50%;
+		position: relative;
+		animation: rotate 1s linear infinite;
+	}
+	.spinner::before {
+		content: '';
+		box-sizing: border-box;
+		position: absolute;
+		inset: 0px;
+		border-radius: 50%;
+		border: 2px solid #000;
+		border-color: inherit;
+		animation: prixClipFix 2s linear infinite;
+	}
+
+	@keyframes rotate {
+		100% {
+			transform: rotate(360deg);
+		}
+	}
+
+	@keyframes prixClipFix {
+		0% {
+			clip-path: polygon(50% 50%, 0 0, 0 0, 0 0, 0 0, 0 0);
+		}
+		25% {
+			clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 0, 100% 0, 100% 0);
+		}
+		50% {
+			clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 100%, 100% 100%, 100% 100%);
+		}
+		75% {
+			clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 100%, 0 100%, 0 100%);
+		}
+		100% {
+			clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 100%, 0 100%, 0 0);
+		}
+	}
+
+	.spinner-2 {
+		height: 100%;
+		width: 100%;
+		border: 1px solid #000;
+		border-color: inherit;
+		border-bottom-color: transparent;
+		border-radius: 50%;
+		display: inline-block;
+		box-sizing: border-box;
+		animation: rotation 0.7s linear infinite;
+	}
+
+	@keyframes rotation {
+		0% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/lxl-web/src/lib/components/Spinner.svelte
+++ b/lxl-web/src/lib/components/Spinner.svelte
@@ -1,50 +1,7 @@
-<span class="spinner-2"></span>
+<span class="spinner"></span>
 
 <style>
 	.spinner {
-		display: block;
-		height: 100%;
-		width: 100%;
-		border-radius: 50%;
-		position: relative;
-		animation: rotate 1s linear infinite;
-	}
-	.spinner::before {
-		content: '';
-		box-sizing: border-box;
-		position: absolute;
-		inset: 0px;
-		border-radius: 50%;
-		border: 2px solid #000;
-		border-color: inherit;
-		animation: prixClipFix 2s linear infinite;
-	}
-
-	@keyframes rotate {
-		100% {
-			transform: rotate(360deg);
-		}
-	}
-
-	@keyframes prixClipFix {
-		0% {
-			clip-path: polygon(50% 50%, 0 0, 0 0, 0 0, 0 0, 0 0);
-		}
-		25% {
-			clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 0, 100% 0, 100% 0);
-		}
-		50% {
-			clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 100%, 100% 100%, 100% 100%);
-		}
-		75% {
-			clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 100%, 0 100%, 0 100%);
-		}
-		100% {
-			clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 100%, 0 100%, 0 0);
-		}
-	}
-
-	.spinner-2 {
 		height: 100%;
 		width: 100%;
 		border: 1px solid #000;

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -398,8 +398,19 @@
 	/* dialog */
 
 	:global(.supersearch-dialog) {
-		@apply static m-0 h-full max-h-screen w-full max-w-full bg-transparent p-0;
-		top: var(--offset-top, 0);
+		position: static;
+		height: 100%;
+		max-height: 100vh;
+		width: 100%;
+		max-width: 100%;
+		background-color: transparent;
+		margin: 0;
+		padding: 0;
+		top: 0;
+
+		@variant sm {
+			top: var(--offset-top, 0);
+		}
 	}
 
 	:global(.supersearch-dialog-wrapper) {

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -208,6 +208,12 @@
 	</div>
 {/snippet}
 
+{#snippet loading()}
+	<span class="-mt-0.5 block size-4" in:fade={{ duration: 200 }}>
+		<Spinner />
+	</span>
+{/snippet}
+
 <form class="relative w-full" action="find" onsubmit={handleSubmit} data-testid="main-search">
 	<SuperSearch
 		name="_q"
@@ -256,9 +262,7 @@
 						onclick={onclickClose}
 					>
 						{#if debouncedLoading}
-							<span class="block size-4" in:fade={{ duration: 200 }}>
-								<Spinner />
-							</span>
+							{@render loading()}
 						{:else}
 							<BiArrowLeft aria-hidden="true" />
 						{/if}
@@ -267,9 +271,7 @@
 				<div class="flex-1 overflow-hidden">
 					<div class={['text-subtle absolute p-4', expanded ? 'hidden sm:block' : 'block']}>
 						{#if debouncedLoading}
-							<span class="block size-4" in:fade={{ duration: 200 }}>
-								<Spinner />
-							</span>
+							{@render loading()}
 						{:else}
 							<BiSearch aria-hidden="true" />
 						{/if}

--- a/packages/supersearch/src/lib/utils/useSearchRequest.svelte.ts
+++ b/packages/supersearch/src/lib/utils/useSearchRequest.svelte.ts
@@ -27,8 +27,11 @@ export function useSearchRequest({
 	const hasMorePaginatedData = $derived(!!moreSearchParams);
 
 	let controller: AbortController;
+	let latestRequest = 0;
 
 	async function _fetchData(searchParams: URLSearchParams) {
+		latestRequest++;
+		const currentRequest = latestRequest;
 		try {
 			isLoading = true;
 			error = undefined;
@@ -52,7 +55,9 @@ export function useSearchRequest({
 				error = 'Failed to fetch data';
 			}
 		} finally {
-			isLoading = false;
+			if (currentRequest === latestRequest) {
+				isLoading = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-362](https://kbse.atlassian.net/browse/LWS-362)

### Solves

Implement a loading spinner for suggestions in Supersearch.

### Summary of changes

* Create new pure CSS `Spinner` component
* Add `isLoading` state and bind to supersearch component
* Create `debouncedLoading` state to avoid spinner flickering, use it to render spinner
* Some modifications to `useSearchRequest`*
* Add `top:0` for expanded supersearch on mobile

\* an aborted request was sometimes setting `isLoading` to false, even though a newer request was out pending. Added a sort of counter to make sure the request is the latest one before setting loading to false. 