### PR TITLE
feat(lxl-web): Use light-weight decorated data for facet values

### DIFF
--- a/lxl-web/src/lib/components/DecoratedDataLite.svelte
+++ b/lxl-web/src/lib/components/DecoratedDataLite.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { DisplayDecoratedLite } from '$lib/types/xl';
+
+	export let data: DisplayDecoratedLite;
+</script>
+
+{#if Array.isArray(data)}
+	{#each data as arrayItem (arrayItem)}
+		{#if Array.isArray(arrayItem)}
+			<span class={arrayItem[1]}>{arrayItem[0]}</span>
+		{:else}
+			{arrayItem}
+		{/if}
+	{/each}
+{/if}
+
+<style lang="postcss">
+	@reference "../../app.css";
+
+	.sigel {
+		color: var(--color-subtle);
+	}
+</style>

--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -2,22 +2,21 @@
 	import { page } from '$app/state';
 	import type { LocaleCode } from '$lib/i18n/locales';
 	import type { FacetGroup } from '$lib/types/search';
-	import { ShowLabelsOptions } from '$lib/types/decoratedData';
 	import {
-		DEFAULT_FACETS_SHOWN,
+		CUSTOM_FACET_SORT,
 		DEFAULT_FACET_SORT,
-		CUSTOM_FACET_SORT
+		DEFAULT_FACETS_SHOWN
 	} from '$lib/constants/facets';
 	import { getUserSettings } from '$lib/contexts/userSettings';
 	import { getMatomoTracker } from '$lib/contexts/matomo';
 	import { popover } from '$lib/actions/popover';
 	import FacetRange from './FacetRange.svelte';
-	import DecoratedData from '../DecoratedData.svelte';
 	import BiChevronRight from '~icons/bi/chevron-right';
 	import BiSortDown from '~icons/bi/sort-down';
 	import BiCheckSquareFill from '~icons/bi/check-square-fill';
 	import BiSquare from '~icons/bi/square';
 	import BiInfo from '~icons/bi/info-circle';
+	import DecoratedDataLite from '$lib/components/DecoratedDataLite.svelte';
 
 	// Todo: Rename FacetGroup -> Facet (facets -> items/facetItems)
 
@@ -162,7 +161,7 @@
 									</div>
 								{/if}
 								<span>
-									<DecoratedData data={facet.object} showLabels={ShowLabelsOptions.Never} />
+									<DecoratedDataLite data={facet.object} />
 									{#if facet.discriminator}
 										<span class="text-subtle">({facet.discriminator})</span>
 									{/if}

--- a/lxl-web/src/lib/types/xl.ts
+++ b/lxl-web/src/lib/types/xl.ts
@@ -174,6 +174,9 @@ export interface LensedOrdered {
 }
 export type DisplayDecorated = unknown;
 
+export type StyleList = string[];
+export type DisplayDecoratedLite = (string | [string, StyleList])[];
+
 export interface VocabData {
 	'@context'?: string | Context;
 	'@graph': Record<string, unknown>[];

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -1,4 +1,4 @@
-import { DisplayUtil, isObject, toString, VocabUtil } from '$lib/utils/xl';
+import { DisplayUtil, isObject, toLite, toString, VocabUtil } from '$lib/utils/xl';
 import {
 	type DisplayDecorated,
 	type FramedData,
@@ -250,7 +250,7 @@ function displayFacetGroups(
 					...('_selected' in o && { selected: o._selected }),
 					totalItems: o.totalItems,
 					view: replacePath(o.view, usePath),
-					object: displayUtil.lensAndFormat(o.object, LensType.Chip, locale),
+					object: toLite(displayUtil.lensAndFormat(o.object, LensType.Chip, locale)),
 					str: toString(displayUtil.lensAndFormat(o.object, LensType.Chip, locale)) || '',
 					discriminator: getUriSlug(getAtPath(o.object, ['inScheme', JsonLd.ID], '')) || ''
 				};
@@ -296,7 +296,7 @@ function displayBoolFilters(
 			selected: o._selected || false,
 			totalItems: o.totalItems,
 			view: replacePath(o.view, usePath),
-			object: displayUtil.lensAndFormat(o.object, LensType.Chip, locale),
+			object: toLite(displayUtil.lensAndFormat(o.object, LensType.Chip, locale)),
 			str: toString(displayUtil.lensAndFormat(o.object, LensType.Chip, locale)) || '',
 			discriminator: '',
 			alias: o.object.alias

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -27,7 +27,8 @@ import {
 	type ShowProperties,
 	type RangeRestriction,
 	type AlternateProperties,
-	type LangContainer
+	type LangContainer,
+	type DisplayDecoratedLite
 } from '$lib/types/xl';
 
 // TODO TESTS!
@@ -918,9 +919,55 @@ export function toString(data: DisplayDecorated) {
 		}
 		return v.join('');
 	} else if (Array.isArray(data)) {
-		data.map(toString).join('');
+		return data.map(toString).join('');
 	} else {
 		return data;
+	}
+}
+
+export function toLite(data: DisplayDecorated): DisplayDecoratedLite {
+	const result: DisplayDecoratedLite = [];
+	// TODO is this what we always want?
+	if (data._display) {
+		_toLite(data._display, result);
+	} else if (typeof data === 'string') {
+		_toLite(data, result);
+	} else if (data[JsonLd.ID]) {
+		result.push(data[JsonLd.ID]);
+	}
+
+	return result;
+}
+
+function _toLite(data: DisplayDecorated, result: DisplayDecoratedLite) {
+	if (isObject(data)) {
+		const v = [];
+		if (Fmt.CONTENT_BEFORE in data && data[Fmt.CONTENT_BEFORE] !== '') {
+			v.push(data[Fmt.CONTENT_BEFORE]);
+		}
+		if (Fmt.DISPLAY in data) {
+			v.push(...data[Fmt.DISPLAY].map(toString));
+		}
+		v.push(
+			...Object.entries(data)
+				.filter(([k]) => !(Object.values(Fmt).includes(k) || [JsonLd.TYPE, JsonLd.ID].includes(k)))
+				.map(([, v]) => toString(v))
+		);
+		if (Fmt.CONTENT_AFTER in data && data[Fmt.CONTENT_AFTER] !== '') {
+			v.push(data[Fmt.CONTENT_AFTER]);
+		}
+		const str = v.join('');
+		if (Fmt.STYLE in data && data[Fmt.STYLE].length > 0) {
+			result.push([str, data[Fmt.STYLE]]);
+		} else {
+			result.push(str);
+		}
+	} else if (Array.isArray(data)) {
+		data.forEach((v) => _toLite(v, result));
+	} else if (typeof data === 'string') {
+		result.push(data);
+	} else if (data !== null) {
+		result.push(`${data}`);
 	}
 }
 


### PR DESCRIPTION
Add an experimental light-weight format for decorated data. Use it for facet values. This shaves ~300kb off of the response when doing a *-query.

data is either
* plain string
* string + array of style names

Nested data is just converted to strings for now.

example
```
[
  "Uppsala universitetsbibliotek",
  ", Ekonomikums bibliotek",
  [" (Ue)", ["sigel"]]
]
```

For facet values there is already a parameter "discriminator" that is ued for `inScheme`. Another option would be to use that for sigel as well.