### PR TITLE
feat(lxl-web): Clearer title links (LWS-377)

### DIFF
--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -80,7 +80,11 @@
 			<header class="card-header" id={titleId}>
 				<hgroup>
 					<h2 class="card-header-title text-base font-medium">
-						<a href={id} class="block hover:underline" aria-describedby={`${bodyId} ${footerId}`}>
+						<a
+							href={id}
+							class="decoration-subtle block underline decoration-dotted hover:decoration-solid focus:decoration-solid"
+							aria-describedby={`${bodyId} ${footerId}`}
+						>
 							<DecoratedData data={item['card-heading']} showLabels={ShowLabelsOptions.Never} />
 						</a>
 					</h2>


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-377](https://kbse.atlassian.net/browse/LWS-377)

### Solves

Clearer title links by adding a dotted underline (which becomes solid on hover/focus)

### Summary of changes

- Add dotted underline on title links

<img width="413" alt="Skärmavbild 2025-06-02 kl  10 39 43" src="https://github.com/user-attachments/assets/08d3113f-1e88-4805-82e5-71898c7ffd76" />
