### PR TITLE
Bugfix/holding modal etc

### DIFF
--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -253,7 +253,7 @@ export function getItemLinksByBibId(
 				const lopacLinksToItem = getLinksToItemFor(bibIdObj, fullHolderData, lopacPaths, locale);
 
 				const linkTemplateEod = getAtPath(fullHolderData, [BibDb.eodUri], []);
-				if (linkTemplateEod && linkTemplateEod.length !== 0) {
+				if (linkTemplateEod && linkTemplateEod.length) {
 					linksToItem = [linkTemplateEod.replace(/%BIB_*ID%/, bibIdObj.bibId), ...linksToItem];
 				}
 
@@ -262,20 +262,20 @@ export function getItemLinksByBibId(
 
 				const itemStatusUri = getAtPath(fullHolderData, [BibDb.ils, BibDb.itemStatusUri], []);
 
-				if (itemStatusUri && itemStatusUri.length !== 0) {
+				if (itemStatusUri && itemStatusUri.length) {
 					allLinks[BibDb.ItemStatus] = [itemStatusUri];
 				}
 
 				const linksToCatalog: string[] = [];
 				const linkToCatalog = getAtPath(fullHolderData, [BibDb.ils, 'url'], undefined);
-				if (linkToCatalog && linkToCatalog.length !== 0) {
+				if (linkToCatalog && linkToCatalog.length) {
 					linksToCatalog.push(linkToCatalog);
 					allLinks[BibDb.LinksToCatalog] = linksToCatalog;
 				}
 
 				const linksToSite: string[] = [];
 				const linkToSite = getAtPath(fullHolderData, ['url', JsonLd.ID], undefined);
-				if (linkToSite && linkToSite.length !== 0) {
+				if (linkToSite && linkToSite.length) {
 					linksToSite.push(linkToSite);
 					allLinks[BibDb.LinksToSite] = linksToSite;
 				}
@@ -292,7 +292,7 @@ export function getItemLinksByBibId(
 				const postalAddress = address.find((a) => a[JsonLd.TYPE] === BibDb.postalAddress);
 				const visitingAddress = address.find((a) => a[JsonLd.TYPE] === BibDb.visitingAddress);
 
-				if (address && address.length !== 0) {
+				if (address && address.length) {
 					addresses.push(
 						toString(displayUtil.lensAndFormat(visitingAddress, LensType.Card, locale)) || ''
 					);
@@ -302,15 +302,15 @@ export function getItemLinksByBibId(
 					allLinks[BibDb.Address] = addresses;
 				}
 
-				if (linksToItem.length !== 0) {
+				if (linksToItem.length) {
 					allLinks[BibDb.LinksToItem] = linksToItem;
 				}
 
-				if (lopacLinksToItem.length !== 0) {
+				if (lopacLinksToItem.length) {
 					allLinks[BibDb.LoanReserveLink] = lopacLinksToItem;
 				}
 
-				if (Object.keys(allLinks).length !== 0) {
+				if (Object.keys(allLinks).length) {
 					linksForHolder[sigel] = allLinks;
 				}
 			}
@@ -329,7 +329,7 @@ function getLinksToItemFor(
 	let linksToItem: string[] = [];
 	for (const path of paths) {
 		const linkTemplate = getAtPath(fullHolderData, path, []);
-		if (linkTemplate && linkTemplate.length !== 0) {
+		if (linkTemplate && linkTemplate.length) {
 			if (path.includes(BibDb.bibIdSearchUriByLang) && bibIdObj.bibId !== '') {
 				const linkTemplateLocalized =
 					linkTemplate[locale] || linkTemplate['sv'] || Object.values(linkTemplate)[0];
@@ -339,10 +339,10 @@ function getLinksToItemFor(
 				// forms in the wild %BIB_ID%, %BIBID%, more???
 				linksToItem = [linkTemplate.replace(/%BIB_*ID%/g, bibIdObj.bibId), ...linksToItem];
 			}
-			if (path.includes(BibDb.isbnSearchUri) && bibIdObj.isbn.length !== 0) {
+			if (path.includes(BibDb.isbnSearchUri) && bibIdObj.isbn.length) {
 				linksToItem = [linkTemplate.replace(/%ISBN%/g, bibIdObj.isbn), ...linksToItem];
 			}
-			if (path.includes(BibDb.issnSearchUri) && bibIdObj.issn.length !== 0) {
+			if (path.includes(BibDb.issnSearchUri) && bibIdObj.issn.length) {
 				linksToItem = [linkTemplate.replace(/%ISSN%/g, bibIdObj.issn), ...linksToItem];
 			}
 		}

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -250,7 +250,7 @@ export function getItemLinksByBibId(
 				const lopacPaths = [[BibDb.lopac, BibDb.bibIdSearchUriByLang]];
 
 				let linksToItem = getLinksToItemFor(bibIdObj, fullHolderData, ilsPaths, locale);
-				const lopacLinksItem = getLinksToItemFor(bibIdObj, fullHolderData, lopacPaths, locale);
+				const lopacLinksToItem = getLinksToItemFor(bibIdObj, fullHolderData, lopacPaths, locale);
 
 				const linkTemplateEod = getAtPath(fullHolderData, [BibDb.eodUri], []);
 				if (linkTemplateEod && linkTemplateEod.length !== 0) {
@@ -306,8 +306,8 @@ export function getItemLinksByBibId(
 					allLinks[BibDb.LinksToItem] = linksToItem;
 				}
 
-				if (lopacLinksItem.length !== 0) {
-					allLinks[BibDb.LoanReserveLink] = lopacLinksItem;
+				if (lopacLinksToItem.length !== 0) {
+					allLinks[BibDb.LoanReserveLink] = lopacLinksToItem;
 				}
 
 				if (Object.keys(allLinks).length !== 0) {
@@ -331,7 +331,9 @@ function getLinksToItemFor(
 		const linkTemplate = getAtPath(fullHolderData, path, []);
 		if (linkTemplate && linkTemplate.length !== 0) {
 			if (path.includes(BibDb.bibIdSearchUriByLang) && bibIdObj.bibId !== '') {
-				linksToItem = [linkTemplate[locale].replace(/%BIB_*ID%/g, bibIdObj.bibId), ...linksToItem];
+				const linkTemplateLocalized =
+					linkTemplate[locale] || linkTemplate['sv'] || Object.values(linkTemplate)[0];
+				linksToItem = [linkTemplateLocalized.replace(/%BIB_*ID%/g, bibIdObj.bibId), ...linksToItem];
 			}
 			if (path.includes(BibDb.bibIdSearchUri) && bibIdObj.bibId !== '') {
 				// forms in the wild %BIB_ID%, %BIBID%, more???

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { fade } from 'svelte/transition';
 	import type { BibIdObj, DecoratedHolder, ItemLinksByBibId } from '$lib/types/holdings';
 	import { BibDb } from '$lib/types/xl';
 	import type { HoldingStatus } from '$lib/types/api';

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingInfo.svelte
@@ -275,15 +275,6 @@
 		& .arrow {
 			@apply rotate-90;
 		}
-
-		& .holder-label {
-			white-space: normal;
-		}
-	}
-
-	.holder-label {
-		@apply flex-1 overflow-hidden text-ellipsis whitespace-nowrap;
-		@apply text-base font-medium;
 	}
 
 	.status-container {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
@@ -52,7 +52,7 @@
 </script>
 
 <li class="border-neutral text-sm not-last:border-b">
-	<h2 class="holder-label mt-4 line-clamp-1">
+	<h2 class="mt-4 line-clamp-2 text-base font-medium">
 		<DecoratedData data={holder.obj} showLabels={ShowLabelsOptions['Never']} />
 	</h2>
 	<div class="">
@@ -101,10 +101,8 @@
 	</div>
 	{#if hasOpeningHoursEtc()}
 		<details>
-			<summary class="my-3 flex cursor-pointer items-baseline">
-				<span
-					class="text-3xs arrow text-subtle mr-0.5 h-3 origin-center rotate-0 transition-transform"
-				>
+			<summary class="my-3 flex cursor-pointer items-baseline gap-0.5">
+				<span class="text-3xs arrow text-subtle h-3 origin-center rotate-0 transition-transform">
 					<BiChevronRight />
 				</span>
 				{page.data.t('holdings.openingHoursEtc')}
@@ -162,10 +160,6 @@
 		& .arrow {
 			@apply rotate-90;
 		}
-	}
-
-	.holder-label {
-		@apply line-clamp-2 text-base font-medium;
 	}
 
 	.status-container {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
@@ -40,6 +40,15 @@
 	function missingAtLeastOneLinkToItem() {
 		return bibIds.find((id) => !hasLinksToItem(id.bibId) && !hasLoanReserveLink(id.bibId));
 	}
+
+	function hasOpeningHoursEtc() {
+		const id = bibIds.at(0);
+		return (
+			id &&
+			(linksByBibId[id.bibId]?.[holder.sigel]?.[BibDb.OpeningHours] ||
+				linksByBibId[id.bibId]?.[holder.sigel]?.[BibDb.Address])
+		);
+	}
 </script>
 
 <li class="border-neutral text-sm not-last:border-b">
@@ -90,37 +99,39 @@
 			{/if}
 		</ul>
 	</div>
-	<details>
-		<summary class="my-3 flex cursor-pointer items-baseline">
-			<span
-				class="text-3xs arrow text-subtle mr-0.5 h-3 origin-center rotate-0 transition-transform"
-			>
-				<BiChevronRight />
-			</span>
-			{page.data.t('holdings.openingHoursEtc')}
-		</summary>
-		<div class="status-container border-neutral bg-page my-3 max-w-md rounded-sm border p-2">
-			<span>
-				{#if bibIds.at(0)}
-					{@const firstBibId = bibIds.at(0).bibId}
-					<ul style="white-space: pre-line">
-						{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.OpeningHours]}
-							<li>
-								{linksByBibId[firstBibId][holder.sigel][BibDb.OpeningHours].at(0)}
-							</li>
-						{/if}
-						{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.Address]}
-							{#each linksByBibId[firstBibId][holder.sigel][BibDb.Address] as address, index (index)}
-								<li class="my-2">
-									{address}
+	{#if hasOpeningHoursEtc()}
+		<details>
+			<summary class="my-3 flex cursor-pointer items-baseline">
+				<span
+					class="text-3xs arrow text-subtle mr-0.5 h-3 origin-center rotate-0 transition-transform"
+				>
+					<BiChevronRight />
+				</span>
+				{page.data.t('holdings.openingHoursEtc')}
+			</summary>
+			<div class="status-container border-neutral bg-page my-3 max-w-md rounded-sm border p-2">
+				<span>
+					{#if bibIds.at(0)}
+						{@const firstBibId = bibIds.at(0).bibId}
+						<ul style="white-space: pre-line">
+							{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.OpeningHours]}
+								<li>
+									{linksByBibId[firstBibId][holder.sigel][BibDb.OpeningHours].at(0)}
 								</li>
-							{/each}
-						{/if}
-					</ul>
-				{/if}
-			</span>
-		</div>
-	</details>
+							{/if}
+							{#if linksByBibId[firstBibId]?.[holder.sigel]?.[BibDb.Address]}
+								{#each linksByBibId[firstBibId][holder.sigel][BibDb.Address] as address, index (index)}
+									<li class="my-2">
+										{address}
+									</li>
+								{/each}
+							{/if}
+						</ul>
+					{/if}
+				</span>
+			</div>
+		</details>
+	{/if}
 </li>
 
 <style lang="postcss">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
@@ -43,7 +43,7 @@
 </script>
 
 <li class="border-neutral text-sm not-last:border-b">
-	<h2 class="holder-label mt-4">
+	<h2 class="holder-label mt-4 line-clamp-1">
 		<DecoratedData data={holder.obj} showLabels={ShowLabelsOptions['Never']} />
 	</h2>
 	<div class="">
@@ -151,15 +151,10 @@
 		& .arrow {
 			@apply rotate-90;
 		}
-
-		& .holder-label {
-			white-space: normal;
-		}
 	}
 
 	.holder-label {
-		@apply flex-1 overflow-hidden text-ellipsis whitespace-nowrap;
-		@apply text-base font-medium;
+		@apply line-clamp-2 text-base font-medium;
 	}
 
 	.status-container {
@@ -182,16 +177,5 @@
 
 	table td {
 		width: auto;
-	}
-
-	.indicator {
-		@apply mb-0.5 inline-block h-2.5 w-2.5 rounded-full align-middle;
-
-		&.unavailable {
-			background-color: var(--color-severe-500);
-		}
-		&.available {
-			background-color: var(--color-success);
-		}
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
@@ -43,11 +43,13 @@
 
 	function hasOpeningHoursEtc() {
 		const id = bibIds.at(0);
-		return (
-			id &&
-			(linksByBibId[id.bibId]?.[holder.sigel]?.[BibDb.OpeningHours] ||
-				linksByBibId[id.bibId]?.[holder.sigel]?.[BibDb.Address])
-		);
+		if (id) {
+			const openingHours = linksByBibId[id.bibId]?.[holder.sigel]?.[BibDb.OpeningHours];
+			const address = linksByBibId[id.bibId]?.[holder.sigel]?.[BibDb.Address];
+
+			return openingHours || address?.join('').trim();
+		}
+		return false;
 	}
 </script>
 


### PR DESCRIPTION
## Description

Cleanup and minor fixes

### Summary of changes

* Allow holder label to take up two rows before ellipsing
* Don't show opening hours/address, if empty
* Remove unused CSS 
* Default to locale code 'sv' if missing 'en' in language-tagged link templates 
