### PR TITLE
fix(lxl-web): Show search start content less often (LWS-372)

### DIFF
--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -39,9 +39,6 @@
 	border-radius: 0;
 }
 
-.lxl-qualifier-key {
-	margin-left: 1px;
-}
 .atomic {
 	background-color: var(--color-accent-100);
 	user-select: none;

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
@@ -70,7 +70,7 @@ class QualifierWidget extends WidgetType {
 	}
 	toDOM(): HTMLElement {
 		const container = document.createElement('span');
-		container.style.cssText = `position: relative; display:inline-flex`;
+		container.style.cssText = `position: relative; display:inline-flex; margin: 0 1px;`;
 		mount(this.qualifierWidget, {
 			props: {
 				key: this.key,


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-372](https://kbse.atlassian.net/browse/LWS-372)

### Solves

Shows the search start content a little less often as it could become intrusive when searching, e.g. when adding spaces after a string part.

The start content is now only shown if the value is empty or if the edited part is **NOT** part of a qualifier or a string  (including spaces).

TODO: fix start content visiblity when editing inside parentheses/groups (probably saved for a later PR).

### Summary of changes

- Show start content if not editing part of qualifier or string
- Ensure text cursor is visible before qualifier