### PR TITLE
fix(lxl-web): Wildcard flash when searching (LWS-379)

### DIFF
--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -214,12 +214,14 @@
 		expandedContentAttributesCompartment.of(initialExpandedContentAttributes)
 	]);
 
+	let showStartContent = $derived(shouldShowStartContentFn(value, selection));
+
 	function handleClickCollapsed() {
 		if (!dialog?.open) showExpandedSearch();
 	}
 
 	function setDefaultRowAndCols() {
-		if (!shouldShowStartContentFn(value, selection)) {
+		if (!showStartContent) {
 			activeRowIndex = defaultResultRow;
 			if (activeRowIndex > 0) {
 				activeColIndex = defaultResultCol;
@@ -633,7 +635,7 @@
 				})}
 			</div>
 			<nav class="supersearch-suggestions" role="rowgroup">
-				{#if startContent && shouldShowStartContentFn(value, selection)}
+				{#if startContent && showStartContent}
 					{@render startContent({
 						getCellId: (rowIndex: number, colIndex: number) => `${id}-item-${rowIndex}x${colIndex}`,
 						isFocusedCell: (rowIndex: number, colIndex: number) =>

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -121,6 +121,7 @@
 	let activeRowIndex: number = $state(0);
 	let activeColIndex: number = $state(0);
 	let prevValue: string = value;
+	let showResults: boolean = $state(true);
 
 	let allowArrowKeyCursorHandling: { vertical: boolean; horizontal: boolean } = $state({
 		vertical: true,
@@ -215,6 +216,14 @@
 	]);
 
 	let showStartContent = $derived(shouldShowStartContentFn(value, selection));
+
+	$effect(() => {
+		if (showStartContent) {
+			showResults = false;
+		} else if (!showResults && value === search.lastSettledQueryValue) {
+			showResults = true;
+		}
+	});
 
 	function handleClickCollapsed() {
 		if (!dialog?.open) showExpandedSearch();
@@ -653,7 +662,7 @@
 						</div>
 					{/if}
 					{#if selection?.anchor === selection?.head}
-						{#if search.data}
+						{#if search.data && showResults}
 							{@const resultItemRows =
 								(Array.isArray(search.paginatedData) &&
 									search.paginatedData.map((page) => page.items).flat()) ||

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -220,7 +220,7 @@
 	$effect(() => {
 		if (showStartContent) {
 			showResults = false;
-		} else if (!showResults && value === search.lastSettledQueryValue) {
+		} else if (!showResults && value === search.lastSuccesfulQuery) {
 			showResults = true;
 		}
 	});

--- a/packages/supersearch/src/lib/utils/useSearchRequest.svelte.ts
+++ b/packages/supersearch/src/lib/utils/useSearchRequest.svelte.ts
@@ -23,6 +23,7 @@ export function useSearchRequest({
 	let error: string | undefined = $state();
 	let data = $state();
 	let paginatedData = $state();
+	let lastSettledQueryValue: string | undefined = $state();
 	let moreSearchParams: URLSearchParams | undefined = $state();
 	const hasMorePaginatedData = $derived(!!moreSearchParams);
 
@@ -63,6 +64,7 @@ export function useSearchRequest({
 
 	async function fetchData(query: string, cursor: number) {
 		data = await _fetchData(queryFn(query, cursor));
+		lastSettledQueryValue = query;
 		if (paginationQueryFn) {
 			paginatedData = [data];
 		}
@@ -105,6 +107,9 @@ export function useSearchRequest({
 		},
 		get hasMorePaginatedData() {
 			return hasMorePaginatedData;
+		},
+		get lastSettledQueryValue() {
+			return lastSettledQueryValue;
 		}
 	};
 }

--- a/packages/supersearch/src/lib/utils/useSearchRequest.svelte.ts
+++ b/packages/supersearch/src/lib/utils/useSearchRequest.svelte.ts
@@ -23,7 +23,7 @@ export function useSearchRequest({
 	let error: string | undefined = $state();
 	let data = $state();
 	let paginatedData = $state();
-	let lastSettledQueryValue: string | undefined = $state();
+	let lastSuccesfulQuery: string | undefined = $state();
 	let moreSearchParams: URLSearchParams | undefined = $state();
 	const hasMorePaginatedData = $derived(!!moreSearchParams);
 
@@ -64,7 +64,7 @@ export function useSearchRequest({
 
 	async function fetchData(query: string, cursor: number) {
 		data = await _fetchData(queryFn(query, cursor));
-		lastSettledQueryValue = query;
+		lastSuccesfulQuery = query;
 		if (paginationQueryFn) {
 			paginatedData = [data];
 		}
@@ -108,8 +108,8 @@ export function useSearchRequest({
 		get hasMorePaginatedData() {
 			return hasMorePaginatedData;
 		},
-		get lastSettledQueryValue() {
-			return lastSettledQueryValue;
+		get lastSuccesfulQuery() {
+			return lastSuccesfulQuery;
 		}
 	};
 }


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-379](https://kbse.atlassian.net/browse/LWS-379)

### Solves

Fixes flashes of wildcard results which could appear while searching (e.g. when the user types after having added a qualifier).

### Summary of changes

- Call `shouldShowStartContentFn` only once
- Fix flash of wildcard results when searching