### PR TITLE
fix(lxlweb): Fix isFindPage route check

### DIFF
--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -45,7 +45,7 @@
 	});
 
 	let cursor = $derived(selection?.head || 0);
-	const isFindPage = $derived(page.url.pathname === '/find');
+	const isFindPage = $derived(page.route.id === '/(app)/[[lang=lang]]/find');
 
 	let superSearch = $state<ReturnType<typeof SuperSearch>>();
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteHeader.svelte
@@ -11,7 +11,7 @@
 	let showHeaderMenu = $state(false);
 	let bannerOffsetHeight: number | undefined = $state();
 	let superSearchWrapperComponent: SvelteComponent;
-	const isFindPage = $derived(page.url.pathname === '/find');
+	const isFindPage = $derived(page.route.id === '/(app)/[[lang=lang]]/find');
 
 	function toggleHeaderMenu() {
 		showHeaderMenu = !showHeaderMenu;


### PR DESCRIPTION
## Description

### Solves

/find page looks different on mobile with language set to english 🤔 
Because the flawed `isFindRoute` does not match route /en/find...
I guess `route.id` is a more reliable thing to check.

### Summary of changes

* Check `isFindPage` using route id instead of url pathname
