### PR TITLE
fix(lxl-web): Show search start content on initial free-text queries (LWS-380)

### DIFF
--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -119,15 +119,17 @@
 
 	function addQualifierKey(qualifierKey: string) {
 		superSearch?.showExpandedSearch(); // keep dialog open (since 'regular' search is hidden on mobile)
+		const charBeforeSelection = q.slice(cursor - 1, cursor);
+		const insert = (charBeforeSelection ? ' ' : '') + `${qualifierKey}:`; // Add extra whitespace before if there already is a character infront of the qualifier key
 		superSearch?.dispatchChange({
 			change: {
 				from: cursor,
 				to: cursor,
-				insert: `${qualifierKey}:`
+				insert
 			},
 			selection: {
-				anchor: cursor + qualifierKey?.length + 1,
-				head: cursor + qualifierKey?.length + 1
+				anchor: cursor + insert.length,
+				head: cursor + insert.length
 			},
 			userEvent: 'input.complete'
 		});

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -155,6 +155,7 @@
 			selection: { anchor: insertCursor, head: insertCursor },
 			userEvent: 'delete'
 		});
+		superSearch?.hideExpandedSearch();
 		goto('/find?' + newSearchParams.toString());
 	}
 

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -27,6 +27,7 @@
 			? ''
 			: addSpaceIfEndingQualifier(page.url.searchParams.get('_q')?.trim() || '')
 	);
+	let initialQ: string | undefined;
 	let selection: Selection | undefined = $state();
 
 	let isLoading: boolean | undefined = $state();
@@ -65,6 +66,7 @@
 		if (to?.url) {
 			const toQ = addSpaceIfEndingQualifier(new URL(to.url).searchParams.get('_q')?.trim() || '');
 			q = page.params.fnurgel ? '' : toQ !== '*' ? toQ : ''; // hide wildcard in input field
+			initialQ = q;
 			superSearch?.hideExpandedSearch();
 		}
 	});
@@ -80,6 +82,12 @@
 	function handleShouldShowStartContent(value: string, selection?: Selection) {
 		/* Show start content if empty */
 		if (!value.trim()) {
+			return true;
+		}
+
+		/* Show start content if value is equal to initial value, or value set after navigation */
+		if (q === initialQ) {
+			initialQ = undefined; // set to undefined so results are shown if the user adds a character and then removes it
 			return true;
 		}
 


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-380](https://kbse.atlassian.net/browse/LWS-380)

### Solves

Shows the search start content if there is an initial free-text query on load (or after navigating).
Suggestions/results are shown if the user edits the query (also if they revert the newly added changes).

### Summary of changes

- Show start content on initial free-text queries
- Add extra whitespace if char before qualifier key
- Prevent flash of old results when removing qualifiers
