### PR TITLE
fix(lxlweb): Fix suggestion link id, write tests (LWS-349)

### DIFF
--- a/lxl-web/src/lib/components/supersearch/Suggestion.svelte
+++ b/lxl-web/src/lib/components/supersearch/Suggestion.svelte
@@ -145,7 +145,7 @@
 			{/key}
 		</button>
 	{:else}
-		<a href={resourceId}>
+		<a href={resourceId} id={getCellId(0)}>
 			{@render resourceSnippet(item)}
 		</a>
 	{/if}

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -1,0 +1,38 @@
+// test implentation of supersearch in lxlweb
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+	await page.goto('/');
+});
+
+test('click input expands dialog', async ({ page }) => {
+	const dialog = await page.locator('#supersearch-dialog');
+	await expect(dialog).not.toHaveAttribute('open');
+	await page.getByTestId('main-search').click();
+	await expect(dialog).toHaveAttribute('open');
+});
+
+test('type & enter performs search', async ({ page }) => {
+	await page.getByRole('combobox').fill('hej');
+	await page.keyboard.press('Enter');
+	await expect(page).toHaveURL('/find?_q=hej&_limit=20&_offset=0&_sort=&_spell=true');
+});
+
+test('start content shown on empty input', async ({ page }) => {
+	await page.getByTestId('main-search').click();
+	await expect(page.getByText('Bygg och förfina din sökning')).toBeVisible();
+});
+
+test('8 suggestions shown after typing', async ({ page }) => {
+	await page.getByRole('combobox').fill('hej');
+	await expect(page.getByText('Bygg och förfina din sökning')).not.toBeVisible();
+	await expect(await page.locator('.suggestion')).toHaveCount(8);
+});
+
+test('navigate to suggested resource using keyboard', async ({ page }) => {
+	await page.getByRole('combobox').fill('a');
+	await expect(await page.locator('.suggestion')).toHaveCount(8);
+	await page.keyboard.press('ArrowDown');
+	await page.keyboard.press('Enter');
+	await expect(page.locator('.resource-page')).toBeVisible();
+});


### PR DESCRIPTION
[LWS-349](https://kbse.atlassian.net/browse/LWS-349)

## Description

### Solves

Caught a regression where you can no longer navigate to a suggestion using the keyboard, since the required `id` was missing from the link element.

This really brought forward the need for tests of our real-world supersearch implementation. I wrote a few very basic ones, including the use case fixed here.

We should add more for every new feature we implement...

### Summary of changes

* Fix suggestion id for links
* Write supersearch-lxlweb tests
