### PR TITLE
feat(lxlweb/facets): Save facet expanded state. Move free online to top.

### DIFF
--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -23,10 +23,10 @@
 		group: FacetGroup;
 		locale: LocaleCode;
 		searchPhrase: string;
-		defaultExpanded: boolean;
+		isDefaultExpanded: boolean;
 	};
 
-	let { group, locale, searchPhrase, defaultExpanded }: FacetGroupProps = $props();
+	let { group, locale, searchPhrase, isDefaultExpanded }: FacetGroupProps = $props();
 
 	const matomoTracker = getMatomoTracker();
 	const userSettings = getUserSettings();
@@ -44,7 +44,7 @@
 	let userExpanded = $derived(
 		userSettings.facetExpanded?.[group.dimension]
 			? userSettings.facetExpanded?.[group.dimension] === ExpandState.OPEN
-			: defaultExpanded
+			: isDefaultExpanded
 	);
 
 	const sortOptions = [

--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -15,7 +15,7 @@
 	import BiSortDown from '~icons/bi/sort-down';
 	import BiInfo from '~icons/bi/info-circle';
 	import FacetValue from '$lib/components/find/FacetValue.svelte';
-	import { ExpandState } from '$lib/types/userSettings';
+	import { ExpandedState } from '$lib/types/userSettings';
 
 	// Todo: Rename FacetGroup -> Facet (facets -> items/facetItems)
 
@@ -43,7 +43,7 @@
 
 	let userExpanded = $derived(
 		userSettings.facetExpanded?.[group.dimension]
-			? userSettings.facetExpanded?.[group.dimension] === ExpandState.OPEN
+			? userSettings.facetExpanded?.[group.dimension] === ExpandedState.OPEN
 			: isDefaultExpanded
 	);
 

--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -5,7 +5,7 @@
 	import {
 		CUSTOM_FACET_SORT,
 		DEFAULT_FACET_SORT,
-		DEFAULT_FACETS_SHOWN
+		DEFAULT_FACET_VALUES_SHOWN
 	} from '$lib/constants/facets';
 	import { getUserSettings } from '$lib/contexts/userSettings';
 	import { getMatomoTracker } from '$lib/contexts/matomo';
@@ -13,10 +13,8 @@
 	import FacetRange from './FacetRange.svelte';
 	import BiChevronRight from '~icons/bi/chevron-right';
 	import BiSortDown from '~icons/bi/sort-down';
-	import BiCheckSquareFill from '~icons/bi/check-square-fill';
-	import BiSquare from '~icons/bi/square';
 	import BiInfo from '~icons/bi/info-circle';
-	import DecoratedDataLite from '$lib/components/DecoratedDataLite.svelte';
+	import FacetValue from '$lib/components/find/FacetValue.svelte';
 
 	// Todo: Rename FacetGroup -> Facet (facets -> items/facetItems)
 
@@ -33,7 +31,7 @@
 
 	const maxItems = group.maxItems;
 	const totalItems = group.facets.length;
-	let defaultItemsShown = $state(DEFAULT_FACETS_SHOWN);
+	let defaultItemsShown = $state(DEFAULT_FACET_VALUES_SHOWN);
 
 	let currentSort = $state(
 		userSettings.facetSort?.[group.dimension] ||
@@ -83,7 +81,7 @@
 	let hasHits = $derived(filteredItems.length > 0);
 	const canShowMoreItems = $derived(filteredItems.length > defaultItemsShown);
 	const canShowFewerItems = $derived(
-		!canShowMoreItems && filteredItems.length > DEFAULT_FACETS_SHOWN
+		!canShowMoreItems && filteredItems.length > DEFAULT_FACET_VALUES_SHOWN
 	);
 	const maxItemsReached = $derived(totalItems === maxItems);
 
@@ -140,37 +138,7 @@
 			>
 				{#each shownItems as facet (facet.view['@id'])}
 					<li class="hover:bg-primary-100">
-						<a
-							class="facet-link ml-4.5 grid grid-cols-[auto_auto] items-end justify-between gap-2 border-l border-l-neutral-200 py-1.5 pr-3 pl-4 font-normal no-underline"
-							href={facet.view['@id']}
-						>
-							<span class="truncate" title={facet.str}>
-								{#if 'selected' in facet}
-									<!-- checkboxes -->
-									<span class="sr-only"
-										>{facet.selected ? page.data.t('search.activeFilter') : ''}</span
-									>
-									<div class="mr-1 inline-block text-xs" aria-hidden="true">
-										{#if facet.selected}
-											<BiCheckSquareFill class="text-accent" />
-										{:else}
-											<BiSquare class="text-subtle" />
-										{/if}
-									</div>
-								{/if}
-								<span>
-									<DecoratedDataLite data={facet.object} />
-									{#if facet.discriminator}
-										<span class="text-subtle">({facet.discriminator})</span>
-									{/if}
-								</span>
-							</span>
-							{#if facet.totalItems > 0}
-								<span class="badge" aria-label="{facet.totalItems} {page.data.t('search.hits')}"
-									>{facet.totalItems.toLocaleString(locale)}</span
-								>
-							{/if}
-						</a>
+						<FacetValue {facet} {locale} />
 					</li>
 				{/each}
 			</ol>
@@ -182,7 +150,7 @@
 						onclick={() =>
 							canShowMoreItems
 								? (defaultItemsShown = totalItems)
-								: (defaultItemsShown = DEFAULT_FACETS_SHOWN)}
+								: (defaultItemsShown = DEFAULT_FACET_VALUES_SHOWN)}
 					>
 						<span class="ml-4.5 block border-l border-l-neutral-200 py-1.5 pr-3 pl-4 text-left">
 							{canShowMoreItems
@@ -226,6 +194,10 @@
 
 	/* hide sorting for bool filters */
 	li[data-dimension='boolFilters'] details[open] .facet-sort {
+		display: none;
+	}
+
+	li[data-dimension='accessFilters'] details[open] .facet-sort {
 		display: none;
 	}
 </style>

--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -41,7 +41,7 @@
 			DEFAULT_FACET_SORT
 	);
 
-	let userExpanded = $derived(
+	let isUserOrDefaultExpanded = $derived(
 		userSettings.facetExpanded?.[group.dimension]
 			? userSettings.facetExpanded?.[group.dimension] === ExpandedState.OPEN
 			: isDefaultExpanded
@@ -87,7 +87,7 @@
 
 	const shownItems = $derived(filteredItems.filter((facet, index) => index < defaultItemsShown));
 	let hasHits = $derived(filteredItems.length > 0);
-	let expanded = $derived(userExpanded || (searchPhrase && hasHits));
+	let expanded = $derived(isUserOrDefaultExpanded || (searchPhrase && hasHits));
 	const canShowMoreItems = $derived(filteredItems.length > defaultItemsShown);
 	const canShowFewerItems = $derived(
 		!canShowMoreItems && filteredItems.length > DEFAULT_FACET_VALUES_SHOWN

--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -31,6 +31,8 @@
 	const matomoTracker = getMatomoTracker();
 	const userSettings = getUserSettings();
 
+	let detailsEl: HTMLDetailsElement | undefined = undefined;
+
 	const maxItems = group.maxItems;
 	const totalItems = group.facets.length;
 	let defaultItemsShown = $state(DEFAULT_FACET_VALUES_SHOWN);
@@ -105,8 +107,10 @@
 	}
 
 	function saveUserExpanded(e: Event): void {
-		const target = e.target as HTMLDetailsElement;
-		userSettings.saveFacetExpanded(group.dimension, target.open);
+		e.preventDefault();
+		if (detailsEl) {
+			userSettings.saveFacetExpanded(group.dimension, !detailsEl.open);
+		}
 	}
 </script>
 
@@ -115,10 +119,11 @@
 	class:has-hits={hasHits}
 	data-dimension={group.dimension}
 >
-	<details class="relative" open={!!expanded} ontoggle={saveUserExpanded}>
+	<details class="relative" open={!!expanded} bind:this={detailsEl}>
 		<summary
 			class="hover:bg-primary-100 flex min-h-9 w-full cursor-pointer items-center gap-2 pr-12 pl-3 text-xs font-medium"
 			data-testid="facet-toggle"
+			onclick={saveUserExpanded}
 		>
 			<span class="arrow text-subtle transition-transform">
 				<BiChevronRight />
@@ -176,7 +181,7 @@
 				<!-- limit reached info -->
 				{#if maxItemsReached && (canShowFewerItems || (!canShowMoreItems && searchPhrase))}
 					<button
-						class="text-error bg-severe-50 m-6 flex items-center gap-1 rounded-sm px-2 py-1"
+						class="text-error bg-severe-50 m-3 flex items-center gap-1 rounded-sm px-2 py-1"
 						use:popover={{
 							title: page.data.t('facet.limitText'),
 							placeAsSibling: false

--- a/lxl-web/src/lib/components/find/FacetValue.svelte
+++ b/lxl-web/src/lib/components/find/FacetValue.svelte
@@ -1,43 +1,42 @@
 <script lang="ts">
-    import { page } from '$app/state';
+	import { page } from '$app/state';
 
-    import BiCheckSquareFill from '~icons/bi/check-square-fill';
-    import BiSquare from '~icons/bi/square';
-    import DecoratedDataLite from '$lib/components/DecoratedDataLite.svelte';
-    import type { Facet, MultiSelectFacet } from '$lib/types/search';
-    import type { LocaleCode } from '$lib/i18n/locales';
+	import BiCheckSquareFill from '~icons/bi/check-square-fill';
+	import BiSquare from '~icons/bi/square';
+	import DecoratedDataLite from '$lib/components/DecoratedDataLite.svelte';
+	import type { Facet, MultiSelectFacet } from '$lib/types/search';
+	import type { LocaleCode } from '$lib/i18n/locales';
 
-    export let facet: Facet | MultiSelectFacet;
-    export let locale: LocaleCode;
-	export let padStyle = "border-l border-l-neutral-200 pl-4 ml-4.5"
+	export let facet: Facet | MultiSelectFacet;
+	export let locale: LocaleCode;
 </script>
 
 <a
-        class="facet-link grid grid-cols-[auto_auto] items-end justify-between gap-2 py-1.5 pr-3 font-normal no-underline {padStyle}"
-        href={facet.view['@id']}
+	class="facet-link ml-4.5 grid grid-cols-[auto_auto] items-end justify-between gap-2 border-l border-l-neutral-200 py-1.5 pr-3 pl-4 font-normal no-underline"
+	href={facet.view['@id']}
 >
 	<span class="truncate" title={facet.str}>
 		{#if 'selected' in facet}
 			<!-- checkboxes -->
-			<span class="sr-only"
-			>{facet.selected ? page.data.t('search.activeFilter') : ''}</span
-			>
+			<span class="sr-only">{facet.selected ? page.data.t('search.activeFilter') : ''}</span>
 			<div class="mr-1 inline-block text-xs" aria-hidden="true">
 				{#if facet.selected}
-					<BiCheckSquareFill class="text-accent"/>
+					<BiCheckSquareFill class="text-accent" />
 				{:else}
-					<BiSquare class="text-subtle"/>
+					<BiSquare class="text-subtle" />
 				{/if}
 			</div>
 		{/if}
 		<span>
-			<DecoratedDataLite data={facet.object}/>
+			<DecoratedDataLite data={facet.object} />
 			{#if facet.discriminator}
 				<span class="text-subtle">({facet.discriminator})</span>
 			{/if}
 		</span>
 	</span>
-    {#if facet.totalItems > 0}
-		<span class="badge" aria-label="{facet.totalItems} {page.data.t('search.hits')}">{facet.totalItems.toLocaleString(locale)}</span>
-    {/if}
+	{#if facet.totalItems > 0}
+		<span class="badge" aria-label="{facet.totalItems} {page.data.t('search.hits')}"
+			>{facet.totalItems.toLocaleString(locale)}</span
+		>
+	{/if}
 </a>

--- a/lxl-web/src/lib/components/find/FacetValue.svelte
+++ b/lxl-web/src/lib/components/find/FacetValue.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+    import { page } from '$app/state';
+
+    import BiCheckSquareFill from '~icons/bi/check-square-fill';
+    import BiSquare from '~icons/bi/square';
+    import DecoratedDataLite from '$lib/components/DecoratedDataLite.svelte';
+    import type { Facet, MultiSelectFacet } from '$lib/types/search';
+    import type { LocaleCode } from '$lib/i18n/locales';
+
+    export let facet: Facet | MultiSelectFacet;
+    export let locale: LocaleCode;
+	export let padStyle = "border-l border-l-neutral-200 pl-4 ml-4.5"
+</script>
+
+<a
+        class="facet-link grid grid-cols-[auto_auto] items-end justify-between gap-2 py-1.5 pr-3 font-normal no-underline {padStyle}"
+        href={facet.view['@id']}
+>
+	<span class="truncate" title={facet.str}>
+		{#if 'selected' in facet}
+			<!-- checkboxes -->
+			<span class="sr-only"
+			>{facet.selected ? page.data.t('search.activeFilter') : ''}</span
+			>
+			<div class="mr-1 inline-block text-xs" aria-hidden="true">
+				{#if facet.selected}
+					<BiCheckSquareFill class="text-accent"/>
+				{:else}
+					<BiSquare class="text-subtle"/>
+				{/if}
+			</div>
+		{/if}
+		<span>
+			<DecoratedDataLite data={facet.object}/>
+			{#if facet.discriminator}
+				<span class="text-subtle">({facet.discriminator})</span>
+			{/if}
+		</span>
+	</span>
+    {#if facet.totalItems > 0}
+		<span class="badge" aria-label="{facet.totalItems} {page.data.t('search.hits')}">{facet.totalItems.toLocaleString(locale)}</span>
+    {/if}
+</a>

--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { getModalContext } from '$lib/contexts/modal';
-	import type { DisplayMapping, Facet, FacetGroup as TypedFacetGroup } from '$lib/types/search';
+	import type { DisplayMapping, FacetGroup as TypedFacetGroup } from '$lib/types/search';
 	import FacetGroup from './FacetGroup.svelte';
 	import MyLibrariesFilter from './MyLibrariesFilter.svelte';
 	import SearchMapping from './SearchMapping.svelte';
@@ -38,40 +38,42 @@
 			<SearchMapping {mapping} />
 		</nav>
 	{/if}
-	<nav
+	{#if facets?.length}
+		<nav
 			class="facet-nav relative flex flex-col gap-2 text-sm"
 			aria-label={page.data.t('search.filters')}
 			data-testid="facets"
-	>
-		<div class="px-3">
-			<input
+		>
+			<div class="px-3">
+				<input
 					bind:value={searchPhrase}
 					placeholder={page.data.t('search.findFilter')}
 					aria-label={page.data.t('search.findFilter')}
 					class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-xs"
 					type="search"
-			/>
-			<BiSearch class="text-subtle absolute top-0 left-6 h-9" />
-		</div>
-		<div class="px-3">
+				/>
+				<BiSearch class="text-subtle absolute top-0 left-6 h-9" />
+			</div>
 			{#if page.route.id === '/(app)/[[lang=lang]]/find'}
-				<MyLibrariesFilter {facets} />
+				<div class="px-3">
+					<MyLibrariesFilter {facets} />
+				</div>
 			{/if}
-		</div>
-		<ol>
-			{#each facets as group, i (group.dimension)}
-				<FacetGroup
+			<ol>
+				{#each facets as group, i (group.dimension)}
+					<FacetGroup
 						{group}
 						locale={page.data.locale}
 						{searchPhrase}
 						defaultExpanded={i < DEFAULT_FACETS_EXPANDED}
-				/>
-			{/each}
-		</ol>
-		<span role="status" class="no-hits-msg px-2 text-xs" aria-atomic="true"
-		>{page.data.t('search.noResults')}</span
-		>
-	</nav>
+					/>
+				{/each}
+			</ol>
+			<span role="status" class="no-hits-msg px-2 text-xs" aria-atomic="true"
+				>{page.data.t('search.noResults')}</span
+			>
+		</nav>
+	{/if}
 </div>
 
 <style lang="postcss">

--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -6,6 +6,7 @@
 	import MyLibrariesFilter from './MyLibrariesFilter.svelte';
 	import SearchMapping from './SearchMapping.svelte';
 	import BiSearch from '~icons/bi/search';
+	import { DEFAULT_FACETS_EXPANDED } from '$lib/constants/facets';
 
 	type filtersPropsType = {
 		facets: TypedFacetGroup[];
@@ -58,8 +59,13 @@
 			{/if}
 		</div>
 		<ol>
-			{#each facets as group (group.dimension)}
-				<FacetGroup {group} locale={page.data.locale} {searchPhrase} />
+			{#each facets as group, i (group.dimension)}
+				<FacetGroup
+						{group}
+						locale={page.data.locale}
+						{searchPhrase}
+						defaultExpanded={i < DEFAULT_FACETS_EXPANDED}
+				/>
 			{/each}
 		</ol>
 		<span role="status" class="no-hits-msg px-2 text-xs" aria-atomic="true"

--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { getModalContext } from '$lib/contexts/modal';
-	import type { DisplayMapping, FacetGroup as TypedFacetGroup } from '$lib/types/search';
+	import type { DisplayMapping, Facet, FacetGroup as TypedFacetGroup } from '$lib/types/search';
 	import FacetGroup from './FacetGroup.svelte';
 	import MyLibrariesFilter from './MyLibrariesFilter.svelte';
 	import SearchMapping from './SearchMapping.svelte';
@@ -37,37 +37,35 @@
 			<SearchMapping {mapping} />
 		</nav>
 	{/if}
-	{#if facets?.length}
-		<nav
+	<nav
 			class="facet-nav relative flex flex-col gap-2 text-sm"
 			aria-label={page.data.t('search.filters')}
 			data-testid="facets"
-		>
-			<div class="px-3">
-				<input
+	>
+		<div class="px-3">
+			<input
 					bind:value={searchPhrase}
 					placeholder={page.data.t('search.findFilter')}
 					aria-label={page.data.t('search.findFilter')}
 					class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-xs"
 					type="search"
-				/>
-				<BiSearch class="text-subtle absolute top-0 left-6 h-9" />
-			</div>
+			/>
+			<BiSearch class="text-subtle absolute top-0 left-6 h-9" />
+		</div>
+		<div class="px-3">
 			{#if page.route.id === '/(app)/[[lang=lang]]/find'}
-				<div class="px-3">
-					<MyLibrariesFilter {facets} />
-				</div>
+				<MyLibrariesFilter {facets} />
 			{/if}
-			<ol>
-				{#each facets as group (group.dimension)}
-					<FacetGroup {group} locale={page.data.locale} {searchPhrase} />
-				{/each}
-			</ol>
-			<span role="status" class="no-hits-msg px-2 text-xs" aria-atomic="true"
-				>{page.data.t('search.noResults')}</span
-			>
-		</nav>
-	{/if}
+		</div>
+		<ol>
+			{#each facets as group (group.dimension)}
+				<FacetGroup {group} locale={page.data.locale} {searchPhrase} />
+			{/each}
+		</ol>
+		<span role="status" class="no-hits-msg px-2 text-xs" aria-atomic="true"
+		>{page.data.t('search.noResults')}</span
+		>
+	</nav>
 </div>
 
 <style lang="postcss">

--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -69,7 +69,7 @@
 					/>
 				{/each}
 			</ol>
-			<span role="status" class="no-hits-msg px-2 text-xs" aria-atomic="true"
+			<span role="status" class="no-hits-msg px-4 text-xs" aria-atomic="true"
 				>{page.data.t('search.noResults')}</span
 			>
 		</nav>

--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -65,7 +65,7 @@
 						{group}
 						locale={page.data.locale}
 						{searchPhrase}
-						defaultExpanded={i < DEFAULT_FACETS_EXPANDED}
+						isDefaultExpanded={i < DEFAULT_FACETS_EXPANDED}
 					/>
 				{/each}
 			</ol>

--- a/lxl-web/src/lib/components/find/MyLibrariesFilter.svelte
+++ b/lxl-web/src/lib/components/find/MyLibrariesFilter.svelte
@@ -32,7 +32,7 @@
 </script>
 
 {#snippet filterContent()}
-	<div class="flex items-baseline gap-2 text-xs">
+	<div class="flex items-baseline gap-2 pl-2 text-xs">
 		<span class="sr-only">{isFilterActive ? page.data.t('search.activeFilter') : ''}</span>
 		<div
 			class={['text-subtle bg-page flex rounded-sm', !myLibrariesValues.length && 'text-subtle/50']}
@@ -48,9 +48,7 @@
 	</div>
 {/snippet}
 
-<div
-	class="text-2xs bg-accent-50 border-neutral flex w-full gap-2 rounded-sm border-b p-3 lg:flex-col lg:gap-1"
->
+<div class="text-2xs bg-accent-50 border-neutral flex w-full gap-2 rounded-sm border-b p-3 lg:flex-col lg:gap-1">
 	{#if myLibrariesValues.length}
 		<a class="no-underline" href={isFilterActive ? removeFilterUrl : applyFilterUrl}>
 			{@render filterContent()}

--- a/lxl-web/src/lib/constants/facets.ts
+++ b/lxl-web/src/lib/constants/facets.ts
@@ -1,3 +1,4 @@
+export const DEFAULT_FACETS_EXPANDED = 4;
 export const DEFAULT_FACET_VALUES_SHOWN = 5;
 export const DEFAULT_FACET_SORT = 'hits.desc';
 export const CUSTOM_FACET_SORT = {

--- a/lxl-web/src/lib/constants/facets.ts
+++ b/lxl-web/src/lib/constants/facets.ts
@@ -1,7 +1,8 @@
-export const DEFAULT_FACETS_SHOWN = 5;
+export const DEFAULT_FACET_VALUES_SHOWN = 5;
 export const DEFAULT_FACET_SORT = 'hits.desc';
 export const CUSTOM_FACET_SORT = {
 	bibliography: 'alpha.asc',
 	itemHeldBy: 'alpha.asc'
 };
+export const TOP_FACETS = ['freeOnline'];
 export const MY_LIBRARIES_FILTER_ALIAS = 'alias-myLibraries';

--- a/lxl-web/src/lib/constants/facets.ts
+++ b/lxl-web/src/lib/constants/facets.ts
@@ -5,5 +5,5 @@ export const CUSTOM_FACET_SORT = {
 	bibliography: 'alpha.asc',
 	itemHeldBy: 'alpha.asc'
 };
-export const TOP_FACETS = ['freeOnline'];
+export const ACCESS_FILTERS = ['freeOnline'];
 export const MY_LIBRARIES_FILTER_ALIAS = 'alias-myLibraries';

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -82,6 +82,7 @@ export default {
 		nationality: 'Nationality',
 		hasOccupation: 'Has Occupation',
 		fieldOfActivity: 'Field of Activity',
+		accessFilters: 'Access',
 		boolFilters: 'Other',
 		limitInfo: 'Some options are not displayed',
 		limitText:

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -81,6 +81,7 @@ export default {
 		nationality: 'Nationalitet/verksamhetsland',
 		hasOccupation: 'Har yrke eller sysselsättning',
 		fieldOfActivity: 'Verksamhetsområde',
+		accessFilters: 'Åtkomst',
 		boolFilters: 'Övrigt',
 		limitInfo: 'Alla val kan ej visas',
 		limitText:

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -123,7 +123,7 @@ interface Slice {
 	maxItems: number;
 }
 
-interface Observation {
+export interface Observation {
 	totalItems: number;
 	view: Link;
 	object: FramedData;

--- a/lxl-web/src/lib/types/userSettings.ts
+++ b/lxl-web/src/lib/types/userSettings.ts
@@ -6,9 +6,17 @@ export interface LibraryItem {
 	sigel: string;
 }
 
+export enum ExpandState {
+	OPEN = 'OPEN',
+	CLOSED = 'CLOSED'
+}
+
 export type UserSettings = {
 	facetSort?: {
 		[dimension: string]: string;
+	};
+	facetExpanded?: {
+		[dimension: string]: ExpandState;
 	};
 	myLibraries?: {
 		[id: string]: LibraryItem;

--- a/lxl-web/src/lib/types/userSettings.ts
+++ b/lxl-web/src/lib/types/userSettings.ts
@@ -6,7 +6,7 @@ export interface LibraryItem {
 	sigel: string;
 }
 
-export enum ExpandState {
+export enum ExpandedState {
 	OPEN = 'OPEN',
 	CLOSED = 'CLOSED'
 }
@@ -16,7 +16,7 @@ export type UserSettings = {
 		[dimension: string]: string;
 	};
 	facetExpanded?: {
-		[dimension: string]: ExpandState;
+		[dimension: string]: ExpandedState;
 	};
 	myLibraries?: {
 		[id: string]: LibraryItem;

--- a/lxl-web/src/lib/utils/userSettings.svelte.ts
+++ b/lxl-web/src/lib/utils/userSettings.svelte.ts
@@ -1,10 +1,16 @@
 import Cookies from 'js-cookie';
-import type { LibraryItem, UserSettings as UserSettingsType } from '$lib/types/userSettings';
+import {
+	ExpandState,
+	type LibraryItem,
+	type UserSettings as UserSettingsType
+} from '$lib/types/userSettings';
 
 enum availableSettings {
 	facetSort = 'facetSort',
+
 	myLibraries = 'myLibraries',
-	leadingPane = 'leadingPane'
+	leadingPane = 'leadingPane',
+	facetExpanded = 'facetExpanded',
 }
 
 export class UserSettings {
@@ -88,11 +94,23 @@ export class UserSettings {
 		return this.settings?.leadingPane;
 	}
 
+	saveFacetExpanded(facet: string, value: boolean) {
+		if (facet) {
+			const facetExpanded = { ...this.settings.facetExpanded };
+			facetExpanded[facet] = value ? ExpandState.OPEN : ExpandState.CLOSED;
+			this.update('facetExpanded', facetExpanded);
+		}
+	}
+
 	get myLibraries() {
 		return this.settings?.myLibraries;
 	}
 
 	get facetSort() {
 		return this.settings?.facetSort;
+	}
+
+	get facetExpanded() {
+		return this.settings?.facetExpanded;
 	}
 }

--- a/lxl-web/src/lib/utils/userSettings.svelte.ts
+++ b/lxl-web/src/lib/utils/userSettings.svelte.ts
@@ -1,6 +1,6 @@
 import Cookies from 'js-cookie';
 import {
-	ExpandState,
+	ExpandedState,
 	type LibraryItem,
 	type UserSettings as UserSettingsType
 } from '$lib/types/userSettings';
@@ -10,7 +10,7 @@ enum availableSettings {
 
 	myLibraries = 'myLibraries',
 	leadingPane = 'leadingPane',
-	facetExpanded = 'facetExpanded',
+	facetExpanded = 'facetExpanded'
 }
 
 export class UserSettings {
@@ -97,7 +97,7 @@ export class UserSettings {
 	saveFacetExpanded(facet: string, value: boolean) {
 		if (facet) {
 			const facetExpanded = { ...this.settings.facetExpanded };
-			facetExpanded[facet] = value ? ExpandState.OPEN : ExpandState.CLOSED;
+			facetExpanded[facet] = value ? ExpandedState.OPEN : ExpandedState.CLOSED;
 			this.update('facetExpanded', facetExpanded);
 		}
 	}

--- a/lxl-web/tests/find.spec.ts
+++ b/lxl-web/tests/find.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
+import { DEFAULT_FACETS_EXPANDED } from '$lib/constants/facets';
 
 test.beforeEach(async ({ page }) => {
 	await page.goto('/find?_q=f&_limit=20&_offset=0&_sort=&_i=f');
@@ -63,6 +64,27 @@ test('sorting the facet sets a cookie', async ({ page, context }) => {
 	expect(afterCookies[0].value).toEqual(
 		'{%22leadingPane%22:{%22open%22:true}%2C%22facetSort%22:{%22rdf:type%22:%22alpha.asc%22}}'
 	);
+});
+
+test('facet opened/closed state is preserved', async ({ page, context }) => {
+	const beforeCookies = await context.cookies();
+	expect(beforeCookies).toEqual([]);
+
+	const firstClosed = DEFAULT_FACETS_EXPANDED;
+
+	await expect(page.getByTestId('facet-list').first()).toBeVisible();
+	await expect(page.getByTestId('facet-list').nth(firstClosed)).toBeHidden();
+
+	await page.getByTestId('facet-toggle').first().click();
+	await page.getByTestId('facet-toggle').nth(firstClosed).click();
+
+	await expect(page.getByTestId('facet-list').first()).toBeHidden();
+	await expect(page.getByTestId('facet-list').nth(firstClosed)).toBeVisible();
+
+	await page.goto('/find?_q=f&_limit=20&_offset=0&_sort=&_i=f');
+
+	await expect(page.getByTestId('facet-list').first()).toBeHidden();
+	await expect(page.getByTestId('facet-list').nth(firstClosed)).toBeVisible();
 });
 
 // Comment out test that fails in CI

--- a/lxl-web/tests/find.spec.ts
+++ b/lxl-web/tests/find.spec.ts
@@ -57,7 +57,7 @@ test('expanded filters have no detectable a11y issues', async ({ page }) => {
 test('sorting the facet sets a cookie', async ({ page, context }) => {
 	const beforeCookies = await context.cookies();
 	expect(beforeCookies).toEqual([]);
-	await page.getByTestId('facet-sort').first().getByRole('combobox').selectOption('alpha.asc');
+	await page.getByTestId('facet-sort').nth(1).getByRole('combobox').selectOption('alpha.asc');
 	const afterCookies = await context.cookies();
 	expect(afterCookies[0].name).toEqual('userSettings');
 	expect(afterCookies[0].value).toEqual(


### PR DESCRIPTION
- Save facet expanded state in userSettings. Default to 4 first open
- Fix bug where facets were not expanded during "find facet" filtering.
- Place 'free online' inside a new "Access" facet
    - Until we have a more detailed design
- Add new FacetValue component (still TODO to rename FacetGroup -> Facet)
    - this refactoring was because of the abandoned idea to place "free online" inside the myLibraries box. Could be reverted.

