### PR TITLE
feat(supersearch, lxl-web): Improved search keyboard navigation

### DIFF
--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -227,6 +227,7 @@
 		transformFn={handleTransform}
 		extensions={[derivedLxlQualifierPlugin]}
 		toggleWithKeyboardShortcut
+		loopingArrowKeyNavigation
 		comboboxAriaLabel={page.data.t('search.search')}
 		defaultInputCol={2}
 		debouncedWait={100}
@@ -490,10 +491,6 @@
 		@variant sm {
 			padding-left: calc(var(--spacing, 0.25rem) * 12);
 		}
-	}
-
-	:global(.supersearch-input .cm-focused) {
-		outline: none;
 	}
 
 	:global(.codemirror-container .cm-content) {

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -239,11 +239,18 @@
 			inputField,
 			getCellId,
 			isFocusedCell,
+			isFocusedRow,
 			onclickClear,
 			onclickClose
 		})}
 			<div
-				class="supersearch-input rounded-d bg-input outline-primary-200 has-focus:outline-primary-600 flex min-h-12 w-full cursor-text overflow-hidden rounded-md outline focus-within:relative"
+				class={[
+					'supersearch-input rounded-d border-primary-200 bg-input flex h-12 w-full cursor-text overflow-hidden rounded-md border focus-within:relative',
+					isFocusedRow() && [
+						'outline-primary-200 has-focus:border-primary-500 has-focus:outline-4',
+						expanded && 'has-focus:outline-primary-200'
+					]
+				]}
 			>
 				{#if expanded}
 					<button

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -227,7 +227,7 @@
 		transformFn={handleTransform}
 		extensions={[derivedLxlQualifierPlugin]}
 		toggleWithKeyboardShortcut
-		loopingArrowKeyNavigation
+		wrappingArrowKeyNavigation
 		comboboxAriaLabel={page.data.t('search.search')}
 		defaultInputCol={2}
 		debouncedWait={100}

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -71,6 +71,15 @@ test('navigate to suggested resource using keyboard', async ({ page }) => {
 	).not.toBeVisible();
 });
 
+test('user can jump from first row to bottom by pressing arrow up', async ({ page }) => {
+	await page.getByRole('combobox').fill('a');
+	await expect(page.getByRole('dialog').getByLabel('Förslag').getByRole('link')).toHaveCount(5);
+	await page.keyboard.press('ArrowUp');
+	await page.keyboard.press('ArrowUp');
+	await page.keyboard.press('Enter');
+	await expect(page.locator('.resource-page')).toBeVisible();
+});
+
 test('qualifier keys can be added using the user interface', async ({ page }) => {
 	await page.getByTestId('main-search').click();
 	await page

--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -169,24 +169,6 @@ test('supports keyboard navigation between rows and columns/cells', async ({ pag
 	await expect(comboboxElement).toHaveAttribute('aria-activedescendant', 'supersearch-item-1x0');
 });
 
-test('user can use control (or meta) key + arrow keys to jump to start or end ', async ({
-	page
-}) => {
-	await page.getByRole('combobox').click();
-	const comboboxElement = page.getByRole('dialog').getByRole('combobox');
-	await expect(comboboxElement, 'no item cell is focused initially').not.toHaveAttribute(
-		'aria-activedescendant',
-		/.+/
-	);
-	await page.getByRole('dialog').getByRole('combobox').fill('a');
-	await expect(page.getByTestId('result-item')).toHaveCount(10);
-	await page.keyboard.press('ControlOrMeta+ArrowDown');
-	await expect(comboboxElement).toHaveAttribute('aria-activedescendant', 'supersearch-item-10x0');
-	await page.keyboard.press('ControlOrMeta+ArrowUp');
-	await page.keyboard.press('ArrowDown');
-	await expect(comboboxElement).toHaveAttribute('aria-activedescendant', 'supersearch-item-1x0');
-});
-
 test('user can toggle expanded search using alt key + arrow up or down (without moving cursor) ', async ({
 	page
 }) => {

--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -150,6 +150,23 @@ test('supports keyboard navigation between rows and columns/cells', async ({ pag
 	await page.getByRole('dialog').getByRole('combobox').press('Escape');
 	await page.getByRole('combobox').click();
 	await expect(comboboxElement).not.toHaveAttribute('aria-activedescendant', /.+/);
+
+	await page.getByRole('dialog').getByRole('combobox').press('Escape');
+	await page.getByTestId('use-looping-arrow-key-navigation').check();
+	await page.getByRole('combobox').fill('a');
+	await expect(page.getByTestId('result-item')).toHaveCount(10);
+	await page.keyboard.press('ArrowUp');
+	await expect(
+		comboboxElement,
+		'user can jump from first row to last by pressing arrow up if useLoopingArrowKeyNavigation is enabled'
+	).toHaveAttribute('aria-activedescendant', 'supersearch-item-10x0');
+	await page.keyboard.press('ArrowDown');
+	await expect(
+		comboboxElement,
+		'user can jump from last row to first by pressing arrow down if useLoopingArrowKeyNavigation is enabled'
+	).not.toHaveAttribute('aria-activedescendant', /.+/);
+	await page.keyboard.press('ArrowDown');
+	await expect(comboboxElement).toHaveAttribute('aria-activedescendant', 'supersearch-item-1x0');
 });
 
 test('syncs collapsed and expanded editor views', async ({ context, page }) => {

--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -169,7 +169,7 @@ test('supports keyboard navigation between rows and columns/cells', async ({ pag
 	await expect(comboboxElement).toHaveAttribute('aria-activedescendant', 'supersearch-item-1x0');
 });
 
-test('user can use control (or meta key) + arrow keys to jump to start or end ', async ({
+test('user can use control (or meta) key + arrow keys to jump to start or end ', async ({
 	page
 }) => {
 	await page.getByRole('combobox').click();
@@ -185,6 +185,21 @@ test('user can use control (or meta key) + arrow keys to jump to start or end ',
 	await page.keyboard.press('ControlOrMeta+ArrowUp');
 	await page.keyboard.press('ArrowDown');
 	await expect(comboboxElement).toHaveAttribute('aria-activedescendant', 'supersearch-item-1x0');
+});
+
+test('user can toggle expanded search using alt key + arrow up or down (without moving cursor) ', async ({
+	page
+}) => {
+	await page.getByRole('combobox').click();
+	await page.getByRole('dialog').getByRole('combobox').fill('abc');
+	await expect(page.getByTestId('result-item')).toHaveCount(10);
+	await page.keyboard.press('ArrowLeft');
+	await page.keyboard.press('Alt+ArrowUp');
+	await expect(page.getByRole('dialog')).not.toBeVisible();
+	await page.keyboard.press('Alt+ArrowDown');
+	await expect(page.getByRole('dialog')).toBeVisible();
+	await page.getByRole('dialog').getByRole('combobox').pressSequentially('x');
+	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveText('abxc');
 });
 
 test('syncs collapsed and expanded editor views', async ({ context, page }) => {

--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -169,6 +169,24 @@ test('supports keyboard navigation between rows and columns/cells', async ({ pag
 	await expect(comboboxElement).toHaveAttribute('aria-activedescendant', 'supersearch-item-1x0');
 });
 
+test('user can use control (or meta key) + arrow keys to jump to start or end ', async ({
+	page
+}) => {
+	await page.getByRole('combobox').click();
+	const comboboxElement = page.getByRole('dialog').getByRole('combobox');
+	await expect(comboboxElement, 'no item cell is focused initially').not.toHaveAttribute(
+		'aria-activedescendant',
+		/.+/
+	);
+	await page.getByRole('dialog').getByRole('combobox').fill('a');
+	await expect(page.getByTestId('result-item')).toHaveCount(10);
+	await page.keyboard.press('ControlOrMeta+ArrowDown');
+	await expect(comboboxElement).toHaveAttribute('aria-activedescendant', 'supersearch-item-10x0');
+	await page.keyboard.press('ControlOrMeta+ArrowUp');
+	await page.keyboard.press('ArrowDown');
+	await expect(comboboxElement).toHaveAttribute('aria-activedescendant', 'supersearch-item-1x0');
+});
+
 test('syncs collapsed and expanded editor views', async ({ context, page }) => {
 	await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 	await page.getByRole('combobox').click();

--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -152,18 +152,18 @@ test('supports keyboard navigation between rows and columns/cells', async ({ pag
 	await expect(comboboxElement).not.toHaveAttribute('aria-activedescendant', /.+/);
 
 	await page.getByRole('dialog').getByRole('combobox').press('Escape');
-	await page.getByTestId('use-looping-arrow-key-navigation').check();
+	await page.getByTestId('use-wrapping-arrow-key-navigation').check();
 	await page.getByRole('combobox').fill('a');
 	await expect(page.getByTestId('result-item')).toHaveCount(10);
 	await page.keyboard.press('ArrowUp');
 	await expect(
 		comboboxElement,
-		'user can jump from first row to last by pressing arrow up if useLoopingArrowKeyNavigation is enabled'
+		'user can jump from first row to last by pressing arrow up if wrappingArrowKeyNavigation is enabled'
 	).toHaveAttribute('aria-activedescendant', 'supersearch-item-10x0');
 	await page.keyboard.press('ArrowDown');
 	await expect(
 		comboboxElement,
-		'user can jump from last row to first by pressing arrow down if useLoopingArrowKeyNavigation is enabled'
+		'user can jump from last row to first by pressing arrow down if wrappingArrowKeyNavigation is enabled'
 	).not.toHaveAttribute('aria-activedescendant', /.+/);
 	await page.keyboard.press('ArrowDown');
 	await expect(comboboxElement).toHaveAttribute('aria-activedescendant', 'supersearch-item-1x0');

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -52,6 +52,7 @@
 					inputField: Snippet;
 					getCellId: (cellIndex: number) => string | undefined;
 					isFocusedCell: (cellIndex: number) => boolean;
+					isFocusedRow: () => boolean;
 					onclickSubmit: (event: MouseEvent) => void;
 					onclickClear: (event: MouseEvent) => void;
 					onclickClose: (event: MouseEvent) => void;
@@ -666,6 +667,7 @@
 			inputField: collapsedInputSnippet,
 			getCellId: () => undefined,
 			isFocusedCell: () => false,
+			isFocusedRow: () => activeRowIndex === 0,
 			onclickSubmit: handleClickSubmit,
 			onclickClear: handleReset,
 			onclickClose: hideExpandedSearch
@@ -682,6 +684,7 @@
 					inputField: expandedInputSnippet,
 					getCellId: (colIndex: number) => `${id}-item-0x${colIndex}`,
 					isFocusedCell: (colIndex: number) => activeRowIndex === 0 && colIndex === activeColIndex,
+					isFocusedRow: () => activeRowIndex === 0,
 					onclickSubmit: handleClickSubmit,
 					onclickClear: handleReset,
 					onclickClose: hideExpandedSearch

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -353,6 +353,14 @@
 		}
 	}
 
+	function controlOrMetaKey(event: KeyboardEvent) {
+		if (!event.ctrlKey && !event.metaKey) return false;
+		const isMac = navigator.userAgent.includes('Mac OS X');
+		if (isMac && event.metaKey) return true;
+		if (!isMac && event.ctrlKey) return true;
+		return false;
+	}
+
 	function handleCollapsedKeyDown(event: KeyboardEvent) {
 		if (event.key === 'Enter' && value.length) {
 			submitClosestForm();
@@ -420,43 +428,55 @@
 			if (rows.length) {
 				switch (event.key) {
 					case 'ArrowUp':
-						if (loopingArrowKeyNavigation && activeRowIndex === 0) {
+						if (controlOrMetaKey(event)) {
+							event.preventDefault();
+							activeRowIndex = 0;
+							activeColIndex = defaultInputCol;
+						} else {
+							if (loopingArrowKeyNavigation && activeRowIndex === 0) {
+								activeRowIndex = rows.length - 1;
+								activeColIndex = 0;
+							} else if (activeRowIndex >= 1) {
+								activeRowIndex--;
+								if (activeRowIndex < 1) {
+									activeColIndex = defaultInputCol;
+									allowArrowKeyCursorHandling = {
+										...allowArrowKeyCursorHandling,
+										horizontal: true
+									};
+								} else {
+									const cols = getColsInRow(activeRowIndex);
+									activeColIndex = Math.min(activeColIndex, cols.length - 1);
+									allowArrowKeyCursorHandling = {
+										...allowArrowKeyCursorHandling,
+										horizontal: cols.length <= 1
+									};
+								}
+							}
+						}
+						break;
+					case 'ArrowDown':
+						if (controlOrMetaKey(event)) {
+							event.preventDefault();
 							activeRowIndex = rows.length - 1;
 							activeColIndex = 0;
-						} else if (activeRowIndex >= 1) {
-							activeRowIndex--;
-							if (activeRowIndex < 1) {
+						} else {
+							if (loopingArrowKeyNavigation && activeRowIndex === rows.length - 1) {
+								activeRowIndex = 0;
 								activeColIndex = defaultInputCol;
-								allowArrowKeyCursorHandling = {
-									...allowArrowKeyCursorHandling,
-									horizontal: true
-								};
-							} else {
+							} else if (activeRowIndex < rows.length - 1) {
+								activeRowIndex++;
 								const cols = getColsInRow(activeRowIndex);
-								activeColIndex = Math.min(activeColIndex, cols.length - 1);
+								if (activeRowIndex === 1) {
+									activeColIndex = 0;
+								} else {
+									activeColIndex = Math.min(activeColIndex, cols.length - 1);
+								}
 								allowArrowKeyCursorHandling = {
 									...allowArrowKeyCursorHandling,
 									horizontal: cols.length <= 1
 								};
 							}
-						}
-						break;
-					case 'ArrowDown':
-						if (loopingArrowKeyNavigation && activeRowIndex === rows.length - 1) {
-							activeRowIndex = 0;
-							activeColIndex = defaultInputCol;
-						} else if (activeRowIndex < rows.length - 1) {
-							activeRowIndex++;
-							const cols = getColsInRow(activeRowIndex);
-							if (activeRowIndex === 1) {
-								activeColIndex = 0;
-							} else {
-								activeColIndex = Math.min(activeColIndex, cols.length - 1);
-							}
-							allowArrowKeyCursorHandling = {
-								...allowArrowKeyCursorHandling,
-								horizontal: cols.length <= 1
-							};
 						}
 						break;
 					case 'ArrowLeft':

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -540,7 +540,7 @@
 	}
 
 	function handleKeyboardShortcut(event: KeyboardEvent) {
-		if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+		if (controlOrMetaKey(event) && event.key === 'k') {
 			event.preventDefault();
 			if (dialog?.open) {
 				hideExpandedSearch();

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -75,7 +75,7 @@
 		defaultResultRow?: number;
 		defaultResultCol?: number;
 		toggleWithKeyboardShortcut?: boolean;
-		loopingArrowKeyNavigation?: boolean;
+		wrappingArrowKeyNavigation?: boolean;
 		debouncedWait?: number;
 		selection?: Selection;
 		isLoading?: boolean;
@@ -104,7 +104,7 @@
 		resultItemRow = fallbackResultItemRow,
 		loadingIndicator,
 		toggleWithKeyboardShortcut = false,
-		loopingArrowKeyNavigation = false,
+		wrappingArrowKeyNavigation = false,
 		defaultInputCol = -1,
 		defaultResultRow = 0,
 		defaultResultCol = 0,
@@ -436,7 +436,7 @@
 							event.preventDefault();
 							hideExpandedSearch();
 						} else {
-							if (loopingArrowKeyNavigation && activeRowIndex === 0) {
+							if (wrappingArrowKeyNavigation && activeRowIndex === 0) {
 								activeRowIndex = rows.length - 1;
 								activeColIndex = 0;
 							} else if (activeRowIndex >= 1) {
@@ -459,7 +459,7 @@
 						}
 						break;
 					case 'ArrowDown':
-						if (loopingArrowKeyNavigation && activeRowIndex === rows.length - 1) {
+						if (wrappingArrowKeyNavigation && activeRowIndex === rows.length - 1) {
 							activeRowIndex = 0;
 							activeColIndex = defaultInputCol;
 						} else if (activeRowIndex < rows.length - 1) {

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -365,6 +365,10 @@
 		if (event.key === 'Enter' && value.length) {
 			submitClosestForm();
 		}
+		if (event.key === 'ArrowDown' && event.altKey) {
+			event.preventDefault();
+			showExpandedSearch();
+		}
 	}
 
 	function handleExpandedKeyDown(event: KeyboardEvent) {
@@ -428,7 +432,10 @@
 			if (rows.length) {
 				switch (event.key) {
 					case 'ArrowUp':
-						if (controlOrMetaKey(event)) {
+						if (event.altKey) {
+							event.preventDefault();
+							hideExpandedSearch();
+						} else if (controlOrMetaKey(event)) {
 							event.preventDefault();
 							activeRowIndex = 0;
 							activeColIndex = defaultInputCol;

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -435,10 +435,6 @@
 						if (event.altKey) {
 							event.preventDefault();
 							hideExpandedSearch();
-						} else if (controlOrMetaKey(event)) {
-							event.preventDefault();
-							activeRowIndex = 0;
-							activeColIndex = defaultInputCol;
 						} else {
 							if (loopingArrowKeyNavigation && activeRowIndex === 0) {
 								activeRowIndex = rows.length - 1;
@@ -463,27 +459,21 @@
 						}
 						break;
 					case 'ArrowDown':
-						if (controlOrMetaKey(event)) {
-							event.preventDefault();
-							activeRowIndex = rows.length - 1;
-							activeColIndex = 0;
-						} else {
-							if (loopingArrowKeyNavigation && activeRowIndex === rows.length - 1) {
-								activeRowIndex = 0;
-								activeColIndex = defaultInputCol;
-							} else if (activeRowIndex < rows.length - 1) {
-								activeRowIndex++;
-								const cols = getColsInRow(activeRowIndex);
-								if (activeRowIndex === 1) {
-									activeColIndex = 0;
-								} else {
-									activeColIndex = Math.min(activeColIndex, cols.length - 1);
-								}
-								allowArrowKeyCursorHandling = {
-									...allowArrowKeyCursorHandling,
-									horizontal: cols.length <= 1
-								};
+						if (loopingArrowKeyNavigation && activeRowIndex === rows.length - 1) {
+							activeRowIndex = 0;
+							activeColIndex = defaultInputCol;
+						} else if (activeRowIndex < rows.length - 1) {
+							activeRowIndex++;
+							const cols = getColsInRow(activeRowIndex);
+							if (activeRowIndex === 1) {
+								activeColIndex = 0;
+							} else {
+								activeColIndex = Math.min(activeColIndex, cols.length - 1);
 							}
+							allowArrowKeyCursorHandling = {
+								...allowArrowKeyCursorHandling,
+								horizontal: cols.length <= 1
+							};
 						}
 						break;
 					case 'ArrowLeft':

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -74,6 +74,7 @@
 		defaultResultRow?: number;
 		defaultResultCol?: number;
 		toggleWithKeyboardShortcut?: boolean;
+		loopingArrowKeyNavigation?: boolean;
 		debouncedWait?: number;
 		selection?: Selection;
 		isLoading?: boolean;
@@ -102,6 +103,7 @@
 		resultItemRow = fallbackResultItemRow,
 		loadingIndicator,
 		toggleWithKeyboardShortcut = false,
+		loopingArrowKeyNavigation = false,
 		defaultInputCol = -1,
 		defaultResultRow = 0,
 		defaultResultCol = 0,
@@ -417,7 +419,10 @@
 			if (rows.length) {
 				switch (event.key) {
 					case 'ArrowUp':
-						if (activeRowIndex >= 1) {
+						if (loopingArrowKeyNavigation && activeRowIndex === 0) {
+							activeRowIndex = rows.length - 1;
+							activeColIndex = 0;
+						} else if (activeRowIndex >= 1) {
 							activeRowIndex--;
 							if (activeRowIndex < 1) {
 								activeColIndex = defaultInputCol;
@@ -436,7 +441,10 @@
 						}
 						break;
 					case 'ArrowDown':
-						if (activeRowIndex < rows.length - 1) {
+						if (loopingArrowKeyNavigation && activeRowIndex === rows.length - 1) {
+							activeRowIndex = 0;
+							activeColIndex = defaultInputCol;
+						} else if (activeRowIndex < rows.length - 1) {
 							activeRowIndex++;
 							const cols = getColsInRow(activeRowIndex);
 							if (activeRowIndex === 1) {
@@ -476,10 +484,10 @@
 
 							if (typeof closestAfter !== 'number' && activeRowIndex < rows.length - 1) {
 								activeRowIndex++;
-								activeColIndex = getColIndexFromId(getColsInRow(activeRowIndex)[0].id);
+								activeColIndex = getColIndexFromId(getColsInRow(activeRowIndex)[0].id) || 0;
 							}
 							if (typeof closestAfter === 'number') {
-								activeColIndex = closestAfter;
+								activeColIndex = closestAfter || 0;
 							}
 						}
 						break;

--- a/packages/supersearch/src/routes/+page.svelte
+++ b/packages/supersearch/src/routes/+page.svelte
@@ -13,6 +13,7 @@
 	let placeholder = $state('Search');
 	let useFormAttribute = $state(false);
 	let useCustomExpandedContent = $state(false);
+	let useLoopingArrowKeyNavigation = $state(false);
 
 	function handlePaginationQuery(searchParams: URLSearchParams, prevData: JSONValue) {
 		const paginatedSearchParams = new URLSearchParams(Array.from(searchParams.entries()));
@@ -97,6 +98,7 @@
 			defaultResultCol={0}
 			form={useFormAttribute ? 'form-outside' : undefined}
 			expandedContent={useCustomExpandedContent ? expandedContent : undefined}
+			loopingArrowKeyNavigation={useLoopingArrowKeyNavigation}
 		>
 			{#snippet inputRow({
 				expanded,
@@ -201,7 +203,6 @@
 		><input type="checkbox" bind:checked={useFormAttribute} data-testid="use-form-attribute" />
 		Use form attribute
 	</label>
-
 	<label
 		><input
 			type="checkbox"
@@ -209,6 +210,14 @@
 			data-testid="use-custom-expanded-content"
 		/>
 		Use custom expanded content
+	</label>
+	<label
+		><input
+			type="checkbox"
+			bind:checked={useLoopingArrowKeyNavigation}
+			data-testid="use-looping-arrow-key-navigation"
+		/>
+		Use looping arrow key navigation
 	</label>
 </fieldset>
 

--- a/packages/supersearch/src/routes/+page.svelte
+++ b/packages/supersearch/src/routes/+page.svelte
@@ -13,7 +13,7 @@
 	let placeholder = $state('Search');
 	let useFormAttribute = $state(false);
 	let useCustomExpandedContent = $state(false);
-	let useLoopingArrowKeyNavigation = $state(false);
+	let useWrappingArrowKeyNavigation = $state(false);
 
 	function handlePaginationQuery(searchParams: URLSearchParams, prevData: JSONValue) {
 		const paginatedSearchParams = new URLSearchParams(Array.from(searchParams.entries()));
@@ -98,7 +98,7 @@
 			defaultResultCol={0}
 			form={useFormAttribute ? 'form-outside' : undefined}
 			expandedContent={useCustomExpandedContent ? expandedContent : undefined}
-			loopingArrowKeyNavigation={useLoopingArrowKeyNavigation}
+			wrappingArrowKeyNavigation={useWrappingArrowKeyNavigation}
 		>
 			{#snippet inputRow({
 				expanded,
@@ -214,10 +214,10 @@
 	<label
 		><input
 			type="checkbox"
-			bind:checked={useLoopingArrowKeyNavigation}
-			data-testid="use-looping-arrow-key-navigation"
+			bind:checked={useWrappingArrowKeyNavigation}
+			data-testid="use-wrapping-arrow-key-navigation"
 		/>
-		Use looping arrow key navigation
+		Use wrapping arrow key navigation
 	</label>
 </fieldset>
 


### PR DESCRIPTION
## Description

### Solves

Improves the keyboard navigation in the supersearch component (adhering to more cases from the [Combobox Pattern in the ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)).

The user can now jump from the first row to the last using `arrow up`, and vice versa jump from the last row to the first by pressing `arrow down`.

~~The `control key` (or `meta key` if on mac) combined with either `arrow up` or `arrow down` can be used to quickly jump the first or last row.~~

And finally, `Alt` + `arrow up` or `arrow down` can toggle the expanded search without moving the cursor.

### Summary of changes

- Add support for wrapping arrow key navigation
- Clearer focused styling of input row
- ~~Add support for jumping to start/end using control/meta + arrow keys~~
- Alt + arrow keys toggles expanded search without moving cursor