### PR TITLE
Feature/link to holdings from hit list

### DIFF
--- a/lxl-web/src/lib/components/Modal.svelte
+++ b/lxl-web/src/lib/components/Modal.svelte
@@ -39,7 +39,7 @@
 </script>
 
 <div
-	class="bg-backdrop pointer-events-none fixed top-0 left-0 z-10 h-full w-full"
+	class="bg-backdrop pointer-events-none fixed top-0 left-0 z-20 h-full w-full"
 	transition:fade={{ duration: 300 }}
 ></div>
 <dialog

--- a/lxl-web/src/lib/components/MyLibsHoldingIndicator.svelte
+++ b/lxl-web/src/lib/components/MyLibsHoldingIndicator.svelte
@@ -12,10 +12,9 @@
 </script>
 
 <span
-	class="text-primary-700 relative p-2 text-lg lg:text-xl"
 	use:popover={{
 		title: `${page.data.t('holdings.availableAt')}: ${librariesString}`
 	}}
 >
-	<BiHouseHeart />
+	<BiHouseHeart class="text-primary-700" />
 </span>

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -8,11 +8,12 @@
 	import getInstanceData from '$lib/utils/getInstanceData';
 	import placeholder from '$lib/assets/img/placeholder.svg';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import SearchItemDebug from '$lib/components/find/SearchItemDebug.svelte';
 	import EsExplain from '$lib/components/find/EsExplain.svelte';
 	import SearchItemDebugHaystack from '$lib/components/find/SearchItemDebugHaystack.svelte';
 	import MyLibsHoldingIndicator from '$lib/components/MyLibsHoldingIndicator.svelte';
+	import { getHoldingsLink, handleClickHoldings } from '$lib/utils/holdings';
 
 	export let item: SearchResultItem;
 
@@ -43,7 +44,7 @@
 							src={item.image.url}
 							width={item.image.widthPx > 0 ? item.image.widthPx : undefined}
 							height={item.image.heightPx > 0 ? item.image.heightPx : undefined}
-							alt={$page.data.t('general.latestInstanceCover')}
+							alt={page.data.t('general.latestInstanceCover')}
 							class:rounded-full={item['@type'] === 'Person'}
 							class="object-contain object-top {item['@type'] !== 'Person'
 								? 'aspect-2/3'
@@ -132,7 +133,7 @@
 						{#if instances?.years}
 							{#if instances.count > 1}
 								{instances?.count}
-								{$page.data.t('search.editions')}
+								{page.data.t('search.editions')}
 								{`(${instances.years})`}
 							{:else}
 								{instances.years}
@@ -156,6 +157,19 @@
 				{/each}
 			</footer>
 		</div>
+		<div>
+			{#if id}
+				<a
+					class="btn btn-cta"
+					href={getHoldingsLink(page.url, id)}
+					data-sveltekit-preload-data="false"
+					data-testid="holding-link"
+					onclick={(event) => handleClickHoldings(event, page.state, id)}
+				>
+					test
+				</a>
+			{/if}
+		</div>
 		{#if item._debug}
 			{#key item._debug}
 				<div class="card-debug z-20 self-start text-left select-text">
@@ -163,7 +177,7 @@
 					<button
 						type="button"
 						class="text-xs"
-						on:click={() => {
+						onclick={() => {
 							showDebugHaystack = !showDebugHaystack;
 						}}
 					>
@@ -172,7 +186,7 @@
 					<button
 						type="button"
 						class="text-xs"
-						on:click={() => {
+						onclick={() => {
 							showDebugExplain = !showDebugExplain;
 						}}
 					>

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -37,11 +37,11 @@
 				data-testid="holding-link"
 				onclick={(event) => handleClickHoldings(event, page.state, id)}
 			>
-				<span class="text-subtle text-base">
+				<span class="text-base">
 					{#if item.heldByMyLibraries?.length}
 						<MyLibsHoldingIndicator libraries={item.heldByMyLibraries} />
 					{:else}
-						<BiHouse />
+						<BiHouse class="text-neutral-400" />
 					{/if}
 				</span>
 				{item.numberOfHolders}

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -31,8 +31,7 @@
 	<div class="card-libraries flex items-start pt-1">
 		{#if id}
 			<a
-				class="btn btn-primary h-7
-							 rounded-full md:h-8"
+				class="btn btn-primary h-7 rounded-full md:h-8"
 				href={getHoldingsLink(page.url, id)}
 				data-sveltekit-preload-data="false"
 				data-testid="holding-link"

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -27,8 +27,11 @@
 	let showDebugHaystack = false;
 </script>
 
+<!--//TODO: look into using grid template areas + container queries instead
+see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c23e223cdda91b17a -->
+
 {#snippet holdingsButton()}
-	<div class="card-libraries flex items-start pt-1">
+	<div class="flex items-start pt-1">
 		{#if id}
 			<a
 				class="btn btn-primary h-7 rounded-full md:h-8"
@@ -235,8 +238,8 @@
 	}
 
 	.search-card {
-		grid-template-areas: 'image content debug libraries';
-		grid-template-columns: 64px 1fr auto auto;
+		grid-template-areas: 'image content debug';
+		grid-template-columns: 64px 1fr auto;
 
 		@container (min-width: 768px) {
 			@apply gap-x-6 px-6 py-4;
@@ -259,10 +262,6 @@
 
 	.card-debug {
 		grid-area: extra;
-	}
-
-	.card-libraries {
-		grid-area: libraries;
 	}
 
 	.card-footer {

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -38,15 +38,13 @@
 				data-testid="holding-link"
 				onclick={(event) => handleClickHoldings(event, page.state, id)}
 			>
-				{#if item.heldByMyLibraries?.length}
-					<span class="[&_svg]:text-primary-700 pr-0.5">
+				<span class="text-subtle text-base">
+					{#if item.heldByMyLibraries?.length}
 						<MyLibsHoldingIndicator libraries={item.heldByMyLibraries} />
-					</span>
-				{:else}
-					<span class="relative pr-0.5 text-lg lg:text-lg">
+					{:else}
 						<BiHouse />
-					</span>
-				{/if}
+					{/if}
+				</span>
 				{item.numberOfHolders}
 				{page.data.t('search.libraries')}
 			</a>

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -14,6 +14,7 @@
 	import SearchItemDebugHaystack from '$lib/components/find/SearchItemDebugHaystack.svelte';
 	import MyLibsHoldingIndicator from '$lib/components/MyLibsHoldingIndicator.svelte';
 	import { getHoldingsLink, handleClickHoldings } from '$lib/utils/holdings';
+	import BiHouse from '~icons/bi/house';
 
 	export let item: SearchResultItem;
 
@@ -194,17 +195,23 @@
 			{/key}
 		{/if}
 		<div class="card-libraries flex items-start">
-			{#if item.heldByMyLibraries?.length}
-				<MyLibsHoldingIndicator libraries={item.heldByMyLibraries} />
-			{/if}
 			{#if id}
 				<a
-					class="btn btn-primary rounded-full"
+					class="btn btn-primary h-8 rounded-full"
 					href={getHoldingsLink(page.url, id)}
 					data-sveltekit-preload-data="false"
 					data-testid="holding-link"
 					onclick={(event) => handleClickHoldings(event, page.state, id)}
 				>
+					{#if item.heldByMyLibraries?.length}
+						<span class="[&_svg]:text-primary-700 pr-0.5">
+							<MyLibsHoldingIndicator libraries={item.heldByMyLibraries} />
+						</span>
+					{:else}
+						<span class="relative pr-0.5 text-lg lg:text-lg">
+							<BiHouse />
+						</span>
+					{/if}
 					{item.numberOfHolders}
 					{page.data.t('search.libraries')}
 				</a>

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -157,19 +157,7 @@
 				{/each}
 			</footer>
 		</div>
-		<div>
-			{#if id}
-				<a
-					class="btn btn-cta"
-					href={getHoldingsLink(page.url, id)}
-					data-sveltekit-preload-data="false"
-					data-testid="holding-link"
-					onclick={(event) => handleClickHoldings(event, page.state, id)}
-				>
-					test
-				</a>
-			{/if}
-		</div>
+
 		{#if item._debug}
 			{#key item._debug}
 				<div class="card-debug z-20 self-start text-left select-text">
@@ -205,11 +193,23 @@
 				{/if}
 			{/key}
 		{/if}
-		{#if item.heldByMyLibraries?.length}
-			<div class="card-libraries flex items-start">
+		<div class="card-libraries flex items-start">
+			{#if item.heldByMyLibraries?.length}
 				<MyLibsHoldingIndicator libraries={item.heldByMyLibraries} />
-			</div>
-		{/if}
+			{/if}
+			{#if id}
+				<a
+					class="btn btn-primary rounded-full"
+					href={getHoldingsLink(page.url, id)}
+					data-sveltekit-preload-data="false"
+					data-testid="holding-link"
+					onclick={(event) => handleClickHoldings(event, page.state, id)}
+				>
+					{item.numberOfHolders}
+					{page.data.t('search.libraries')}
+				</a>
+			{/if}
+		</div>
 	</article>
 </div>
 

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -27,6 +27,33 @@
 	let showDebugHaystack = false;
 </script>
 
+{#snippet holdingsButton()}
+	<div class="card-libraries flex items-start pt-1">
+		{#if id}
+			<a
+				class="btn btn-primary h-7
+							 rounded-full md:h-8"
+				href={getHoldingsLink(page.url, id)}
+				data-sveltekit-preload-data="false"
+				data-testid="holding-link"
+				onclick={(event) => handleClickHoldings(event, page.state, id)}
+			>
+				{#if item.heldByMyLibraries?.length}
+					<span class="[&_svg]:text-primary-700 pr-0.5">
+						<MyLibsHoldingIndicator libraries={item.heldByMyLibraries} />
+					</span>
+				{:else}
+					<span class="relative pr-0.5 text-lg lg:text-lg">
+						<BiHouse />
+					</span>
+				{/if}
+				{item.numberOfHolders}
+				{page.data.t('search.libraries')}
+			</a>
+		{/if}
+	</div>
+{/snippet}
+
 <div class="search-card-container">
 	<article
 		class="search-card border-neutral relative grid w-full gap-x-4 border-t px-0 py-3 font-normal transition-shadow md:px-4"
@@ -156,6 +183,9 @@
 						</span>
 					{/if}
 				{/each}
+				<div class="md:hidden">
+					{@render holdingsButton()}
+				</div>
 			</footer>
 		</div>
 
@@ -194,28 +224,8 @@
 				{/if}
 			{/key}
 		{/if}
-		<div class="card-libraries flex items-start">
-			{#if id}
-				<a
-					class="btn btn-primary h-8 rounded-full"
-					href={getHoldingsLink(page.url, id)}
-					data-sveltekit-preload-data="false"
-					data-testid="holding-link"
-					onclick={(event) => handleClickHoldings(event, page.state, id)}
-				>
-					{#if item.heldByMyLibraries?.length}
-						<span class="[&_svg]:text-primary-700 pr-0.5">
-							<MyLibsHoldingIndicator libraries={item.heldByMyLibraries} />
-						</span>
-					{:else}
-						<span class="relative pr-0.5 text-lg lg:text-lg">
-							<BiHouse />
-						</span>
-					{/if}
-					{item.numberOfHolders}
-					{page.data.t('search.libraries')}
-				</a>
-			{/if}
+		<div class="hidden md:inline">
+			{@render holdingsButton()}
 		</div>
 	</article>
 </div>

--- a/lxl-web/src/lib/components/find/SearchResultOld.svelte
+++ b/lxl-web/src/lib/components/find/SearchResultOld.svelte
@@ -16,7 +16,6 @@
 	let showFiltersModal = false;
 	export let searchResult: SearchResult;
 	export let showMapping: boolean = false;
-	const holdingsParam = $page.url.searchParams.get('holdings');
 
 	$: sortOrder = $page.url.searchParams.get('_sort');
 	const sortOptions = [
@@ -212,9 +211,7 @@
 			</ol>
 			<Pagination data={searchResult} />
 		</div>
-		{#if holdingsParam}
-			<HoldingsModal></HoldingsModal>
-		{/if}
+		<HoldingsModal></HoldingsModal>
 	</div>
 {/if}
 

--- a/lxl-web/src/lib/components/find/SearchResultOld.svelte
+++ b/lxl-web/src/lib/components/find/SearchResultOld.svelte
@@ -11,10 +11,12 @@
 	import BiChevronDown from '~icons/bi/chevron-down';
 	import BiSortDown from '~icons/bi/sort-down';
 	import type { SearchResult, DisplayMapping } from '$lib/types/search';
+	import HoldingsModal from '../../../routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte';
 
 	let showFiltersModal = false;
 	export let searchResult: SearchResult;
 	export let showMapping: boolean = false;
+	const holdingsParam = $page.url.searchParams.get('holdings');
 
 	$: sortOrder = $page.url.searchParams.get('_sort');
 	const sortOptions = [
@@ -210,6 +212,9 @@
 			</ol>
 			<Pagination data={searchResult} />
 		</div>
+		{#if holdingsParam}
+			<HoldingsModal></HoldingsModal>
+		{/if}
 	</div>
 {/if}
 

--- a/lxl-web/src/lib/components/find/SearchResultOld.svelte
+++ b/lxl-web/src/lib/components/find/SearchResultOld.svelte
@@ -211,7 +211,7 @@
 			</ol>
 			<Pagination data={searchResult} />
 		</div>
-		<HoldingsModal></HoldingsModal>
+		<HoldingsModal workFnurgel={$page.state.holdings}></HoldingsModal>
 	</div>
 {/if}
 

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -130,7 +130,8 @@ export default {
 		goToResource: 'Go to the resource',
 		addLibraries: 'Add libraries',
 		changeLibraries: 'Change libraries',
-		noAddedLibrariesText: 'You have not chosen any favourite libraries.'
+		noAddedLibrariesText: 'You have not chosen any favourite libraries.',
+		libraries: 'libraries'
 	},
 	supersearch: {
 		addQualifiers: 'Add filter',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -129,7 +129,8 @@ export default {
 		goToResource: 'Gå till resursen',
 		addLibraries: 'Lägg till bibliotek',
 		changeLibraries: 'Ändra bibliotek',
-		noAddedLibrariesText: 'Du har inte valt några favoritbibliotek.'
+		noAddedLibrariesText: 'Du har inte valt några favoritbibliotek.',
+		libraries: 'bibliotek'
 	},
 	supersearch: {
 		addQualifiers: 'Lägg till filter',

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -2,7 +2,6 @@ import { JsonLd, type Link, type DisplayDecorated, type FramedData, LensType } f
 import { type SecureImageResolution } from '$lib/types/auxd';
 import { type LibraryItem } from '$lib/types/userSettings';
 import { LxlLens } from '$lib/types/display';
-import type { BibIdObj } from '$lib/types/holdings';
 
 export interface SearchResult {
 	itemOffset: number;
@@ -37,7 +36,7 @@ export interface SearchResultItem {
 	image: SecureImageResolution | undefined;
 	typeStr: string;
 	heldByMyLibraries?: LibraryItem[];
-	bibIdsByInstanceId: Record<string, BibIdObj>;
+	numberOfHolders: number;
 	_debug?: ItemDebugInfo;
 }
 

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -2,6 +2,7 @@ import { JsonLd, type Link, type DisplayDecorated, type FramedData, LensType } f
 import { type SecureImageResolution } from '$lib/types/auxd';
 import { type LibraryItem } from '$lib/types/userSettings';
 import { LxlLens } from '$lib/types/display';
+import type { BibIdObj } from '$lib/types/holdings';
 
 export interface SearchResult {
 	itemOffset: number;
@@ -36,6 +37,7 @@ export interface SearchResultItem {
 	image: SecureImageResolution | undefined;
 	typeStr: string;
 	heldByMyLibraries?: LibraryItem[];
+	bibIdsByInstanceId: Record<string, BibIdObj>;
 	_debug?: ItemDebugInfo;
 }
 

--- a/lxl-web/src/lib/utils/centerOnWork.ts
+++ b/lxl-web/src/lib/utils/centerOnWork.ts
@@ -1,0 +1,16 @@
+import type { FramedData } from '$lib/types/xl';
+
+// TODO: handle titles correctly
+export function centerOnWork(mainEntity: FramedData): FramedData {
+	if ('instanceOf' in mainEntity) {
+		const result = mainEntity.instanceOf;
+		delete mainEntity.instanceOf;
+		result['@reverse'] = { instanceOf: [mainEntity] };
+		if (!result.hasTitle && mainEntity.hasTitle) {
+			result.hasTitle = mainEntity.hasTitle;
+		}
+		return result;
+	} else {
+		return mainEntity;
+	}
+}

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -54,30 +54,10 @@ function sortHoldings(holdings) {
 	});
 }
 
-// export function getHoldersByInstanceId(
-// 	holdingsByInstanceId,
-// 	displayUtil: DisplayUtil,
-// 	locale: LocaleCode
-// ): HoldersByType {
-// 	return Object.entries(holdingsByInstanceId).reduce((acc, [id, holdings]) => {
-// 		const heldBys = holdings.map((holdingItem) => {
-// 			return {
-// 				obj: displayUtil.lensAndFormat(holdingItem.heldBy, LensType.Chip, locale),
-// 				sigel: holdingItem.heldBy.sigel,
-// 				str: toString(displayUtil.lensAndFormat(holdingItem.heldBy, LensType.Chip, locale)) || ''
-// 			};
-// 		});
-// 		const uniqueHeldBys = [
-// 			...new Map(heldBys.map((heldByItem) => [heldByItem.obj['@id'], heldByItem])).values()
-// 		];
-// 		return { ...acc, [id]: uniqueHeldBys };
-// 	}, {});
-// }
-
 export function getHoldersCount(mainEntity): number {
 	const instances = mainEntity['@reverse']?.instanceOf;
 	const holders = new Set();
-	instances.forEach((instance) => {
+	instances?.forEach((instance) => {
 		const holdings = instance['@reverse']?.itemOf;
 		holdings?.forEach((h) => {
 			if (h.heldBy) {

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -11,7 +11,7 @@ import type {
 import { LensType, type FramedData, JsonLd, BibDb } from '$lib/types/xl';
 import type { LocaleCode } from '$lib/i18n/locales';
 import type { LibraryItem, UserSettings } from '$lib/types/userSettings';
-import { relativizeUrl } from '$lib/utils/http';
+import { relativizeUrl, stripAnchor } from '$lib/utils/http';
 import { DisplayUtil, toString } from '$lib/utils/xl.js';
 import getAtPath from '$lib/utils/getAtPath';
 import { holdersCache } from '$lib/utils/holdersCache.svelte';
@@ -29,7 +29,7 @@ export function handleClickHoldings(
 ) {
 	console.log('state', JSON.stringify(state));
 	event.preventDefault();
-	pushState(event.currentTarget.href, { ...state, holdings: id });
+	pushState(event.currentTarget.href, { ...state, holdings: stripAnchor(id) });
 }
 
 export function getSelectedHolding(value: string, instanceIdsByType: { [key: string]: string[] }) {

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -27,7 +27,6 @@ export function handleClickHoldings(
 	state: object,
 	id: string
 ) {
-	console.log('state', JSON.stringify(state));
 	event.preventDefault();
 	pushState(event.currentTarget.href, { ...state, holdings: stripAnchor(id) });
 }

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -159,58 +159,6 @@ export function getBibIdsByInstanceId(
 	}, {});
 }
 
-// TODO: We do not have access to the full record when calling getBibIdsByInstanceId
-// hence this version which is not dependent on the resource/record parameter
-export function getBibIdsByInstanceId2(
-	mainEntity,
-	displayUtil: DisplayUtil,
-	locale: LocaleCode
-): Record<string, BibIdObj> {
-	return mainEntity['@reverse']?.instanceOf?.reduce((acc, instance) => {
-		const id = relativizeUrl(instance['@id'])?.replace('#it', '');
-
-		const bibId = instance.meta?.controlNumber;
-		const type = instance['@type'];
-		const holders = instance['@reverse']?.itemOf?.map((i) => i?.heldBy?.sigel);
-		const publication = instance.publication;
-		let str = '';
-		if (publication) {
-			str =
-				toString(displayUtil.lensAndFormat(instance.publication[0], LensType.Token, locale)) || '';
-		}
-
-		const onr = '';
-
-		const isbn: string[] = [];
-		const issn: string[] = [];
-		instance.identifiedBy?.forEach((el: { '@type': string; value: string }) => {
-			if (el['@type'] === 'ISBN') {
-				isbn.push(el.value);
-			}
-
-			if (el['@type'] === 'ISSN') {
-				issn.push(el.value);
-			}
-		});
-
-		if (!id) {
-			return acc;
-		}
-		return {
-			...acc,
-			[id]: {
-				bibId,
-				'@type': type,
-				holders,
-				onr,
-				isbn,
-				issn,
-				str
-			}
-		};
-	}, {});
-}
-
 export function getHoldingsByType(mainEntity: FramedData) {
 	const holdingsByType = mainEntity['@reverse']?.instanceOf?.reduce((acc, instanceOfItem) => {
 		const type = instanceOfItem['@type'];

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -74,6 +74,20 @@ function sortHoldings(holdings) {
 // 	}, {});
 // }
 
+export function getHoldersCount(mainEntity): number {
+	const instances = mainEntity['@reverse']?.instanceOf;
+	const holders = new Set();
+	instances.forEach((instance) => {
+		const holdings = instance['@reverse']?.itemOf;
+		holdings?.forEach((h) => {
+			if (h.heldBy) {
+				holders.add(h.heldBy['@id']);
+			}
+		});
+	});
+	return holders.size;
+}
+
 export function getHoldingsByInstanceId(
 	mainEntity,
 	displayUtil: DisplayUtil,

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -54,25 +54,25 @@ function sortHoldings(holdings) {
 	});
 }
 
-export function getHoldersByInstanceId(
-	holdingsByInstanceId,
-	displayUtil: DisplayUtil,
-	locale: LocaleCode
-): HoldersByType {
-	return Object.entries(holdingsByInstanceId).reduce((acc, [id, holdings]) => {
-		const heldBys = holdings.map((holdingItem) => {
-			return {
-				obj: displayUtil.lensAndFormat(holdingItem.heldBy, LensType.Chip, locale),
-				sigel: holdingItem.heldBy.sigel,
-				str: toString(displayUtil.lensAndFormat(holdingItem.heldBy, LensType.Chip, locale)) || ''
-			};
-		});
-		const uniqueHeldBys = [
-			...new Map(heldBys.map((heldByItem) => [heldByItem.obj['@id'], heldByItem])).values()
-		];
-		return { ...acc, [id]: uniqueHeldBys };
-	}, {});
-}
+// export function getHoldersByInstanceId(
+// 	holdingsByInstanceId,
+// 	displayUtil: DisplayUtil,
+// 	locale: LocaleCode
+// ): HoldersByType {
+// 	return Object.entries(holdingsByInstanceId).reduce((acc, [id, holdings]) => {
+// 		const heldBys = holdings.map((holdingItem) => {
+// 			return {
+// 				obj: displayUtil.lensAndFormat(holdingItem.heldBy, LensType.Chip, locale),
+// 				sigel: holdingItem.heldBy.sigel,
+// 				str: toString(displayUtil.lensAndFormat(holdingItem.heldBy, LensType.Chip, locale)) || ''
+// 			};
+// 		});
+// 		const uniqueHeldBys = [
+// 			...new Map(heldBys.map((heldByItem) => [heldByItem.obj['@id'], heldByItem])).values()
+// 		];
+// 		return { ...acc, [id]: uniqueHeldBys };
+// 	}, {});
+// }
 
 export function getHoldingsByInstanceId(
 	mainEntity,

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -27,6 +27,7 @@ export function handleClickHoldings(
 	state: object,
 	id: string
 ) {
+	console.log('state', JSON.stringify(state));
 	event.preventDefault();
 	pushState(event.currentTarget.href, { ...state, holdings: id });
 }

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -30,7 +30,7 @@ import { Width } from '$lib/types/auxd';
 import { bestImage, bestSize, toSecure } from '$lib/utils/auxd';
 import getAtPath from '$lib/utils/getAtPath';
 import { getUriSlug } from '$lib/utils/http';
-import { getHoldingsByInstanceId, getMyLibsFromHoldings } from './holdings';
+import {getHoldersCount, getHoldingsByInstanceId, getMyLibsFromHoldings } from './holdings';
 import getTypeLike from '$lib/utils/getTypeLike';
 import { ACCESS_FILTERS, MY_LIBRARIES_FILTER_ALIAS } from '$lib/constants/facets';
 
@@ -87,7 +87,8 @@ export async function asResult(
 				image: toSecure(bestSize(bestImage(i, locale), Width.SMALL), auxdSecret),
 				typeStr: getTypeLike(i, vocabUtil)
 					.map((t) => toString(displayUtil.lensAndFormat(t, LensType.Chip, locale)))
-					.join(' · ')
+					.join(' · '),
+				numberOfHolders: getHoldersCount(i)
 			})),
 		...('stats' in view && {
 			facetGroups: displayFacetGroups(view, displayUtil, locale, translate, usePath)

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
@@ -8,6 +8,9 @@
 	const isFindRoute = $derived(page.route.id === '/(app)/[[lang=lang]]/find');
 </script>
 
+<!-- if holdings=fnurgel rendera ut holdingskomponent som
+laddar det den behöver onMount-->
+
 <svelte:head>
 	<title>{getPageTitle()}</title>
 	<base href={data.base} />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
@@ -8,9 +8,6 @@
 	const isFindRoute = $derived(page.route.id === '/(app)/[[lang=lang]]/find');
 </script>
 
-<!-- if holdings=fnurgel rendera ut holdingskomponent som
-laddar det den behöver onMount-->
-
 <svelte:head>
 	<title>{getPageTitle()}</title>
 	<base href={data.base} />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -22,6 +22,7 @@ import {
 import { DebugFlags } from '$lib/types/userSettings';
 import { holdersCache } from '$lib/utils/holdersCache.svelte.js';
 import getTypeLike from '$lib/utils/getTypeLike';
+import { getUriSlug } from '$lib/utils/http';
 
 export const load = async ({ params, url, locals, fetch }) => {
 	const displayUtil = locals.display;
@@ -81,8 +82,9 @@ export const load = async ({ params, url, locals, fetch }) => {
 	if (holdersCache.holders) {
 		console.log('Current number of cached holders:', Object.keys(holdersCache.holders).length);
 	}
-
+	console.log('holdersByType', holdersByType);
 	return {
+		workFnurgel: getUriSlug(resourceId || undefined),
 		type: mainEntity[JsonLd.TYPE],
 		types: types,
 		title: toString(heading),

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -23,6 +23,7 @@ import { DebugFlags } from '$lib/types/userSettings';
 import { holdersCache } from '$lib/utils/holdersCache.svelte.js';
 import getTypeLike from '$lib/utils/getTypeLike';
 import { getUriSlug } from '$lib/utils/http';
+import { centerOnWork } from '$lib/utils/centerOnWork';
 
 export const load = async ({ params, url, locals, fetch }) => {
 	const displayUtil = locals.display;
@@ -153,21 +154,6 @@ export const load = async ({ params, url, locals, fetch }) => {
 		return (await recordsRes.json()) as PartialCollectionView;
 	}
 };
-
-// TODO: handle titles correctly
-function centerOnWork(mainEntity: FramedData): FramedData {
-	if ('instanceOf' in mainEntity) {
-		const result = mainEntity.instanceOf;
-		delete mainEntity.instanceOf;
-		result['@reverse'] = { instanceOf: [mainEntity] };
-		if (!result.hasTitle && mainEntity.hasTitle) {
-			result.hasTitle = mainEntity.hasTitle;
-		}
-		return result;
-	} else {
-		return mainEntity;
-	}
-}
 
 function getSortedInstances(instances: Record<string, unknown>[]) {
 	return instances.sort((a, b) => {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -90,8 +90,6 @@ export const load = async ({ params, url, locals, fetch }) => {
 
 	const itemLinksByBibId = getItemLinksByBibId(bibIdsByInstanceId, locale, displayUtil);
 
-	console.log('itemLinksByBibId', itemLinksByBibId);
-
 	return {
 		type: mainEntity[JsonLd.TYPE],
 		types: types,

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -90,6 +90,8 @@ export const load = async ({ params, url, locals, fetch }) => {
 
 	const itemLinksByBibId = getItemLinksByBibId(bibIdsByInstanceId, locale, displayUtil);
 
+	console.log('itemLinksByBibId', itemLinksByBibId);
+
 	return {
 		type: mainEntity[JsonLd.TYPE],
 		types: types,

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -82,7 +82,6 @@ export const load = async ({ params, url, locals, fetch }) => {
 	if (holdersCache.holders) {
 		console.log('Current number of cached holders:', Object.keys(holdersCache.holders).length);
 	}
-	console.log('holdersByType', holdersByType);
 	return {
 		workFnurgel: getUriSlug(resourceId || undefined),
 		type: mainEntity[JsonLd.TYPE],

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -17,10 +17,7 @@ import getAtPath from '$lib/utils/getAtPath';
 import {
 	getHoldingsByInstanceId,
 	getHoldingsByType,
-	getHoldersByType,
-	getBibIdsByInstanceId,
-	getItemLinksByBibId,
-	fetchHoldersIfAbsent
+	getHoldersByType
 } from '$lib/utils/holdings.js';
 import { DebugFlags } from '$lib/types/userSettings';
 import { holdersCache } from '$lib/utils/holdersCache.svelte.js';
@@ -78,17 +75,12 @@ export const load = async ({ params, url, locals, fetch }) => {
 
 	const images = getImages(mainEntity, locale).map((i) => toSecure(i, env.AUXD_SECRET));
 	const holdingsByInstanceId = getHoldingsByInstanceId(mainEntity, displayUtil, locale);
-	const bibIdsByInstanceId = getBibIdsByInstanceId(mainEntity, displayUtil, resource, locale);
 	const holdingsByType = getHoldingsByType(mainEntity);
 	const holdersByType = getHoldersByType(holdingsByType, displayUtil, locale);
-
-	await fetchHoldersIfAbsent(holdersByType);
 
 	if (holdersCache.holders) {
 		console.log('Current number of cached holders:', Object.keys(holdersCache.holders).length);
 	}
-
-	const itemLinksByBibId = getItemLinksByBibId(bibIdsByInstanceId, locale, displayUtil);
 
 	return {
 		type: mainEntity[JsonLd.TYPE],
@@ -96,13 +88,9 @@ export const load = async ({ params, url, locals, fetch }) => {
 		title: toString(heading),
 		heading,
 		overview: overviewWithoutHasInstance,
-		details: displayUtil.lensAndFormat(mainEntity, LxlLens.PageDetails, locale),
 		instances: sortedInstances,
 		holdingsByInstanceId,
-		bibIdsByInstanceId,
 		holdersByType,
-		itemLinksByBibId: itemLinksByBibId,
-		full: overview,
 		images,
 		searchResult: searchPromise ? await searchPromise : null
 	};

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -1,21 +1,15 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { afterNavigate, goto } from '$app/navigation';
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
-	import type { DecoratedHolder } from '$lib/types/holdings';
-	import { type ResourceData } from '$lib/types/resourceData';
 	import { Width } from '$lib/types/auxd';
 	import { getUserSettings } from '$lib/contexts/userSettings';
 
 	import getPageTitle from '$lib/utils/getPageTitle';
-	import isFnurgel from '$lib/utils/isFnurgel';
 	import { getHoldingsLink, getMyLibsFromHoldings, handleClickHoldings } from '$lib/utils/holdings';
 	import { relativizeUrl } from '$lib/utils/http';
 	import { getResourceId } from '$lib/utils/resourceData';
 
 	import InstancesList from './InstancesList.svelte';
-	import Holdings from './Holdings.svelte';
-	import Modal from '$lib/components/Modal.svelte';
 	import ResourceImage from '$lib/components/ResourceImage.svelte';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import SearchResultOld from '$lib/components/find/SearchResultOld.svelte';
@@ -23,26 +17,13 @@
 	import BiSearch from '~icons/bi/search';
 	import BiHouseHeart from '~icons/bi/house-heart';
 	import getTypeIcon from '$lib/utils/getTypeIcon';
+	import HoldingsModal from './HoldingsModal.svelte';
 
 	const { data } = $props();
 	const userSettings = getUserSettings();
-	const ASIDE_SEARCH_CARD_MAX_HEIGHT = 140;
+	const shouldShowHeaderBackground = $derived(!data.instances?.length);
 
-	let selectedHolding: string | undefined = $state();
-	let latestHoldingUrl: string | undefined = $state();
-	let holdingsInstanceElement: HTMLElement | undefined = $state();
-	let expandedHoldingsInstance = $state(false);
-	let previousURL: URL;
-	let searchPhrase = $state('');
-	let displayedHolders: DecoratedHolder[] = $state([]);
-
-	const selectedHoldingInstance = $derived(
-		selectedHolding
-			? data.instances?.find((instanceItem) => instanceItem['@id'].includes(selectedHolding)) ||
-					data.overview
-			: undefined
-	);
-
+	//TODO: duplicated
 	const localizedInstanceTypes = $derived(
 		Object.values(data.instances).reduce((acc, instanceItem) => {
 			if (instanceItem['@type'] && instanceItem?._label) {
@@ -54,71 +35,6 @@
 			return acc;
 		}, {})
 	);
-
-	// we should preferably only rely on $page.url.searchParams.get('holdings') but a workaround is needed due to a SvelteKit bug causing $page.url not to be updated after pushState. See: https://github.com/sveltejs/kit/pull/11994
-	const holdingUrl = $derived(page.state.holdings || page.url.searchParams.get('holdings') || null);
-
-	const shouldShowHeaderBackground = $derived(!data.instances?.length);
-	const expandableHoldingsInstance = $derived(
-		holdingsInstanceElement?.scrollHeight > ASIDE_SEARCH_CARD_MAX_HEIGHT
-	);
-
-	const filteredHolders = $derived(
-		displayedHolders
-			.filter((holder) => {
-				return holder.str?.toLowerCase().indexOf(searchPhrase.toLowerCase()) > -1;
-			})
-			.filter((h) => h.str)
-	);
-
-	const myLibsHolders = $derived(
-		displayedHolders.filter((holder) => {
-			if (userSettings.myLibraries) {
-				return Object.values(userSettings.myLibraries).some((lib) => lib.sigel === holder.sigel);
-			} else return false;
-		})
-	);
-
-	$effect(() => {
-		if (holdingUrl) {
-			selectedHolding = isFnurgel(holdingUrl) ? holdingUrl : (data.overview as string);
-			latestHoldingUrl = holdingUrl;
-		}
-	});
-
-	$effect(() => {
-		if (latestHoldingUrl) {
-			if (
-				isFnurgel(latestHoldingUrl) &&
-				selectedHolding &&
-				data.holdingsByInstanceId[selectedHolding]
-			) {
-				// show holdings for an instance
-				displayedHolders = data.holdingsByInstanceId[selectedHolding].map(
-					(holding) => holding.heldBy
-				);
-			} else if (data.holdersByType?.[latestHoldingUrl]) {
-				// show holdings by type
-				displayedHolders = data.holdersByType[latestHoldingUrl];
-			}
-		}
-	});
-
-	afterNavigate(({ to }) => {
-		if (to) {
-			previousURL = to.url;
-		}
-	});
-
-	function handleCloseHoldings() {
-		if (!previousURL?.searchParams.has('holdings')) {
-			history.back();
-		} else {
-			const newSearchParams = new URLSearchParams([...Array.from(page.url.searchParams.entries())]);
-			newSearchParams.delete('holdings');
-			goto(page.url.pathname + `?${newSearchParams.toString()}`, { replaceState: true });
-		}
-	}
 </script>
 
 <svelte:head>
@@ -216,114 +132,13 @@
 			</div>
 		</div>
 	{/if}
-	{#if holdingUrl && selectedHoldingInstance}
-		<Modal close={handleCloseHoldings}>
-			<span slot="title">{data.t('holdings.findAtYourNearestLibrary')}</span>
-			<div class="flex flex-col text-sm">
-				<div
-					class="bg-page border-b-neutral relative mb-4 flex w-full flex-col gap-x-4 rounded-md border-b p-5 text-xs transition-shadow"
-				>
-					<div
-						id="instance-details"
-						class="overview relative"
-						class:expandable={expandableHoldingsInstance}
-						class:expanded={expandedHoldingsInstance}
-						style="--max-height:{ASIDE_SEARCH_CARD_MAX_HEIGHT}px"
-						bind:this={holdingsInstanceElement}
-					>
-						<h2 class="mb-2">
-							<span class="font-medium">
-								<DecoratedData
-									data={data.title}
-									block
-									keyed={false}
-									allowPopovers={false}
-									allowLinks={false}
-								/>
-							</span>
-							{#if selectedHolding && data.instances?.length !== 1}
-								<span> · </span>
-								{#if isFnurgel(selectedHolding)}
-									{selectedHoldingInstance['_label']}
-								{:else if localizedInstanceTypes?.[latestHoldingUrl]}
-									{localizedInstanceTypes[latestHoldingUrl]}
-								{/if}
-							{/if}
-						</h2>
-						<DecoratedData
-							data={selectedHoldingInstance}
-							block
-							keyed={false}
-							allowPopovers={false}
-							allowLinks={false}
-						/>
-					</div>
-					<button
-						class="link-subtle mt-2 text-left"
-						onclick={() => (expandedHoldingsInstance = !expandedHoldingsInstance)}
-						aria-expanded={expandedHoldingsInstance}
-						aria-controls="instance-details"
-					>
-						{expandedHoldingsInstance
-							? page.data.t('search.hideDetails')
-							: page.data.t('search.showDetails')}</button
-					>
-				</div>
-				<div>
-					<h2 class="font-medium">
-						{data.t('holdings.availableAt')}
-						{#if latestHoldingUrl && isFnurgel(latestHoldingUrl)}
-							{data.holdingsByInstanceId[latestHoldingUrl].length}
-							{data.holdingsByInstanceId[latestHoldingUrl].length === 1
-								? data.t('holdings.library')
-								: data.t('holdings.libraries')}
-						{:else if latestHoldingUrl && data.holdersByType?.[latestHoldingUrl]}
-							{data.holdersByType[latestHoldingUrl].length}
-							{data.holdersByType[latestHoldingUrl].length === 1
-								? data.t('holdings.library')
-								: data.t('holdings.libraries')}
-						{/if}
-					</h2>
-					<!-- my libraries holdings -->
-					{#if myLibsHolders.length}
-						<div class="border-neutral bg-accent-50 my-4 rounded-sm border-b p-4 pb-0">
-							<h3 class="flex items-center gap-2">
-								<span aria-hidden="true" class="text-primary-700 text-base">
-									<BiHouseHeart />
-								</span>
-								<span class="font-medium">{page.data.t('myPages.favouriteLibraries')}</span>
-							</h3>
-							<ul class="w-full">
-								{#each myLibsHolders as holder, i (holder.sigel || i)}
-									<Holdings {holder} {holdingUrl} linksByBibId={data.itemLinksByBibId} />
-								{/each}
-							</ul>
-						</div>
-					{/if}
-					<div class="relative mt-2 mb-4">
-						<input
-							bind:value={searchPhrase}
-							placeholder={page.data.t('holdings.findLibrary')}
-							aria-label={page.data.t('holdings.findLibrary')}
-							class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-xs"
-							type="search"
-						/>
-						<BiSearch class="text-subtle absolute top-0 left-2.5 h-9" />
-					</div>
-					<ul class="w-full">
-						{#each filteredHolders as holder, i (holder.sigel || i)}
-							<Holdings {holder} {holdingUrl} linksByBibId={data.itemLinksByBibId} />
-						{/each}
-						{#if filteredHolders.length === 0}
-							<li class="m-3">
-								<span role="alert">{page.data.t('search.noResults')}</span>
-							</li>
-						{/if}
-					</ul>
-				</div>
-			</div>
-		</Modal>
-	{/if}
+	<HoldingsModal
+		holdingsByInstanceId={data.holdingsByInstanceId}
+		itemLinksByBibId={data.itemLinksByBibId}
+		instances={data.instances}
+		title={data.title}
+		overview={data.overview}
+	></HoldingsModal>
 </article>
 <SearchResultOld searchResult={page.data.searchResult} showMapping />
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -131,7 +131,7 @@
 			</div>
 		</div>
 	{/if}
-	<HoldingsModal></HoldingsModal>
+	<HoldingsModal workFnurgel={page.data.workFnurgel}></HoldingsModal>
 </article>
 <SearchResultOld searchResult={page.data.searchResult} showMapping />
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -14,8 +14,6 @@
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import SearchResultOld from '$lib/components/find/SearchResultOld.svelte';
 	import MyLibrariesIndicator from '$lib/components/MyLibsHoldingIndicator.svelte';
-	import BiSearch from '~icons/bi/search';
-	import BiHouseHeart from '~icons/bi/house-heart';
 	import getTypeIcon from '$lib/utils/getTypeIcon';
 	import HoldingsModal from './HoldingsModal.svelte';
 
@@ -204,38 +202,6 @@
 			display: block;
 			width: fit-content;
 			white-space: nowrap;
-		}
-	}
-
-	.expandable {
-		max-height: var(--max-height);
-		overflow: hidden;
-	}
-
-	.expandable:not(.expanded)::after {
-		height: 3rem;
-		width: 100%;
-		position: absolute;
-		content: '';
-		bottom: 0;
-		left: 0;
-		pointer-events: none;
-		background: linear-gradient(
-			to bottom,
-			--alpha(var(--color-page) / 0%),
-			--alpha(var(--color-page) / 100%)
-		);
-		overflow: hidden;
-	}
-
-	.expanded {
-		max-height: initial;
-	}
-
-	#instance-details {
-		& :global(.contribution-role),
-		& :global(.property-label) {
-			font-size: var(--text-2xs);
 		}
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -131,7 +131,9 @@
 			</div>
 		</div>
 	{/if}
-	<HoldingsModal workFnurgel={page.data.workFnurgel}></HoldingsModal>
+	{#if !page.data.searchResult}
+		<HoldingsModal workFnurgel={page.data.workFnurgel}></HoldingsModal>
+	{/if}
 </article>
 <SearchResultOld searchResult={page.data.searchResult} showMapping />
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -22,7 +22,7 @@
 	const { data } = $props();
 	const userSettings = getUserSettings();
 	const shouldShowHeaderBackground = $derived(!data.instances?.length);
-
+	const holdingsParam = page.url.searchParams.get('holdings');
 	//TODO: duplicated
 	const localizedInstanceTypes = $derived(
 		Object.values(data.instances).reduce((acc, instanceItem) => {
@@ -132,14 +132,9 @@
 			</div>
 		</div>
 	{/if}
-	<HoldingsModal
-		holdingsByInstanceId={data.holdingsByInstanceId}
-		itemLinksByBibId={data.itemLinksByBibId}
-		instances={data.instances}
-		title={data.title}
-		overview={data.overview}
-		holdersByType={data.holdersByType}
-	></HoldingsModal>
+	{#if holdingsParam}
+		<HoldingsModal></HoldingsModal>
+	{/if}
 </article>
 <SearchResultOld searchResult={page.data.searchResult} showMapping />
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -138,6 +138,7 @@
 		instances={data.instances}
 		title={data.title}
 		overview={data.overview}
+		holdersByType={data.holdersByType}
 	></HoldingsModal>
 </article>
 <SearchResultOld searchResult={page.data.searchResult} showMapping />

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -22,7 +22,6 @@
 	const { data } = $props();
 	const userSettings = getUserSettings();
 	const shouldShowHeaderBackground = $derived(!data.instances?.length);
-	const holdingsParam = page.url.searchParams.get('holdings');
 	//TODO: duplicated
 	const localizedInstanceTypes = $derived(
 		Object.values(data.instances).reduce((acc, instanceItem) => {
@@ -132,9 +131,7 @@
 			</div>
 		</div>
 	{/if}
-	{#if holdingsParam}
-		<HoldingsModal></HoldingsModal>
-	{/if}
+	<HoldingsModal></HoldingsModal>
 </article>
 <SearchResultOld searchResult={page.data.searchResult} showMapping />
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
@@ -6,6 +6,7 @@
 	import BiChevronRight from '~icons/bi/chevron-right';
 	import { BibDb } from '$lib/types/xl';
 	import HoldingInfo from './HoldingInfo.svelte';
+	import isFnurgel from '$lib/utils/isFnurgel';
 
 	type HoldingsProps = {
 		holder: DecoratedHolder;
@@ -22,12 +23,20 @@
 	// if holdingUrl is an instance fnurgel, add its mapped bibId object into arr,
 	// else add all ids of current type with holdings for current sigel
 	const bibIds = $derived.by(() => {
-		return bibIdsByInstanceId?.[holdingUrl]
-			? [bibIdsByInstanceId[holdingUrl]]
-			: Object.keys(bibIdsByInstanceId)
-					.filter((i) => bibIdsByInstanceId[i]['@type'] === holdingUrl)
-					.filter((i) => bibIdsByInstanceId[i].holders?.includes(sigel))
-					.map((i) => bibIdsByInstanceId[i]);
+		if (bibIdsByInstanceId?.[holdingUrl]) {
+			return [bibIdsByInstanceId[holdingUrl]];
+		} else if (!isFnurgel(holdingUrl)) {
+			// holdingUrl is type
+			return Object.keys(bibIdsByInstanceId)
+				.filter((i) => bibIdsByInstanceId[i]['@type'] === holdingUrl)
+				.filter((i) => bibIdsByInstanceId[i].holders?.includes(sigel))
+				.map((i) => bibIdsByInstanceId[i]);
+		} else {
+			// holdingUrl is a workFnurgel
+			return Object.keys(bibIdsByInstanceId)
+				.filter((i) => bibIdsByInstanceId[i].holders?.includes(sigel))
+				.map((i) => bibIdsByInstanceId[i]);
+		}
 	});
 
 	function hasLinksToItem(id: string) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
@@ -17,7 +17,6 @@
 
 	const { holder, holdingUrl, linksByBibId, bibIdsByInstanceId }: HoldingsProps = $props();
 
-	const sigel = holder?.sigel;
 	let instancesCollapsed = $state(true);
 
 	// if holdingUrl is an instance fnurgel, add its mapped bibId object into arr,
@@ -29,12 +28,12 @@
 			// holdingUrl is type
 			return Object.keys(bibIdsByInstanceId)
 				.filter((i) => bibIdsByInstanceId[i]['@type'] === holdingUrl)
-				.filter((i) => bibIdsByInstanceId[i].holders?.includes(sigel))
+				.filter((i) => bibIdsByInstanceId[i].holders?.includes(holder.sigel))
 				.map((i) => bibIdsByInstanceId[i]);
 		} else {
 			// holdingUrl is a workFnurgel
 			return Object.keys(bibIdsByInstanceId)
-				.filter((i) => bibIdsByInstanceId[i].holders?.includes(sigel))
+				.filter((i) => bibIdsByInstanceId[i].holders?.includes(holder.sigel))
 				.map((i) => bibIdsByInstanceId[i]);
 		}
 	});

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/Holdings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import type { DecoratedHolder, ItemLinksByBibId } from '$lib/types/holdings';
+	import type { BibIdObj, DecoratedHolder, ItemLinksByBibId } from '$lib/types/holdings';
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
 	import DecoratedData from '$lib/components/DecoratedData.svelte';
 	import BiChevronRight from '~icons/bi/chevron-right';
@@ -11,9 +11,10 @@
 		holder: DecoratedHolder;
 		holdingUrl: string;
 		linksByBibId: ItemLinksByBibId;
+		bibIdsByInstanceId: Record<string, BibIdObj>;
 	};
 
-	const { holder, holdingUrl, linksByBibId }: HoldingsProps = $props();
+	const { holder, holdingUrl, linksByBibId, bibIdsByInstanceId }: HoldingsProps = $props();
 
 	const sigel = holder?.sigel;
 	let instancesCollapsed = $state(true);
@@ -21,12 +22,12 @@
 	// if holdingUrl is an instance fnurgel, add its mapped bibId object into arr,
 	// else add all ids of current type with holdings for current sigel
 	const bibIds = $derived.by(() => {
-		return page.data.bibIdsByInstanceId?.[holdingUrl]
-			? [page.data.bibIdsByInstanceId[holdingUrl]]
-			: Object.keys(page.data.bibIdsByInstanceId)
-					.filter((i) => page.data.bibIdsByInstanceId[i]['@type'] === holdingUrl)
-					.filter((i) => page.data.bibIdsByInstanceId[i].holders?.includes(sigel))
-					.map((i) => page.data.bibIdsByInstanceId[i]);
+		return bibIdsByInstanceId?.[holdingUrl]
+			? [bibIdsByInstanceId[holdingUrl]]
+			: Object.keys(bibIdsByInstanceId)
+					.filter((i) => bibIdsByInstanceId[i]['@type'] === holdingUrl)
+					.filter((i) => bibIdsByInstanceId[i].holders?.includes(sigel))
+					.map((i) => bibIdsByInstanceId[i]);
 	});
 
 	function hasLinksToItem(id: string) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
@@ -27,23 +27,11 @@
 		bibIdsByInstanceId: Record<string, BibIdObj>;
 	};
 
-	let data: HoldingsModalProps | undefined = $state();
-
-	onMount(async () => {
-		console.log('ON MOUNT');
-		const fnurgel = page.url.searchParams.get('holdings');
-		if (fnurgel && isFnurgel(fnurgel)) {
-			const result = await fetch(`/api/holdings/${fnurgel}`);
-			data = await result.json();
-		}
-	});
-
-	// Also call the onMount functions when the fnurgel changes!!
-
-	const userSettings = getUserSettings();
 	const ASIDE_SEARCH_CARD_MAX_HEIGHT = 140;
-	let previousURL: URL;
+	const userSettings = getUserSettings();
 
+	let data: HoldingsModalProps | undefined = $state();
+	let previousURL: URL;
 	let displayedHolders: DecoratedHolder[] = $state([]);
 	let selectedHolding: string | undefined = $state();
 	let latestHoldingUrl: string | undefined = $state();
@@ -102,20 +90,29 @@
 		})
 	);
 
+	onMount(async () => {
+		console.log('ON MOUNT');
+		getForHoldingUrl();
+	});
+
+	$effect(() => {
+		console.log('EFFECT!!!');
+		getForHoldingUrl();
+	});
+
+	function getForHoldingUrl() {
+		if (latestHoldingUrl && isFnurgel(latestHoldingUrl)) {
+			fetch(`/api/holdings/${latestHoldingUrl}`).then((res) => {
+				res.json().then((d) => (data = d));
+			});
+		}
+	}
+
 	$effect(() => {
 		if (holdingUrl) {
 			selectedHolding = isFnurgel(holdingUrl) ? holdingUrl : (data?.overview as string);
 			latestHoldingUrl = holdingUrl;
 			console.log('holdingUrl', latestHoldingUrl);
-		}
-	});
-
-	$effect(() => {
-		console.log('EFFECT!!!');
-		if (latestHoldingUrl && isFnurgel(latestHoldingUrl)) {
-			fetch(`/api/holdings/${latestHoldingUrl}`).then((res) => {
-				res.json().then((d) => (data = d));
-			});
 		}
 	});
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
@@ -27,8 +27,14 @@
 		bibIdsByInstanceId: Record<string, BibIdObj>;
 	};
 
+	type HoldingsModalParams = {
+		workFnurgel: string;
+	};
+
 	const ASIDE_SEARCH_CARD_MAX_HEIGHT = 140;
 	const userSettings = getUserSettings();
+
+	const { workFnurgel }: HoldingsModalParams = $props();
 
 	let data: HoldingsModalProps | undefined = $state();
 	let previousURL: URL;
@@ -60,19 +66,17 @@
 	);
 
 	//TODO: duplicated
-	// if (data?.holdersByType) {
-	// 	const localizedInstanceTypes = $derived(
-	// 		Object.values(data?.instances).reduce((acc, instanceItem) => {
-	// 			if (instanceItem['@type'] && instanceItem?._label) {
-	// 				return {
-	// 					...acc,
-	// 					[instanceItem['@type'] as string]: instanceItem._label
-	// 				};
-	// 			}
-	// 			return acc;
-	// 		}, {})
-	// 	);
-	// }
+	// const localizedInstanceTypes = $derived(
+	// 	Object.values(data?.instances).reduce((acc, instanceItem) => {
+	// 		if (instanceItem['@type'] && instanceItem?._label) {
+	// 			return {
+	// 				...acc,
+	// 				[instanceItem['@type'] as string]: instanceItem._label
+	// 			};
+	// 		}
+	// 		return acc;
+	// 	}, {})
+	// );
 
 	const filteredHolders = $derived(
 		displayedHolders
@@ -91,18 +95,20 @@
 	);
 
 	onMount(async () => {
-		console.log('ON MOUNT');
-		getForHoldingUrl();
+		console.log('onMount');
+		getDataForWork();
 	});
 
 	$effect(() => {
-		console.log('EFFECT!!!');
-		getForHoldingUrl();
+		console.log('effect');
+		getDataForWork();
 	});
 
-	function getForHoldingUrl() {
-		if (latestHoldingUrl && isFnurgel(latestHoldingUrl)) {
-			fetch(`/api/holdings/${latestHoldingUrl}`).then((res) => {
+	function getDataForWork() {
+		if (workFnurgel) {
+			console.log('workfnurgel', workFnurgel);
+			console.log('Preparing data for work with ID:', workFnurgel);
+			fetch(`/api/holdings/${workFnurgel}`).then((res) => {
 				res.json().then((d) => (data = d));
 			});
 		}
@@ -112,12 +118,12 @@
 		if (holdingUrl) {
 			selectedHolding = isFnurgel(holdingUrl) ? holdingUrl : (data?.overview as string);
 			latestHoldingUrl = holdingUrl;
-			console.log('holdingUrl', latestHoldingUrl);
 		}
 	});
 
 	// Need to check that holdingsByInstanceId contains instanceId
 	$effect(() => {
+		console.log('data?.holdersByType', JSON.stringify(data?.holdersByType));
 		if (latestHoldingUrl) {
 			if (
 				isFnurgel(latestHoldingUrl) &&
@@ -125,6 +131,7 @@
 				data?.holdingsByInstanceId[selectedHolding]
 			) {
 				// show holdings for an instance
+				console.log('Hej');
 				displayedHolders = data?.holdingsByInstanceId[selectedHolding].map(
 					(holding) => holding.heldBy
 				);
@@ -175,8 +182,8 @@
 							<span> · </span>
 							{#if isFnurgel(selectedHolding)}
 								{selectedHoldingInstance['_label']}
-							{:else if localizedInstanceTypes?.[latestHoldingUrl]}
-								{localizedInstanceTypes[latestHoldingUrl]}
+								<!--{:else if localizedInstanceTypes?.[latestHoldingUrl]}-->
+								<!--	{localizedInstanceTypes[latestHoldingUrl]}-->
 							{/if}
 						{/if}
 					</h2>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
@@ -95,18 +95,15 @@
 	);
 
 	onMount(async () => {
-		console.log('onMount');
 		getDataForWork();
 	});
 
 	$effect(() => {
-		console.log('effect');
 		getDataForWork();
 	});
 
 	function getDataForWork() {
 		if (workFnurgel) {
-			console.log('workfnurgel', workFnurgel);
 			console.log('Preparing data for work with ID:', workFnurgel);
 			fetch(`/api/holdings/${workFnurgel}`).then((res) => {
 				res.json().then((d) => (data = d));
@@ -121,9 +118,7 @@
 		}
 	});
 
-	// Need to check that holdingsByInstanceId contains instanceId
 	$effect(() => {
-		console.log('data?.holdersByType', JSON.stringify(data?.holdersByType));
 		if (latestHoldingUrl) {
 			if (
 				isFnurgel(latestHoldingUrl) &&
@@ -131,13 +126,21 @@
 				data?.holdingsByInstanceId[selectedHolding]
 			) {
 				// show holdings for an instance
-				console.log('Hej');
 				displayedHolders = data?.holdingsByInstanceId[selectedHolding].map(
 					(holding) => holding.heldBy
 				);
 			} else if (data?.holdersByType?.[latestHoldingUrl]) {
 				// show holdings by type
 				displayedHolders = data?.holdersByType[latestHoldingUrl];
+			} else if (isFnurgel(latestHoldingUrl) && data?.holdersByType) {
+				// show all (associated with a work)
+				displayedHolders = [
+					...new Map(
+						Object.values(data.holdersByType)
+							.flat()
+							.map((holder) => [holder.sigel, holder])
+					).values()
+				];
 			}
 		}
 	});

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
@@ -65,7 +65,7 @@
 		holdingsInstanceElement?.scrollHeight > ASIDE_SEARCH_CARD_MAX_HEIGHT
 	);
 
-	//TODO: duplicated
+	//TODO: duplicated + not working, is this really needed? Used in the "holding instance summary".
 	// const localizedInstanceTypes = $derived(
 	// 	Object.values(data?.instances).reduce((acc, instanceItem) => {
 	// 		if (instanceItem['@type'] && instanceItem?._label) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
@@ -1,0 +1,242 @@
+<script lang="ts">
+	import type {
+		DecoratedHolder,
+		HoldersByType,
+		HoldingsByInstanceId,
+		ItemLinksByBibId
+	} from '$lib/types/holdings';
+	import isFnurgel from '$lib/utils/isFnurgel';
+	import Holdings from './Holdings.svelte';
+	import Modal from '$lib/components/Modal.svelte';
+	import DecoratedData from '$lib/components/DecoratedData.svelte';
+	import { page } from '$app/state';
+	import { afterNavigate, goto } from '$app/navigation';
+	import BiSearch from '~icons/bi/search';
+	import BiHouseHeart from '~icons/bi/house-heart';
+	import { getUserSettings } from '$lib/contexts/userSettings';
+
+	// Props we need to pass:
+	// holdingsByInstanceId = getHoldingsByInstanceId(mainEntity, displayUtil, locale);
+
+	// Title/ heading, overview
+	// can all be derived from mainEntity
+	// but still should be calculated on the server?
+
+	// data.instances does not have to be sorted in this context
+	// although getSortedInstances is called in +page.server.ts
+
+	type HoldingsModalProps = {
+		holdingsByInstanceId: HoldingsByInstanceId;
+		itemLinksByBibId: ItemLinksByBibId;
+		instances: Record<string, unknown>[];
+		title: string;
+		overview: unknown;
+		holdersByType?: HoldersByType;
+	};
+
+	const {
+		holdingsByInstanceId,
+		itemLinksByBibId,
+		instances,
+		title,
+		overview,
+		holdersByType
+	}: HoldingsModalProps = $props();
+
+	const userSettings = getUserSettings();
+	const ASIDE_SEARCH_CARD_MAX_HEIGHT = 140;
+	let previousURL: URL;
+
+	let displayedHolders: DecoratedHolder[] = $state([]);
+	let selectedHolding: string | undefined = $state();
+	let latestHoldingUrl: string | undefined = $state();
+	let holdingsInstanceElement: HTMLElement | undefined = $state();
+	let expandedHoldingsInstance = $state(false);
+	let searchPhrase = $state('');
+
+	// we should preferably only rely on $page.url.searchParams.get('holdings') but a workaround is needed due to a SvelteKit bug causing $page.url not to be updated after pushState. See: https://github.com/sveltejs/kit/pull/11994
+	const holdingUrl = $derived(page.state.holdings || page.url.searchParams.get('holdings') || null);
+
+	const selectedHoldingInstance = $derived(
+		selectedHolding
+			? instances?.find((instanceItem) => instanceItem['@id'].includes(selectedHolding)) || overview
+			: undefined
+	);
+
+	afterNavigate(({ to }) => {
+		if (to) {
+			previousURL = to.url;
+		}
+	});
+
+	const expandableHoldingsInstance = $derived(
+		holdingsInstanceElement?.scrollHeight > ASIDE_SEARCH_CARD_MAX_HEIGHT
+	);
+
+	//TODO: duplicated
+	const localizedInstanceTypes = $derived(
+		Object.values(instances).reduce((acc, instanceItem) => {
+			if (instanceItem['@type'] && instanceItem?._label) {
+				return {
+					...acc,
+					[instanceItem['@type'] as string]: instanceItem._label
+				};
+			}
+			return acc;
+		}, {})
+	);
+
+	const filteredHolders = $derived(
+		displayedHolders
+			.filter((holder) => {
+				return holder.str?.toLowerCase().indexOf(searchPhrase.toLowerCase()) > -1;
+			})
+			.filter((h) => h.str)
+	);
+
+	const myLibsHolders = $derived(
+		displayedHolders.filter((holder) => {
+			if (userSettings.myLibraries) {
+				return Object.values(userSettings.myLibraries).some((lib) => lib.sigel === holder.sigel);
+			} else return false;
+		})
+	);
+
+	$effect(() => {
+		if (holdingUrl) {
+			selectedHolding = isFnurgel(holdingUrl) ? holdingUrl : (overview as string);
+			latestHoldingUrl = holdingUrl;
+		}
+	});
+
+	$effect(() => {
+		if (latestHoldingUrl) {
+			if (isFnurgel(latestHoldingUrl) && selectedHolding && holdingsByInstanceId[selectedHolding]) {
+				// show holdings for an instance
+				displayedHolders = holdingsByInstanceId[selectedHolding].map((holding) => holding.heldBy);
+			} else if (holdersByType?.[latestHoldingUrl]) {
+				// show holdings by type
+				displayedHolders = holdersByType[latestHoldingUrl];
+			}
+		}
+	});
+
+	function handleCloseHoldings() {
+		if (!previousURL?.searchParams.has('holdings')) {
+			history.back();
+		} else {
+			const newSearchParams = new URLSearchParams([...Array.from(page.url.searchParams.entries())]);
+			newSearchParams.delete('holdings');
+			goto(page.url.pathname + `?${newSearchParams.toString()}`, { replaceState: true });
+		}
+	}
+</script>
+
+{#if holdingUrl && selectedHoldingInstance}
+	<Modal close={handleCloseHoldings}>
+		<span slot="title">{page.data.t('holdings.findAtYourNearestLibrary')}</span>
+		<div class="flex flex-col text-sm">
+			<div
+				class="bg-page border-b-neutral relative mb-4 flex w-full flex-col gap-x-4 rounded-md border-b p-5 text-xs transition-shadow"
+			>
+				<div
+					id="instance-details"
+					class="overview relative"
+					class:expandable={expandableHoldingsInstance}
+					class:expanded={expandedHoldingsInstance}
+					style="--max-height:{ASIDE_SEARCH_CARD_MAX_HEIGHT}px"
+					bind:this={holdingsInstanceElement}
+				>
+					<h2 class="mb-2">
+						<span class="font-medium">
+							<DecoratedData
+								data={title}
+								block
+								keyed={false}
+								allowPopovers={false}
+								allowLinks={false}
+							/>
+						</span>
+						{#if selectedHolding && instances?.length !== 1}
+							<span> · </span>
+							{#if isFnurgel(selectedHolding)}
+								{selectedHoldingInstance['_label']}
+							{:else if localizedInstanceTypes?.[latestHoldingUrl]}
+								{localizedInstanceTypes[latestHoldingUrl]}
+							{/if}
+						{/if}
+					</h2>
+					<DecoratedData
+						data={selectedHoldingInstance}
+						block
+						keyed={false}
+						allowPopovers={false}
+						allowLinks={false}
+					/>
+				</div>
+				<button
+					class="link-subtle mt-2 text-left"
+					onclick={() => (expandedHoldingsInstance = !expandedHoldingsInstance)}
+					aria-expanded={expandedHoldingsInstance}
+					aria-controls="instance-details"
+				>
+					{expandedHoldingsInstance
+						? page.data.t('search.hideDetails')
+						: page.data.t('search.showDetails')}</button
+				>
+			</div>
+			<div>
+				<h2 class="font-medium">
+					{page.data.t('holdings.availableAt')}
+					{#if latestHoldingUrl && isFnurgel(latestHoldingUrl)}
+						{holdingsByInstanceId[latestHoldingUrl].length}
+						{holdingsByInstanceId[latestHoldingUrl].length === 1
+							? page.data.t('holdings.library')
+							: page.data.t('holdings.libraries')}
+					{:else if latestHoldingUrl && holdersByType?.[latestHoldingUrl]}
+						{holdersByType[latestHoldingUrl].length}
+						{holdersByType[latestHoldingUrl].length === 1
+							? page.data.t('holdings.library')
+							: page.data.t('holdings.libraries')}
+					{/if}
+				</h2>
+				<!-- my libraries holdings -->
+				{#if myLibsHolders.length}
+					<div class="border-neutral bg-accent-50 my-4 rounded-sm border-b p-4 pb-0">
+						<h3 class="flex items-center gap-2">
+							<span aria-hidden="true" class="text-primary-700 text-base">
+								<BiHouseHeart />
+							</span>
+							<span class="font-medium">{page.data.t('myPages.favouriteLibraries')}</span>
+						</h3>
+						<ul class="w-full">
+							{#each myLibsHolders as holder, i (holder.sigel || i)}
+								<Holdings {holder} {holdingUrl} linksByBibId={itemLinksByBibId} />
+							{/each}
+						</ul>
+					</div>
+				{/if}
+				<div class="relative mt-2 mb-4">
+					<input
+						bind:value={searchPhrase}
+						placeholder={page.data.t('holdings.findLibrary')}
+						aria-label={page.data.t('holdings.findLibrary')}
+						class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-xs"
+						type="search"
+					/>
+					<BiSearch class="text-subtle absolute top-0 left-2.5 h-9" />
+				</div>
+				<ul class="w-full">
+					{#each filteredHolders as holder, i (holder.sigel || i)}
+						<Holdings {holder} {holdingUrl} linksByBibId={itemLinksByBibId} />
+					{/each}
+					{#if filteredHolders.length === 0}
+						<li class="m-3">
+							<span role="alert">{page.data.t('search.noResults')}</span>
+						</li>
+					{/if}
+				</ul>
+			</div>
+		</div>
+	</Modal>
+{/if}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
@@ -247,7 +247,7 @@
 								<span class="font-medium">{page.data.t('myPages.favouriteLibraries')}</span>
 							</h3>
 							<ul class="w-full">
-								{#each myLibsHolders as holder, i (holder.sigel || i)}
+								{#each myLibsHolders as holder, i (i)}
 									<Holdings
 										{holder}
 										{holdingUrl}
@@ -269,7 +269,7 @@
 						<BiSearch class="text-subtle absolute top-0 left-2.5 h-9" />
 					</div>
 					<ul class="w-full">
-						{#each filteredHolders as holder, i (holder.sigel || i)}
+						{#each filteredHolders as holder, i (i)}
 							<Holdings
 								{holder}
 								{holdingUrl}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
@@ -107,7 +107,6 @@
 	function getDataForWork() {
 		if (workFnurgel) {
 			loading = true;
-			console.log('Preparing data for work with ID:', workFnurgel);
 			fetch(`/api/holdings/${workFnurgel}`).then((res) => {
 				res.json().then((d) => {
 					data = d;

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/HoldingsModal.svelte
@@ -288,3 +288,37 @@
 		{/if}
 	</Modal>
 {/if}
+
+<style>
+	.expandable {
+		max-height: var(--max-height);
+		overflow: hidden;
+	}
+
+	.expandable:not(.expanded)::after {
+		height: 3rem;
+		width: 100%;
+		position: absolute;
+		content: '';
+		bottom: 0;
+		left: 0;
+		pointer-events: none;
+		background: linear-gradient(
+			to bottom,
+			--alpha(var(--color-page) / 0%),
+			--alpha(var(--color-page) / 100%)
+		);
+		overflow: hidden;
+	}
+
+	.expanded {
+		max-height: initial;
+	}
+
+	#instance-details {
+		& :global(.contribution-role),
+		& :global(.property-label) {
+			font-size: var(--text-2xs);
+		}
+	}
+</style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/InstancesList.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/InstancesList.svelte
@@ -126,7 +126,9 @@
 										page.data.holdingsByInstanceId[id]
 									)}
 									{#if myLibsWithHolding.length}
-										<MyLibrariesIndicator libraries={myLibsWithHolding} />
+										<span class="p-2">
+											<MyLibrariesIndicator libraries={myLibsWithHolding} />
+										</span>
 									{/if}
 									<a
 										href={getHoldingsLink(page.url, id)}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -11,6 +11,7 @@
 	import TrailingPanes from '$lib/components/find/TrailingPanes.svelte';
 	import Pagination from '$lib/components/find/Pagination.svelte';
 	import SiteFooter from '../SiteFooter.svelte';
+	import HoldingsModal from '../[fnurgel=fnurgel]/HoldingsModal.svelte';
 
 	const searchResult: SearchResult = $derived(page.data.searchResult);
 </script>
@@ -48,6 +49,7 @@
 			<SiteFooter />
 		</div>
 		<TrailingPanes />
+		<HoldingsModal workFnurgel={page.state.holdings}></HoldingsModal>
 	</div>
 {/if}
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -49,7 +49,8 @@
 			<SiteFooter />
 		</div>
 		<TrailingPanes />
-		<HoldingsModal workFnurgel={page.state.holdings}></HoldingsModal>
+		<HoldingsModal workFnurgel={page.state.holdings || page.url.searchParams.get('holdings')}
+		></HoldingsModal>
 	</div>
 {/if}
 

--- a/lxl-web/src/routes/api/holdings/[[lang=lang]]/[fnurgel=fnurgel]/+server.ts
+++ b/lxl-web/src/routes/api/holdings/[[lang=lang]]/[fnurgel=fnurgel]/+server.ts
@@ -1,0 +1,81 @@
+import { env } from '$env/dynamic/private';
+import { getSupportedLocale } from '$lib/i18n/locales';
+import type { ApiError } from '$lib/types/api';
+import type { FramedData } from '$lib/types/xl';
+import { LxlLens } from '$lib/types/display';
+import { pickProperty, toString } from '$lib/utils/xl';
+import {
+	fetchHoldersIfAbsent,
+	getBibIdsByInstanceId,
+	getHoldersByInstanceId,
+	getHoldingsByInstanceId,
+	getItemLinksByBibId
+} from '$lib/utils/holdings';
+import { error, json } from '@sveltejs/kit';
+import jmespath from 'jmespath';
+
+export async function GET({ url, params, locals }) {
+	console.log('url', url);
+	console.log('params', params);
+
+	const displayUtil = locals.display;
+	const locale = getSupportedLocale(params.lang);
+	const resourceRes = await fetch(`${env.API_URL}/${params.fnurgel}?framed=true`, {
+		headers: { Accept: 'application/ld+json' }
+	});
+
+	if (resourceRes.status === 404) {
+		throw error(resourceRes.status, { message: 'Not found' });
+	}
+
+	if (!resourceRes.ok) {
+		try {
+			const err = (await resourceRes.json()) as ApiError;
+			throw error(err.status_code, { message: err.message, status: err.status });
+		} catch (e) {
+			console.warn(e);
+			throw error(resourceRes?.status, { message: resourceRes?.statusText });
+		}
+	}
+	const resource = await resourceRes.json();
+	const mainEntity = centerOnWork(resource['mainEntity'] as FramedData);
+	const heading = displayUtil.lensAndFormat(mainEntity, LxlLens.PageHeading, locale);
+
+	const overview = displayUtil.lensAndFormat(mainEntity, LxlLens.PageOverView, locale);
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [_, overviewWithoutHasInstance] = pickProperty(overview, ['hasInstance']);
+	const instances = jmespath.search(overview, '*[].hasInstance[]');
+
+	const holdingsByInstanceId = getHoldingsByInstanceId(mainEntity, displayUtil, locale);
+	const bibIdsByInstanceId = getBibIdsByInstanceId(mainEntity, displayUtil, resource, locale);
+	const itemLinksByBibId = getItemLinksByBibId(bibIdsByInstanceId, locale, displayUtil);
+	const holdersByInstanceId = getHoldersByInstanceId(holdingsByInstanceId, displayUtil, locale);
+
+	//get all holders
+	await fetchHoldersIfAbsent(Object.values(holdersByInstanceId).flat());
+	console.log('bibIdsByInstanceId', bibIdsByInstanceId);
+
+	return json({
+		bibIdsByInstanceId: bibIdsByInstanceId,
+		holdingsByInstanceId: holdingsByInstanceId,
+		itemLinksByBibId: itemLinksByBibId,
+		instances: instances,
+		title: toString(heading),
+		overview: overviewWithoutHasInstance
+	});
+
+	//TODO: duplicated, extract to holdings.ts? or similar
+	function centerOnWork(mainEntity: FramedData): FramedData {
+		if ('instanceOf' in mainEntity) {
+			const result = mainEntity.instanceOf;
+			delete mainEntity.instanceOf;
+			result['@reverse'] = { instanceOf: [mainEntity] };
+			if (!result.hasTitle && mainEntity.hasTitle) {
+				result.hasTitle = mainEntity.hasTitle;
+			}
+			return result;
+		} else {
+			return mainEntity;
+		}
+	}
+}

--- a/lxl-web/src/routes/api/holdings/[[lang=lang]]/[fnurgel=fnurgel]/+server.ts
+++ b/lxl-web/src/routes/api/holdings/[[lang=lang]]/[fnurgel=fnurgel]/+server.ts
@@ -15,17 +15,12 @@ import {
 import { error, json } from '@sveltejs/kit';
 import jmespath from 'jmespath';
 
-export async function GET({ url, params, locals }) {
-	console.log('url', url);
-	console.log('params', params);
-
+export async function GET({ params, locals }) {
 	const displayUtil = locals.display;
 	const locale = getSupportedLocale(params.lang);
-	console.log('params.fnurgel', params.fnurgel);
 	const resourceRes = await fetch(`${env.API_URL}/${params.fnurgel}?framed=true`, {
 		headers: { Accept: 'application/ld+json' }
 	});
-	console.log('resourceRes', resourceRes);
 
 	if (resourceRes.status === 404) {
 		throw error(resourceRes.status, { message: 'Not found' });
@@ -52,7 +47,6 @@ export async function GET({ url, params, locals }) {
 	const holdingsByInstanceId = getHoldingsByInstanceId(mainEntity, displayUtil, locale);
 	const bibIdsByInstanceId = getBibIdsByInstanceId(mainEntity, displayUtil, resource, locale);
 	const itemLinksByBibId = getItemLinksByBibId(bibIdsByInstanceId, locale, displayUtil);
-	// const holdersByInstanceId = getHoldersByInstanceId(holdingsByInstanceId, displayUtil, locale);
 
 	// Should this be passed as a parameter to HoldingsModal.svelte instead?
 	const holdingsByType = getHoldingsByType(mainEntity);

--- a/lxl-web/src/routes/api/holdings/[[lang=lang]]/[fnurgel=fnurgel]/+server.ts
+++ b/lxl-web/src/routes/api/holdings/[[lang=lang]]/[fnurgel=fnurgel]/+server.ts
@@ -53,7 +53,6 @@ export async function GET({ url, params, locals }) {
 
 	//get all holders
 	await fetchHoldersIfAbsent(Object.values(holdersByInstanceId).flat());
-	console.log('bibIdsByInstanceId', bibIdsByInstanceId);
 
 	return json({
 		bibIdsByInstanceId: bibIdsByInstanceId,

--- a/lxl-web/src/routes/api/holdings/[[lang=lang]]/[fnurgel=fnurgel]/+server.ts
+++ b/lxl-web/src/routes/api/holdings/[[lang=lang]]/[fnurgel=fnurgel]/+server.ts
@@ -14,6 +14,7 @@ import {
 } from '$lib/utils/holdings';
 import { error, json } from '@sveltejs/kit';
 import jmespath from 'jmespath';
+import { centerOnWork } from '$lib/utils/centerOnWork';
 
 export async function GET({ params, locals }) {
 	const displayUtil = locals.display;
@@ -56,6 +57,7 @@ export async function GET({ params, locals }) {
 	// holdingsByType => has just .heldBy without .obj
 	await fetchHoldersIfAbsent(Object.values(holdersByType).flat());
 
+	//TODO: cache response for a short amount of time?
 	return json({
 		bibIdsByInstanceId: bibIdsByInstanceId,
 		holdingsByInstanceId: holdingsByInstanceId,
@@ -65,19 +67,4 @@ export async function GET({ params, locals }) {
 		overview: overviewWithoutHasInstance,
 		holdersByType: holdersByType
 	});
-
-	//TODO: duplicated, extract to holdings.ts? or similar
-	function centerOnWork(mainEntity: FramedData): FramedData {
-		if ('instanceOf' in mainEntity) {
-			const result = mainEntity.instanceOf;
-			delete mainEntity.instanceOf;
-			result['@reverse'] = { instanceOf: [mainEntity] };
-			if (!result.hasTitle && mainEntity.hasTitle) {
-				result.hasTitle = mainEntity.hasTitle;
-			}
-			return result;
-		} else {
-			return mainEntity;
-		}
-	}
 }


### PR DESCRIPTION
## Description

Allow access to books etc directly from the search results view.

Mobile:

![Screenshot from 2025-06-26 11-38-19](https://github.com/user-attachments/assets/ae651efd-b54b-4f07-958b-c0f26bbbfa76)

Desktop:

![Screenshot from 2025-06-26 11-37-09](https://github.com/user-attachments/assets/c3a0500a-1152-4218-8d0c-9f55f58419fb)


### Tickets involved
[LWS-384](https://kbse.atlassian.net/browse/LWS-384)

### Summary of changes

* Extract relevant parts of product page to a new HoldingsModal component.
* Define a new api route for fetching everything that is needed for the holdings modal.
* Move data initialization taking place in the product page load function to the new api route, making it accessible from other parts of the app, such as the search results list. 
* Add button for accessing holding modal in search card.

It should be straight forward to make this align with the new panes design, but that can be done in a separate PR.
