### PR TITLE
feat(lxl-web): Simplified toolbar component

### DIFF
--- a/lxl-web/src/lib/components/Toolbar.svelte
+++ b/lxl-web/src/lib/components/Toolbar.svelte
@@ -14,14 +14,14 @@
 	class="flex h-[var(--toolbar-height)] place-content-between items-center gap-2 overflow-hidden border-b border-b-neutral-200 px-3"
 >
 	{#if leadingActions}
-		<div>
+		<div class="flex gap-1">
 			{@render leadingActions()}
 		</div>
 	{/if}
 	{@render children?.()}
 
 	{#if trailingActions}
-		<div class="ml-auto">
+		<div class="ml-auto flex gap-1">
 			{@render trailingActions()}
 		</div>
 	{/if}

--- a/lxl-web/src/lib/components/Toolbar.svelte
+++ b/lxl-web/src/lib/components/Toolbar.svelte
@@ -3,33 +3,26 @@
 
 	type ToolbarProps = {
 		leadingActions?: Snippet;
-		centerActions?: Snippet;
 		trailingActions?: Snippet;
+		children?: Snippet;
 	};
 
-	let { leadingActions, centerActions, trailingActions }: ToolbarProps = $props();
+	let { leadingActions, trailingActions, children }: ToolbarProps = $props();
 </script>
 
 <div
-	class="h-[var(--toolbar-height)] content-center overflow-hidden border-b border-b-neutral-200 px-3"
+	class="flex h-[var(--toolbar-height)] place-content-between items-center gap-2 overflow-hidden border-b border-b-neutral-200 px-3"
 >
-	<ul class="grid grid-cols-3 grid-rows-1">
-		<li class="flex gap-1 justify-self-start">
-			{#if leadingActions}
-				{@render leadingActions()}
-			{/if}
-		</li>
+	{#if leadingActions}
+		<div>
+			{@render leadingActions()}
+		</div>
+	{/if}
+	{@render children?.()}
 
-		<li class="flex gap-1 justify-self-center">
-			{#if centerActions}
-				{@render centerActions()}
-			{/if}
-		</li>
-
-		<li class="flex gap-1 justify-self-end">
-			{#if trailingActions}
-				{@render trailingActions()}
-			{/if}
-		</li>
-	</ul>
+	{#if trailingActions}
+		<div class="ml-auto">
+			{@render trailingActions()}
+		</div>
+	{/if}
 </div>


### PR DESCRIPTION
## Description

### Solves

Simplifies the toolbar component.

### Summary of changes

- Unnecessarily rendered empty list elements are removed (they were previously rendered if any of the snippet props were undefined).

- The list elements are reworked into normal div elements as it isn't certain that the contents of the toolbar makes sense in the context of a list. However, feel free to add lists _inside_ the leadingActions/trailingActions snippets e.g. lists of toolbar buttons).

- The `centerActions` snippet prop is removed in favour of normal children props.

