### PR TITLE
fix(cataloging): don't treat certain terms as fnurgels

### DIFF
--- a/cataloging/src/components/shared/id-pill.vue
+++ b/cataloging/src/components/shared/id-pill.vue
@@ -48,10 +48,9 @@ export default {
         if (fnurgel && this.isLibrisResource) {
           return fnurgel;
         }
-        return id
+        return decodeURI(id)
           .replace('https://', '')
           .replace('http://', '');
-          // TODO? uridecode for display?
       }
       return null;
     },

--- a/cataloging/src/utils/record.js
+++ b/cataloging/src/utils/record.js
@@ -61,9 +61,9 @@ export function extractFnurgel(uri) {
   // TODO: Make more checks before returning something
   const recordUri = uri.split('#')[0];
 
-  // If Marc entity, don't proceed
-  if (recordUri.indexOf('marc/') !== -1) {
-    return recordUri;
+  // If Marc entity or term, don't proceed
+  if (recordUri.includes('marc/') || recordUri.includes('term/')) {
+    return undefined;
   }
 
   const splitUri = recordUri.split('/');


### PR DESCRIPTION
Some id.kb.se terms were displayed weirdly because they contained exactly 15 or 16 characters and were treated as fnurgels. Fix that + also decode URIs while we're at it (or?). 

https://kbse.atlassian.net/browse/LXL-3786