### PR TITLE
chore(lxl-web): Prebuild local packages on dev and build

### DIFF
--- a/lxl-web/package.json
+++ b/lxl-web/package.json
@@ -4,9 +4,10 @@
 	"type": "module",
 	"private": true,
 	"scripts": {
-		"dev": "vite dev",
-		"dev:host": "vite dev --host",
-		"build": "vite build",
+		"prebuild-local-packages": "npm run prepare -w codemirror-lang-lxlquery && npm run build -w supersearch",
+		"dev": "npm run prebuild-local-packages && vite dev",
+		"dev:host": "npm run prebuild-local-packages && vite dev --host",
+		"build": "npm run prebuild-local-packages && vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"test": "npm run test:integration && npm run test:unit",


### PR DESCRIPTION
## Description

### Solves

Removes the need to remember to run `npm run prepare -w codemirror-lang-lxlquery && npm run build -w supersearch` before running `npm run dev` (or `npm run build`) after cloning the repo.

### Summary of changes
- Add npm script for prebuilding local packages (`prebuild-local-packages`)
