### PR TITLE
feat(lxl-web): Scroll buttons on horizontal lists (LWS-402)

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -285,6 +285,25 @@
 		}
 	}
 
+	.btn-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background-color: var(--color-page);
+		border-radius: calc(infinity * 1px);
+		border: 1px solid var(--color-neutral);
+		color: var(--color-body);
+		width: calc(var(--spacing) * 11);
+		height: calc(var(--spacing) * 11);
+
+		&:not(:disabled) {
+			&:hover,
+			&:focus {
+				background-color: var(--color-accent-100);
+			}
+		}
+	}
+
 	.tab {
 		padding: calc(var(--spacing) * 1) calc(var(--spacing) * 2);
 	}

--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -291,7 +291,7 @@
 		justify-content: center;
 		background-color: var(--color-page);
 		border-radius: calc(infinity * 1px);
-		border: 1px solid var(--color-neutral);
+		border: 1px solid var(--color-neutral-300);
 		color: var(--color-body);
 		width: calc(var(--spacing) * 11);
 		height: calc(var(--spacing) * 11);

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -149,7 +149,7 @@
 											{#if relationItem.totalItems > 10}
 												{page.data.t('resource.all')}
 											{/if}
-											{relationItem.totalItems}
+											{relationItem.totalItems.toLocaleString(page.data.locale)}
 											{#if relationItem.totalItems === 1}
 												{page.data.t('resource.result')}
 											{:else}

--- a/lxl-web/src/lib/components/SearchResultList.svelte
+++ b/lxl-web/src/lib/components/SearchResultList.svelte
@@ -115,8 +115,4 @@
 			display: none;
 		}
 	}
-
-	.scroll-button {
-		display: none;
-	}
 </style>

--- a/lxl-web/src/lib/components/SearchResultList.svelte
+++ b/lxl-web/src/lib/components/SearchResultList.svelte
@@ -67,14 +67,14 @@
 			{/each}
 		</ul>
 		<button
-			class="scroll-button btn btn-icon absolute top-[calc(50%-22px)] left-2 hidden shadow-lg disabled:opacity-25 noscript:hidden"
+			class="scroll-button btn btn-icon absolute top-[calc(50%-22px)] left-2 hidden shadow-lg disabled:opacity-50 disabled:shadow-none noscript:hidden"
 			onclick={scrollLeft}
 			disabled={disabledLeftScrollButton}
 		>
 			<IconChevronLeft class="size-5" />
 		</button>
 		<button
-			class="scroll-button btn btn-icon absolute top-[calc(50%-22px)] right-2 hidden shadow-lg disabled:opacity-25 noscript:hidden"
+			class="scroll-button btn btn-icon absolute top-[calc(50%-22px)] right-2 hidden shadow-lg disabled:opacity-50 disabled:shadow-none noscript:hidden"
 			onclick={scrollRight}
 			disabled={disabledRightScrollButton}
 		>

--- a/lxl-web/src/lib/components/SearchResultList.svelte
+++ b/lxl-web/src/lib/components/SearchResultList.svelte
@@ -50,9 +50,9 @@
 </script>
 
 {#snippet horizontalList()}
-	<div class="horizontal-list relative">
+	<div class="horizontal-list @container relative">
 		<ul
-			class="scrollbar-hidden @container flex gap-3 overflow-x-auto overscroll-x-contain px-3 sm:px-6 @3xl:px-0"
+			class="scrollbar-hidden flex gap-3 overflow-x-auto overscroll-x-contain px-3 sm:px-6 @3xl:px-0"
 			bind:this={ulElement}
 			bind:clientWidth
 			onscroll={updateDisabledScrollButtons}
@@ -67,14 +67,14 @@
 			{/each}
 		</ul>
 		<button
-			class="scroll-button btn btn-icon absolute top-[calc(50%-22px)] left-2 hidden shadow-lg disabled:opacity-50 disabled:shadow-none noscript:hidden"
+			class="scroll-button btn btn-icon absolute top-[calc(33cqw-44px)] left-1 hidden shadow-lg disabled:opacity-50 disabled:shadow-none @lg:top-[calc(26cqw-44px)] @3xl:top-[calc(21cqw-44px)] @5xl:top-[calc(17cqw-44px)] noscript:hidden"
 			onclick={scrollLeft}
 			disabled={disabledLeftScrollButton}
 		>
 			<IconChevronLeft class="size-5" />
 		</button>
 		<button
-			class="scroll-button btn btn-icon absolute top-[calc(50%-22px)] right-2 hidden shadow-lg disabled:opacity-50 disabled:shadow-none noscript:hidden"
+			class="scroll-button btn btn-icon absolute top-[calc(33cqw-44px)] right-1 hidden shadow-lg disabled:opacity-50 disabled:shadow-none @lg:top-[calc(26cqw-44px)] @3xl:top-[calc(21cqw-44px)] @5xl:top-[calc(17cqw-44px)] noscript:hidden"
 			onclick={scrollRight}
 			disabled={disabledRightScrollButton}
 		>

--- a/lxl-web/src/lib/components/SearchResultList.svelte
+++ b/lxl-web/src/lib/components/SearchResultList.svelte
@@ -1,25 +1,86 @@
 <script lang="ts">
 	import SearchResultItem from '$lib/components/SearchResultItem.svelte';
 	import type { SearchResultItem as SearchResultItemType } from '$lib/types/search';
+	import { onMount } from 'svelte';
+	import IconChevronLeft from '~icons/bi/chevron-left';
+	import IconChevronRight from '~icons/bi/chevron-right';
 
 	type Props = { items: SearchResultItemType[]; type: 'horizontal' };
 
+	const SCROLL_AMOUNT = 0.85;
 	let { items, type }: Props = $props();
+	let ulElement: HTMLUListElement | undefined;
+	let clientWidth: number | undefined = $state();
+	let disabledLeftScrollButton = $state(true);
+	let disabledRightScrollButton = $state(false);
+
+	function getPreferredScrollBehaviour() {
+		return window.matchMedia(`(prefers-reduced-motion: reduce)`).matches ? 'instant' : 'smooth';
+	}
+	function scrollLeft() {
+		ulElement?.scrollBy({
+			left: ulElement.clientWidth * -SCROLL_AMOUNT,
+			behavior: getPreferredScrollBehaviour()
+		});
+	}
+
+	function scrollRight() {
+		ulElement?.scrollBy({
+			left: ulElement.clientWidth * SCROLL_AMOUNT,
+			behavior: getPreferredScrollBehaviour()
+		});
+	}
+
+	function updateDisabledScrollButtons() {
+		if (ulElement) {
+			if (ulElement.scrollLeft <= 0) {
+				disabledLeftScrollButton = true;
+			} else {
+				disabledLeftScrollButton = false;
+			}
+			if (ulElement.scrollLeft >= ulElement.scrollWidth - ulElement.clientWidth) {
+				disabledRightScrollButton = true;
+			} else {
+				disabledRightScrollButton = false;
+			}
+		}
+	}
+
+	onMount(() => updateDisabledScrollButtons());
 </script>
 
 {#snippet horizontalList()}
-	<ul
-		class="horizontal-list scrollbar-hidden @container flex gap-3 overflow-x-auto overscroll-x-contain px-3 sm:px-6 @3xl:px-0"
-	>
-		{#each items as item (item['@id'])}
-			<!-- TODO: Rework width attributes for more exact values -->
-			<li
-				class="min-w-[33%] flex-0 overflow-x-hidden text-center text-xs @lg:min-w-[26%] @3xl:min-w-[21%] @5xl:min-w-[17%]"
-			>
-				<SearchResultItem data={item} />
-			</li>
-		{/each}
-	</ul>
+	<div class="horizontal-list relative">
+		<ul
+			class="scrollbar-hidden @container flex gap-3 overflow-x-auto overscroll-x-contain px-3 sm:px-6 @3xl:px-0"
+			bind:this={ulElement}
+			bind:clientWidth
+			onscroll={updateDisabledScrollButtons}
+		>
+			{#each items as item (item['@id'])}
+				<!-- TODO: Rework width attributes for more exact values -->
+				<li
+					class="min-w-[33%] flex-0 overflow-x-hidden text-center text-xs @lg:min-w-[26%] @3xl:min-w-[21%] @5xl:min-w-[17%]"
+				>
+					<SearchResultItem data={item} />
+				</li>
+			{/each}
+		</ul>
+		<button
+			class="scroll-button btn btn-icon absolute top-[calc(50%-22px)] left-2 hidden shadow-lg disabled:opacity-25 noscript:hidden"
+			onclick={scrollLeft}
+			disabled={disabledLeftScrollButton}
+		>
+			<IconChevronLeft class="size-5" />
+		</button>
+		<button
+			class="scroll-button btn btn-icon absolute top-[calc(50%-22px)] right-2 hidden shadow-lg disabled:opacity-25 noscript:hidden"
+			onclick={scrollRight}
+			disabled={disabledRightScrollButton}
+		>
+			<IconChevronRight class="size-5" />
+		</button>
+	</div>
 {/snippet}
 
 {#if type === 'horizontal'}
@@ -28,6 +89,14 @@
 
 <style lang="postcss">
 	.horizontal-list {
+		@media (any-pointer: fine) and (scripting: enabled) {
+			&:hover,
+			&:focus-within {
+				.scroll-button {
+					display: flex;
+				}
+			}
+		}
 		& :global(.decorated-card-header-top) {
 			margin-top: calc(var(--spacing) * 2);
 		}
@@ -45,5 +114,9 @@
 		& :global(.contribution-role) {
 			display: none;
 		}
+	}
+
+	.scroll-button {
+		display: none;
 	}
 </style>


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-402](https://kbse.atlassian.net/browse/LWS-402)

### Solves

Adds scroll buttons on horizontal lists indicating that the lists are scrollable.

<img width="786" height="425" alt="Skärmavbild 2025-08-15 kl  14 42 40" src="https://github.com/user-attachments/assets/83654f31-5e77-44ef-a343-7d1541fd4da4" />


The scroll buttons are only shown when the user has at least one accurate input pointing device (such as a mouse) and hovers over the lists.

The scroll buttons are therefor hidden on mobile devices where users are more accustomed to horizontally scrollable sections.

The new [::scroll-button](https://developer.mozilla.org/en-US/docs/Web/CSS/::scroll-button) CSS psuedo element could have been used to remove the need for JavaScript but sadly the support is still quite lacking ([64.34% at the time of writing according to caniuse.com](https://caniuse.com/mdn-css_selectors_scroll-button)).

For now, the scroll-buttons are instead hidden if Javascript is disabled.


### Summary of changes
- Add icon button utility class
- Add scroll buttons
- Use localized number formatting