### PR TITLE
fix(lxl-web): Add editions to table of contents

### DIFF
--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -106,6 +106,7 @@
 			<section>
 				<div class="decorated-overview">
 					<InstancesList
+						{uidPrefix}
 						data={instances}
 						columns={[
 							{

--- a/lxl-web/src/lib/components/TableOfContents.svelte
+++ b/lxl-web/src/lib/components/TableOfContents.svelte
@@ -39,7 +39,12 @@
 		if (!mobile) {
 			const closestArticle = tocElement.closest('article');
 			if (closestArticle) {
-				const sections = Array.from(closestArticle.querySelectorAll<HTMLElement>(':scope [id]'));
+				const sections = itemsWithTop
+					.flatMap((item) => [
+						document.getElementById(item.id),
+						...(item.children?.map((childItem) => document.getElementById(childItem.id)) || [])
+					])
+					.filter((item) => item !== null);
 
 				if (sections) {
 					observer = new IntersectionObserver(handleObserve, {

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -203,7 +203,8 @@ export default {
 		show: 'Show',
 		all: 'all',
 		results: 'results',
-		result: 'result'
+		result: 'result',
+		editions: 'Editions'
 	},
 	holdings: {
 		availabilityByType: 'Availability by type',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -202,7 +202,8 @@ export default {
 		show: 'Visa',
 		all: 'alla',
 		results: 'träffar',
-		result: 'träff'
+		result: 'träff',
+		editions: 'Utgåvor'
 	},
 	holdings: {
 		availabilityByType: 'Tillgänglighet utifrån medietyp',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -91,8 +91,22 @@ export const load = async ({ params, locals, fetch }) => {
 		},
 		{}
 	);
+	// TODO: Replace with a custom getProperty method (similar to pickProperty)
+	const instances = jmespath.search(overview, '*[].hasInstance[]');
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [_, overviewWithoutHasInstance] = pickProperty(overview, ['hasInstance']);
+	const sortedInstances = getSortedInstances([...instances]);
 
 	const tableOfContents: TableOfContentsItem[] = [
+		...(instances.length
+			? [
+					{
+						id: 'editions',
+						label: translate('resource.editions')
+					}
+				]
+			: []),
 		...(relations.length
 			? [
 					{
@@ -106,14 +120,6 @@ export const load = async ({ params, locals, fetch }) => {
 				]
 			: [])
 	];
-
-	// TODO: Replace with a custom getProperty method (similar to pickProperty)
-	const instances = jmespath.search(overview, '*[].hasInstance[]');
-
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const [_, overviewWithoutHasInstance] = pickProperty(overview, ['hasInstance']);
-	const sortedInstances = getSortedInstances([...instances]);
-
 	const images = getImages(mainEntity, locale).map((i) => toSecure(i, env.AUXD_SECRET));
 	const holdingsByInstanceId = getHoldingsByInstanceId(mainEntity, displayUtil, locale);
 	const holdingsByType = getHoldingsByType(mainEntity);

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/InstancesList.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/InstancesList.svelte
@@ -2,6 +2,7 @@
 	import jmespath from 'jmespath';
 	import { page } from '$app/state';
 	import { replaceState } from '$app/navigation';
+	import { SvelteURLSearchParams } from 'svelte/reactivity';
 
 	import type { ResourceData } from '$lib/types/resourceData';
 	import { getUserSettings } from '$lib/contexts/userSettings';
@@ -20,10 +21,11 @@
 	 * - [] Add tests (e.g. rows should be expandable and permalink should work, and that opened state should be saved when navigating forward and backwards). The tests should probably be placed inside +page.svelte...
 	 */
 	type InstancesListProps = {
+		uidPrefix?: string;
 		data: ResourceData;
 		columns: { header: string; data: string }[];
 	};
-	const { data, columns }: InstancesListProps = $props();
+	const { uidPrefix, data, columns }: InstancesListProps = $props();
 
 	let instancesList: HTMLUListElement | undefined = $state();
 	let userSettings = getUserSettings();
@@ -50,7 +52,7 @@
 	}
 
 	function getCollapseAllUrl(url: URL) {
-		const newSearchParams = new URLSearchParams([...Array.from(url.searchParams.entries())]);
+		const newSearchParams = new SvelteURLSearchParams([...Array.from(url.searchParams.entries())]);
 		newSearchParams.delete('expanded');
 		return `${url.origin}${url.pathname}${newSearchParams.size ? '?' + newSearchParams.toString() : ''}`;
 	}
@@ -74,7 +76,9 @@
 <div>
 	{#if Array.isArray(data) && data.length > 1}
 		<div class="flex items-center justify-between pb-4">
-			<h2 class="font-heading text-2xl capitalize">{page.data.t('search.editions')}</h2>
+			<h2 class="font-heading text-2xl capitalize" id="{uidPrefix}editions">
+				{page.data.t('resource.editions')}
+			</h2>
 			<a
 				href={getCollapseAllUrl(page.url)}
 				data-sveltekit-preload-data="false"
@@ -154,7 +158,7 @@
 			{/each}
 		</ul>
 	{:else}
-		<InstancesListContent data={data[0]} id={relativizeUrl(getResourceId(data[0]))} />
+		<InstancesListContent data={data[0]} id="{uidPrefix}{relativizeUrl(getResourceId(data[0]))}" />
 	{/if}
 </div>
 


### PR DESCRIPTION
## Description

### Solves

Add editions to table of contents on resource pages and fixes issue where each work instance got an observer (causing console warnings on e.g. https://beta.libris-qa.kb.se/9s2g6qpv7j59f46p).

### Summary of changes

- Add editions to table of contents
- Ensure only toc sections get intersection observers
