### PR TITLE
feat(lxl-web): Navigation between results (LWS-221)

### DIFF
--- a/lxl-web/package.json
+++ b/lxl-web/package.json
@@ -54,6 +54,7 @@
 		"typescript": "^5.9.2",
 		"typescript-eslint": "^8.39.1",
 		"unplugin-icons": "^22.2.0",
+		"valibot": "^1.1.0",
 		"vanilla-cookieconsent": "^3.1.0",
 		"vite": "^7.1.2",
 		"vitest": "^3.2.4"

--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -146,8 +146,8 @@
 	--color-error: var(--color-severe);
 	--color-app-header: var(--color-primary-100);
 	--color-input: var(--color-page);
-
 	--color-placeholder: var(--color-neutral-500);
+	--color-disabled: var(--color-neutral-400);
 }
 
 @layer base {

--- a/lxl-web/src/app.d.ts
+++ b/lxl-web/src/app.d.ts
@@ -3,6 +3,7 @@
 import type { MatomoTracker } from '$lib/types/matomo';
 import type { UserSettings } from '$lib/types/userSettings';
 import type { DisplayUtil, VocabUtil } from '$lib/utils/xl';
+import type { AdjecentSearchResult } from '$lib/types/search';
 import 'unplugin-icons/types/svelte';
 
 declare global {
@@ -23,6 +24,7 @@ declare global {
 		interface PageState {
 			expandedInstances?: string[];
 			holdings?: string;
+			adjecentSearchResults?: AdjecentSearchResult[];
 		}
 		// interface Platform {}
 	}

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { page } from '$app/state';
-
 	import TableOfContents, { type TableOfContentsItem } from './TableOfContents.svelte';
 	import DecoratedData from './DecoratedData.svelte';
 	import ResourceImage from './ResourceImage.svelte';
@@ -13,7 +12,7 @@
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
 	import type { HoldersByType } from '$lib/types/holdings';
 	import type { Relation } from '$lib/utils/relations';
-	import type { SearchResultItem } from '$lib/types/search';
+	import type { SearchResultItem, AdjecentSearchResult } from '$lib/types/search';
 	import SearchResultList from './SearchResultList.svelte';
 
 	type Props = {
@@ -29,6 +28,7 @@
 		instances: Record<string, unknown>[]; // TODO: fix better types
 		holdersByType: HoldersByType;
 		tableOfContents: TableOfContentsItem[];
+		adjecentSearchResults?: AdjecentSearchResult[];
 	};
 
 	const {
@@ -43,7 +43,8 @@
 		relationsPreviewsByQualifierKey,
 		instances,
 		holdersByType,
-		tableOfContents
+		tableOfContents,
+		adjecentSearchResults
 	}: Props = $props();
 
 	const uidPrefix = $derived(uid ? `${uid}-` : ''); // used for prefixing id's when resource is rendered inside panes
@@ -51,6 +52,11 @@
 	let TypeIcon = $derived(type ? getTypeIcon(type) : undefined);
 </script>
 
+{#if adjecentSearchResults}
+	<div>
+		{JSON.stringify(adjecentSearchResults)}
+	</div>
+{/if}
 <article class="@container [&_[id]]:scroll-mt-3 sm:[&_[id]]:scroll-mt-6">
 	{#if tableOfContents.length}
 		<section data-testid="toc-mobile" class="contents @7xl:hidden">
@@ -106,7 +112,6 @@
 			<section>
 				<div class="decorated-overview">
 					<InstancesList
-						{uidPrefix}
 						data={instances}
 						columns={[
 							{
@@ -150,7 +155,7 @@
 											{#if relationItem.totalItems > 10}
 												{page.data.t('resource.all')}
 											{/if}
-											{relationItem.totalItems.toLocaleString(page.data.locale)}
+											{relationItem.totalItems}
 											{#if relationItem.totalItems === 1}
 												{page.data.t('resource.result')}
 											{:else}

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -54,7 +54,7 @@
 </script>
 
 {#if adjecentSearchResults}
-	<div class="border-b-neutral border-b px-3 sm:px-6">
+	<div class="border-b-neutral @container border-b">
 		<AdjecentResults {fnurgel} {adjecentSearchResults} />
 	</div>
 {/if}

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -54,7 +54,9 @@
 </script>
 
 {#if adjecentSearchResults}
-	<AdjecentResults {fnurgel} {adjecentSearchResults} />
+	<div class="border-b-neutral border-b px-3 sm:px-6">
+		<AdjecentResults {fnurgel} {adjecentSearchResults} />
+	</div>
 {/if}
 <article class="@container [&_[id]]:scroll-mt-3 sm:[&_[id]]:scroll-mt-6">
 	{#if tableOfContents.length}

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -14,6 +14,7 @@
 	import type { Relation } from '$lib/utils/relations';
 	import type { SearchResultItem, AdjecentSearchResult } from '$lib/types/search';
 	import SearchResultList from './SearchResultList.svelte';
+	import AdjecentResults from './resource/AdjecentResults.svelte';
 
 	type Props = {
 		fnurgel: string;
@@ -53,9 +54,7 @@
 </script>
 
 {#if adjecentSearchResults}
-	<div>
-		{JSON.stringify(adjecentSearchResults)}
-	</div>
+	<AdjecentResults {fnurgel} {adjecentSearchResults} />
 {/if}
 <article class="@container [&_[id]]:scroll-mt-3 sm:[&_[id]]:scroll-mt-6">
 	{#if tableOfContents.length}

--- a/lxl-web/src/lib/components/TableOfContents.svelte
+++ b/lxl-web/src/lib/components/TableOfContents.svelte
@@ -146,7 +146,7 @@
 		<div class="border-b-neutral border-b">
 			<label
 				id={`${uidPrefix}toc-label`}
-				class="bg-page text-2xs text-subtle flex h-11 cursor-pointer items-center gap-1.5 px-3 sm:px-6 has-checked:[&+nav]:block"
+				class="bg-page text-2xs text-subtle flex min-h-10 cursor-pointer items-center gap-1.5 px-3 sm:px-6 has-checked:[&+nav]:block"
 			>
 				<IconToC class="size-4" />
 				<h2>{page.data.t('tableOfContents.onThisPage')}</h2>

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import type { SearchResultItem } from '$lib/types/search';
 	import { LensType } from '$lib/types/xl';
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
@@ -15,6 +16,7 @@
 	import MyLibsHoldingIndicator from '$lib/components/MyLibsHoldingIndicator.svelte';
 	import { getHoldingsLink, handleClickHoldings } from '$lib/utils/holdings';
 	import BiHouse from '~icons/bi/house';
+	import { asAdjecentSearchResult } from '$lib/utils/adjecentSearchResult';
 
 	interface Props {
 		item: SearchResultItem;
@@ -31,6 +33,16 @@
 	let showDebugHaystack = $state(false);
 
 	const TypeIcon = $derived(getTypeIcon(item['@type']));
+
+	function passAlongAdjecentSearchResults(event: MouseEvent) {
+		event.preventDefault();
+		goto((event.currentTarget as HTMLAnchorElement).href, {
+			state: {
+				...page.state,
+				adjecentSearchResults: [asAdjecentSearchResult(page.data.searchResult)] // TODO: save adjecent results together with optional pane references so it will work with multiple panes
+			}
+		});
+	}
 </script>
 
 <!--//TODO: look into using grid template areas + container queries instead
@@ -71,6 +83,7 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 				aria-labelledby={titleId}
 				aria-describedby={`${bodyId} ${footerId}`}
 				tabindex="-1"
+				onclick={passAlongAdjecentSearchResults}
 			>
 				<div class="pointer-events-none relative flex">
 					{#if item.image}
@@ -133,6 +146,7 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 							href={id}
 							class="link-subtle block decoration-neutral-400"
 							aria-describedby={`${bodyId} ${footerId}`}
+							onclick={passAlongAdjecentSearchResults}
 						>
 							<DecoratedData data={item['card-heading']} showLabels={ShowLabelsOptions.Never} />
 						</a>

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -4,7 +4,7 @@
 	import { LensType } from '$lib/types/xl';
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
 	import { LxlLens } from '$lib/types/display';
-	import { relativizeUrl } from '$lib/utils/http';
+	import { relativizeUrl, stripAnchor } from '$lib/utils/http';
 	import getTypeIcon from '$lib/utils/getTypeIcon';
 	import getInstanceData from '$lib/utils/getInstanceData';
 	import placeholder from '$lib/assets/img/placeholder.svg';
@@ -20,11 +20,12 @@
 
 	interface Props {
 		item: SearchResultItem;
+		uidPrefix?: string;
 	}
 
-	let { item }: Props = $props();
+	let { item, uidPrefix = '' }: Props = $props();
 
-	let id = $derived(relativizeUrl(item['@id']));
+	let id = $derived(`${uidPrefix}${stripAnchor(relativizeUrl(item['@id']))}`);
 	let titleId = $derived(`card-title-${id}`);
 	let bodyId = $derived(`card-body-${id}`);
 	let footerId = $derived(`card-footer-${id}`);
@@ -74,6 +75,7 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 
 <div class="search-card-container">
 	<article
+		{id}
 		class="search-card border-neutral relative grid w-full gap-x-4 border-t px-0 py-3 font-normal transition-shadow md:px-4"
 		data-testid="search-card"
 	>

--- a/lxl-web/src/lib/components/resource/AdjecentResults.svelte
+++ b/lxl-web/src/lib/components/resource/AdjecentResults.svelte
@@ -3,9 +3,8 @@
 	import { afterNavigate, goto } from '$app/navigation';
 	import type { AdjecentSearchResult } from '$lib/types/search';
 	import { relativizeUrl } from '$lib/utils/http';
-	import IconListUl from '~icons/bi/chevron-right';
+	import IconChevronLeft from '~icons/bi/chevron-left';
 	import IconChevronRight from '~icons/bi/chevron-right';
-	import IconChevronleft from '~icons/bi/chevron-left';
 	import capitalize from '$lib/utils/capitalize';
 	import { getPreviousItemFnurgel, getNextItemFnurgel } from '$lib/utils/adjecentSearchResult';
 	import { getAdjecentSearchResult } from '$lib/remotes/adjecentSearchResult.remote';
@@ -103,29 +102,21 @@
 </script>
 
 {#snippet previousResultContent()}
-	<IconChevronleft class="inline" />
-	{page.data.t('resource.previous')}
-	<span class="hidden @xl:inline">{page.data.t('resource.result')}</span>
+	<IconChevronLeft class="mr-0.5 inline" />{page.data.t('resource.previous')}
 {/snippet}
 
 {#snippet nextResultContent()}
-	{page.data.t('resource.next')}
-	<span class="hidden @xl:inline">{page.data.t('resource.result')}</span>
-	<IconChevronRight class="inline" />
+	{page.data.t('resource.next')}<IconChevronRight class="ml-0.5 inline" />
 {/snippet}
 
 {#if currentSearchResult}
-	<div class="flex min-h-12 items-center gap-1 text-xs">
-		<a
-			href={relativizeUrl(currentSearchResult['@id'])}
-			class="btn btn-primary inline-block whitespace-nowrap"
-		>
-			<IconListUl class="inline" />
-			<span class="@xl:hidden">{page.data.t('resource.showInSearchResultsShort')}</span>
-			<span class="hidden @xl:inline">{page.data.t('resource.showInSearchResults')}</span>
-		</a>
+	<div class="@container flex min-h-12 items-center gap-2 text-xs">
 		{#if typeof indexOfTotalSearchResults === 'number'}
-			<span class="text-2xs ml-1 truncate">
+			<a href={relativizeUrl(currentSearchResult['@id'])} class="link text-2xs whitespace-nowrap">
+				<span class="@xl:hidden">{page.data.t('resource.showInSearchResultsShort')}</span>
+				<span class="hidden @xl:inline">{page.data.t('resource.showInSearchResults')}</span>
+			</a>
+			<span class="text-2xs truncate">
 				{capitalize(page.data.t('resource.result'))}
 				<span class="font-medium">
 					{(indexOfTotalSearchResults + 1).toLocaleString(page.data.locale)}
@@ -136,35 +127,29 @@
 				</span>
 			</span>
 		{/if}
-		{#if previousItemFnurgel || nextItemFnurgel}
-			<span class="ml-auto flex gap-2">
+		<span class="text-2xs ml-auto flex gap-2">
+			<span class="after:text-subtle after:ml-2 after:content-['·']">
 				{#if previousItemFnurgel}
-					<a
-						href={previousItemFnurgel}
-						class="btn btn-primary"
-						onclick={passAlongAdjecentSearchResults}
-					>
+					<a href={previousItemFnurgel} class="link" onclick={passAlongAdjecentSearchResults}>
 						{@render previousResultContent()}
 					</a>
 				{:else}
-					<span class="text-disabled btn btn-primary">
+					<span class="text-disabled">
 						{@render previousResultContent()}
 					</span>
 				{/if}
+			</span>
+			<span>
 				{#if nextItemFnurgel}
-					<a
-						href={nextItemFnurgel}
-						class="btn btn-primary"
-						onclick={passAlongAdjecentSearchResults}
-					>
+					<a href={nextItemFnurgel} class="link" onclick={passAlongAdjecentSearchResults}>
 						{@render nextResultContent()}
 					</a>
 				{:else}
-					<span class="text-disabled btn btn-primary">
+					<span class="text-disabled">
 						{@render nextResultContent()}
 					</span>
 				{/if}
 			</span>
-		{/if}
+		</span>
 	</div>
 {/if}

--- a/lxl-web/src/lib/components/resource/AdjecentResults.svelte
+++ b/lxl-web/src/lib/components/resource/AdjecentResults.svelte
@@ -110,13 +110,13 @@
 {/snippet}
 
 {#if currentSearchResult}
-	<div class="@container flex min-h-12 items-center gap-2 text-xs">
+	<div class="text-2xs flex min-h-12 items-center gap-2 px-3 sm:px-6 @7xl:text-xs">
 		{#if typeof indexOfTotalSearchResults === 'number'}
-			<a href={relativizeUrl(currentSearchResult['@id'])} class="link text-2xs whitespace-nowrap">
+			<a href={relativizeUrl(currentSearchResult['@id'])} class="link whitespace-nowrap">
 				<span class="@xl:hidden">{page.data.t('resource.showInSearchResultsShort')}</span>
 				<span class="hidden @xl:inline">{page.data.t('resource.showInSearchResults')}</span>
 			</a>
-			<span class="text-2xs truncate">
+			<span class="truncate">
 				{capitalize(page.data.t('resource.result'))}
 				<span class="font-medium">
 					{(indexOfTotalSearchResults + 1).toLocaleString(page.data.locale)}
@@ -127,7 +127,7 @@
 				</span>
 			</span>
 		{/if}
-		<span class="text-2xs ml-auto flex gap-2">
+		<span class="ml-auto flex gap-2">
 			<span class="after:text-subtle after:ml-2 after:content-['·']">
 				{#if previousItemFnurgel}
 					<a href={previousItemFnurgel} class="link" onclick={passAlongAdjecentSearchResults}>

--- a/lxl-web/src/lib/components/resource/AdjecentResults.svelte
+++ b/lxl-web/src/lib/components/resource/AdjecentResults.svelte
@@ -110,7 +110,7 @@
 {/snippet}
 
 {#if currentSearchResult}
-	<div class="text-2xs flex min-h-12 items-center gap-2 px-3 sm:px-6 @7xl:text-xs">
+	<div class="text-2xs flex min-h-10 items-center gap-2 px-3 sm:px-6 @7xl:min-h-11 @7xl:text-xs">
 		{#if typeof indexOfTotalSearchResults === 'number'}
 			<a href={relativizeUrl(currentSearchResult['@id'])} class="link whitespace-nowrap">
 				<span class="@xl:hidden">{page.data.t('resource.showInSearchResultsShort')}</span>

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -204,7 +204,12 @@ export default {
 		all: 'all',
 		results: 'results',
 		result: 'result',
-		editions: 'Editions'
+		editions: 'Editions',
+		previous: 'Previous',
+		next: 'Next',
+		resultOf: 'of',
+		showInSearchResults: 'Show in search results',
+		showInSearchResultsShort: 'Show all results'
 	},
 	holdings: {
 		availabilityByType: 'Availability by type',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -203,7 +203,12 @@ export default {
 		all: 'alla',
 		results: 'träffar',
 		result: 'träff',
-		editions: 'Utgåvor'
+		editions: 'Utgåvor',
+		previous: 'Föregående',
+		next: 'Nästa',
+		resultOf: 'av',
+		showInSearchResults: 'Visa i träfflista',
+		showInSearchResultsShort: 'Visa träfflista'
 	},
 	holdings: {
 		availabilityByType: 'Tillgänglighet utifrån medietyp',

--- a/lxl-web/src/lib/remotes/adjecentSearchResult.remote.ts
+++ b/lxl-web/src/lib/remotes/adjecentSearchResult.remote.ts
@@ -1,0 +1,21 @@
+import { error } from '@sveltejs/kit';
+import { query, getRequestEvent } from '$app/server';
+import { env } from '$env/dynamic/private';
+import * as v from 'valibot';
+import type { PartialCollectionView } from '$lib/types/search';
+import { type ApiError } from '$lib/types/api';
+import { asAdjecentSearchResult } from '$lib/utils/adjecentSearchResult';
+
+export const getAdjecentSearchResult = query(v.string(), async (viewId) => {
+	const { fetch, url } = getRequestEvent();
+	const searchParams = new URL(url.origin + viewId).searchParams;
+	const res = await fetch(`${env.API_URL}/find.jsonld?${searchParams.toString()}`);
+
+	if (!res.ok) {
+		const err = (await res.json()) as ApiError;
+		return error(err.status_code, { message: err.message, status: err.status });
+	}
+
+	const data = (await res.json()) as PartialCollectionView;
+	return asAdjecentSearchResult(data);
+});

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -224,3 +224,15 @@ export interface QualifierSuggestion {
 	_q: string;
 	cursor: number;
 }
+
+export interface AdjecentSearchResult {
+	[JsonLd.ID]: string;
+	itemOffset: number;
+	itemsPerPage: number;
+	totalItems: number;
+	first: Link;
+	last: Link;
+	previous?: Link;
+	next?: Link;
+	items: Link[];
+}

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -4,6 +4,7 @@ import { type LibraryItem } from '$lib/types/userSettings';
 import { LxlLens } from '$lib/types/display';
 
 export interface SearchResult {
+	[JsonLd.ID]: string;
 	itemOffset: number;
 	itemsPerPage: number;
 	totalItems: number;

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -106,6 +106,7 @@ export interface PartialCollectionView {
 	};
 	first: Link;
 	last: Link;
+	previous?: Link;
 	next?: Link;
 	items: FramedData[];
 	stats?: {

--- a/lxl-web/src/lib/utils/adjecentSearchResult.ts
+++ b/lxl-web/src/lib/utils/adjecentSearchResult.ts
@@ -1,0 +1,31 @@
+import type { SearchResult, PartialCollectionView } from '$lib/types/search';
+import type { AdjecentSearchResult } from '$lib/types/search';
+
+export function asAdjecentSearchResult(
+	data: SearchResult | PartialCollectionView
+): AdjecentSearchResult {
+	const {
+		'@id': id,
+		itemOffset,
+		itemsPerPage,
+		totalItems,
+		first,
+		last,
+		next,
+		previous,
+		items
+	} = data;
+	return {
+		'@id': id,
+		itemOffset,
+		itemsPerPage,
+		totalItems,
+		first,
+		last,
+		next,
+		previous,
+		items: items.map(({ '@id': itemId }) => ({
+			'@id': itemId as string
+		}))
+	};
+}

--- a/lxl-web/src/lib/utils/adjecentSearchResult.ts
+++ b/lxl-web/src/lib/utils/adjecentSearchResult.ts
@@ -1,5 +1,6 @@
 import type { SearchResult, PartialCollectionView } from '$lib/types/search';
 import type { AdjecentSearchResult } from '$lib/types/search';
+import { relativizeUrl, stripAnchor } from '$lib/utils/http';
 
 export function asAdjecentSearchResult(
 	data: SearchResult | PartialCollectionView
@@ -28,4 +29,63 @@ export function asAdjecentSearchResult(
 			'@id': itemId as string
 		}))
 	};
+}
+
+export function getPreviousItemFnurgel(
+	adjecentSearchResults?: AdjecentSearchResult[],
+	searchResultIndex?: number,
+	itemIndex?: number
+): string | undefined {
+	if (
+		adjecentSearchResults &&
+		typeof searchResultIndex === 'number' &&
+		typeof itemIndex === 'number'
+	) {
+		/** if previous fnurgel is part of current search result view, get fnurgel from previous item */
+		if (itemIndex > 0) {
+			return stripAnchor(
+				relativizeUrl(adjecentSearchResults[searchResultIndex].items[itemIndex - 1]['@id'])
+			);
+		}
+		/** otherwise get previous fnurgel from last item of previous search result view */
+		if (searchResultIndex > 0 && itemIndex === 0) {
+			return stripAnchor(
+				relativizeUrl(
+					adjecentSearchResults[searchResultIndex - 1].items[
+						adjecentSearchResults[searchResultIndex - 1].items.length - 1
+					]['@id']
+				)
+			);
+		}
+	}
+	return undefined;
+}
+
+export function getNextItemFnurgel(
+	adjecentSearchResults?: AdjecentSearchResult[],
+	searchResultIndex?: number,
+	itemIndex?: number
+): string | undefined {
+	if (
+		adjecentSearchResults &&
+		typeof searchResultIndex === 'number' &&
+		typeof itemIndex === 'number'
+	) {
+		/** if next fnurgel is part of current search result view , get fnurgel from next item*/
+		if (itemIndex >= 0 && itemIndex < adjecentSearchResults[searchResultIndex].items.length - 1) {
+			return stripAnchor(
+				relativizeUrl(adjecentSearchResults[searchResultIndex].items[itemIndex + 1]['@id'])
+			);
+		}
+		/** otherwise get next fnurgel from first item of next search result view */
+		if (
+			searchResultIndex >= 0 &&
+			itemIndex === adjecentSearchResults[searchResultIndex]?.items.length - 1
+		) {
+			return stripAnchor(
+				relativizeUrl(adjecentSearchResults[searchResultIndex + 1]?.items?.[0]['@id'])
+			);
+		}
+	}
+	return undefined;
 }

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -53,6 +53,7 @@ export async function asResult(
 		: {};
 
 	return {
+		'@id': view['@id'],
 		...('next' in view && { next: replacePath(view.next as Link, usePath) }),
 		...('previous' in view && { previous: replacePath(view.previous as Link, usePath) }),
 		itemOffset: view.itemOffset,

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
-
 	import getPageTitle from '$lib/utils/getPageTitle';
-
 	import Resource from '$lib/components/Resource.svelte';
 
 	const { data } = $props();
@@ -24,5 +22,6 @@
 		instances={data.instances}
 		holdersByType={data.holdersByType}
 		tableOfContents={data.tableOfContents}
+		adjecentSearchResults={page.state.adjecentSearchResults}
 	/>
 </div>

--- a/lxl-web/svelte.config.js
+++ b/lxl-web/svelte.config.js
@@ -31,6 +31,9 @@ const config = {
 				'frame-ancestors': ['self', 'http://*.kb.se', 'http://*.localhost:*'],
 				'img-src': ['self', 'kb.se', '*.kb.se', 'data:']
 			}
+		},
+		experimental: {
+			remoteFunctions: true
 		}
 	}
 };

--- a/lxl-web/tests/navigation-between-results.spec.ts
+++ b/lxl-web/tests/navigation-between-results.spec.ts
@@ -2,7 +2,8 @@ import { expect, test } from '@playwright/test';
 
 let articleIds: string[] = [];
 
-test.beforeAll(async ({ page }) => {
+test.beforeAll(async ({ browser }) => {
+	const page = await browser.newPage();
 	await page.goto('/find?_q=f&_offset=0&_limit=40');
 	articleIds = await page
 		.getByRole('main')

--- a/lxl-web/tests/navigation-between-results.spec.ts
+++ b/lxl-web/tests/navigation-between-results.spec.ts
@@ -61,5 +61,5 @@ test('navigation between results also works when changing _limit value', async (
 	await page.getByRole('main').getByRole('link').getByText('Föregående').click();
 	await expect(page).toHaveURL(articleIds[9]);
 	await page.getByRole('main').getByRole('link').getByText('Visa i träfflista').click();
-	await expect(page).toHaveURL('/find?_q=f&_limit=2&_offset=8');
+	await expect(page).toHaveURL('/find?_q=f&_offset=8&_limit=2');
 });

--- a/lxl-web/tests/navigation-between-results.spec.ts
+++ b/lxl-web/tests/navigation-between-results.spec.ts
@@ -14,7 +14,7 @@ test.beforeAll(async ({ page }) => {
 		);
 });
 
-test('page displays the site header', async ({ page }) => {
+test('navigation between results works', async ({ page }) => {
 	await page.goto('/find?_q=f&_offset=0&_limit=20');
 	await page.getByRole('main').getByRole('article').getByRole('link').first().click();
 	await expect(page).toHaveURL(articleIds[0]);

--- a/lxl-web/tests/navigation-between-results.spec.ts
+++ b/lxl-web/tests/navigation-between-results.spec.ts
@@ -49,3 +49,16 @@ test('navigation between results works', async ({ page }) => {
 		'button for navigating to search results works when navigating to result which is part of other search results'
 	).toHaveURL('/find?_q=f&_limit=20');
 });
+
+test('navigation between results also works when changing _limit value', async ({ page }) => {
+	await page.goto('/find?_q=f&_limit=2');
+	await page.getByRole('main').getByRole('article').getByRole('link').first().click();
+	await page.getByRole('link').getByText('6', { exact: true }).click();
+	await expect(page).toHaveURL('/find?_q=f&_limit=2&_offset=10');
+	await page.getByRole('main').getByRole('article').getByRole('link').first().click();
+	await expect(page).toHaveURL(articleIds[10]);
+	await page.getByRole('main').getByRole('link').getByText('Föregående').click();
+	await expect(page).toHaveURL(articleIds[9]);
+	await page.getByRole('main').getByRole('link').getByText('Visa i träfflista').click();
+	await expect(page).toHaveURL('/find?_q=f&_limit=2&_offset=8');
+});

--- a/lxl-web/tests/navigation-between-results.spec.ts
+++ b/lxl-web/tests/navigation-between-results.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+let articleIds: string[] = [];
+
+test.beforeAll(async ({ page }) => {
+	await page.goto('/find?_q=f&_offset=0&_limit=40');
+	articleIds = await page
+		.getByRole('main')
+		.getByRole('article')
+		.evaluateAll((elements) =>
+			elements
+				.map((element) => element.getAttribute('id'))
+				.filter((item) => typeof item === 'string')
+		);
+});
+
+test('page displays the site header', async ({ page }) => {
+	await page.goto('/find?_q=f&_offset=0&_limit=20');
+	await page.getByRole('main').getByRole('article').getByRole('link').first().click();
+	await expect(page).toHaveURL(articleIds[0]);
+	await page.getByRole('main').getByRole('link').getByText('Nästa').click();
+	await expect(page, 'button for navigating to next result works').toHaveURL(articleIds[1]);
+	await page.getByRole('main').getByRole('link').getByText('Föregående').click();
+	await expect(page, 'button for navigating to previous result works').toHaveURL(articleIds[0]);
+	await page.getByRole('main').getByRole('link').getByText('Visa i träfflista').click();
+	await expect(page, 'button for navigating to search results works').toHaveURL(
+		'/find?_q=f&_limit=20'
+	);
+	await page.getByRole('main').getByRole('article').nth(19).getByRole('link').first().click();
+	await expect(page).toHaveURL(articleIds[19]);
+	await page.getByRole('main').getByRole('link').getByText('Nästa').click();
+	await expect(page, 'navigating to result on next search results works').toHaveURL(articleIds[20]);
+	await page.getByRole('main').getByRole('link').getByText('Nästa').click();
+	await expect(page, 'navigating to result on next search results works').toHaveURL(articleIds[21]);
+	await page.getByRole('main').getByRole('link').getByText('Visa i träfflista').click();
+	await expect(
+		page,
+		'button for navigating to search results works when navigating to result which is part of other search results'
+	).toHaveURL('/find?_q=f&_offset=20&_limit=20');
+	await page.getByRole('main').getByRole('article').getByRole('link').first().click();
+	await expect(page).toHaveURL(articleIds[20]);
+	await page.getByRole('main').getByRole('link').getByText('Föregående').click();
+	await expect(page, 'navigating to result on previous search results works').toHaveURL(
+		articleIds[19]
+	);
+	await page.getByRole('main').getByRole('link').getByText('Visa i träfflista').click();
+	await expect(
+		page,
+		'button for navigating to search results works when navigating to result which is part of other search results'
+	).toHaveURL('/find?_q=f&_limit=20');
+
+	await expect(page.getByRole('banner')).toBeVisible();
+});

--- a/lxl-web/tests/navigation-between-results.spec.ts
+++ b/lxl-web/tests/navigation-between-results.spec.ts
@@ -48,6 +48,4 @@ test('page displays the site header', async ({ page }) => {
 		page,
 		'button for navigating to search results works when navigating to result which is part of other search results'
 	).toHaveURL('/find?_q=f&_limit=20');
-
-	await expect(page.getByRole('banner')).toBeVisible();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.39.1",
         "unplugin-icons": "^22.2.0",
+        "valibot": "^1.1.0",
         "vanilla-cookieconsent": "^3.1.0",
         "vite": "^7.1.2",
         "vitest": "^3.2.4"
@@ -12142,6 +12143,21 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.1.0.tgz",
+      "integrity": "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vanilla-cookieconsent": {


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-221](https://kbse.atlassian.net/browse/LWS-221)

### Solves

Adds navigation between search result items on the resource page.

It works by passing along the search results data (with only the data which is needed) when clicking on a search result link on the `/find` page. This data is then used to calculate the previous/next result fnurgel and index of total results.

Subsequent searches are done if the user navigates to results which aren't part of the original search results. SvelteKit's newly added [remote functions](https://svelte.dev/docs/kit/remote-functions) are used here for the sake of simplicity; the feature is however still experimental but hopefully won't change too much in upcoming SvelteKit versions. 🤞 

### Summary of changes

- Pass along search result when navigating to resource page (using `page.state`)
- Add navigation between results on resource page
- Add `id` attributes to search result `<article>` elements. These ids will be used for anchor links to the specific resources when pressing _"Show in search results"_ (we first have to fix the issue where the [`<base>`-element](https://github.com/libris/lxlviewer/blob/develop/lxl-web/src/routes/(app)/%5B%5Blang%3Dlang%5D%5D/%2Blayout.svelte#L13) causes hashed urls to redirect to the start page).
- Add tests
- Add missing `@id` on search result data, and missing `previous` property on `PartialCollectionView` type.
