### PR TITLE
(paused) LXL-1639

### DIFF
--- a/cataloging/src/components/inspector/create-item-button.vue
+++ b/cataloging/src/components/inspector/create-item-button.vue
@@ -29,50 +29,21 @@ export default {
       default: false,
     },
   },
-  data() {
-    return {
-      itemData: {},
-    };
-  },
   emits: ['done'],
   methods: {
     translatePhrase,
-    buildItem() {
-      const embellishedReference = DisplayUtil.getCard(
-        this.mainEntity,
-        this.resources,
-        this.inspector.data.quoted,
-        this.settings,
-      );
-      embellishedReference['@id'] = this.mainEntity['@id'];
-      embellishedReference['@type'] = this.mainEntity['@type']; // fixes broken itemOf chip FIXME: why does getCard drop @type?
-
-      this.itemData = RecordUtil.getItemObject(
-        this.mainEntity['@id'],
-        this.user.getActiveLibraryUri(),
-        embellishedReference,
-      );
-
-      this.$emit('done');
-    },
     gotoHolding() {
       const locationParts = this.holdingId.split('/');
       const fnurgel = locationParts[locationParts.length - 1];
       this.$router.push({ path: `/${fnurgel}` });
     },
     previewHolding() {
-      const merged = DataUtil.getMergedItems(
-        this.itemData.record,
-        this.itemData.mainEntity,
-        null,
-        this.itemData.quoted
-      );
-
-      this.$store.dispatch('setInsertData', merged);
+      const locationParts = this.mainEntity['@id'].split('/');
+      const fnurgel = locationParts[locationParts.length - 1];
 
       this.$router.push({
-        path: '/new',
-        query: this.newItemQuery
+        name: 'NewHolding',
+        params: { fnurgel },
       });
     },
     performItemAction() {
@@ -107,23 +78,18 @@ export default {
       return {
         record: JSON.stringify(this.itemData.record),
         entity: JSON.stringify(this.itemData.mainEntity),
-        quoted: this.itemData.quoted
+        quoted: this.itemData.quoted,
       };
     },
-    newItemUrl() {
+    ewItemUrl() {
       return this.$router.resolve({
         path: '/new',
-        query: this.newItemQuery
+        query: this.newItemQuery,
       }).href;
-    }
+    },
   },
   components: {
     'rounded-button': RoundedButton,
-  },
-  mounted() {
-    this.$nextTick(() => {
-      this.buildItem();
-    });
   },
   watch: {
     'inspector.event'(val) {
@@ -144,19 +110,17 @@ export default {
   <div class="CreateItem create-item-button-container">
     <!--<textarea id="copyItem" name="data" class="hidden">{{itemData | json}}</textarea>-->
     <template v-if="!compact">
-    <a
-      v-if="!hasHolding || checkingHolding"
-      :href="newItemUrl"
-      @click.prevent="previewHolding"
-      class="btn btn--md CreateItem-btn"
-      :class="{ 'is-disabled': disabled, 'btn-primary': !disabled }"
-      v-tooltip.top="keyBindText"
-    >
-      <i class="fa fa-plus-circle" v-if="!hasHolding && !checkingHolding" />
-      <i class="fa fa-fw fa-circle-o-notch fa-spin" v-if="checkingHolding" />
-      {{ translatePhrase("Add holding") }}
-      <span>({{ user.settings.activeSigel }})</span>
-    </a>
+      <a
+        v-if="!hasHolding || checkingHolding"
+        :href="newItemUrl" 
+        class="btn btn--md CreateItem-btn"
+        :class="{ 'is-disabled': disabled, 'btn-primary': !disabled }"
+        v-tooltip.top="keyBindText">
+        <i class="fa fa-plus-circle" v-if="!hasHolding && !checkingHolding" />
+        <i class="fa fa-fw fa-circle-o-notch fa-spin" v-if="checkingHolding" />
+        {{ translatePhrase("Add holding") }}
+        <span>({{ user.settings.activeSigel }})</span>
+      </a>
       <button
         class="btn btn--md CreateItem-btn"
         v-if="hasHolding"
@@ -164,34 +128,27 @@ export default {
         :disabled="disabled"
         @click.prevent="gotoHolding()"
         v-tooltip.top="keyBindText">
-        <i
-          class="fa fa-check-circle"
-          v-if="hasHolding && !checkingHolding" />
+        <i class="fa fa-check-circle" v-if="hasHolding && !checkingHolding" />
         {{ translatePhrase("Show holding") }}
-        <span>({{user.settings.activeSigel}})</span>
+        <span>({{ user.settings.activeSigel }})</span>
       </button>
     </template>
     <template v-if="compact">
-      <rounded-button
-        v-tooltip.top="tooltipText"
-        :icon="hasHolding ? 'check' : 'plus'"
-        :indicator="hasHolding"
-        :label="hasHolding
-          ? `${user.settings.activeSigel} ${translatePhrase('has holding')}`
-          : `${translatePhrase('Add holding for')} ${user.settings.activeSigel}`"
-        @click="performItemAction()" />
+      <rounded-button v-tooltip.top="tooltipText" :icon="hasHolding ? 'check' : 'plus'" :indicator="hasHolding" :label="hasHolding
+        ? `${user.settings.activeSigel} ${translatePhrase('has holding')}`
+        : `${translatePhrase('Add holding for')} ${user.settings.activeSigel}`" @click="performItemAction()" />
     </template>
   </div>
 </template>
 
 <style lang="less">
-
 .CreateItem {
   &-btn {
     box-shadow: none;
     background: @white;
     color: @brand-primary;
     border: 2px solid @brand-primary;
+
     &:hover,
     &:focus,
     &:active,
@@ -200,10 +157,12 @@ export default {
       background: @white;
       color: @btn-primary--hover;
     }
+
     &--hasHolding {
       background: @brand-primary;
       color: @white;
       border: none;
+
       &:hover,
       &:focus,
       &:active,
@@ -225,5 +184,4 @@ export default {
     }
   }
 }
-
 </style>

--- a/cataloging/src/views/Inspector.vue
+++ b/cataloging/src/views/Inspector.vue
@@ -112,6 +112,25 @@ export default {
       detailedEnrichmentModal.open = false;
       this.$store.dispatch('setInspectorStatusValue', { property: 'detailedEnrichmentModal', value: detailedEnrichmentModal });
     },
+
+    buildItem() {
+      const embellishedReference = DisplayUtil.getCard(
+        this.mainEntity,
+        this.resources,
+        this.inspector.data.quoted,
+        this.settings,
+      );
+      embellishedReference['@id'] = this.mainEntity['@id'];
+      embellishedReference['@type'] = this.mainEntity['@type'];
+
+      const itemData = RecordUtil.getItemObject(
+        this.mainEntity['@id'],
+        this.user.getActiveLibraryUri(),
+        embellishedReference,
+      );
+
+      this.$store.dispatch('setInsertData', itemData);
+    },
     applyOverride(data) {
       this.$store.dispatch('setInspectorData', data);
       this.$store.dispatch('pushNotification', {
@@ -243,6 +262,10 @@ export default {
       } else {
         console.log('Initializing view for new document');
         this.loadNewDocument();
+      }
+
+      if (this.$route.name === 'Inspector' || this.$route.name === 'NewHolding') {
+        this.loadDocument();
       }
     },
     confirmApplyRecordAsTemplate(detailed = false) {
@@ -465,6 +488,10 @@ export default {
     loadNewDocument() {
       const insertData = this.inspector.insertData;
       this.$store.dispatch('setInspectorStatusValue', { property: 'isNew', value: true });
+
+      if (!this.inspector.insertData || Object.keys(this.inspector.insertData).length === 0) {
+        this.buildItem(); // <- move buildItem logic here from create-item-button.vue
+      }
 
       if (!insertData.hasOwnProperty('@graph') || insertData['@graph'].length === 0) {
         this.$store.dispatch('removeLoadingIndicator', 'Loading document');


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description
Open the form in a new tab (new functionality), open the form on the button click (keep this old functionality as well)

### Tickets involved
[LXL-1639](https://kbse.atlassian.net/browse/LXL-1639) - Redo button to open form in a new tab

### Solves
The user can open the form in a new tab, so they can more easily fill out the form without needing to open it in the same tab and risk losing their search from the previous page.

### Summary of changes
TBD
