### PR TITLE
chore(lxl-web): Skip prebuilding local dependencies on dev

### DIFF
--- a/lxl-web/README.md
+++ b/lxl-web/README.md
@@ -8,6 +8,12 @@ Install dependencies with `npm install` (or `pnpm install` or `yarn`).
 
 Add an `.env` file (see `.env.example` for the required environment variables).
 
+Local packages (`supersearch` and `codemirror-lang-lxlquery`) also needs to be prebuilt, the easiest way is by running:
+
+```bash
+npm run prebuild-local-packages
+```
+
 Start a development server:
 
 ```bash

--- a/lxl-web/package.json
+++ b/lxl-web/package.json
@@ -5,8 +5,8 @@
 	"private": true,
 	"scripts": {
 		"prebuild-local-packages": "npm run prepare -w codemirror-lang-lxlquery && npm run build -w supersearch",
-		"dev": "npm run prebuild-local-packages && vite dev",
-		"dev:host": "npm run prebuild-local-packages && vite dev --host",
+		"dev": "vite dev",
+		"dev:host": "vite dev --host",
 		"build": "npm run prebuild-local-packages && vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",


### PR DESCRIPTION
## Description

### Solves

Skip prebuilding local dependencies (e.g. `packages/supersearch` and `packages/codemirror-lang-lxlquery`) when running `npm run dev` due to popular demand (as it takes a couple of extra seconds and waiting is no fun...)

Prebuilding is however still done on `npm run build` so everything in https://github.com/libris/lxlviewer/pull/1349 is not reverted.


### Summary of changes

- Skip prebuilding local dependencies when running `npm run dev`
- Update readme (add step regarding prebuilding)
