### PR TITLE
Fix broken generation of label tail after • changed to ·

### DIFF
--- a/cataloging/src/components/search/facet.vue
+++ b/cataloging/src/components/search/facet.vue
@@ -29,19 +29,19 @@ export default {
       return MathUtil.getCompactNumber(this.facet.amount);
     },
     label() {
-      if (this.facet.label.indexOf('•') >= 0 && this.alwaysShowLabelTail) {
+      if (this.facet.label.indexOf('·') >= 0 && this.alwaysShowLabelTail) {
         const label = this.facet.label;
-        return label.substring(0, label.lastIndexOf('•'));
+        return label.substring(0, label.lastIndexOf('·'));
       }
 
       return this.facet.label;
     },
     labelTail() {
-      if (this.facet.label.indexOf('•') >= 0 && this.alwaysShowLabelTail) {
+      if (this.facet.label.indexOf('·') >= 0 && this.alwaysShowLabelTail) {
         const label = this.facet.label;
-        const label2 = label.substring(label.lastIndexOf('•') + 1, label.length);
+        const label2 = label.substring(label.lastIndexOf('·') + 1, label.length);
         const nbsp = '\xa0';
-        return `${nbsp}• ${label2}`;
+        return `${nbsp}· ${label2}`;
       }
 
       return '';


### PR DESCRIPTION
## Description

### Tickets involved
[LG-59](https://kbse.atlassian.net/browse/LG-59)

### Solves

Sigel not visible in facets for libraries with long names/labels.

### Summary of changes

Match on · instead of • 

<img width="279" height="205" alt="Screenshot from 2025-09-15 10-37-07" src="https://github.com/user-attachments/assets/dca549f2-2d0c-4af1-8a8a-659c5b7e90ad" />
