### PR TITLE
draft: chore(lxl-web): Fix failing CI tests

### DIFF
--- a/lxl-web/tests/error.spec.ts
+++ b/lxl-web/tests/error.spec.ts
@@ -3,7 +3,7 @@ import AxeBuilder from '@axe-core/playwright';
 
 test.describe('404 page', async () => {
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/not-found');
+		await page.goto('/not-found', { waitUntil: 'commit' });
 	});
 	test('has expected h1', async ({ page }) => {
 		await expect(page.getByRole('heading', { name: '404' })).toBeVisible();
@@ -16,10 +16,10 @@ test.describe('404 page', async () => {
 
 test.describe('English 404 page', () => {
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/en/not-found');
+		await page.goto('/en/not-found', { waitUntil: 'commit' });
 	});
 	test('has expected h1', async ({ page }) => {
-		await page.goto('/en/not-found');
+		await page.goto('/en/not-found', { waitUntil: 'commit' });
 		await expect(page.getByRole('heading', { name: '404' })).toBeVisible();
 	});
 	test('should not have any detectable a11y issues', async ({ page }) => {
@@ -30,7 +30,7 @@ test.describe('English 404 page', () => {
 
 test.describe('Missing resource page', () => {
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/5nxb2lhk30q35zdb');
+		await page.goto('/5nxb2lhk30q35zdb', { waitUntil: 'commit' });
 	});
 	test('has expected h1', async ({ page }) => {
 		await expect(page.getByRole('heading', { name: '404' })).toBeVisible();

--- a/lxl-web/tests/find.spec.ts
+++ b/lxl-web/tests/find.spec.ts
@@ -3,7 +3,7 @@ import AxeBuilder from '@axe-core/playwright';
 import { DEFAULT_FACETS_EXPANDED } from '$lib/constants/facets';
 
 test.beforeEach(async ({ page }) => {
-	await page.goto('/find?_q=f&_limit=20&_offset=0&_sort=&_i=f');
+	await page.goto('/find?_q=f&_limit=20&_offset=0&_sort=&_i=f', { waitUntil: 'commit' });
 });
 
 test('should not have any detectable a11y issues', async ({ page }) => {
@@ -81,7 +81,7 @@ test('facet opened/closed state is preserved', async ({ page, context }) => {
 	await expect(page.getByTestId('facet-list').first()).toBeHidden();
 	await expect(page.getByTestId('facet-list').nth(firstClosed)).toBeVisible();
 
-	await page.goto('/find?_q=f&_limit=20&_offset=0&_sort=&_i=f');
+	await page.goto('/find?_q=f&_limit=20&_offset=0&_sort=&_i=f', { waitUntil: 'commit' });
 
 	await expect(page.getByTestId('facet-list').first()).toBeHidden();
 	await expect(page.getByTestId('facet-list').nth(firstClosed)).toBeVisible();

--- a/lxl-web/tests/index.spec.ts
+++ b/lxl-web/tests/index.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
 test.beforeEach(async ({ page }) => {
-	await page.goto('/');
+	await page.goto('/', { waitUntil: 'commit' });
 });
 
 test('should not have any detectable a11y issues', async ({ page }) => {

--- a/lxl-web/tests/navigation-between-results.spec.ts
+++ b/lxl-web/tests/navigation-between-results.spec.ts
@@ -4,7 +4,7 @@ let articleIds: string[] = [];
 
 test.beforeAll(async ({ browser }) => {
 	const page = await browser.newPage();
-	await page.goto('/find?_q=f&_offset=0&_limit=40');
+	await page.goto('/find?_q=f&_offset=0&_limit=40', { waitUntil: 'commit' });
 	articleIds = await page
 		.getByRole('main')
 		.getByRole('article')
@@ -16,7 +16,7 @@ test.beforeAll(async ({ browser }) => {
 });
 
 test('navigation between results works', async ({ page }) => {
-	await page.goto('/find?_q=f&_offset=0&_limit=20');
+	await page.goto('/find?_q=f&_offset=0&_limit=20', { waitUntil: 'commit' });
 	await page.getByRole('main').getByRole('article').getByRole('link').first().click();
 	await expect(page).toHaveURL(articleIds[0]);
 	await page.getByRole('main').getByRole('link').getByText('Nästa').click();
@@ -52,7 +52,7 @@ test('navigation between results works', async ({ page }) => {
 });
 
 test('navigation between results also works when changing _limit value', async ({ page }) => {
-	await page.goto('/find?_q=f&_limit=2');
+	await page.goto('/find?_q=f&_limit=2', { waitUntil: 'commit' });
 	await page.getByRole('main').getByRole('article').getByRole('link').first().click();
 	await page.getByRole('link').getByText('6', { exact: true }).click();
 	await expect(page).toHaveURL('/find?_q=f&_limit=2&_offset=10');

--- a/lxl-web/tests/resource.spec.ts
+++ b/lxl-web/tests/resource.spec.ts
@@ -2,14 +2,14 @@ import { expect, test, devices } from '@playwright/test';
 
 test('decorated data label visibilty is correct after page navigations', async ({ page }) => {
 	// TODO: We should probably mock the required requests but something similar to https://github.com/markjaquith/sveltekit-playwright-fetch-mock would be needed to mock the server-side fetches.
-	await page.goto('/h08ndxddfg5v2pjf');
+	await page.goto('/h08ndxddfg5v2pjf', { waitUntil: 'commit' });
 	await expect(page.getByText('Medverkan och funktion')).toBeHidden();
 	await page.getByText('Jonas Hassen Khemiri, 1978-').first().click();
 	await expect(page.getByRole('article').getByText('Språk')).toBeVisible();
 });
 
 test('initially opened holdings modals are closable', async ({ page }) => {
-	await page.goto('/h08ndxddfg5v2pjf?holdings=Electronic');
+	await page.goto('/h08ndxddfg5v2pjf?holdings=Electronic', { waitUntil: 'commit' });
 	await page.getByTestId('close-modal').first().click();
 	await expect(page).toHaveURL('/h08ndxddfg5v2pjf');
 	await expect(page.getByTestId('modal')).toBeHidden();
@@ -19,7 +19,7 @@ test('initially opened holdings modals are closable', async ({ page }) => {
 });
 
 test('decorated data in holdings modal is not duplicated while closing modal', async ({ page }) => {
-	await page.goto('/h08ndxddfg5v2pjf');
+	await page.goto('/h08ndxddfg5v2pjf', { waitUntil: 'commit' });
 	await page.getByTestId('holding-link').first().click();
 	await expect(page.locator('dialog [data-type="Text"]')).toHaveCount(1);
 	await page.keyboard.press('Escape');
@@ -30,7 +30,7 @@ test('decorated data in holdings modal is not duplicated while closing modal', a
 });
 
 test('table of contents', async ({ page }) => {
-	await page.goto('/khwz18234vvmvn7');
+	await page.goto('/khwz18234vvmvn7', { waitUntil: 'commit' });
 	await expect(page.getByTestId('toc')).toBeVisible();
 	await expect(page.getByTestId('toc-mobile')).not.toBeVisible();
 	await expect(
@@ -72,7 +72,7 @@ test('table of contents', async ({ page }) => {
 		page.getByTestId('toc-mobile').locator('a').first(),
 		'enter keypress toggles table of contents while focused on toggle'
 	).toBeVisible();
-	await page.goto('/2jr64jg10461zcj2');
+	await page.goto('/2jr64jg10461zcj2', { waitUntil: 'commit' });
 	await expect(
 		page.getByTestId('toc'),
 		'table of contents is hidden if there are no items to show'

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -46,14 +46,14 @@ test('expanded content shows persistant items and results', async ({ page }) => 
 		'results are shown if there is an initial query'
 	).toHaveCount(5);
 	await page.getByRole('dialog').getByLabel('Förslag').getByRole('link').first().click();
-	await page.waitForURL(/\/[a-z0-9]{15,}$/); // fnurgel route
+	await page.waitForURL(/\/[a-z0-9]{15,}$/, { waitUntil: 'commit' }); // fnurgel route
 	await expect(
 		page.getByRole('combobox').locator('.lxl-qualifier-key'),
 		'query is kept when navigating from find routes...'
 	).toContainText('Språk');
 	await expect(page.getByRole('combobox').locator('.lxl-qualifier-value')).toContainText('Svenska');
 	await page.locator('.home').getByRole('link').click(); // click on home link
-	await page.waitForURL('/'); // fnurgel route
+	await page.waitForURL('/', { waitUntil: 'commit' }); // fnurgel route
 	await expect(
 		page.getByRole('combobox'),
 		'...except when navigating to start/index (which should be seen as a reset)'
@@ -121,7 +121,7 @@ test('qualifier keys can be added using the user interface', async ({ page }) =>
 		'all suggestions are persons related to the query "jan"'
 	).toHaveCount(5);
 	await page.getByRole('dialog').getByLabel('Förslag').getByRole('link').first().click();
-	await page.waitForURL('**/find?**');
+	await page.waitForURL('**/find?**', { waitUntil: 'commit' });
 	await expect(page.url()).toContain('contributor');
 	await expect(
 		page.getByRole('combobox').locator('.lxl-qualifier-key'),
@@ -144,7 +144,7 @@ test('qualifier keys can be added using the user interface', async ({ page }) =>
 	).toHaveCount(5);
 	await page.getByRole('dialog').getByRole('combobox').pressSequentially('Swahili');
 	await page.getByRole('dialog').getByLabel('Förslag').getByRole('link').first().click();
-	await page.waitForURL(/spr%C3%A5k/);
+	await page.waitForURL(/spr%C3%A5k/, { waitUntil: 'commit' });
 	await expect(page.url()).toContain('contributor');
 	await expect(page.url(), 'url contains both contributor and language').toContain(
 		encodeURIComponent('språk')
@@ -169,7 +169,7 @@ test('qualifier keys can be added using the user interface', async ({ page }) =>
 		page.getByRole('dialog').getByLabel('Förslag').getByRole('link').filter({ hasText: 'ämne' })
 	).toHaveCount(5);
 	await page.getByRole('dialog').getByLabel('Förslag').getByRole('link').first().click();
-	await page.waitForURL(/A4mne/);
+	await page.waitForURL(/A4mne/, { waitUntil: 'commit' });
 	await expect(
 		page.getByRole('combobox').locator('.lxl-qualifier-key').first(),
 		'qualifier is added in the beginning if the cursor is placed there'

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -2,7 +2,7 @@
 import { test, expect } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
-	await page.goto('/');
+	await page.goto('/', { waitUntil: 'commit' });
 });
 
 test('click input expands dialog', async ({ page }) => {
@@ -37,7 +37,9 @@ test('expanded content shows persistant items and results', async ({ page }) => 
 		page.getByRole('dialog').getByLabel('Förslag').getByRole('link'),
 		'search results are shown after typing'
 	).toHaveCount(5);
-	await page.goto('/find?_limit=20&_offset=0&_q=language%3A"lang%3Aswe"&_sort=&_spell=true');
+	await page.goto('/find?_limit=20&_offset=0&_q=language%3A"lang%3Aswe"&_sort=&_spell=true', {
+		waitUntil: 'commit'
+	});
 	await page.getByTestId('main-search').click();
 	await expect(
 		page.getByRole('dialog').getByLabel('Förslag').getByRole('link'),


### PR DESCRIPTION
## Description

### Solves

Hopefully solves failing CI Tests

### Summary of changes

- Add `{ waitUntil: 'commit' }` to all playwright `page.goto` calls
- Add `{ waitUntil: 'commit' }` to all playwright `page.waitForURL` calls
