### PR TITLE
chore(lxl-web): Try fixing uploading playwright traces

### DIFF
--- a/.github/workflows/lxl-web.yml
+++ b/.github/workflows/lxl-web.yml
@@ -42,7 +42,8 @@ jobs:
         if: ${{ failure() }}
         with:
           name: playwright-traces
-          path: test-results
+          path: lxl-web/test-results/
+          include-hidden-files: true
           retention-days: 30
   lighthouseci:
     runs-on: ubuntu-latest

--- a/lxl-web/tests/find.spec.ts
+++ b/lxl-web/tests/find.spec.ts
@@ -25,7 +25,7 @@ test('can change the language', async ({ page }) => {
 });
 
 test('displays 20 search cards on a page', async ({ page }) => {
-	await expect(page.getByTestId('search-card')).toHaveCount(20);
+	await expect(page.getByTestId('search-card')).toHaveCount(19);
 });
 
 test('search card contains a link', async ({ page }) => {

--- a/lxl-web/tests/find.spec.ts
+++ b/lxl-web/tests/find.spec.ts
@@ -25,7 +25,7 @@ test('can change the language', async ({ page }) => {
 });
 
 test('displays 20 search cards on a page', async ({ page }) => {
-	await expect(page.getByTestId('search-card')).toHaveCount(19);
+	await expect(page.getByTestId('search-card')).toHaveCount(20);
 });
 
 test('search card contains a link', async ({ page }) => {


### PR DESCRIPTION
Upload artifacts in the form of playwright traces after CI run.

To use it:
1. Goto a run [summary](https://github.com/libris/lxlviewer/actions/runs/17763324204)
2. Scroll down to the artifacts section and download playwright-traces.zip
3. Unpack it and drag a trace.zip into https://trace.playwright.dev/ (can also be run locally)