### PR TITLE
chore(lxl-web): Add await before all playwright expect methods

### DIFF
--- a/lxl-web/tests/error.spec.ts
+++ b/lxl-web/tests/error.spec.ts
@@ -24,7 +24,7 @@ test.describe('English 404 page', () => {
 	});
 	test('should not have any detectable a11y issues', async ({ page }) => {
 		const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-		expect.soft(accessibilityScanResults.violations).toEqual([]);
+		await expect.soft(accessibilityScanResults.violations).toEqual([]);
 	});
 });
 
@@ -37,7 +37,7 @@ test.describe('Missing resource page', () => {
 	});
 	test('should not have any detectable a11y issues', async ({ page }) => {
 		const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-		expect.soft(accessibilityScanResults.violations).toEqual([]);
+		await expect.soft(accessibilityScanResults.violations).toEqual([]);
 	});
 });
 

--- a/lxl-web/tests/find.spec.ts
+++ b/lxl-web/tests/find.spec.ts
@@ -8,7 +8,7 @@ test.beforeEach(async ({ page }) => {
 
 test('should not have any detectable a11y issues', async ({ page }) => {
 	const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-	expect.soft(accessibilityScanResults.violations).toEqual([]);
+	await expect.soft(accessibilityScanResults.violations).toEqual([]);
 });
 
 test('page displays the site header', async ({ page }) => {
@@ -52,23 +52,23 @@ test('expanded filters have no detectable a11y issues', async ({ page }) => {
 		await el.click();
 	}
 	const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-	expect.soft(accessibilityScanResults.violations).toEqual([]);
+	await expect.soft(accessibilityScanResults.violations).toEqual([]);
 });
 
 test('sorting the facet sets a cookie', async ({ page, context }) => {
 	const beforeCookies = await context.cookies();
-	expect(beforeCookies).toEqual([]);
+	await expect(beforeCookies).toEqual([]);
 	await page.getByTestId('facet-sort').nth(1).getByRole('combobox').selectOption('alpha.asc');
 	const afterCookies = await context.cookies();
-	expect(afterCookies[0].name).toEqual('userSettings');
-	expect(afterCookies[0].value).toEqual(
+	await expect(afterCookies[0].name).toEqual('userSettings');
+	await expect(afterCookies[0].value).toEqual(
 		'{%22leadingPane%22:{%22open%22:true}%2C%22facetSort%22:{%22rdf:type%22:%22alpha.asc%22}}'
 	);
 });
 
 test('facet opened/closed state is preserved', async ({ page, context }) => {
 	const beforeCookies = await context.cookies();
-	expect(beforeCookies).toEqual([]);
+	await expect(beforeCookies).toEqual([]);
 
 	const firstClosed = DEFAULT_FACETS_EXPANDED;
 

--- a/lxl-web/tests/index.spec.ts
+++ b/lxl-web/tests/index.spec.ts
@@ -7,7 +7,7 @@ test.beforeEach(async ({ page }) => {
 
 test('should not have any detectable a11y issues', async ({ page }) => {
 	const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-	expect.soft(accessibilityScanResults.violations).toEqual([]);
+	await expect.soft(accessibilityScanResults.violations).toEqual([]);
 });
 
 test('index page has expected h1', async ({ page }) => {

--- a/lxl-web/tests/resource.spec.ts
+++ b/lxl-web/tests/resource.spec.ts
@@ -24,7 +24,7 @@ test('decorated data in holdings modal is not duplicated while closing modal', a
 	await expect(page.locator('dialog [data-type="Text"]')).toHaveCount(1);
 	await page.keyboard.press('Escape');
 	await page.waitForTimeout(10);
-	expect(page.locator('dialog [data-type="Text"]')).toHaveCount(1);
+	await expect(page.locator('dialog [data-type="Text"]')).toHaveCount(1);
 	await page.getByTestId('modal').waitFor({ state: 'hidden' });
 	await expect(page.getByTestId('modal')).toBeHidden();
 });

--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -341,8 +341,8 @@ test('allows custom expanded content', async ({ page }) => {
 
 test('supports custom loading indicator snippet', async ({ page }) => {
 	await page.getByRole('combobox').fill('hello world');
-	await expect(async () =>
-		expect(page.getByTestId('loading-indicator')).toHaveText('Loading...')
+	await expect(
+		async () => await expect(page.getByTestId('loading-indicator')).toHaveText('Loading...')
 	).toPass();
 	await expect(page.getByTestId('loading-indicator')).not.toBeVisible();
 });
@@ -351,8 +351,8 @@ test('exports isLoading and hasResults as bindable props (should be treated as r
 	page
 }) => {
 	await page.getByRole('combobox').fill('hello world');
-	await expect(async () =>
-		expect(page.getByTestId('is-loading-bind')).toHaveText('is loading: true')
+	await expect(
+		async () => await expect(page.getByTestId('is-loading-bind')).toHaveText('is loading: true')
 	).toPass();
 	await expect(page.getByTestId('is-loading-bind')).toHaveText('is loading: false');
 	await expect(page.getByTestId('has-data-bind')).toHaveText('has data: true');


### PR DESCRIPTION
## Checklist:
- [ ] I have run the unit tests. `yarn test:unit`
- [ ] I have run the linter. `yarn lint`

## Description

### Tickets involved
[LXL-NNNN](https://kbse.atlassian.net/browse/LXL-NNNN), [LXL-NNNN](https://kbse.atlassian.net/browse/LXL-NNNN)

### Solves

Description of what this solves

### Summary of changes

Summary of changes
