### PR TITLE
bugfix(lxlweb): Update holdings data after navigating between resources

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -11,7 +11,7 @@
 	import HoldingsContent from '$lib/components/HoldingsContent.svelte';
 
 	const { data } = $props();
-	const holdings: HoldingsData = $state({
+	const holdings: HoldingsData = $derived({
 		...data.holdings,
 		instances: data.instances,
 		overview: data.overview,


### PR DESCRIPTION
## Description

### Solves

Should fix the following bug:
1. Go to /btmbf3tn24ln737#work-record
2. Navigate to "Upp & ner"
3. Modal still shows one holding even though there are 9.

(Sometimes the library info is missing when hitting a resource page directly. Proposed fix for that is [here](https://github.com/libris/lxlviewer/pull/1380) )

### Summary of changes

* Make holdings variable a `$derived` of the page data