### PR TITLE
Wait 1 second before loading search hitlist after removing a record

### DIFF
--- a/cataloging/src/views/Inspector.vue
+++ b/cataloging/src/views/Inspector.vue
@@ -396,8 +396,12 @@ export default {
           type: 'success',
           message: `${labelByLang(this.recordType)} ${StringUtil.getUiPhraseByLang('was deleted', this.user.settings.language, this.resources.i18n)}!`,
         });
-        // Force reload
-        this.$router.go(-1);
+
+        // Wait so that the change is available in the index when the search hitlist is loaded
+        setTimeout(() => {
+          this.$router.go(-1);
+        }, 1000);
+
       }, (error) => {
         if (error.status === 403) {
           this.$store.dispatch('pushNotification', { type: 'danger', message: `${StringUtil.getUiPhraseByLang('Forbidden', this.user.settings.language, this.resources.i18n)} - ${StringUtil.getUiPhraseByLang('This entity may have active links', this.user.settings.language, this.resources.i18n)} - ${error.statusText}` });

--- a/cataloging/src/views/Inspector.vue
+++ b/cataloging/src/views/Inspector.vue
@@ -400,7 +400,7 @@ export default {
         // Wait so that the change is available in the index when the search hitlist is loaded
         setTimeout(() => {
           this.$router.go(-1);
-        }, 1000);
+        }, 1100);
 
       }, (error) => {
         if (error.status === 403) {


### PR DESCRIPTION
## Checklist:
- [x] I have run the unit tests. `yarn test:unit`
- [x] I have run the linter. `yarn lint`

### Tickets involved
[LXL-4689](https://kbse.atlassian.net/browse/LXL-4689)

## Solves

When navigating to a holding directly from the search hitlist, then removing it, the user is navigated back to the hitlist. In the search card of the record for which the holding was `itemOf`, the button for creating a new holding was not available (instead this button stated, incorrectly, that the user still had a holding for this record).

### Summary of changes

Add 1000ms timeout.
