### PR TITLE
feat(lxlweb): Free online in search result card

### DIFF
--- a/lxl-web/src/lib/actions/popover/Popover.svelte
+++ b/lxl-web/src/lib/actions/popover/Popover.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, type Snippet } from 'svelte';
 	import { computePosition, offset, shift, inline, flip, arrow } from '@floating-ui/dom';
 	import SearchCard from '$lib/components/find/SearchCard.svelte';
 	import type { SearchResultItem } from '$lib/types/search';
@@ -7,6 +7,7 @@
 	interface PopoverProps {
 		title?: string | undefined;
 		resourceData?: SearchResultItem | undefined;
+		snippet?: Snippet;
 		referenceElement: HTMLElement;
 		onMouseOver: (event: MouseEvent) => void;
 		onMouseLeave: (event: MouseEvent) => void;
@@ -21,7 +22,8 @@
 		onMouseOver,
 		onMouseLeave,
 		onFocus,
-		onBlur
+		onBlur,
+		snippet
 	}: PopoverProps = $props();
 
 	let popoverElement: HTMLElement;
@@ -93,6 +95,8 @@
 	<div class="p-2">
 		{#if resourceData}
 			<SearchCard item={resourceData} allowPopovers={false} allowActions={false} />
+		{:else if snippet}
+			{@render snippet?.()}
 		{:else if title}
 			{title}
 		{/if}

--- a/lxl-web/src/lib/actions/popover/index.ts
+++ b/lxl-web/src/lib/actions/popover/index.ts
@@ -2,7 +2,7 @@ import type { Action } from 'svelte/action';
 import Popover from './Popover.svelte';
 import type { LocaleCode } from '$lib/i18n/locales';
 import type { ResourceData } from '$lib/types/resourceData';
-import { mount, unmount } from 'svelte';
+import { mount, unmount, type Snippet } from 'svelte';
 
 /**
  * Svelte action used for showing either a generic title or decorated data for a resource (by supplying the resource id or resource data).
@@ -22,14 +22,16 @@ import { mount, unmount } from 'svelte';
 type Parameter = {
 	title?: string;
 	resource?: { id: string; lang: LocaleCode } | { data: ResourceData[] };
+	snippet?: Snippet;
 	placeAsSibling?: boolean; // place popover next to node in the DOM (to force it on top of modal, for example)
 };
 
 export const popover: Action<HTMLElement, Parameter> = (
 	node,
-	{ title, resource, placeAsSibling }: Parameter = {
+	{ title, resource, snippet, placeAsSibling }: Parameter = {
 		title: undefined,
 		resource: undefined,
+		snippet: undefined,
 		placeAsSibling: false
 	}
 ) => {
@@ -73,6 +75,7 @@ export const popover: Action<HTMLElement, Parameter> = (
 						referenceElement: node,
 						title,
 						resourceData,
+						snippet,
 						onMouseOver: startFloatingElementInteraction,
 						onFocus: startFloatingElementInteraction,
 						onMouseLeave: endFloatingElementInteraction,

--- a/lxl-web/src/lib/actions/popover/index.ts
+++ b/lxl-web/src/lib/actions/popover/index.ts
@@ -24,16 +24,12 @@ type Parameter = {
 	resource?: { id: string; lang: LocaleCode } | { data: ResourceData[] };
 	snippet?: Snippet;
 	placeAsSibling?: boolean; // place popover next to node in the DOM (to force it on top of modal, for example)
+	onFocus?: boolean;
 };
 
 export const popover: Action<HTMLElement, Parameter> = (
 	node,
-	{ title, resource, snippet, placeAsSibling }: Parameter = {
-		title: undefined,
-		resource: undefined,
-		snippet: undefined,
-		placeAsSibling: false
-	}
+	{ title, resource, snippet, placeAsSibling = false, onFocus = true }: Parameter = {}
 ) => {
 	const FETCH_DELAY = 250;
 	const ATTACH_DELAY = 500;
@@ -52,8 +48,11 @@ export const popover: Action<HTMLElement, Parameter> = (
 
 	node.addEventListener('mouseover', attachPopover);
 	node.addEventListener('mouseout', removePopover);
-	node.addEventListener('focus', attachPopover);
-	node.addEventListener('blur', removePopover);
+
+	if (onFocus) {
+		node.addEventListener('focus', attachPopover);
+		node.addEventListener('blur', removePopover);
+	}
 
 	async function attachPopover() {
 		try {

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -20,11 +20,12 @@
 	import { asAdjecentSearchResult } from '$lib/utils/adjecentSearchResult';
 	import TypeIcon from '$lib/components/TypeIcon.svelte';
 	import { getCiteLink, handleClickCite } from '$lib/utils/citation';
+	import { bookAspectRatio } from '$lib/utils/getTypeLike';
 	import BiHouse from '~icons/bi/house';
 	import BiQuote from '~icons/bi/quote';
 	import BiHeartFill from '~icons/bi/heart-fill';
 	import BiHeart from '~icons/bi/heart';
-	import { bookAspectRatio } from '$lib/utils/getTypeLike';
+	import BiBoxArrowUpRight from '~icons/bi/box-arrow-up-right';
 
 	interface Props {
 		item: SearchResultItem | LibraryResultItem;
@@ -336,6 +337,16 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 						>
 							<BiQuote class="size-4 text-neutral-400" />
 							<span>{page.data.t('citations.cite')}</span>
+						</a>
+					{/if}
+					{#if item.associatedMedia?.length}
+						<a
+							class="btn btn-primary h-7 rounded-full md:h-8"
+							href={item.associatedMedia?.[0].uri[0]}
+							target="_blank"
+						>
+							<span>Fritt online</span>
+							<BiBoxArrowUpRight />
 						</a>
 					{/if}
 					{#if isLibraryCard(item)}

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -350,7 +350,7 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 							href={firstFreeOnlineLink}
 							target="_blank"
 							use:popover={{
-								placeAsSibling: true,
+								onFocus: false,
 								snippet: freeLinks
 							}}
 						>

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -336,16 +336,6 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 			</footer>
 			{#if allowActions}
 				<div class="card-actions flex gap-1 self-end pt-1">
-					{#if isInstanceCard}
-						<a
-							class="btn btn-primary h-7 rounded-full md:h-8"
-							href={getCiteLink(page.url, id)}
-							onclick={(event) => handleClickCite(event, page.state, id)}
-						>
-							<BiQuote class="size-4 text-neutral-400" />
-							<span>{page.data.t('citations.cite')}</span>
-						</a>
-					{/if}
 					{#if firstFreeOnlineLink}
 						{#snippet freeLinks()}
 							<DecoratedData
@@ -360,11 +350,22 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 							href={firstFreeOnlineLink}
 							target="_blank"
 							use:popover={{
+								placeAsSibling: true,
 								snippet: freeLinks
 							}}
 						>
-							<span>Fritt online</span>
-							<BiBoxArrowUpRight />
+							<BiBoxArrowUpRight class="text-neutral-400" />
+							<span>{page.data.t('search.freeOnline')}</span>
+						</a>
+					{/if}
+					{#if isInstanceCard}
+						<a
+							class="btn btn-primary h-7 rounded-full md:h-8"
+							href={getCiteLink(page.url, id)}
+							onclick={(event) => handleClickCite(event, page.state, id)}
+						>
+							<BiQuote class="size-4 text-neutral-400" />
+							<span>{page.data.t('citations.cite')}</span>
 						</a>
 					{/if}
 					{#if isLibraryCard(item)}

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -7,6 +7,7 @@
 	import type { LibraryResultItem, SearchResultItem } from '$lib/types/search';
 	import { JsonLd, LensType } from '$lib/types/xl';
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
+	import { type ResourceData } from '$lib/types/resourceData';
 	import { LxlLens } from '$lib/types/display';
 	import { relativizeUrl, trimSlashes, stripAnchor } from '$lib/utils/http';
 	import getInstanceData from '$lib/utils/getInstanceData';
@@ -77,10 +78,10 @@
 		return url.toString();
 	});
 
-	const firstFreeOnlineLink = $derived(
-		item.freeOnline &&
-			(item.freeOnline?._display?.[0]?.associatedMedia?.[0]?.[JsonLd.ID] ||
-				item.freeOnline?._display?.[0]?.associatedMedia?.[JsonLd.ID])
+	const firstMediaLink = $derived(
+		item.mediaLinks &&
+			(item.mediaLinks?._display?.[0]?.associatedMedia?.[0]?.[JsonLd.ID] ||
+				item.mediaLinks?._display?.[0]?.associatedMedia?.[JsonLd.ID])
 	);
 
 	let showDebugExplain = $state(false);
@@ -336,10 +337,10 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 			</footer>
 			{#if allowActions}
 				<div class="card-actions flex gap-1 self-end pt-1">
-					{#if firstFreeOnlineLink}
-						{#snippet freeLinks()}
+					{#if firstMediaLink}
+						{#snippet mediaLinksPopover()}
 							<DecoratedData
-								data={item.freeOnline}
+								data={item.mediaLinks as ResourceData}
 								showLabels={ShowLabelsOptions.Never}
 								allowPopovers={false}
 								block
@@ -347,11 +348,11 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 						{/snippet}
 						<a
 							class="btn btn-primary h-7 rounded-full md:h-8"
-							href={firstFreeOnlineLink}
+							href={firstMediaLink}
 							target="_blank"
 							use:popover={{
 								onFocus: false,
-								snippet: freeLinks
+								snippet: mediaLinksPopover
 							}}
 						>
 							<BiBoxArrowUpRight class="text-neutral-400" />

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -2,6 +2,7 @@
 	import { browser } from '$app/environment';
 	import { onDestroy } from 'svelte';
 	import { goto, onNavigate, replaceState } from '$app/navigation';
+	import popover from '$lib/actions/popover';
 	import { getUserSettings } from '$lib/contexts/userSettings';
 	import type { LibraryResultItem, SearchResultItem } from '$lib/types/search';
 	import { JsonLd, LensType } from '$lib/types/xl';
@@ -75,6 +76,12 @@
 		}
 		return url.toString();
 	});
+
+	const firstFreeOnlineLink = $derived(
+		item.freeOnline &&
+			(item.freeOnline?._display?.[0]?.associatedMedia?.[0]?.[JsonLd.ID] ||
+				item.freeOnline?._display?.[0]?.associatedMedia?.[JsonLd.ID])
+	);
 
 	let showDebugExplain = $state(false);
 	let showDebugHaystack = $state(false);
@@ -339,11 +346,22 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 							<span>{page.data.t('citations.cite')}</span>
 						</a>
 					{/if}
-					{#if item.associatedMedia?.length}
+					{#if firstFreeOnlineLink}
+						{#snippet freeLinks()}
+							<DecoratedData
+								data={item.freeOnline}
+								showLabels={ShowLabelsOptions.Never}
+								allowPopovers={false}
+								block
+							/>
+						{/snippet}
 						<a
 							class="btn btn-primary h-7 rounded-full md:h-8"
-							href={item.associatedMedia?.[0].uri[0]}
+							href={firstFreeOnlineLink}
 							target="_blank"
+							use:popover={{
+								snippet: freeLinks
+							}}
 						>
 							<span>Fritt online</span>
 							<BiBoxArrowUpRight />

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -179,7 +179,8 @@ export default {
 		libraries: 'libraries',
 		allInFacet: 'All in',
 		noExactMatches: 'No exact matches',
-		showingResultsFor: 'Showing results for'
+		showingResultsFor: 'Showing results for',
+		freeOnline: 'Free online'
 	},
 	supersearch: {
 		search: 'Search',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -179,7 +179,8 @@ export default {
 		libraries: 'bibliotek',
 		allInFacet: 'Allt inom',
 		noExactMatches: 'Inga exakta träffar',
-		showingResultsFor: 'Visar resultat för'
+		showingResultsFor: 'Visar resultat för',
+		freeOnline: 'Fritt online'
 	},
 	supersearch: {
 		search: 'Sök',

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -57,7 +57,7 @@ export interface SearchResultItem {
 	typeForIcon: string; // FIXME
 	typeStr: string;
 	selectTypeStr: string; // FIXME
-	associatedMedia?: DisplayDecorated[];
+	freeOnline: DisplayDecorated | null;
 	heldByMyLibraries?: (LibraryId | OrgId)[] | null;
 	numberOfHolders: number;
 	_debug?: ItemDebugInfo;

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -57,6 +57,7 @@ export interface SearchResultItem {
 	typeForIcon: string; // FIXME
 	typeStr: string;
 	selectTypeStr: string; // FIXME
+	associatedMedia?: DisplayDecorated[];
 	heldByMyLibraries?: (LibraryId | OrgId)[] | null;
 	numberOfHolders: number;
 	_debug?: ItemDebugInfo;

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -57,7 +57,7 @@ export interface SearchResultItem {
 	typeForIcon: string; // FIXME
 	typeStr: string;
 	selectTypeStr: string; // FIXME
-	freeOnline: DisplayDecorated | null;
+	mediaLinks: DisplayDecorated | null;
 	heldByMyLibraries?: (LibraryId | OrgId)[] | null;
 	numberOfHolders: number;
 	_debug?: ItemDebugInfo;

--- a/lxl-web/src/lib/utils/copyMediaLinksToWork.ts
+++ b/lxl-web/src/lib/utils/copyMediaLinksToWork.ts
@@ -1,0 +1,14 @@
+import type { FramedData } from '$lib/types/xl';
+import getAtPath from './getAtPath';
+import { asArray } from './xl';
+
+export function copyMediaLinksToWork(mainEntity: FramedData) {
+	const cp = (thing: FramedData, fromPath: (string | number | object)[], toProp: string) => {
+		const v = getAtPath(thing, fromPath).filter((v) => v['cataloguersNote'] != 'digipic');
+		if (v.length > 0) {
+			thing[toProp] = asArray(thing[toProp]).concat(v);
+		}
+	};
+	cp(mainEntity, ['@reverse', 'instanceOf', '*', 'associatedMedia', '*'], 'associatedMedia');
+	cp(mainEntity, ['@reverse', 'instanceOf', '*', 'isPrimaryTopicOf', '*'], 'isPrimaryTopicOf');
+}

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -128,7 +128,7 @@ export function asSearchResultItem(
 			typeForIcon: getTypeForIcon(getTypeLike(i, vocabUtil)) || '', // FIXME
 			selectTypeStr: selectTypeStr(getTypeLike(i, vocabUtil), displayUtil, locale), // FIXME
 			numberOfHolders: getHoldersCount(i, vocabUtil),
-			associatedMedia: getAtPath(i, ['@reverse', 'instanceOf', '*', 'associatedMedia', '*']),
+			associatedMedia: displayUtil.lensAndFormat(getMediaLinks(i), LensType.Card, locale),
 			...(isLibrary(i) && {
 				libraryId: i[JsonLd.ID],
 				displayStr: toString(displayUtil.lensAndFormat(i, LensType.Chip, locale))
@@ -539,6 +539,10 @@ function addMyLibrariesBoolFilter(boolFilters: Observation[] | undefined, transl
 		}
 	}
 	return boolFilters;
+}
+
+function getMediaLinks(item: FramedData) {
+	return getAtPath(item, ['@reverse', 'instanceOf', '*', 'associatedMedia', '*']);
 }
 
 /**

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -36,7 +36,7 @@ import {
 } from '$lib/types/search';
 
 import { getTranslator, type TranslateFn } from '$lib/i18n';
-import { type LocaleCode as LangCode, type LocaleCode } from '$lib/i18n/locales';
+import { type LocaleCode as LangCode } from '$lib/i18n/locales';
 import type { MyLibrariesType } from '$lib/types/userSettings';
 import { LxlLens } from '$lib/types/display';
 import { Width } from '$lib/types/auxd';
@@ -553,7 +553,7 @@ function addMyLibrariesBoolFilter(boolFilters: Observation[] | undefined, transl
 function getMediaLinks(
 	item: FramedData,
 	displayUtil: DisplayUtil,
-	locale: LocaleCode
+	locale: LangCode
 ): DisplayDecorated | null {
 	const _item = { ...item };
 	copyMediaLinksToWork(_item);

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -137,7 +137,7 @@ export function asSearchResultItem(
 			typeForIcon: getTypeForIcon(getTypeLike(i, vocabUtil)) || '', // FIXME
 			selectTypeStr: selectTypeStr(getTypeLike(i, vocabUtil), displayUtil, locale), // FIXME
 			numberOfHolders: getHoldersCount(i, vocabUtil),
-			freeOnline: getMediaLinks(i, displayUtil, locale),
+			mediaLinks: getMediaLinks(i, displayUtil, locale),
 			...(isLibrary(i) && {
 				libraryId: i[JsonLd.ID],
 				displayStr: toString(displayUtil.lensAndFormat(i, LensType.Chip, locale))
@@ -559,9 +559,9 @@ function getMediaLinks(
 	copyMediaLinksToWork(_item);
 	const formatted = displayUtil.lensAndFormat(_item, LensType.WebOverview2, locale);
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const [freeOnline, _] = pickProperty(formatted, ['associatedMedia']);
-	if (freeOnline._display?.length) {
-		return freeOnline;
+	const [mediaLinks, _] = pickProperty(formatted, ['associatedMedia']);
+	if (mediaLinks._display?.length) {
+		return mediaLinks;
 	}
 	return null;
 }

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -128,6 +128,7 @@ export function asSearchResultItem(
 			typeForIcon: getTypeForIcon(getTypeLike(i, vocabUtil)) || '', // FIXME
 			selectTypeStr: selectTypeStr(getTypeLike(i, vocabUtil), displayUtil, locale), // FIXME
 			numberOfHolders: getHoldersCount(i, vocabUtil),
+			associatedMedia: getAtPath(i, ['@reverse', 'instanceOf', '*', 'associatedMedia', '*']),
 			...(isLibrary(i) && {
 				libraryId: i[JsonLd.ID],
 				displayStr: toString(displayUtil.lensAndFormat(i, LensType.Chip, locale))

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -1,4 +1,12 @@
-import { asArray, DisplayUtil, isObject, toLite, toString, VocabUtil } from '$lib/utils/xl';
+import {
+	asArray,
+	DisplayUtil,
+	isObject,
+	pickProperty,
+	toLite,
+	toString,
+	VocabUtil
+} from '$lib/utils/xl';
 import {
 	Base,
 	type DisplayDecorated,
@@ -28,7 +36,7 @@ import {
 } from '$lib/types/search';
 
 import { getTranslator, type TranslateFn } from '$lib/i18n';
-import { type LocaleCode as LangCode } from '$lib/i18n/locales';
+import { type LocaleCode as LangCode, type LocaleCode } from '$lib/i18n/locales';
 import type { MyLibrariesType } from '$lib/types/userSettings';
 import { LxlLens } from '$lib/types/display';
 import { Width } from '$lib/types/auxd';
@@ -37,6 +45,7 @@ import getAtPath from '$lib/utils/getAtPath';
 import { getUriSlug } from '$lib/utils/http';
 import { isLibraryOrg } from '$lib/utils/holdings';
 import { getRefinedOrgs } from '$lib/utils/getRefinedOrgs.server';
+import { copyMediaLinksToWork } from '$lib/utils/copyMediaLinksToWork';
 import { getHoldersByType, getHoldersCount, getHoldingsByType } from '$lib/utils/holdings.server';
 import { getMyLibsFromHoldings } from '$lib/utils/holdings';
 import getTypeLike, { getTypeForIcon, toTypes, type TypeLike } from '$lib/utils/getTypeLike';
@@ -128,7 +137,7 @@ export function asSearchResultItem(
 			typeForIcon: getTypeForIcon(getTypeLike(i, vocabUtil)) || '', // FIXME
 			selectTypeStr: selectTypeStr(getTypeLike(i, vocabUtil), displayUtil, locale), // FIXME
 			numberOfHolders: getHoldersCount(i, vocabUtil),
-			associatedMedia: displayUtil.lensAndFormat(getMediaLinks(i), LensType.Card, locale),
+			freeOnline: getMediaLinks(i, displayUtil, locale),
 			...(isLibrary(i) && {
 				libraryId: i[JsonLd.ID],
 				displayStr: toString(displayUtil.lensAndFormat(i, LensType.Chip, locale))
@@ -541,8 +550,20 @@ function addMyLibrariesBoolFilter(boolFilters: Observation[] | undefined, transl
 	return boolFilters;
 }
 
-function getMediaLinks(item: FramedData) {
-	return getAtPath(item, ['@reverse', 'instanceOf', '*', 'associatedMedia', '*']);
+function getMediaLinks(
+	item: FramedData,
+	displayUtil: DisplayUtil,
+	locale: LocaleCode
+): DisplayDecorated | null {
+	const _item = { ...item };
+	copyMediaLinksToWork(_item);
+	const formatted = displayUtil.lensAndFormat(_item, LensType.WebOverview2, locale);
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [freeOnline, _] = pickProperty(formatted, ['associatedMedia']);
+	if (freeOnline._display?.length) {
+		return freeOnline;
+	}
+	return null;
 }
 
 /**

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -13,7 +13,6 @@ import type { HoldingsData } from '$lib/types/holdings.js';
 
 import { asArray, first, pickProperty, toString } from '$lib/utils/xl.js';
 import { bestImage, toSecure } from '$lib/utils/auxd';
-import getAtPath from '$lib/utils/getAtPath';
 import { getSortedInstances } from '$lib/utils/getSortedInstances';
 import {
 	getBibIdsByInstanceId,
@@ -29,6 +28,7 @@ import { appendMyLibrariesParam, asSearchResultItem, displayMappings } from '$li
 import { getRefinedOrgs } from '$lib/utils/getRefinedOrgs.server';
 import { getSearchResults } from '$lib/remotes/searchResult.remote';
 import { SearchResultsSchema } from '$lib/schemas/searchResult';
+import { copyMediaLinksToWork } from '$lib/utils/copyMediaLinksToWork';
 
 export const load = async ({ params, locals, fetch, url }) => {
 	const displayUtil = locals.display;
@@ -333,14 +333,3 @@ export const load = async ({ params, locals, fetch, url }) => {
 		isWork
 	};
 };
-
-function copyMediaLinksToWork(mainEntity: FramedData) {
-	const cp = (thing: FramedData, fromPath: (string | number | object)[], toProp: string) => {
-		const v = getAtPath(thing, fromPath).filter((v) => v['cataloguersNote'] != 'digipic');
-		if (v.length > 0) {
-			thing[toProp] = asArray(thing[toProp]).concat(v);
-		}
-	};
-	cp(mainEntity, ['@reverse', 'instanceOf', '*', 'associatedMedia', '*'], 'associatedMedia');
-	cp(mainEntity, ['@reverse', 'instanceOf', '*', 'isPrimaryTopicOf', '*'], 'isPrimaryTopicOf');
-}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -89,7 +89,9 @@ export const load = async ({ params, locals, fetch, url }) => {
 	}
 
 	const mainEntity = { ...centerOnWork(resource['mainEntity'] as FramedData) };
-	copyMediaLinksToWork(mainEntity);
+	if (isWork) {
+		copyMediaLinksToWork(mainEntity);
+	}
 
 	resourceId = resource.mainEntity['@id'];
 


### PR DESCRIPTION
## Description
### Solves

If the item is available online, display a card action that is the first link, also display a popover with all the available links
<img width="848" height="142" alt="Skärmavbild 2026-03-04 kl  15 11 41" src="https://github.com/user-attachments/assets/3990facc-4470-44f5-9753-0fcfcb41b4f9" />

Also fixes the bug with duplicate properties on some resource pages by not `copyMediaLinksToWork` unless work.
Example [before](https://beta.libris-qa.kb.se/sdzfjsz5q7vd72gt) [after](http://localhost:5173/sdzfjsz5q7vd72gt)
### Summary of changes
* Add `mediaLinks` prop to `SearchResultItem`
* Extract `copyMediaLinksToWork` util to own file, then use it to get the links and format them.
* Enable the `popover` component to also accept a `snippet` to render as content. Render the links using `DecoratedData`.
* Add prop to optionally turn of `focus` and `blur` listeners for the popover (default is on). This is because this popover is useless with keyboard navigation unless you can tab to the links. We could make it accessible, but it would then mean you need to tab past all the links when navigating in the result list. This would probably come across as annoying. The links can still be accessed through the resource page.
* Fix duplicate display of `associatedMedia` prop (+ more duplicates) by only using `copyMediaLinksToWork` for a _work_ resource.