### PR TITLE
fix(lxlweb): Use web-token for search mapping

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -515,6 +515,12 @@
 					"@type": "fresnel:Lens",
 					"classLensDomain": "Instance",
 					"showProperties": ["hasTitle"]
+				},
+				"Library": {
+					"@id": "Library-web-tokens",
+					"@type": "fresnel:Lens",
+					"showProperties": ["name", "qualifier"],
+					"classLensDomain": "Library"
 				}
 			}
 		},

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -521,6 +521,12 @@
 					"@type": "fresnel:Lens",
 					"showProperties": ["name", "qualifier"],
 					"classLensDomain": "Library"
+				},
+				"bibdb:Organization": {
+					"@id": "bibdb:Organization-web-tokens",
+					"@type": "fresnel:Lens",
+					"showProperties": ["name"],
+					"classLensDomain": "bibdb:Organization"
 				}
 			}
 		},

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -190,8 +190,8 @@ export function displayMappings(
 
 				return {
 					...(isObject(m.property) && { [JsonLd.ID]: m.property[JsonLd.ID] }),
-					display: displayUtil.lensAndFormat(value, LensType.Chip, locale),
-					displayStr: toString(displayUtil.lensAndFormat(value, LensType.Chip, locale)) || '',
+					display: displayUtil.lensAndFormat(value, LensType.WebToken, locale),
+					displayStr: toString(displayUtil.lensAndFormat(value, LensType.WebToken, locale)) || '',
 					label,
 					operator,
 					...(m.property?.[JsonLd.TYPE] === '_Invalid' && { invalid: m.property?.label }),
@@ -213,12 +213,12 @@ export function displayMappings(
 				return {
 					display: displayUtil.lensAndFormat(
 						{ ...defaultType, ...m.object },
-						LensType.Chip,
+						LensType.WebToken,
 						locale
 					),
 					displayStr:
 						toString(
-							displayUtil.lensAndFormat({ ...defaultType, ...m.object }, LensType.Chip, locale)
+							displayUtil.lensAndFormat({ ...defaultType, ...m.object }, LensType.WebToken, locale)
 						) || translate(`filterAlias.${m.object?.alias}`), // Allow frontend-defined displayStr for custom filter aliases
 					label: '',
 					operator,


### PR DESCRIPTION
## Description
### Solves

How about we use our new `web-token` to get rid of person lifespan in pills?
Ever since we hid the qualifier key, birthdate etc seems (even more) superfluous.
Also created a new library token omitting `sigel`.

<img width="848" height="65" alt="Skärmavbild 2026-03-05 kl  09 55 33" src="https://github.com/user-attachments/assets/73f87aa8-5c84-489e-802d-4346be2cba35" />

### Summary of changes
* Format `display` and `displayStr` in search mapping using `web-tokens`
* Add `Library-web-tokens`
