### PR TITLE
feat(lxl-web): Add qualifier keys from filters help page

### DIFF
--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { mount, unmount } from 'svelte';
+	import { mount, onMount, unmount } from 'svelte';
 	import { page } from '$app/state';
 	import { afterNavigate } from '$app/navigation';
+	import { resolve } from '$app/paths';
 	import {
 		SuperSearch,
 		lxlQualifierPlugin,
@@ -23,6 +24,7 @@
 	import IconGo from '~icons/bi/arrow-right-short';
 	import IconSearch from '~icons/bi/search';
 	import '$lib/styles/lxlquery.css';
+	import { getSearchContext } from '$lib/contexts/search';
 
 	interface Props {
 		placeholder: string;
@@ -33,6 +35,8 @@
 		qualifierSuggestions: QualifierSuggestion2[];
 	}
 
+	export type ChangeQueryParams = { insert: string; from?: number; to?: number };
+
 	let {
 		placeholder = '',
 		ariaLabelledBy,
@@ -41,6 +45,9 @@
 		onCursorChange,
 		qualifierSuggestions
 	}: Props = $props();
+
+	const searchContext = getSearchContext();
+
 	let q = $state(addSpaceIfEndingQualifier(page.url.searchParams.get('_q')?.trim() || ''));
 	let selection: Selection | undefined = $state();
 
@@ -255,6 +262,25 @@
 		return data;
 	}
 
+	export function changeQuery(params: ChangeQueryParams) {
+		const { insert } = params;
+		const from = params.from || q.length;
+		const to = params.to || q.length;
+		const before = q.slice(0, from);
+		superSearch?.dispatchChange({
+			change: {
+				from,
+				to,
+				insert
+			},
+			selection: {
+				anchor: (before + insert).length,
+				head: (before + insert).length
+			},
+			userEvent: 'input'
+		});
+	}
+
 	function addQualifierKey(qualifierKey: string) {
 		superSearch?.resetData();
 		superSearch?.showExpandedSearch(); // keep dialog open (since 'regular' search is hidden on mobile)
@@ -363,6 +389,10 @@
 			onCursorChange?.(null);
 		}
 	});
+
+	onMount(() => {
+		searchContext.changeQuery = changeQuery;
+	});
 </script>
 
 {#key page.data.locale}
@@ -454,7 +484,7 @@
 					<svelte:element
 						this={clearUrl ? 'a' : 'button'}
 						role={clearUrl ? undefined : 'button'}
-						href={clearUrl}
+						href={clearUrl ? resolve(clearUrl) : undefined}
 						onclick={(e: MouseEvent) => {
 							userClearedSearch = true;
 							onclickClear(e);
@@ -528,7 +558,7 @@
 								</button>
 								{#if qualifierSuggestionsExpanded}
 									<a
-										href={page.data.localizeHref('/help/filters')}
+										href={resolve(page.data.localizeHref('/help/filters'))}
 										id={getCellId(1, filteredQualifierSuggestions.length + 2)}
 										class={[
 											'text-2xs link-subtle ml-1',

--- a/lxl-web/src/lib/contexts/search.ts
+++ b/lxl-web/src/lib/contexts/search.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'svelte';
+import type { ChangeQueryParams } from '$lib/components/supersearch/SuperSearchWrapper.svelte';
+
+export const [getSearchContext, setSearchContext] = createContext<{
+	changeQuery?: (params: ChangeQueryParams) => void;
+}>();

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
@@ -4,6 +4,7 @@
 	import AppBar from './AppBar.svelte';
 	import { page } from '$app/state';
 	import { setHomepageContext } from '$lib/contexts/homepage';
+	import { setSearchContext } from '$lib/contexts/search';
 
 	const { children } = $props();
 
@@ -15,6 +16,7 @@
 	});
 
 	setHomepageContext(homepageCache);
+	setSearchContext({});
 </script>
 
 <svelte:head>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/filters/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/filters/+page.svelte
@@ -2,9 +2,11 @@
 	import getPageTitle from '$lib/utils/getPageTitle';
 	import Meta from '$lib/components/Meta.svelte';
 	import { page } from '$app/state';
+	import { getSearchContext } from '$lib/contexts/search';
 
 	let { data } = $props();
 
+	const searchContext = getSearchContext();
 	const pageTitle = page.data.t('help.pageTitle');
 </script>
 
@@ -33,8 +35,10 @@
 					<td>
 						<button
 							class="qualifier text-body bg-accent-50 text-2xs hover:bg-accent-100 inline-block min-h-8 min-w-9 shrink-0 rounded-md px-1.5 font-medium whitespace-nowrap capitalize"
-							>{f.label}</button
+							onclick={() => searchContext.changeQuery?.({ insert: ` ${f.key}:` })}
 						>
+							{f.label}
+						</button>
 						<ul class="mt-2 font-mono">
 							<li class="text-xs">{f.key}</li>
 							{#each f.queryCodes as q (q)}

--- a/lxl-web/tests/help.filter.spec.ts
+++ b/lxl-web/tests/help.filter.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test.beforeEach(async ({ page }) => {
+	await page.goto('/help/filters');
+});
+
+test('should not have any detectable a11y issues', async ({ page }) => {
+	const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+	await expect.soft(accessibilityScanResults.violations).toEqual([]);
+});
+
+test('qualifier keys can be added from filter list', async ({ page }) => {
+	await page.getByRole('main').getByRole('button').getByText('Bibliografi').click();
+	await expect(page.getByRole('combobox').first()).toContainText('Bibliografi');
+	await expect(page.getByRole('combobox').last()).toContainText('Bibliografi');
+	await page.keyboard.press('Escape');
+	await page.getByRole('main').getByRole('button').getByText('Biblioteksorganisation').click();
+	await expect(page.getByRole('combobox').first()).toContainText('Bibliografi');
+	await expect(page.getByRole('combobox').first()).toContainText(' Biblioteksorganisation');
+});

--- a/lxl-web/tests/help.filters.spec.ts
+++ b/lxl-web/tests/help.filters.spec.ts
@@ -1,14 +1,16 @@
 import { expect, test } from '@playwright/test';
-import AxeBuilder from '@axe-core/playwright';
+// import AxeBuilder from '@axe-core/playwright';
 
 test.beforeEach(async ({ page }) => {
 	await page.goto('/help/filters');
 });
 
+/*
 test('should not have any detectable a11y issues', async ({ page }) => {
 	const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
 	await expect.soft(accessibilityScanResults.violations).toEqual([]);
 });
+*/
 
 test('qualifier keys can be added from filter list', async ({ page }) => {
 	await page.getByRole('main').getByRole('button').getByText('Bibliografi').click();


### PR DESCRIPTION
## Description

### Solves

Adds support for adding qualifier keys from the `/help/filters` page.

Currently there is no smartness regarding inserted whitespace; it inserts an extra whitespace before the qualifier key as a safety precaution (but could also lead to repeated whitespaces if there already is one present).

### Summary of changes

- Expose function to change supersearch query using context
- Use changeQuery function to add qualifier keys
- Add test
