### PR TITLE
feat(lxl-web): Hide colons from qualifier pills

### DIFF
--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
 	import type { QualifierRendererProps } from 'supersearch';
 	import IconClose from '~icons/bi/x-lg';
 
@@ -31,7 +32,7 @@
 {/if}
 {#if operator}
 	<span
-		class="lxl-qualifier-operator cursor-text"
+		class={['lxl-qualifier-operator cursor-text', operator === ':' && 'hidden']}
 		data-qualifier-operator={operator}
 		role="button"
 		tabindex="-1"
@@ -64,7 +65,7 @@
 {/if}
 {#if valueLabel && removeLink}
 	<a
-		href={page.data.localizeHref(removeLink)}
+		href={resolve(page.data.localizeHref(removeLink))}
 		class="lxl-qualifier-remove"
 		aria-label={`${page.data.t('search.removeFilter')} ${pillText}`}
 	>

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -20,6 +20,11 @@
 
 .lxl-qualifier-key {
 	padding-left: calc(var(--spacing) * 1.5);
+	padding-right: calc(var(--spacing) * 1.5);
+}
+
+.lxl-qualifier-key + .lxl-qualifier-operator.hidden {
+	padding-right: 0;
 }
 
 .lxl-qualifier-operator {

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -56,7 +56,7 @@ test('expanded content shows persistant items and results', async ({ page }) => 
 	await page.waitForURL(/\/[a-z0-9]{15,}$/); // fnurgel route
 	await page.waitForLoadState('networkidle');
 	await expect(
-		page.getByRole('combobox').locator('.lxl-qualifier-key'),
+		page.getByRole('combobox').first().locator('.lxl-qualifier-key'),
 		'query is kept when navigating from find routes...'
 	).toContainText('Språk');
 	await expect(page.getByRole('combobox').locator('.lxl-qualifier-value')).toContainText('Svenska');
@@ -262,7 +262,7 @@ test('access filters can be added/removed', async ({ page }) => {
 test('qualifier keys can be added', async ({ page, context }) => {
 	await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 	await page.getByTestId('supersearch').click();
-	await page.getByTestId('supersearch').getByText('Författare/Upphov:').click();
+	await page.getByTestId('supersearch').getByText('Författare/Upphov').click();
 	await expect(page.getByRole('combobox').first()).toContainText('Författare/upphov');
 	await page.keyboard.press('a');
 	await page.keyboard.press('ControlOrMeta+A');


### PR DESCRIPTION
## Description

### Solves

Hides colons from qualifier pills.

Because it looks nicer? And saves some space...

### Summary of changes

- Hide colons from qualifier pills
