### PR TITLE
fix(supersearch): set estimated height on pill widget

### DIFF
--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -141,7 +141,7 @@
 .lxl-ghost-group {
 	display: inline-block;
 	width: 6px;
-	height: 10px;
+	height: 20px;
 	background-color: transparent;
 }
 

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/qualifierDecoration.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/qualifierDecoration.ts
@@ -20,6 +20,9 @@ class QualifierWidget extends WidgetType {
 			this.props.removeLink === other.props.removeLink
 		);
 	}
+	get estimatedHeight(): number {
+		return 30;
+	}
 
 	toDOM(view: EditorView): HTMLElement {
 		const container = document.createElement('span');


### PR DESCRIPTION
## Description

### Solves

Would like some help to see if this fixes the Firefox "cursor jumping down" bug in supersearch pills. 
I've rarely seen it myself, and not at all on this branch...

`npm run prebuild-local-packages`  

### Summary of changes

* Set widget `estimatedHeight`
