### PR TITLE
feat(lxlweb): icons/thumbs in pills

### DIFF
--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -2,12 +2,13 @@
 	import { page } from '$app/state';
 	import type { QualifierRendererProps } from 'supersearch';
 	import IconClose from '~icons/bi/x-lg';
+	import TypeIcon from '../TypeIcon.svelte';
 
 	interface Props extends QualifierRendererProps {
 		onclick?: () => void;
 	}
 
-	const { key, keyLabel, operator, value, valueLabel, removeLink, onclick }: Props = $props();
+	const { key, keyLabel, operator, value, valueLabel, removeLink, type, onclick }: Props = $props();
 
 	const pillText = $derived(`${keyLabel || ''}${operator} ${valueLabel || ''}`);
 
@@ -59,6 +60,9 @@
 			{valueLabel}
 		{/if}
 		-->
+		{#if type}
+			<TypeIcon {type} class="mr-0.5 mb-0.5 inline align-middle" />
+		{/if}
 		{valueLabel}
 	</span>
 {/if}

--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import type { QualifierRendererProps } from 'supersearch';
+	import { relativizeUrl, stripAnchor, trimSlashes } from '$lib/utils/http';
+	import { getPersonImage } from '$lib/utils/getPersonImage';
 	import IconClose from '~icons/bi/x-lg';
 	import TypeIcon from '../TypeIcon.svelte';
 
@@ -8,7 +11,21 @@
 		onclick?: () => void;
 	}
 
-	const { key, keyLabel, operator, value, valueLabel, removeLink, type, onclick }: Props = $props();
+	const { key, keyLabel, operator, value, valueLabel, removeLink, type, id, onclick }: Props =
+		$props();
+
+	const resourceId = $derived(stripAnchor(trimSlashes(relativizeUrl(id))));
+	let image = $state(null);
+
+	const getImage = async () => {
+		image = await getPersonImage(resourceId as string);
+	};
+
+	onMount(() => {
+		if (type === 'Person' && resourceId) {
+			getImage();
+		}
+	});
 
 	const pillText = $derived(`${keyLabel || ''}${operator} ${valueLabel || ''}`);
 
@@ -29,6 +46,7 @@
 	>
 		{keyLabel}
 	</span>
+	<span class="sr-only">{keyLabel}</span>
 {/if}
 {#if operator}
 	<span
@@ -60,8 +78,18 @@
 			{valueLabel}
 		{/if}
 		-->
-		{#if type}
-			<TypeIcon {type} class="mr-0.5 mb-0.5 inline align-middle" />
+
+		{#if image || type}
+			<span
+				class="icon-wrapper mr-0.5 mb-1 inline-flex size-5 items-center justify-center align-middle"
+				aria-hidden="true"
+			>
+				{#if image}
+					<img src={image} alt="" class="aspect-square rounded-full object-contain object-top" />
+				{:else if type}
+					<TypeIcon {type} class="text-[15px]" />
+				{/if}
+			</span>
 		{/if}
 		{valueLabel}
 	</span>
@@ -88,4 +116,8 @@
 		}
 	}
 		*/
+
+	.icon-wrapper:empty {
+		display: none;
+	}
 </style>

--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -87,7 +87,7 @@
 				{#if image}
 					<img src={image} alt="" class="aspect-square rounded-full object-contain object-top" />
 				{:else if type}
-					<TypeIcon {type} class="text-[15px]" />
+					<TypeIcon {type} class="text-sm" />
 				{/if}
 			</span>
 		{/if}

--- a/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
+++ b/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
@@ -1,4 +1,5 @@
 import type { DisplayMapping } from '$lib/types/search';
+import { JsonLd } from '$lib/types/xl';
 
 let prevSuggestMapping: DisplayMapping[] | undefined;
 
@@ -17,6 +18,7 @@ function getLabelFromMappings(
 	const valueLabel = suggestLabels.valueLabel || pageLabels.valueLabel;
 	let invalid = suggestLabels.invalid !== false && pageLabels.invalid !== false;
 	const removeLink = suggestLabels.removeLink || pageLabels.removeLink;
+	const type = suggestLabels.type || pageLabels.type;
 
 	if (suggestMapping?.length) {
 		// save latest mapping as fallback for error responses etc
@@ -28,7 +30,7 @@ function getLabelFromMappings(
 		invalid = false;
 	}
 
-	return { key, value, keyLabel, valueLabel, removeLink, invalid };
+	return { key, value, keyLabel, valueLabel, removeLink, invalid, type };
 }
 
 function iterateMapping(
@@ -40,6 +42,7 @@ function iterateMapping(
 	let valueLabel: string | undefined;
 	let removeLink: string | undefined;
 	let invalid: boolean | undefined;
+	let type: string | undefined;
 
 	if (mapping && Array.isArray(mapping)) {
 		_iterate(mapping);
@@ -55,11 +58,12 @@ function iterateMapping(
 						invalid = false;
 						keyLabel = el.label;
 					}
-					const isLinked = !!el.display?.['@id'];
+					const isLinked = !!el.display?.[JsonLd.ID];
 					if (isLinked && value === el?._value && el?.displayStr) {
 						// only use atomic ranges for linked values
 						valueLabel = el.displayStr;
-						removeLink = el.up?.['@id'];
+						removeLink = el.up?.[JsonLd.ID];
+						type = el?.display?.[JsonLd.TYPE];
 					}
 				} else if (!key && value === el?._value && el?.displayStr) {
 					// ...unless a filter alias (no key, only value)
@@ -69,7 +73,7 @@ function iterateMapping(
 			});
 		}
 	}
-	return { keyLabel, valueLabel, removeLink, invalid };
+	return { keyLabel, valueLabel, removeLink, invalid, type };
 }
 
 export default getLabelFromMappings;

--- a/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
+++ b/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
@@ -19,6 +19,7 @@ function getLabelFromMappings(
 	let invalid = suggestLabels.invalid !== false && pageLabels.invalid !== false;
 	const removeLink = suggestLabels.removeLink || pageLabels.removeLink;
 	const type = suggestLabels.type || pageLabels.type;
+	const id = suggestLabels.id || pageLabels.id;
 
 	if (suggestMapping?.length) {
 		// save latest mapping as fallback for error responses etc
@@ -30,7 +31,7 @@ function getLabelFromMappings(
 		invalid = false;
 	}
 
-	return { key, value, keyLabel, valueLabel, removeLink, invalid, type };
+	return { key, value, keyLabel, valueLabel, removeLink, invalid, type, id };
 }
 
 function iterateMapping(
@@ -43,6 +44,7 @@ function iterateMapping(
 	let removeLink: string | undefined;
 	let invalid: boolean | undefined;
 	let type: string | undefined;
+	let id: string | undefined;
 
 	if (mapping && Array.isArray(mapping)) {
 		_iterate(mapping);
@@ -64,6 +66,9 @@ function iterateMapping(
 						valueLabel = el.displayStr;
 						removeLink = el.up?.[JsonLd.ID];
 						type = el?.display?.[JsonLd.TYPE];
+						if (type === 'Person') {
+							id = el?.display?.[JsonLd.ID];
+						}
 					}
 				} else if (!key && value === el?._value && el?.displayStr) {
 					// ...unless a filter alias (no key, only value)
@@ -73,7 +78,7 @@ function iterateMapping(
 			});
 		}
 	}
-	return { keyLabel, valueLabel, removeLink, invalid, type };
+	return { keyLabel, valueLabel, removeLink, invalid, type, id };
 }
 
 export default getLabelFromMappings;

--- a/lxl-web/src/lib/utils/getPersonImage.ts
+++ b/lxl-web/src/lib/utils/getPersonImage.ts
@@ -1,0 +1,30 @@
+const images = new Map();
+const pending = new Map();
+
+export async function getPersonImage(id: string) {
+	if (images.has(id)) {
+		return images.get(id);
+	}
+
+	if (pending.has(id)) {
+		return pending.get(id);
+	}
+
+	const promise = (async () => {
+		const res = await fetch(`/api/sv/${id}`);
+		if (!res.ok) {
+			pending.delete(id);
+		}
+
+		const data = await res.json();
+		const image = data.image.url;
+
+		images.set(id, image);
+		pending.delete(id);
+
+		return image;
+	})();
+
+	pending.set(id, promise);
+	return promise;
+}

--- a/packages/supersearch/src/lib/types/lxlQualifierPlugin.ts
+++ b/packages/supersearch/src/lib/types/lxlQualifierPlugin.ts
@@ -9,6 +9,7 @@ export interface QualifierValidationResponse {
 	keyLabel?: string;
 	valueLabel?: string;
 	removeLink?: string;
+	type?: string;
 	invalid: boolean;
 }
 
@@ -39,6 +40,7 @@ export type QualifierRendererProps = {
 	operator: string;
 	value?: string;
 	valueLabel?: string;
+	type?: string;
 	removeLink?: string;
 };
 

--- a/packages/supersearch/src/lib/types/lxlQualifierPlugin.ts
+++ b/packages/supersearch/src/lib/types/lxlQualifierPlugin.ts
@@ -41,6 +41,7 @@ export type QualifierRendererProps = {
 	value?: string;
 	valueLabel?: string;
 	type?: string;
+	id?: string;
 	removeLink?: string;
 };
 


### PR DESCRIPTION
## Description
### Solves

Just trying out display of type icon / thumb images (for Persons) in pills
<img width="504" height="66" alt="Skärmavbild 2026-03-10 kl  16 35 13" src="https://github.com/user-attachments/assets/3a37f8af-d45b-4ddd-afe8-31d98a43a5f5" />

### Summary of changes

* `type` and `id` are appended to props passed from mapping -> validator function -> `QualifierPill`
* Use type with `TypeIcon` component
* If `id` && `Person`, get and display the thumb using a `getPersonImage` util:
   * `getPersonImage` fetches a resource once, then caches the image url, returning it for subsequent calls. This is because QualifierPill re-mounts all the time (and it has to, because the removeLink needs to recalculate as you type) and we can't fetch the resource again on every keystroke.
