### PR TITLE
fix(lxl-web, supersearch): Fix supersearch cursor issue

### DIFF
--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -42,8 +42,8 @@
 								type={m.display?.[JsonLd.TYPE]}
 								id={m.display[JsonLd.ID]}
 								{isRedundantKeyLabel}
-							/>
-						</span>
+							/>{' '}</span
+						>
 					{:else}
 						<!-- free text search -->
 						<span class="flex h-full items-center gap-1 pl-1.5">
@@ -72,7 +72,16 @@
 					{#each children as child, i (`${i}-${depth}`)}
 						{@const _child = Array.isArray(child) ? child : [child]}
 						{#if operator}
-							<span class="operator-{operator} text-sm uppercase">{operator}</span>
+							<span
+								class={[
+									`operator-${operator}`,
+									'text-sm uppercase',
+									operator === 'and' && 'sr-only',
+									operator === 'or' && 'first-of-type:sr-only'
+								]}
+							>
+								{operator}
+							</span>
 						{/if}
 						<SearchMapping depth={depth + 1} mapping={_child} />
 					{/each}
@@ -94,14 +103,6 @@
 
 <style lang="postcss">
 	@reference 'tailwindcss';
-
-	.operator-and {
-		display: none;
-	}
-
-	.group-or .operator-or:first-of-type {
-		display: none;
-	}
 
 	/* we can give _r pills a special styling if we want */
 	.variable-_r .lxl-qualifier,

--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -46,17 +46,17 @@
 </script>
 
 {#snippet imageSnippet()}
-			<span
-				class="icon-wrapper my-1.25 inline-flex size-5 items-center justify-center align-bottom"
-				aria-hidden="true"
-			>
-				{#if image}
-					<img src={image} alt="" class="aspect-square rounded-full object-contain object-top" />
-				{:else if type}
-					<TypeIcon {type} class="text-sm" />
-				{/if}
-			</span>
+	<span
+		class="icon-wrapper my-1.25 inline-flex size-5 items-center justify-center align-bottom"
+		aria-hidden="true"
+	>
+		{#if image}
+			<img src={image} alt="" class="aspect-square rounded-full object-contain object-top" />
+		{:else if type}
+			<TypeIcon {type} class="text-sm" />
 		{/if}
+	</span>
+{/snippet}
 {#snippet keyLabelSnippet()}
 	<span
 		data-qualifier-key={key}
@@ -92,7 +92,6 @@
 {/snippet}
 {#snippet removeLinkSnippet()}
 	<a
-		// eslint-disable-next-line svelte/no-navigation-without-resolve
 		href={page.data.localizeHref(removeLink)}
 		class="lxl-qualifier-remove"
 		aria-label={`${page.data.t('search.removeFilter')} ${pillText}`}
@@ -100,7 +99,7 @@
 	>
 {/snippet}
 
-{#if keyLabel}{@render keyLabelSnippet()}{/if}{#if operator}{@render operatorSnippet()}{/if}{#if image || type}{@render imageSnippet()}{/if}{#if valueLabel}{@render valueLabelSnippet()}{/if}{#if valueLabel && removeLink}{@render removeLinkSnippet()}{/if}
+{#if keyLabel}{@render keyLabelSnippet()}{/if}{#if operator}{@render operatorSnippet()}{/if}{#if image || type}{@render imageSnippet()}{/if}{#if valueLabel}{@render valueLabelSnippet()}{/if}{#if valueLabel && removeLink}{@render removeLinkSnippet()}{/if}
 
 <style lang="postcss">
 	/** TODO: Add when resource links are available 

--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -46,14 +46,11 @@
 </script>
 
 {#snippet imageSnippet()}
-	<span
-		class="icon-wrapper my-1.25 inline-flex size-5 items-center justify-center align-bottom"
-		aria-hidden="true"
-	>
+	<span class="empty:hidden" aria-hidden="true">
 		{#if image}
-			<img src={image} alt="" class="aspect-square rounded-full object-contain object-top" />
+			<img src={image} alt="" class="mr-0.75 mb-0.75 inline size-5 rounded-full object-contain" />
 		{:else if type}
-			<TypeIcon {type} class="text-sm" />
+			<TypeIcon {type} class="mr-0.75 mb-0.75 inline text-sm" />
 		{/if}
 	</span>
 {/snippet}
@@ -64,7 +61,7 @@
 		role="button"
 		tabindex="-1"
 		{onclick}
-		onkeypress={onclick}>&nbsp;{keyLabel}</span
+		onkeypress={onclick}>{keyLabel}</span
 	>
 {/snippet}
 {#snippet operatorSnippet()}
@@ -88,18 +85,19 @@
 		tabindex="-1"
 		{onclick}
 		onkeypress={onclick}
-	></span>
+		>{#if image || type}{@render imageSnippet()}{/if}{valueLabel}</span
+	>
 {/snippet}
 {#snippet removeLinkSnippet()}
 	<a
 		href={page.data.localizeHref(removeLink)}
 		class="lxl-qualifier-remove"
 		aria-label={`${page.data.t('search.removeFilter')} ${pillText}`}
-		><IconClose class="inline" aria-hidden="true" /></a
+		><IconClose class="mb-0.5 inline" aria-hidden="true" /></a
 	>
 {/snippet}
 
-{#if keyLabel}{@render keyLabelSnippet()}{/if}{#if operator}{@render operatorSnippet()}{/if}{#if image || type}{@render imageSnippet()}{/if}{#if valueLabel}{@render valueLabelSnippet()}{/if}{#if valueLabel && removeLink}{@render removeLinkSnippet()}{/if}
+{#if keyLabel}{@render keyLabelSnippet()}{/if}{#if operator}{@render operatorSnippet()}{/if}{#if valueLabel}{@render valueLabelSnippet()}{/if}{#if valueLabel && removeLink}{@render removeLinkSnippet()}{/if}
 
 <style lang="postcss">
 	/** TODO: Add when resource links are available 
@@ -113,8 +111,4 @@
 		}
 	}
 		*/
-
-	.icon-wrapper:empty {
-		display: none;
-	}
 </style>

--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -57,7 +57,7 @@
 {#snippet keyLabelSnippet()}
 	<span
 		data-qualifier-key={key}
-		class={['lxl-qualifier-key cursor-text', isRedundantKeyLabel && 'redundant-label sr-only']}
+		class={['lxl-qualifier-key cursor-text', isRedundantKeyLabel && 'redundant-label']}
 		role="button"
 		tabindex="-1"
 		{onclick}

--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -45,53 +45,7 @@
 	 */
 </script>
 
-{#if keyLabel}
-	<span
-		data-qualifier-key={key}
-		class={['lxl-qualifier-key cursor-text', isRedundantKeyLabel && 'redundant-label']}
-		role="button"
-		tabindex="-1"
-		{onclick}
-		onkeypress={onclick}
-	>
-		{keyLabel}
-	</span>
-{/if}
-{#if operator}
-	<span
-		class={[
-			'lxl-qualifier-operator cursor-text',
-			(isRedundantKeyLabel || operator === ':') && 'hidden'
-		]}
-		data-qualifier-operator={operator}
-		role="button"
-		tabindex="-1"
-		{onclick}
-		onkeypress={onclick}
-	>
-		{operator}
-	</span>
-{/if}
-{#if valueLabel}
-	<span
-		class={[keyLabel && operator ? 'lxl-qualifier-value' : 'lxl-qualifier-alias', 'cursor-text']}
-		data-qualifier-value={value}
-		role="button"
-		tabindex="-1"
-		{onclick}
-		onkeypress={onclick}
-	>
-		<!--
-		{#if resourceLink}
-			<span class="hidden">{valueLabel}</span><a href={page.data.localizeHref(`/${resourceLink}`)} class="link inline-block"
-				>{valueLabel}</a
-			>
-		{:else}
-			{valueLabel}
-		{/if}
-		-->
-
-		{#if image || type}
+{#snippet imageSnippet()}
 			<span
 				class="icon-wrapper my-1.25 inline-flex size-5 items-center justify-center align-bottom"
 				aria-hidden="true"
@@ -103,18 +57,50 @@
 				{/if}
 			</span>
 		{/if}
-		<span>{valueLabel}</span>
-	</span>
-{/if}
-{#if valueLabel && removeLink}
+{#snippet keyLabelSnippet()}
+	<span
+		data-qualifier-key={key}
+		class={['lxl-qualifier-key cursor-text', isRedundantKeyLabel && 'redundant-label']}
+		role="button"
+		tabindex="-1"
+		{onclick}
+		onkeypress={onclick}>&nbsp;{keyLabel}</span
+	>
+{/snippet}
+{#snippet operatorSnippet()}
+	<span
+		class={[
+			'lxl-qualifier-operator cursor-text',
+			(isRedundantKeyLabel || operator === ':') && 'hidden'
+		]}
+		data-qualifier-operator={operator}
+		role="button"
+		tabindex="-1"
+		{onclick}
+		onkeypress={onclick}>{operator}</span
+	>
+{/snippet}
+{#snippet valueLabelSnippet()}
+	<span
+		class={[keyLabel && operator ? 'lxl-qualifier-value' : 'lxl-qualifier-alias', 'cursor-text']}
+		data-qualifier-value={value}
+		role="button"
+		tabindex="-1"
+		{onclick}
+		onkeypress={onclick}
+	></span>
+{/snippet}
+{#snippet removeLinkSnippet()}
 	<a
+		// eslint-disable-next-line svelte/no-navigation-without-resolve
 		href={page.data.localizeHref(removeLink)}
 		class="lxl-qualifier-remove"
 		aria-label={`${page.data.t('search.removeFilter')} ${pillText}`}
+		><IconClose class="inline" aria-hidden="true" /></a
 	>
-		<IconClose aria-hidden="true" />
-	</a>
-{/if}
+{/snippet}
+
+{#if keyLabel}{@render keyLabelSnippet()}{/if}{#if operator}{@render operatorSnippet()}{/if}{#if image || type}{@render imageSnippet()}{/if}{#if valueLabel}{@render valueLabelSnippet()}{/if}{#if valueLabel && removeLink}{@render removeLinkSnippet()}{/if}
 
 <style lang="postcss">
 	/** TODO: Add when resource links are available 

--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -57,7 +57,7 @@
 {#snippet keyLabelSnippet()}
 	<span
 		data-qualifier-key={key}
-		class={['lxl-qualifier-key cursor-text', isRedundantKeyLabel && 'redundant-label']}
+		class={['lxl-qualifier-key cursor-text', isRedundantKeyLabel && 'redundant-label sr-only']}
 		role="button"
 		tabindex="-1"
 		{onclick}
@@ -68,7 +68,7 @@
 	<span
 		class={[
 			'lxl-qualifier-operator cursor-text',
-			(isRedundantKeyLabel || operator === ':') && 'hidden'
+			(isRedundantKeyLabel || operator === ':') && 'sr-only'
 		]}
 		data-qualifier-operator={operator}
 		role="button"

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -646,11 +646,7 @@
 			}
 		}
 
-		@variant sm {
-			font-size: var(--text-sm);
-		}
-
-		@variant @5xl {
+		@variant lg {
 			font-size: 0.9375rem;
 		}
 	}
@@ -853,15 +849,19 @@
 	.expanded.supersearch-input :global(.cm-scroller) {
 		min-height: calc(var(--spacing) * 14);
 		scrollbar-width: thin;
-		max-height: 106px;
+		max-height: 128px;
 		overflow-x: hidden;
 
 		@variant sm {
 			min-height: calc(var(--spacing) * 11);
 		}
+	}
 
-		@variant lg {
-			margin-top: 0px;
+	.expanded.supersearch-input :global(.cm-content) {
+		margin-block: calc(var(--spacing) * 1.5);
+
+		@variant sm {
+			margin-block: 0;
 		}
 	}
 
@@ -918,22 +918,9 @@
 	:global(.codemirror-container .cm-placeholder) {
 		font-size: var(--text-base);
 		color: var(--color-placeholder);
-		margin-top: 1px;
 
-		@variant sm {
-			font-size: var(--text-sm);
-		}
-
-		@variant @7xl {
-			margin-top: 0px;
-		}
-		@variant @5xl {
-			font-size: 0.9375rem;
-		}
-	}
-	.expanded :global(.codemirror-container .cm-placeholder) {
 		@variant lg {
-			margin-top: 1px;
+			font-size: 0.9375rem;
 		}
 	}
 

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -866,7 +866,7 @@
 	}
 
 	.supersearch-input :global(.cm-line) {
-		line-height: 30px;
+		line-height: 32px;
 		padding-left: calc(var(--spacing) * 11);
 
 		@variant sm {
@@ -894,18 +894,6 @@
 		margin: 0;
 		padding: calc(var(--spacing) * 1.5) 0;
 		min-height: var(--search-input-height);
-
-		@variant lg {
-			padding: calc(var(--spacing) * 2) 0;
-		}
-	}
-
-	.expanded.supersearch-input :global(.cm-content) {
-		padding: calc(var(--spacing) * 3) 0;
-
-		@variant sm {
-			padding: calc(var(--spacing) * 1.5) 0;
-		}
 
 		@variant lg {
 			padding: calc(var(--spacing) * 2) 0;

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -1,13 +1,8 @@
 .lxl-qualifier {
-	position: relative;
-	height: calc(var(--spacing) * 7.5);
 	color: var(--text-body);
-	outline: 1px solid var(--color-accent-200);
-	outline-offset: -1px;
-	border-radius: var(--radius-md);
 	transition: background-color 0.1s ease;
-	z-index: 1;
-	font-size: var(--text-base);
+	font-size: var(--text-sm);
+	white-space: nowrap;
 	/* pointer-events: none; */
 
 	@media screen and (min-width: 640px) {
@@ -16,24 +11,54 @@
 }
 
 .lxl-qualifier.editing {
-	padding-left: calc(var(--spacing) * 1.5);
-	padding-right: calc(var(--spacing) * 1.5);
-	outline-color: var(--color-accent-400);
-	outline-style: dashed;
+	padding-block: calc(var(--spacing) * 1.5);
+	padding-inline: var(--spacing);
+	border: 2px dashed var(--color-accent-400);
+	border-radius: var(--radius-md);
 }
 
 .lxl-qualifier-key {
-	position: relative;
-	padding-left: calc(var(--spacing) * 1.5);
-	padding-right: calc(var(--spacing) * 1.5);
+	padding-block: calc(var(--spacing) * 1.5);
+	border-block: 1px solid var(--color-accent-200);
+	border-inline-start: 1px solid var(--color-accent-200);
+
+	border-radius: var(--radius-md) 0 0 var(--radius-md);
+	background-color: var(--color-accent-50);
 }
 
-.lxl-qualifier-key + .lxl-qualifier-operator.hidden {
-	padding-right: 0;
+.lxl-qualifier-value {
+	padding-block: calc(var(--spacing) * 1.5);
+	border-block: 1px solid var(--color-accent-200);
+	border-inline-end: 1px solid var(--color-accent-200);
+	border-radius: 0 var(--radius-md) var(--radius-md) 0;
+}
+
+.atomic .lxl-qualifier-value,
+.atomic .lxl-qualifier-alias {
+	color: var(--color-link);
+	font-weight: var(--font-weight-medium);
+	padding-block: calc(var(--spacing) * 1.5);
+	padding-inline: var(--spacing);
+	border: 1px solid var(--color-accent-200);
+	background-color: var(--color-accent-50);
+	border-radius: var(--radius-md) 0 0 var(--radius-md);
 }
 
 .lxl-qualifier-operator {
-	position: relative;
+	padding-block: calc(var(--spacing) * 1.5);
+	border-block: 1px solid var(--color-accent-200);
+	border-inline-end: 1px solid var(--color-accent-200);
+	background-color: var(--color-accent-50);
+
+	&[data-qualifier-operator='\:'] {
+		color: transparent;
+	}
+}
+
+.lxl-ghost-paren {
+	padding-block: calc(var(--spacing) * 1.5);
+	color: transparent;
+	user-select: none;
 }
 
 .lxl-ghost-group ~ .lxl-not-term > .lxl-qualifier-value {
@@ -41,11 +66,11 @@
 }
 
 .lxl-qualifier-remove {
-	display: flex;
-	align-items: center;
-	height: 100%;
-	padding-right: calc(var(--spacing) * 1.5);
-	padding-left: calc(var(--spacing) * 1.5);
+	border-block: 1px solid var(--color-accent-200);
+	border-inline-end: 1px solid var(--color-accent-200);
+	padding-block: calc(var(--spacing) * 1.5);
+
+	padding-inline: var(--spacing);
 	color: var(--color-subtle);
 	background-color: inherit;
 	transition: background-color 0.1s ease;
@@ -58,49 +83,17 @@
 }
 
 .atomic {
-	background-color: var(--color-accent-50);
-	display: inline-flex;
-	align-items: center;
-	height: 100%;
-	margin-right: 1px;
-	border-top-left-radius: var(--radius-md);
-	border-bottom-left-radius: var(--radius-md);
-	user-select: none;
+	user-select: all;
 	pointer-events: auto;
 }
 
 .atomic:has(.lxl-qualifier-remove) {
 	border-top-right-radius: var(--radius-md);
-	border-bottom-right-radius: var(--radius-md);
 }
 
 .atomic .lxl-qualifier-key {
 	/* font-weight: var(--font-weight-medium); */
 	white-space: nowrap;
-}
-
-.atomic .lxl-qualifier-value,
-.atomic .lxl-qualifier-alias {
-	color: var(--color-link);
-	font-weight: var(--font-weight-medium);
-	padding-left: calc(var(--spacing) * 1.5);
-	padding-right: calc(var(--spacing) * 1.5);
-	white-space: nowrap;
-}
-
-.atomic .lxl-qualifier-operator {
-	padding-right: calc(var(--spacing) * 1.5);
-}
-
-.atomic .lxl-qualifier-key::after {
-	content: '';
-	position: absolute;
-	top: 0px;
-	right: 0px;
-	height: calc(var(--spacing) * 7.5);
-	width: 1px;
-	background-color: var(--color-accent-200);
-	z-index: 0;
 }
 
 .lxl-invalid,

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -18,10 +18,9 @@
 }
 
 .lxl-qualifier-key {
+	padding-inline: var(--spacing);
 	padding-block: calc(var(--spacing) * 1.5);
-	border-block: 1px solid var(--color-accent-200);
-	border-inline-start: 1px solid var(--color-accent-200);
-
+	border: 1px solid var(--color-accent-200);
 	border-radius: var(--radius-md) 0 0 var(--radius-md);
 	background-color: var(--color-accent-50);
 }
@@ -39,9 +38,17 @@
 	font-weight: var(--font-weight-medium);
 	padding-block: calc(var(--spacing) * 1.5);
 	padding-inline: var(--spacing);
-	border: 1px solid var(--color-accent-200);
+	border-inline-end: none;
 	background-color: var(--color-accent-50);
+}
+
+.atomic .lxl-qualifier-value {
+	border-radius: 0;
+}
+
+.redundant-label ~ .lxl-qualifier-value {
 	border-radius: var(--radius-md) 0 0 var(--radius-md);
+	border-inline-start: 1px solid var(--color-accent-200);
 }
 
 .lxl-qualifier-operator {
@@ -49,10 +56,14 @@
 	border-block: 1px solid var(--color-accent-200);
 	border-inline-end: 1px solid var(--color-accent-200);
 	background-color: var(--color-accent-50);
-
+	white-space: nowrap;
 	&[data-qualifier-operator='\:'] {
 		color: transparent;
 	}
+}
+
+.atomic .lxl-qualifier-operator {
+	border-inline-end: none;
 }
 
 .lxl-ghost-paren {
@@ -60,7 +71,6 @@
 	color: transparent;
 	user-select: none;
 }
-
 .lxl-ghost-group ~ .lxl-not-term > .lxl-qualifier-value {
 	padding: 0;
 }
@@ -69,10 +79,9 @@
 	border-block: 1px solid var(--color-accent-200);
 	border-inline-end: 1px solid var(--color-accent-200);
 	padding-block: calc(var(--spacing) * 1.5);
-
 	padding-inline: var(--spacing);
 	color: var(--color-subtle);
-	background-color: inherit;
+	background-color: var(--color-accent-50);
 	transition: background-color 0.1s ease;
 	border-top-right-radius: var(--radius-md);
 	border-bottom-right-radius: var(--radius-md);
@@ -80,6 +89,10 @@
 
 .lxl-qualifier-remove:hover {
 	background-color: var(--color-accent-100);
+}
+
+.lxl-not-term .atomic .lxl-qualifier-remove:hover {
+	background-color: var(--color-severe-100);
 }
 
 .atomic {
@@ -107,23 +120,32 @@
 
 .lxl-not-term .atomic {
 	background-color: var(--color-severe-50);
+	border-color: var(--color-severe-200);
 }
 
 .lxl-not-term .lxl-qualifier {
-	outline-color: var(--color-severe-200);
+	border-color: var(--color-severe-200);
 }
 
 .lxl-not-term .lxl-qualifier-remove:hover {
-	background-color: var(--color-severe-100);
+	border-color: var(--color-severe-100);
 }
 
 .lxl-not-term .atomic .lxl-qualifier-key::after {
 	background-color: var(--color-severe-200);
 }
 
+.lxl-not-term .atomic .lxl-qualifier-key,
 .lxl-not-term .atomic .lxl-qualifier-value,
-.lxl-not-term .atomic .lxl-qualifier-alias {
+.lxl-not-term .atomic .lxl-qualifier-alias,
+.lxl-not-term .atomic .lxl-qualifier-remove {
+	background-color: var(--color-severe-50);
+	border-color: var(--color-severe-200);
 	color: var(--color-body);
+}
+
+.lxl-not-term .atomic .lxl-qualifier-key {
+	color: var(--color-severe-600);
 }
 
 .lxl-boolean-operator {

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -36,12 +36,6 @@
 	position: relative;
 }
 
-.lxl-qualifier-value:not(:has(~ .lxl-ghost-group)) {
-	/* make up for missing ghost group width */
-	padding-right: calc(var(--spacing) * 1.5);
-	padding-left: calc(var(--spacing) * 1.5);
-}
-
 .lxl-ghost-group ~ .lxl-not-term > .lxl-qualifier-value {
 	padding: 0;
 }

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -151,3 +151,8 @@
 .lxl-boolean-operator {
 	color: var(--color-body);
 }
+
+/* hide key and operator for linked values */
+.atomic .redundant-label:has(~ .lxl-qualifier-value) {
+	@apply sr-only;
+}

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -151,8 +151,3 @@
 .lxl-boolean-operator {
 	color: var(--color-body);
 }
-
-/* hide key and operator for linked values */
-.atomic .redundant-label:has(~ .lxl-qualifier-value) {
-	display: none;
-}

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -143,13 +143,6 @@
 	color: var(--color-body);
 }
 
-.lxl-ghost-group {
-	display: inline-block;
-	width: 6px;
-	height: 20px;
-	background-color: transparent;
-}
-
 /* hide key and operator for linked values */
 .atomic .redundant-label:has(~ .lxl-qualifier-value) {
 	display: none;

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
@@ -60,7 +60,7 @@
 			aria-label={ariaLabel}
 			aria-describedby={ariaDescribedBy}
 			bind:this={fallbackInputElement}
-			class="placeholder:text-placeholder w-full pl-11 text-base focus:outline-none sm:px-3 sm:text-sm sm:@3xl:pl-4 @5xl:text-[0.9375rem]"
+			class="placeholder:text-placeholder w-full pl-11 text-base focus:outline-none sm:px-3 lg:text-[0.9375rem] sm:@3xl:pl-4"
 		/>
 		<button
 			type="submit"

--- a/lxl-web/tests/find.mobile.spec.ts
+++ b/lxl-web/tests/find.mobile.spec.ts
@@ -42,7 +42,7 @@ test('mapping displays the correct search query', async ({ page }) => {
 	await page.goto('/find?_q=språk%3A"lang%3Aswe"+sommar');
 	await page.getByRole('link', { name: 'Sökfilter' }).click();
 	const mapping = page.getByRole('navigation', { name: 'Valda filter' });
-	await expect(mapping).toHaveText('and Språk :  Svenska and sommar   Rensa', {
+	await expect(mapping).toHaveText('and Språk:Svenska and sommar   Rensa', {
 		ignoreCase: true
 	});
 });
@@ -54,7 +54,7 @@ test('mapping displays the correct search query 2', async ({ page }) => {
 	await page.getByRole('link', { name: 'Sökfilter' }).click();
 	const mapping = await page.getByRole('navigation', { name: 'Valda filter' });
 	const innerText =
-		'and or Medverkan och funktion :  * or and Kategori :  Litteratur and not Titel :  "pirater"    and Har omslags-/miniatyrbild   Rensa';
+		'and or Medverkan och funktion:* or and Kategori:Litteratur and not Titel:"pirater"    and Har omslags-/miniatyrbild   Rensa';
 	await expect(mapping).toHaveText(innerText, { ignoreCase: true });
 });
 
@@ -65,7 +65,7 @@ test('mapping displays the correct search query 3', async ({ page }) => {
 	await page.getByRole('link', { name: 'Sökfilter' }).click();
 	const mapping = page.getByRole('navigation', { name: 'Valda filter' });
 	const mappingText =
-		'and Titel :  "pippi långstrump" and or Språk :  Engelska or and Språk :  Franska and not Språk :  tyska    and lindgren   Rensa';
+		'and Titel:"pippi långstrump" and or Språk:Engelska or and Språk:Franska and not Språk:tyska    and lindgren   Rensa';
 	await expect(mapping).toHaveText(mappingText, { ignoreCase: true });
 });
 

--- a/lxl-web/tests/help.filters.spec.ts
+++ b/lxl-web/tests/help.filters.spec.ts
@@ -14,10 +14,10 @@ test('should not have any detectable a11y issues', async ({ page }) => {
 
 test('qualifier keys can be added from filter list', async ({ page }) => {
 	await page.getByRole('main').getByRole('button').getByText('Bibliografi').click();
-	await expect(page.getByRole('combobox').first()).toContainText('Bibliografi');
-	await expect(page.getByRole('combobox').last()).toContainText('Bibliografi');
+	await expect(page.getByRole('combobox').first()).toContainText('Ingår i bibliografi');
+	await expect(page.getByRole('combobox').last()).toContainText('Ingår i bibliografi');
 	await page.keyboard.press('Escape');
 	await page.getByRole('main').getByRole('button').getByText('Biblioteksorganisation').click();
-	await expect(page.getByRole('combobox').first()).toContainText('Bibliografi');
+	await expect(page.getByRole('combobox').first()).toContainText('Ingår i bibliografi');
 	await expect(page.getByRole('combobox').first()).toContainText(' Biblioteksorganisation');
 });

--- a/lxl-web/tests/subsets.spec.ts
+++ b/lxl-web/tests/subsets.spec.ts
@@ -11,7 +11,7 @@ test('The search placeholder is replaced when using a subset', async ({ page }) 
 });
 
 test('_r param is preserved when navigating around the app', async ({ page }) => {
-	await page.goto('/find?_q=f&_offset=0&_limit=20&_r=itemHeldBy%3A"sigel%3AArkm"');
+	await page.goto('/find?_q=a&_offset=0&_limit=20&_r=itemHeldBy%3A%22sigel%3AArkm%22');
 	await page.getByRole('main').getByRole('article').getByRole('link').first().click();
 	await expect(page).toHaveURL(/_r=itemHeldBy%3A%22sigel%3AArkm%22/);
 	await page.getByRole('main').getByRole('link').getByText('Nästa').click();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2035,27 +2035,27 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
-      "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.4.0",
+        "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.27.0",
         "@lezer/common": "^1.1.0"
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
-      "integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
+      "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
-        "@lezer/common": "^1.1.0",
+        "@lezer/common": "^1.5.0",
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
@@ -2082,21 +2082,21 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
-      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.38.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.8.tgz",
-      "integrity": "sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
+      "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/state": "^6.5.0",
+        "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
@@ -2945,7 +2945,9 @@
       }
     },
     "node_modules/@lezer/common": {
-      "version": "1.2.3",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
       "license": "MIT"
     },
     "node_modules/@lezer/generator": {
@@ -3215,9 +3217,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.47.1.tgz",
-      "integrity": "sha512-lTahKRJip0knffA/GTNFJMrToD+CM+JJ+Qt5kjzBK/sFQ0EWqfKW3AYQSlZXN98tX0lx66083U9JYIMioMMK7g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -3229,9 +3231,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.47.1.tgz",
-      "integrity": "sha512-uqxkb3RJLzlBbh/bbNQ4r7YpSZnjgMgyoEOY7Fy6GCbelkDSAzeiogxMG9TfLsBbqmGsdDObo3mzGqa8hps4MA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -3243,9 +3245,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.47.1.tgz",
-      "integrity": "sha512-tV6reObmxBDS4DDyLzTDIpymthNlxrLBGAoQx6m2a7eifSNEZdkXQl1PE4ZjCkEDPVgNXSzND/k9AQ3mC4IOEQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -3257,9 +3259,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.47.1.tgz",
-      "integrity": "sha512-XuJRPTnMk1lwsSnS3vYyVMu4x/+WIw1MMSiqj5C4j3QOWsMzbJEK90zG+SWV1h0B1ABGCQ0UZUjti+TQK35uHQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -3271,9 +3273,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.47.1.tgz",
-      "integrity": "sha512-79BAm8Ag/tmJ5asCqgOXsb3WY28Rdd5Lxj8ONiQzWzy9LvWORd5qVuOnjlqiWWZJw+dWewEktZb5yiM1DLLaHw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -3285,9 +3287,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.47.1.tgz",
-      "integrity": "sha512-OQ2/ZDGzdOOlyfqBiip0ZX/jVFekzYrGtUsqAfLDbWy0jh1PUU18+jYp8UMpqhly5ltEqotc2miLngf9FPSWIA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -3299,13 +3301,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.47.1.tgz",
-      "integrity": "sha512-HZZBXJL1udxlCVvoVadstgiU26seKkHbbAMLg7680gAcMnRNP9SAwTMVet02ANA94kXEI2VhBnXs4e5nf7KG2A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3313,13 +3318,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.47.1.tgz",
-      "integrity": "sha512-sZ5p2I9UA7T950JmuZ3pgdKA6+RTBr+0FpK427ExW0t7n+QwYOcmDTK/aRlzoBrWyTpJNlS3kacgSlSTUg6P/Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3327,13 +3335,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.47.1.tgz",
-      "integrity": "sha512-3hBFoqPyU89Dyf1mQRXCdpc6qC6At3LV6jbbIOZd72jcx7xNk3aAp+EjzAtN6sDlmHFzsDJN5yeUySvorWeRXA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3341,27 +3352,50 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.47.1.tgz",
-      "integrity": "sha512-49J4FnMHfGodJWPw73Ve+/hsPjZgcXQGkmqBGZFvltzBKRS+cvMiWNLadOMXKGnYRhs1ToTGM0sItKISoSGUNA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.47.1.tgz",
-      "integrity": "sha512-4yYU8p7AneEpQkRX03pbpLmE21z5JNys16F1BZBZg5fP9rIlb0TkeQjn5du5w4agConCCEoYIG57sNxjryHEGg==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3369,13 +3403,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.47.1.tgz",
-      "integrity": "sha512-fAiq+J28l2YMWgC39jz/zPi2jqc0y3GSRo1yyxlBHt6UN0yYgnegHSRPa3pnHS5amT/efXQrm0ug5+aNEu9UuQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3383,13 +3437,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.47.1.tgz",
-      "integrity": "sha512-daoT0PMENNdjVYYU9xec30Y2prb1AbEIbb64sqkcQcSaR0zYuKkoPuhIztfxuqN82KYCKKrj+tQe4Gi7OSm1ow==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3397,13 +3454,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.47.1.tgz",
-      "integrity": "sha512-JNyXaAhWtdzfXu5pUcHAuNwGQKevR+6z/poYQKVW+pLaYOj9G1meYc57/1Xv2u4uTxfu9qEWmNTjv/H/EpAisw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3411,13 +3471,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.47.1.tgz",
-      "integrity": "sha512-U/CHbqKSwEQyZXjCpY43/GLYcTVKEXeRHw0rMBJP7fP3x6WpYG4LTJWR3ic6TeYKX6ZK7mrhltP4ppolyVhLVQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3425,13 +3488,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.47.1.tgz",
-      "integrity": "sha512-uTLEakjxOTElfeZIGWkC34u2auLHB1AYS6wBjPGI00bWdxdLcCzK5awjs25YXpqB9lS8S0vbO0t9ZcBeNibA7g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3439,9 +3505,26 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.47.1.tgz",
-      "integrity": "sha512-Ft+d/9DXs30BK7CHCTX11FtQGHUdpNDLJW0HHLign4lgMgBcPFN3NkdIXhC5r9iwsMwYreBBc4Rho5ieOmKNVQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
       ],
@@ -3449,13 +3532,27 @@
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.47.1.tgz",
-      "integrity": "sha512-N9X5WqGYzZnjGAFsKSfYFtAShYjwOmFJoWbLg3dYixZOZqU7hdMq+/xyS14zKLhFhZDhP9VfkzQnsdk0ZDS9IA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -3467,9 +3564,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.47.1.tgz",
-      "integrity": "sha512-O+KcfeCORZADEY8oQJk4HK8wtEOCRE4MdOkb8qGZQNun3jzmj2nmhV/B/ZaaZOkPmJyvm/gW9n0gsB4eRa1eiQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -3480,10 +3577,24 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.47.1.tgz",
-      "integrity": "sha512-CpKnYa8eHthJa3c+C38v/E+/KZyF1Jdh2Cz3DyKZqEWYgrM1IHFArXNWvBLPQCKUEsAqqKX27tTqVEFbDNUcOA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -3546,9 +3657,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.49.5",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.49.5.tgz",
-      "integrity": "sha512-dCYqelr2RVnWUuxc+Dk/dB/SjV/8JBndp1UovCyCZdIQezd8TRwFLNZctYkzgHxRJtaNvseCSRsuuHPeUgIN/A==",
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.55.0.tgz",
+      "integrity": "sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3557,13 +3668,12 @@
         "@types/cookie": "^0.6.0",
         "acorn": "^8.14.1",
         "cookie": "^0.6.0",
-        "devalue": "^5.6.2",
+        "devalue": "^5.6.4",
         "esm-env": "^1.2.2",
         "kleur": "^4.1.5",
         "magic-string": "^0.30.5",
         "mrmime": "^2.0.0",
-        "sade": "^1.8.1",
-        "set-cookie-parser": "^2.6.0",
+        "set-cookie-parser": "^3.0.0",
         "sirv": "^3.0.0"
       },
       "bin": {
@@ -3574,10 +3684,10 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
+        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
         "svelte": "^4.0.0 || ^5.0.0-next.0",
         "typescript": "^5.3.3",
-        "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
+        "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
@@ -4096,6 +4206,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/unist": {
       "version": "2.0.11",
       "dev": true,
@@ -4315,13 +4432,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4512,7 +4629,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -4588,7 +4707,9 @@
       }
     },
     "node_modules/aria-query": {
-      "version": "5.3.2",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5660,9 +5781,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
-      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
+      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6480,13 +6601,14 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.1.tgz",
-      "integrity": "sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
+      "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@typescript-eslint/types": "^8.2.0"
       }
     },
     "node_modules/esrecurse": {
@@ -6710,7 +6832,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/for-each": {
@@ -9468,7 +9592,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -9689,7 +9815,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -11008,9 +11136,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.47.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.47.1.tgz",
-      "integrity": "sha512-iasGAQoZ5dWDzULEUX3jiW0oB1qyFOepSyDyoU6S/OhVlDIwj5knI5QBa5RRQ0sK7OE0v+8VIi2JuV+G+3tfNg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11024,26 +11152,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.47.1",
-        "@rollup/rollup-android-arm64": "4.47.1",
-        "@rollup/rollup-darwin-arm64": "4.47.1",
-        "@rollup/rollup-darwin-x64": "4.47.1",
-        "@rollup/rollup-freebsd-arm64": "4.47.1",
-        "@rollup/rollup-freebsd-x64": "4.47.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.47.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.47.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.47.1",
-        "@rollup/rollup-linux-arm64-musl": "4.47.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.47.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.47.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.47.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.47.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.47.1",
-        "@rollup/rollup-linux-x64-gnu": "4.47.1",
-        "@rollup/rollup-linux-x64-musl": "4.47.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.47.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.47.1",
-        "@rollup/rollup-win32-x64-msvc": "4.47.1",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -11194,7 +11327,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.0.1.tgz",
+      "integrity": "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -11646,9 +11781,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.46.4",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.46.4.tgz",
-      "integrity": "sha512-VJwdXrmv9L8L7ZasJeWcCjoIuMRVbhuxbss0fpVnR8yorMmjNDwcjIH08vS6wmSzzzgAG5CADQ1JuXPS2nwt9w==",
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.54.0.tgz",
+      "integrity": "sha512-TTDxwYnHkova6Wsyj1PGt9TByuWqvMoeY1bQiuAf2DM/JeDSMw7FjRKzk8K/5mJ99vGOKhbCqTDpyAKwjp4igg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11656,13 +11791,14 @@
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
         "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
-        "aria-query": "^5.3.1",
+        "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.2",
+        "devalue": "^5.6.4",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.1",
+        "esrap": "^2.2.2",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -11707,21 +11843,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/svelte-check/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/svelte-eslint-parser": {
@@ -13313,7 +13434,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/language": "^6.11.3",
+        "@codemirror/language": "^6.12.2",
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
       },
@@ -13334,9 +13455,9 @@
     "packages/supersearch": {
       "version": "0.0.1",
       "devDependencies": {
-        "@codemirror/commands": "^6.10.2",
-        "@codemirror/state": "^6.5.4",
-        "@codemirror/view": "6.38.8",
+        "@codemirror/commands": "6.10.3",
+        "@codemirror/state": "6.6.0",
+        "@codemirror/view": "6.40.0",
         "@eslint/compat": "^1.3.2",
         "@playwright/test": "^1.55.0",
         "@sveltejs/adapter-auto": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9610,7 +9610,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -12022,7 +12024,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.17.1",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3051,7 +3051,9 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "28.0.3",
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.2.tgz",
+      "integrity": "sha512-S/ggWH1LU7jTyi9DxZOKyxpVd4hF/OZ0JrEbeLjXk/DFXwRny0tjD2c992zOUYQobLrVkRVMDdmHP16HKP7GRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3077,15 +3079,20 @@
     },
     "node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -3641,16 +3648,16 @@
       }
     },
     "node_modules/@sveltejs/adapter-node": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.5.1.tgz",
-      "integrity": "sha512-VpZdPNRPQuZRtgfAMETPWWKpZx9JwXmUUsgz/+eSpw/Oh7+2O1uZHlsQTuyfxydJHPrRzjfu/ItcJjY4oscCiQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.5.4.tgz",
+      "integrity": "sha512-45X92CXW+2J8ZUzPv3eLlKWEzINKiiGeFWTjyER4ZN4sGgNoaoeSkCY/QYNxHpPXy71QPsctwccBo9jJs0ySPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rollup/plugin-commonjs": "^28.0.1",
+        "@rollup/plugin-commonjs": "^29.0.0",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
-        "rollup": "^4.9.5"
+        "rollup": "^4.59.0"
       },
       "peerDependencies": {
         "@sveltejs/kit": "^2.4.0"
@@ -5516,6 +5523,8 @@
     },
     "node_modules/commondir": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7549,6 +7558,8 @@
     },
     "node_modules/is-reference": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11489,7 +11500,9 @@
       "license": "MIT"
     },
     "node_modules/sjcl": {
-      "version": "1.0.8",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.9.tgz",
+      "integrity": "sha512-dWM71tkSHxe7zEZj0/COjtJdmErIxp7UMp8a6D4xx8dTTtJLc4lFL+HAX8s6lvASyQQ2iYMHwa7rhhQq7MT5MA==",
       "license": "(BSD-2-Clause OR GPL-2.0-only)",
       "engines": {
         "node": "*"
@@ -13434,7 +13447,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/language": "^6.12.2",
+        "@codemirror/language": "6.12.2",
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
       },

--- a/packages/codemirror-lang-lxlquery/package.json
+++ b/packages/codemirror-lang-lxlquery/package.json
@@ -19,7 +19,7 @@
 	"types": "dist/index.d.ts",
 	"sideEffects": false,
 	"dependencies": {
-		"@codemirror/language": "^6.11.3",
+		"@codemirror/language": "6.12.2",
 		"@lezer/highlight": "^1.0.0",
 		"@lezer/lr": "^1.0.0"
 	},

--- a/packages/supersearch/e2e/ghostGroup.spec.ts
+++ b/packages/supersearch/e2e/ghostGroup.spec.ts
@@ -20,8 +20,9 @@ test('re-add group when deleting it', async ({ page }) => {
 	await page.getByRole('combobox').click();
 	const combo = page.getByRole('dialog').getByRole('combobox');
 	await combo.pressSequentially('titel:pippi');
+	await expect(page.getByTestId('supersearch-input-value')).toHaveText('titel:(pippi)');
 	await page.keyboard.down('Shift');
-	for (let i = 0; i < 6; i++) {
+	for (let i = 0; i < 5; i++) {
 		await combo.press('ArrowLeft');
 	}
 	await page.keyboard.up('Shift');
@@ -169,11 +170,11 @@ test('user selects and deletes the start of a group; repair start', async ({ pag
 	await page.getByRole('combobox').click();
 	const combo = page.getByRole('dialog').getByRole('combobox');
 	await combo.pressSequentially('titel:pippi långstrump');
-	for (let i = 0; i < 17; i++) {
+	for (let i = 0; i < 16; i++) {
 		await combo.press('ArrowLeft');
 	}
 	await page.keyboard.down('Shift');
-	for (let i = 0; i < 6; i++) {
+	for (let i = 0; i < 5; i++) {
 		await combo.press('ArrowRight');
 	}
 	await page.keyboard.up('Shift');
@@ -297,7 +298,7 @@ test('typing text between the operator and group ends up inside the group', asyn
 		await combo.press('ArrowLeft');
 	}
 	await combo.pressSequentially('hej');
-	await expect(page.getByTestId('supersearch-input-value')).toHaveText('title:(hejpippi)');
+	await expect(page.getByTestId('supersearch-input-value')).toHaveText('title:(hej pippi)');
 });
 
 test('pasting text between the operator and group ends up inside the group', async ({ page }) => {
@@ -308,10 +309,12 @@ test('pasting text between the operator and group ends up inside the group', asy
 		await combo.press('ArrowLeft');
 	}
 	await combo.pressSequentially('hej');
-	await expect(page.getByTestId('supersearch-input-value')).toHaveText('title:(hejpippi)');
+	await expect(page.getByTestId('supersearch-input-value')).toHaveText('title:(hej pippi)');
 });
 
-test('typing ")" between the operator and group is skipped', async ({ page }) => {
+test('typing ")" between the operator and group creates a new group before the previous', async ({
+	page
+}) => {
 	await page.getByRole('combobox').click();
 	const combo = page.getByRole('dialog').getByRole('combobox');
 	await combo.pressSequentially('title:pippi');
@@ -319,7 +322,7 @@ test('typing ")" between the operator and group is skipped', async ({ page }) =>
 		await combo.press('ArrowLeft');
 	}
 	await combo.pressSequentially(')');
-	await expect(page.getByTestId('supersearch-input-value')).toHaveText('title:(pippi)');
+	await expect(page.getByTestId('supersearch-input-value')).toHaveText('title:() (pippi)');
 });
 
 test('No longer a valid qualifier; remove group', async ({ page }) => {

--- a/packages/supersearch/e2e/ghostGroup.spec.ts
+++ b/packages/supersearch/e2e/ghostGroup.spec.ts
@@ -474,3 +474,15 @@ test('multiple opening ( in group does not destroy succeeding qualifiers', async
 	await combo.pressSequentially('(((');
 	await expect(page.getByTestId('supersearch-input-value')).toHaveText('a:(a((()))a)b:(bb)');
 });
+
+test('selecting from anchor ghost group to ghost group start and then inserting char works (without adding extra parens characters)', async ({
+	page
+}) => {
+	await page.getByRole('combobox').click();
+	const combo = page.getByRole('dialog').getByRole('combobox');
+	await combo.pressSequentially('title:hej');
+	await page.keyboard.down('Shift');
+	for (let i = 0; i < 5; i++) await combo.press('ArrowLeft');
+	await combo.pressSequentially('a');
+	await expect(page.getByTestId('supersearch-input-value')).toHaveText('title:(a)');
+});

--- a/packages/supersearch/package.json
+++ b/packages/supersearch/package.json
@@ -37,9 +37,9 @@
 		"svelte": "^5.0.0"
 	},
 	"devDependencies": {
-		"@codemirror/commands": "^6.10.2",
-		"@codemirror/state": "^6.5.4",
-		"@codemirror/view": "6.38.8",
+		"@codemirror/commands": "6.10.3",
+		"@codemirror/state": "6.6.0",
+		"@codemirror/view": "6.40.0",
 		"@eslint/compat": "^1.3.2",
 		"@playwright/test": "^1.55.0",
 		"@sveltejs/adapter-auto": "^6.1.0",

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -143,7 +143,7 @@
 	let comboboxElement: HTMLDivElement | undefined = $state();
 	let expanded = $state(false);
 	let activeRowIndex: number = $state(0);
-	let activeColIndex: number = $state(0);
+	let activeColIndex: number = $state(-1);
 	let prevValue: string = value;
 
 	let allowArrowKeyCursorHandling: { vertical: boolean; horizontal: boolean } = $state({
@@ -756,15 +756,19 @@
 	});
 
 	$effect(() => {
-		collapsedEditorView?.dispatch({
-			effects: collapsedContentAttributesCompartment.reconfigure(collapsedContentAttributes)
-		});
+		if (collapsedContentAttributes !== initialCollapsedContentAttributes) {
+			collapsedEditorView?.dispatch({
+				effects: collapsedContentAttributesCompartment.reconfigure(collapsedContentAttributes)
+			});
+		}
 	});
 
 	$effect(() => {
-		expandedEditorView?.dispatch({
-			effects: expandedContentAttributesCompartment.reconfigure(expandedContentAttributes)
-		});
+		if (expandedContentAttributes !== initialExpandedContentAttributes) {
+			expandedEditorView?.dispatch({
+				effects: expandedContentAttributesCompartment.reconfigure(expandedContentAttributes)
+			});
+		}
 	});
 
 	$effect(() => {

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/ghostGroup.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/ghostGroup.ts
@@ -519,61 +519,6 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 };
 
 /**
- * Re-add parens on bulk changes (select - delete)
- * Prevents any following qualifiers being parsed as belonging to the same group...
- */
-export const repairGhostGroup = (tr: Transaction) => {
-	if (!tr.docChanged || (!tr.isUserEvent('delete') && !tr.isUserEvent('input'))) {
-		return tr;
-	}
-
-	const start = tr.startState;
-	const after = tr.state;
-	const startTree = syntaxTree(start);
-	const afterDoc = after.doc;
-
-	const repairs: { from: number; insert: string }[] = [];
-
-	tr.changes.iterChanges((fromA, toA) => {
-		// only react to larger deletions (backspaces jumps over ')')
-		if (toA - fromA <= 1) return;
-
-		const deletedText = start.sliceDoc(fromA, toA);
-		if (!deletedText.includes(')') && !deletedText.includes('(')) return;
-
-		// Find if deleted parens belonged to a ghost group
-		const nodeBefore = startTree.resolveInner(fromA, -1);
-		const nodeAfter = startTree.resolveInner(toA, 1);
-
-		const ghostGroup =
-			getParent(nodeBefore, 'QualifierOuterGroup') || getParent(nodeAfter, 'QualifierOuterGroup');
-		if (!ghostGroup) return;
-
-		// Map ghost group to after-state
-		const mappedFrom = tr.changes.mapPos(ghostGroup.from, 1);
-		const mappedTo = tr.changes.mapPos(ghostGroup.to, -1);
-
-		// Repair
-		const openChar = afterDoc.sliceString(mappedFrom, mappedFrom + 1);
-		if (openChar !== '(') repairs.push({ from: mappedFrom, insert: '(' });
-
-		const closeChar = afterDoc.sliceString(mappedTo - 1, mappedTo);
-		if (closeChar !== ')') repairs.push({ from: mappedTo, insert: ')' });
-	});
-
-	if (!repairs.length) return tr;
-
-	return [
-		tr,
-		{
-			changes: repairs,
-			sequential: true,
-			userEvent: 'input.complete'
-		}
-	];
-};
-
-/**
  * Prevents destroying the ghost group by typing ')' inside the group, parsed as end of group.
  * Or typing '(' which can interfere with succeeding qualifiers
  * Autocompletes ')' with '(' and reverse; removes any stray ')' when deleting '('.

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/ghostGroup.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/ghostGroup.ts
@@ -250,12 +250,12 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 
 	const tree = syntaxTree(tr.startState);
 
-	const anchorGroup = getParent(
+	const groupAtAnchor = getParent(
 		tree.resolveInner(tr.startState.selection.main.anchor),
 		'QualifierOuterGroup'
 	);
 
-	const headGroup = getParent(
+	const groupAtHead = getParent(
 		tree.resolveInner(tr.startState.selection.main.head),
 		'QualifierOuterGroup'
 	);
@@ -283,8 +283,8 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 	if (tr.startState.selection.main.empty) {
 		if (
 			groupAfterAnchor &&
-			!anchorGroup &&
-			!headGroup &&
+			!groupAtAnchor &&
+			!groupAtHead &&
 			tr.newDoc.slice(tr.newSelection.main.from - 1, tr.newSelection.main.from).toString() === '('
 		) {
 			debugLog('remove newly added opening parens');
@@ -305,8 +305,8 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 
 		if (
 			groupAfterAnchor &&
-			!anchorGroup &&
-			!headGroup &&
+			!groupAtAnchor &&
+			!groupAtHead &&
 			tr.newDoc.slice(tr.newSelection.main.from - 1, tr.newSelection.main.from).toString() === ')'
 		) {
 			debugLog('add new group if closing parenthesis is inserted before group');
@@ -332,7 +332,7 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 
 		if (
 			groupAfterAnchor &&
-			!anchorGroup &&
+			!groupAtAnchor &&
 			tr.startState.sliceDoc(0, tr.startState.selection.main.from).toString() ===
 				tr.newDoc.sliceString(0, tr.startState.selection.main.from)
 		) {
@@ -356,18 +356,18 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 	}
 
 	if (
-		anchorGroup &&
-		headGroup &&
-		anchorGroup.from === headGroup.from &&
-		anchorGroup.to === headGroup.to
+		groupAtAnchor &&
+		groupAtHead &&
+		groupAtAnchor.from === groupAtHead.from &&
+		groupAtAnchor.to === groupAtHead.to
 	) {
 		debugLog("Don't do anything as changes are made inside the same group");
 		return tr;
 	}
 
 	if (
-		!anchorGroup &&
-		!headGroup &&
+		!groupAtAnchor &&
+		!groupAtHead &&
 		((groupBeforeAnchor && !groupBeforeHead) || (groupAfterAnchor && !groupAfterHead)) &&
 		tr.newDoc.length ===
 			tr.startState.doc.length -
@@ -390,7 +390,7 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 		];
 	}
 
-	if (!anchorGroup && !headGroup && groupAfterHead) {
+	if (!groupAtAnchor && !groupAtHead && groupAfterHead) {
 		debugLog('Remove parentheses before-hand');
 		return [
 			{
@@ -413,7 +413,7 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 		];
 	}
 
-	if (anchorGroup && anchorGroup.to < tr.startState.selection.main.to) {
+	if (groupAtAnchor && groupAtAnchor.to < tr.startState.selection.main.to) {
 		if (groupAfterHead) {
 			debugLog(
 				'Remove following closing parenthesis as selection is done rightward and selection head is followed directly by another ghost group'
@@ -428,7 +428,7 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 					userEvent: 'input'
 				}
 			];
-		} else if (headGroup && headGroup.from < tr.startState.selection.main.to) {
+		} else if (groupAtHead && groupAtHead.from < tr.startState.selection.main.to) {
 			debugLog('Is this needed?');
 			return tr;
 		} else {
@@ -446,7 +446,7 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 			];
 		}
 	}
-	if (anchorGroup && anchorGroup.from < tr.startState.selection.main.from) {
+	if (groupAtAnchor && groupAtAnchor.from < tr.startState.selection.main.from) {
 		debugLog(
 			'Insert a closing parenthesis as selection is done rightward and selection anchor is outside ghost group'
 		);
@@ -461,9 +461,9 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 	}
 
 	if (
-		anchorGroup &&
-		!headGroup &&
-		anchorGroup.from > tr.startState.selection.main.from &&
+		groupAtAnchor &&
+		!groupAtHead &&
+		groupAtAnchor.from > tr.startState.selection.main.from &&
 		!groupAfterHead
 	) {
 		debugLog(
@@ -471,7 +471,7 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 		);
 		return [
 			{
-				changes: [{ from: anchorGroup.to - 1, to: anchorGroup.to, insert: '' }],
+				changes: [{ from: groupAtAnchor.to - 1, to: groupAtAnchor.to, insert: '' }],
 				sequential: true,
 				userEvent: 'input'
 			},
@@ -479,7 +479,7 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 		];
 	}
 
-	if (anchorGroup && !headGroup && !groupAfterHead) {
+	if (groupAtAnchor && !groupAtHead && !groupAfterHead) {
 		debugLog('Insert an opening parenthesis .... ');
 		return [
 			tr,
@@ -491,7 +491,7 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 		];
 	}
 
-	if (!anchorGroup && groupAfterAnchor && headGroup) {
+	if (!groupAtAnchor && groupAfterAnchor && groupAtHead) {
 		debugLog('Editing from start of group to inside of head, space is added after');
 		return [
 			tr,
@@ -503,7 +503,7 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 		];
 	}
 
-	if (headGroup && !anchorGroup && headGroup.from <= tr.startState.selection.main.from) {
+	if (groupAtHead && !groupAtAnchor && groupAtHead.from <= tr.startState.selection.main.from) {
 		debugLog('Add a closing parenthesis!');
 		return [
 			tr,

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/ghostGroup.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/ghostGroup.ts
@@ -3,6 +3,7 @@ import { syntaxTree } from '@codemirror/language';
 import type { SyntaxNode } from '@lezer/common';
 import { qualifierStateField } from './qualifierValidation.js';
 import { startEditingQualifier, stopEditingQualifier } from './qualifierEffects.js';
+import { env } from '$env/dynamic/public';
 
 // ghostGroup refers to an outer enclosing group of the qualifier value (exported from grammar as QualifierOuterGroup)
 // It will hidden to the user and have to appear, be maintained and disappear automatically
@@ -18,7 +19,6 @@ export const createGhostGroup = (tr: Transaction) => {
 			return tr;
 		}
 	}
-
 	// run on valdation change -> atomic range change
 	const rangesChanged =
 		tr.startState.field(qualifierStateField).atomicRanges.size !==
@@ -229,49 +229,271 @@ export const jumpPastParens = (tr: Transaction) => {
 	return tr;
 };
 
-/**
- * Prevents dislocating the ghost group by typing between the operator and group
- */
-export const handleInputBeforeGroup = (tr: Transaction) => {
-	if (!tr.docChanged || !tr.isUserEvent('input')) return tr;
+function debugLog(message: unknown) {
+	if (env.PUBLIC_DEBUG_GHOST_GROUP && env.PUBLIC_DEBUG_GHOST_GROUP.toLowerCase() === 'true') {
+		console.log('DEBUG GHOST GROUP:', (message as object).toString());
+	}
+}
 
-	const start = tr.startState;
-	const head = start.selection.main.head;
+export const handleChangesInGhostGroup = (tr: Transaction) => {
+	// Ensure the transaction is the result of direct user input (Transaction.isUserEvent only checks for a specific user event type while checking the annotation directly allows for any type of user event)
+	if (!tr.annotation(Transaction.userEvent)) {
+		return tr;
+	}
+	if (
+		!tr.docChanged ||
+		tr.isUserEvent('select') ||
+		tr.isUserEvent('undo') ||
+		tr.isUserEvent('redo')
+	)
+		return tr;
 
-	// detect ghost group directly after cursor
-	const nodeAfter = syntaxTree(start).resolveInner(head, +1);
-	const ghostGroup = getParent(nodeAfter, 'QualifierOuterGroup');
-	if (!ghostGroup) return tr;
+	const tree = syntaxTree(tr.startState);
 
-	if (head !== ghostGroup.from) return tr;
+	const anchorGroup = getParent(
+		tree.resolveInner(tr.startState.selection.main.anchor),
+		'QualifierOuterGroup'
+	);
 
-	// shift text changes +1 position to the right
-	const shiftedChanges: { from: number; to?: number; insert?: string }[] = [];
-	let totalInsertedLength = 0;
+	const headGroup = getParent(
+		tree.resolveInner(tr.startState.selection.main.head),
+		'QualifierOuterGroup'
+	);
 
-	tr.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
-		if (inserted.toString() === ')') {
-			// don't shift ')' and break the group
-			return;
+	const groupAfterAnchor = getParent(
+		tree.resolveInner(tr.startState.selection.main.anchor, 1),
+		'QualifierOuterGroup'
+	);
+
+	const groupBeforeAnchor = getParent(
+		tree.resolveInner(tr.startState.selection.main.anchor, -1),
+		'QualifierOuterGroup'
+	);
+
+	const groupAfterHead = getParent(
+		tree.resolveInner(tr.startState.selection.main.head, 1),
+		'QualifierOuterGroup'
+	);
+	if (tr.startState.selection.main.empty) {
+		if (
+			!headGroup &&
+			groupAfterHead &&
+			tr.newSelection.main.from >= tr.startState.selection.main.from
+		) {
+			debugLog('Add space after insert and rebuild parenthesis');
+			// this could probably be simplified (so rebuilding of parenthesis isn't needed)
+			return [
+				{
+					changes: [
+						{
+							from: tr.startState.selection.main.from,
+							to: tr.startState.selection.main.from + 1,
+							insert: ' '
+						}
+					],
+					sequential: true,
+					userEvent: 'input'
+				},
+				tr,
+				{
+					changes: [
+						{
+							from: tr.startState.selection.main.from,
+							insert: '('
+						}
+					],
+					sequential: true,
+					userEvent: 'input'
+				}
+			];
 		}
-		shiftedChanges.push({
-			from: fromA + 1,
-			to: toA + 1,
-			insert: inserted.toString()
-		});
-		totalInsertedLength += inserted.length;
-	});
+		return tr;
+	}
 
-	const newSelection = { anchor: head + 1 + totalInsertedLength };
+	if (
+		anchorGroup &&
+		headGroup &&
+		anchorGroup.from === headGroup.from &&
+		anchorGroup.to === headGroup.to
+	) {
+		debugLog("Don't do anything as changes are made inside the same group");
+		return tr;
+	}
 
-	return [
-		{
-			changes: shiftedChanges,
-			sequential: true,
-			selection: newSelection,
-			userEvent: tr.annotation(Transaction.userEvent) || 'input.complete'
+	if (!anchorGroup && !headGroup && groupBeforeAnchor && groupAfterHead) {
+		debugLog("Don't do anything special...");
+		return tr;
+	}
+
+	if (!anchorGroup && !headGroup && groupAfterHead) {
+		debugLog('Remove parentheses before-hand');
+		return [
+			{
+				changes: [
+					{
+						from: tr.startState.selection.main.from,
+						to: tr.startState.selection.main.from + 1,
+						insert: ''
+					},
+					{
+						from: tr.startState.selection.main.to - 1,
+						to: tr.startState.selection.main.to,
+						insert: ''
+					}
+				],
+				sequential: true,
+				userEvent: 'input'
+			},
+			tr
+		];
+	}
+
+	if (anchorGroup && anchorGroup.to < tr.startState.selection.main.to) {
+		if (groupAfterHead) {
+			debugLog(
+				'Remove following closing parenthesis as selection is done rightward and selection head is followed directly by another ghost group'
+			);
+			return [
+				tr,
+				{
+					changes: [
+						{ from: tr.newSelection.main.from, to: tr.newSelection.main.from + 1, insert: ' ' }
+					],
+					sequential: true,
+					userEvent: 'input'
+				}
+			];
+		} else if (headGroup && headGroup.from < tr.startState.selection.main.to) {
+			debugLog('Is this needed?');
+			return tr;
+		} else {
+			debugLog(
+				'Insert a closing parenthesis as selection is done rightward and selection head is outside ghost group'
+			);
+
+			return [
+				tr,
+				{
+					changes: [{ from: tr.newSelection.main.to, insert: ')' }],
+					sequential: true,
+					userEvent: 'input'
+				}
+			];
 		}
-	];
+	}
+
+	if (anchorGroup && anchorGroup.from === tr.startState.selection.main.from) {
+		debugLog(
+			'Insert a opening parenthesis if anchor group starts at the same position as the selection'
+		);
+		return [
+			tr,
+			{
+				changes: [{ from: tr.startState.selection.main.from, insert: '(' }],
+				sequential: true,
+				userEvent: 'input'
+			}
+		];
+	}
+
+	if (anchorGroup && anchorGroup.from < tr.startState.selection.main.from) {
+		debugLog(
+			'Insert a closing parenthesis as selection is done rightward and selection anchor is outside ghost group'
+		);
+		return [
+			tr,
+			{
+				changes: [{ from: tr.newSelection.main.to, insert: ')' }],
+				sequential: true,
+				userEvent: 'input'
+			}
+		];
+	}
+
+	if (
+		anchorGroup &&
+		!headGroup &&
+		anchorGroup.from > tr.startState.selection.main.from &&
+		!groupAfterHead
+	) {
+		debugLog(
+			'Remove opening parenthesis in anchor group as selection is done leftward and selection head is outside group.'
+		);
+		return [
+			{
+				changes: [{ from: anchorGroup.to - 1, to: anchorGroup.to, insert: '' }],
+				sequential: true,
+				userEvent: 'input'
+			},
+			tr
+		];
+	}
+
+	if (anchorGroup && !headGroup && !groupAfterHead) {
+		debugLog('Insert an opening parenthesis .... ');
+		return [
+			tr,
+			{
+				changes: [{ from: tr.newSelection.main.from, insert: '(' }],
+				sequential: true,
+				userEvent: 'input'
+			}
+		];
+	}
+
+	if (!anchorGroup && groupAfterAnchor && headGroup) {
+		debugLog('Re-add opening parenthesis');
+		return [
+			tr,
+			{
+				changes: [{ from: tr.startState.selection.main.from, insert: '(' }],
+				sequential: true,
+				userEvent: 'input'
+			}
+		];
+	}
+
+	if (headGroup) {
+		if (headGroup.from <= tr.startState.selection.main.from) {
+			if (anchorGroup) {
+				debugLog('Keep as is... because?');
+				return tr;
+			} else {
+				debugLog('Add a closing parenthesis!');
+				return [
+					tr,
+					{
+						changes: [{ from: tr.newSelection.main.to, insert: ')' }],
+						sequential: true,
+						userEvent: 'input'
+					}
+				];
+			}
+		}
+	}
+
+	if (groupAfterHead) {
+		debugLog('Remove parentheses from following group after selection');
+		return [
+			{
+				changes: [
+					{ from: groupAfterHead.to - 1, to: groupAfterHead.to, insert: '' },
+					{
+						from: groupAfterHead.from,
+						to: groupAfterHead.from + 1,
+						insert: ''
+					}
+				],
+				sequential: true,
+				userEvent: 'input'
+			},
+			tr
+		];
+	}
+
+	// console.log('tr.ss',  tr.newSelection.main.from, tr.newSelection.main.to)
+	// Get ghost group on newSelection
+	return tr;
 };
 
 /**

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/ghostGroup.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/ghostGroup.ts
@@ -270,36 +270,81 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 		'QualifierOuterGroup'
 	);
 
+	const groupBeforeHead = getParent(
+		tree.resolveInner(tr.startState.selection.main.head, -1),
+		'QualifierOuterGroup'
+	);
+
 	const groupAfterHead = getParent(
 		tree.resolveInner(tr.startState.selection.main.head, 1),
 		'QualifierOuterGroup'
 	);
+
 	if (tr.startState.selection.main.empty) {
 		if (
+			groupAfterAnchor &&
+			!anchorGroup &&
 			!headGroup &&
-			groupAfterHead &&
-			tr.newSelection.main.from >= tr.startState.selection.main.from
+			tr.newDoc.slice(tr.newSelection.main.from - 1, tr.newSelection.main.from).toString() === '('
 		) {
-			debugLog('Add space after insert and rebuild parenthesis');
-			// this could probably be simplified (so rebuilding of parenthesis isn't needed)
+			debugLog('remove newly added opening parens');
 			return [
+				tr,
 				{
-					changes: [
-						{
-							from: tr.startState.selection.main.from,
-							to: tr.startState.selection.main.from + 1,
-							insert: ' '
-						}
-					],
+					changes: {
+						from: tr.newSelection.main.from - 1,
+						to: tr.newSelection.main.from,
+						insert: ''
+					},
+					selection: { anchor: tr.newSelection.main.from },
 					sequential: true,
 					userEvent: 'input'
-				},
+				}
+			];
+		}
+
+		if (
+			groupAfterAnchor &&
+			!anchorGroup &&
+			!headGroup &&
+			tr.newDoc.slice(tr.newSelection.main.from - 1, tr.newSelection.main.from).toString() === ')'
+		) {
+			debugLog('add new group if closing parenthesis is inserted before group');
+			return [
 				tr,
 				{
 					changes: [
 						{
-							from: tr.startState.selection.main.from,
+							from: tr.newSelection.main.from,
+							insert: ' '
+						},
+						{
+							from: tr.newSelection.main.from - 1,
 							insert: '('
+						}
+					],
+					selection: { anchor: tr.newSelection.main.from },
+					sequential: true,
+					userEvent: 'input'
+				}
+			];
+		}
+
+		if (
+			groupAfterAnchor &&
+			!anchorGroup &&
+			tr.startState.sliceDoc(0, tr.startState.selection.main.from).toString() ===
+				tr.newDoc.sliceString(0, tr.startState.selection.main.from)
+		) {
+			debugLog('Add space after insert and remove newly added parens');
+			return [
+				tr,
+				{
+					changes: [
+						{
+							from: tr.newSelection.main.head,
+							to: tr.newSelection.main.head + 2,
+							insert: ' '
 						}
 					],
 					sequential: true,
@@ -320,9 +365,29 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 		return tr;
 	}
 
-	if (!anchorGroup && !headGroup && groupBeforeAnchor && groupAfterHead) {
-		debugLog("Don't do anything special...");
-		return tr;
+	if (
+		!anchorGroup &&
+		!headGroup &&
+		((groupBeforeAnchor && !groupBeforeHead) || (groupAfterAnchor && !groupAfterHead)) &&
+		tr.newDoc.length ===
+			tr.startState.doc.length -
+				(tr.startState.selection.main.to - tr.startState.selection.main.from)
+	) {
+		debugLog('Re-add parens as entire group was removed');
+		return [
+			tr,
+			{
+				changes: [
+					{
+						from: tr.newSelection.main.from,
+						insert: '()'
+					}
+				],
+				sequential: true,
+				selection: { anchor: tr.newSelection.main.from + 1 },
+				userEvent: 'input'
+			}
+		];
 	}
 
 	if (!anchorGroup && !headGroup && groupAfterHead) {
@@ -381,21 +446,6 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 			];
 		}
 	}
-
-	if (anchorGroup && anchorGroup.from === tr.startState.selection.main.from) {
-		debugLog(
-			'Insert a opening parenthesis if anchor group starts at the same position as the selection'
-		);
-		return [
-			tr,
-			{
-				changes: [{ from: tr.startState.selection.main.from, insert: '(' }],
-				sequential: true,
-				userEvent: 'input'
-			}
-		];
-	}
-
 	if (anchorGroup && anchorGroup.from < tr.startState.selection.main.from) {
 		debugLog(
 			'Insert a closing parenthesis as selection is done rightward and selection anchor is outside ghost group'
@@ -442,57 +492,29 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 	}
 
 	if (!anchorGroup && groupAfterAnchor && headGroup) {
-		debugLog('Re-add opening parenthesis');
+		debugLog('Editing from start of group to inside of head, space is added after');
 		return [
 			tr,
 			{
-				changes: [{ from: tr.startState.selection.main.from, insert: '(' }],
+				changes: [{ from: tr.newSelection.main.to, to: tr.newSelection.main.to + 1, insert: '' }],
 				sequential: true,
-				userEvent: 'input'
+				userEvent: 'delete'
 			}
 		];
 	}
 
-	if (headGroup) {
-		if (headGroup.from <= tr.startState.selection.main.from) {
-			if (anchorGroup) {
-				debugLog('Keep as is... because?');
-				return tr;
-			} else {
-				debugLog('Add a closing parenthesis!');
-				return [
-					tr,
-					{
-						changes: [{ from: tr.newSelection.main.to, insert: ')' }],
-						sequential: true,
-						userEvent: 'input'
-					}
-				];
-			}
-		}
-	}
-
-	if (groupAfterHead) {
-		debugLog('Remove parentheses from following group after selection');
+	if (headGroup && !anchorGroup && headGroup.from <= tr.startState.selection.main.from) {
+		debugLog('Add a closing parenthesis!');
 		return [
+			tr,
 			{
-				changes: [
-					{ from: groupAfterHead.to - 1, to: groupAfterHead.to, insert: '' },
-					{
-						from: groupAfterHead.from,
-						to: groupAfterHead.from + 1,
-						insert: ''
-					}
-				],
+				changes: [{ from: tr.newSelection.main.to, insert: ')' }],
 				sequential: true,
 				userEvent: 'input'
-			},
-			tr
+			}
 		];
 	}
 
-	// console.log('tr.ss',  tr.newSelection.main.from, tr.newSelection.main.to)
-	// Get ghost group on newSelection
 	return tr;
 };
 

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/ghostGroup.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/ghostGroup.ts
@@ -259,22 +259,18 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 		tree.resolveInner(tr.startState.selection.main.head),
 		'QualifierOuterGroup'
 	);
-
 	const groupAfterAnchor = getParent(
 		tree.resolveInner(tr.startState.selection.main.anchor, 1),
 		'QualifierOuterGroup'
 	);
-
 	const groupBeforeAnchor = getParent(
 		tree.resolveInner(tr.startState.selection.main.anchor, -1),
 		'QualifierOuterGroup'
 	);
-
 	const groupBeforeHead = getParent(
 		tree.resolveInner(tr.startState.selection.main.head, -1),
 		'QualifierOuterGroup'
 	);
-
 	const groupAfterHead = getParent(
 		tree.resolveInner(tr.startState.selection.main.head, 1),
 		'QualifierOuterGroup'
@@ -355,6 +351,25 @@ export const handleChangesInGhostGroup = (tr: Transaction) => {
 		return tr;
 	}
 
+	if (groupAtAnchor && !groupAtHead && groupAfterHead) {
+		debugLog(
+			'Remove closing parenthesis before-hand when selecting from anchor group to group start'
+		);
+		return [
+			{
+				changes: [
+					{
+						from: groupAfterHead.to - 1,
+						to: groupAfterHead.to,
+						insert: ''
+					}
+				],
+				sequential: true,
+				userEvent: 'input'
+			},
+			tr
+		];
+	}
 	if (
 		groupAtAnchor &&
 		groupAtHead &&

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
@@ -10,8 +10,8 @@ import {
 	createGhostGroup,
 	handleChangesInGhostGroup,
 	jumpPastParens,
-	removeGhostGroup,
-	repairGhostGroup
+	removeGhostGroup
+	// repairGhostGroup
 } from './ghostGroup.js';
 import insertSpaceAroundQualifier from './insertSpaceAroundQualifier.js';
 
@@ -44,10 +44,10 @@ const lxlQualifierPlugin = (validateFn: QualifierValidator, renderFn?: Qualifier
 
 				// ghost group filters -->
 				EditorState.transactionFilter.of(jumpPastParens),
-				EditorState.transactionFilter.of(createGhostGroup),
 				EditorState.transactionFilter.of(handleChangesInGhostGroup),
+				EditorState.transactionFilter.of(createGhostGroup),
 				EditorState.transactionFilter.of(removeGhostGroup),
-				EditorState.transactionFilter.of(repairGhostGroup),
+				// EditorState.transactionFilter.of(repairGhostGroup),
 				EditorState.transactionFilter.of(balanceInnerParens),
 				// <--
 

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
@@ -11,7 +11,6 @@ import {
 	handleChangesInGhostGroup,
 	jumpPastParens,
 	removeGhostGroup
-	// repairGhostGroup
 } from './ghostGroup.js';
 import insertSpaceAroundQualifier from './insertSpaceAroundQualifier.js';
 

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
@@ -8,7 +8,7 @@ import { stopEditingOnEnterOrEsc } from './qualifierKeyMaps.js';
 import {
 	balanceInnerParens,
 	createGhostGroup,
-	handleInputBeforeGroup,
+	handleChangesInGhostGroup,
 	jumpPastParens,
 	removeGhostGroup,
 	repairGhostGroup
@@ -45,7 +45,7 @@ const lxlQualifierPlugin = (validateFn: QualifierValidator, renderFn?: Qualifier
 				// ghost group filters -->
 				EditorState.transactionFilter.of(jumpPastParens),
 				EditorState.transactionFilter.of(createGhostGroup),
-				EditorState.transactionFilter.of(handleInputBeforeGroup),
+				EditorState.transactionFilter.of(handleChangesInGhostGroup),
 				EditorState.transactionFilter.of(removeGhostGroup),
 				EditorState.transactionFilter.of(repairGhostGroup),
 				EditorState.transactionFilter.of(balanceInnerParens),

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/qualifierDecoration.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/qualifierDecoration.ts
@@ -60,6 +60,7 @@ class GhostGroupWidget extends WidgetType {
 	}
 	toDOM(): HTMLElement {
 		const container = document.createElement('span');
+		// container.className = 'lxl-ghost-group';
 		container.textContent = ' ';
 		return container;
 	}

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/qualifierDecoration.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/qualifierDecoration.ts
@@ -60,7 +60,7 @@ class GhostGroupWidget extends WidgetType {
 	}
 	toDOM(): HTMLElement {
 		const container = document.createElement('span');
-		container.className = 'lxl-ghost-group';
+		container.textContent = ' ';
 		return container;
 	}
 }

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/qualifierDecoration.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/qualifierDecoration.ts
@@ -21,7 +21,7 @@ class QualifierWidget extends WidgetType {
 		);
 	}
 	get estimatedHeight(): number {
-		return 30;
+		return 32;
 	}
 
 	toDOM(view: EditorView): HTMLElement {
@@ -54,18 +54,6 @@ class QualifierWidget extends WidgetType {
 	}
 }
 
-class GhostGroupWidget extends WidgetType {
-	eq(): boolean {
-		return true;
-	}
-	toDOM(): HTMLElement {
-		const container = document.createElement('span');
-		// container.className = 'lxl-ghost-group';
-		container.textContent = ' ';
-		return container;
-	}
-}
-
 export function addDecorations(view: EditorView) {
 	const SHOW_GHOST_GROUP = false;
 	const { qualifiers, editing } = view.state.field(qualifierStateField);
@@ -80,9 +68,6 @@ export function addDecorations(view: EditorView) {
 			decorations.push(
 				Decoration.mark({
 					class: `lxl-qualifier${isEditing ? ' editing' : ''}`,
-					attributes: {
-						style: 'display: inline-block; margin-left: 1px; margin-right: 1px;'
-					},
 					inclusive: true
 				}).range(qualifier.node.from, qualifier.node.to)
 			);
@@ -112,13 +97,13 @@ export function addDecorations(view: EditorView) {
 						doc.slice(openingParens, openingParens + 1) === '(' &&
 						doc.slice(closingParens - 1, closingParens) === ')'
 					) {
-						const parensMark = Decoration.replace({
-							widget: new GhostGroupWidget(),
-							inclusive: false
+						const ghostParenMark = Decoration.mark({
+							class: 'lxl-ghost-paren',
+							attributes: { 'aria-hidden': 'true' }
 						});
 
-						decorations.push(parensMark.range(openingParens, openingParens + 1));
-						decorations.push(parensMark.range(closingParens - 1, closingParens));
+						decorations.push(ghostParenMark.range(openingParens, openingParens + 1));
+						decorations.push(ghostParenMark.range(closingParens - 1, closingParens));
 					}
 				}
 			}


### PR DESCRIPTION
## Description

### Solves

Fixes issue with text cursor not being able to escape qualifier values on Firefox, while using the latest versions of Codemirror (https://github.com/libris/lxlviewer/pull/1523 was a temporary fix which required a downgraded version of `@codemirror/view`). 

This is now done by replacing ghostgroup parens with a inline whitespace (instead of an `inline-block` element).

### Summary of changes

- Replace ghostgroup parens with whitespaces and use inline elements instead of inline-blocks (which [doesn't seem to be supported by the library](https://github.com/codemirror/dev/issues/1594#issuecomment-3095456994))
- Proper highlighting inside qualifiers
- Prevent unnecessary contentattributes effect triggers
- Bump codemirror packages and use exact version as of now
- `repairGhostGroup` seems to be redundant with the additions made in `handleChangesInGhostGroup`so it is removed.
