### PR TITLE
fix(lxl-web/resource): Don't display empty details section

### DIFF
--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state';
 	import TableOfContents, { type TableOfContentsItem } from './TableOfContents.svelte';
 	import { type SecureImage, Width as ImageWidth } from '$lib/types/auxd';
-	import { JsonLd } from '$lib/types/xl';
+	import { type DisplayDecorated, Fmt, JsonLd } from '$lib/types/xl';
 	import { ShowLabelsOptions } from '$lib/types/decoratedData';
 	import type { HoldingsData } from '$lib/types/holdings';
 	import type { ResourceData } from '$lib/types/resourceData';
@@ -39,16 +39,16 @@
 		typeForIcon: string;
 		image: SecureImage;
 		decoratedData: {
-			headingTop: DecoratedData;
-			heading: DecoratedData;
-			headingExtra: DecoratedData;
-			overview: DecoratedData[];
-			overview2: DecoratedData[];
-			overviewFooter: DecoratedData;
-			summary: DecoratedData[];
-			resourceTableOfContents: DecoratedData[];
-			details: DecoratedData[];
-			token: DecoratedData;
+			headingTop: DisplayDecorated;
+			heading: DisplayDecorated;
+			headingExtra: DisplayDecorated;
+			overview: DisplayDecorated[];
+			overview2: DisplayDecorated[];
+			overviewFooter: DisplayDecorated;
+			summary: DisplayDecorated[];
+			resourceTableOfContents: DisplayDecorated[];
+			details: DisplayDecorated[];
+			token: DisplayDecorated;
 		};
 		relations: Relation[];
 		relationsPreviewsByQualifierKey: Record<string, SearchResultItem[]>;
@@ -384,26 +384,28 @@
 					<ExpandableArea content={resourceTableOfContents} collapsedHeightPx={300} />
 				</section>
 			{/if}
-			<section
-				class="-mx-3 my-6 bg-neutral-100 px-3 pb-6 @sm:-mx-6 @sm:px-6 @2xl:mx-0 @2xl:rounded-lg"
-			>
-				<h2 id="{uidPrefix}details" class="my-4 text-xl font-medium">
-					{page.data.t('resource.details')}
-				</h2>
-				<div class="decorated-data-section decorated-spacious decorated-details">
-					{#each decoratedData.details as details (details)}
-						<div class="mb-2">
-							<DecoratedData
-								data={details}
-								showLabels={ShowLabelsOptions.Always}
-								allowFindLinks={true}
-								block
-								limit={{ contribution: 5, hasVariant: 10 }}
-							/>
-						</div>
-					{/each}
-				</div>
-			</section>
+			{#if decoratedData.details.length && decoratedData.details.some((d) => d[Fmt.DISPLAY] && d[Fmt.DISPLAY].length > 0)}
+				<section
+					class="-mx-3 my-6 bg-neutral-100 px-3 pb-6 @sm:-mx-6 @sm:px-6 @2xl:mx-0 @2xl:rounded-lg"
+				>
+					<h2 id="{uidPrefix}details" class="my-4 text-xl font-medium">
+						{page.data.t('resource.details')}
+					</h2>
+					<div class="decorated-data-section decorated-spacious decorated-details">
+						{#each decoratedData.details as details (details)}
+							<div class="mb-2">
+								<DecoratedData
+									data={details}
+									showLabels={ShowLabelsOptions.Always}
+									allowFindLinks={true}
+									block
+									limit={{ contribution: 5, hasVariant: 10 }}
+								/>
+							</div>
+						{/each}
+					</div>
+				</section>
+			{/if}
 			<div class="text-sm">
 				<p>
 					{page.data.t('resource.uriLink')}: <a href={uri} class="link">{uri}</a>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -4,7 +4,7 @@ import { getSupportedLocale } from '$lib/i18n/locales.js';
 import { getTranslator } from '$lib/i18n';
 import * as v from 'valibot';
 
-import { Bibframe, type FramedData, JsonLd, LensType } from '$lib/types/xl.js';
+import { Bibframe, Fmt, type FramedData, JsonLd, LensType } from '$lib/types/xl.js';
 import { LxlLens } from '$lib/types/display';
 import { type ApiError } from '$lib/types/api.js';
 import type { PartialCollectionView, ResourceSearchResult } from '$lib/types/search.js';
@@ -283,10 +283,14 @@ export const load = async ({ params, locals, fetch, url }) => {
 					}
 				]
 			: []),
-		{
-			id: 'details',
-			label: translate('resource.details')
-		}
+		...(details.length && details.some((d) => d[Fmt.DISPLAY] && d[Fmt.DISPLAY].length > 0)
+			? [
+					{
+						id: 'resourceTableOfContents',
+						label: translate('resource.tableOfContents')
+					}
+				]
+			: [])
 	];
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
### Solves
On resource page: Remove Details section when there are no details to display.

Example:
https://beta.libris.kb.se/g0bsnzc9d3kb2d25
