### PR TITLE
fix(lxlweb): fix mylibraries indicator for instances / too many btns on narrow card

### DIFF
--- a/lxl-web/src/lib/components/find/Pagination.svelte
+++ b/lxl-web/src/lib/components/find/Pagination.svelte
@@ -82,7 +82,7 @@
 	<nav
 		aria-label={page.data.t('search.pagination')}
 		data-testid="pagination"
-		class="pagination mt-4 py-4"
+		class="pagination @container/pagination mt-4 py-4"
 	>
 		<ol class="flex items-center justify-center">
 			<!-- prev -->
@@ -106,13 +106,13 @@
 				>
 			</li>
 			<!-- sm sequence -->
-			<li class="flex sm:hidden">
+			<li class="flex @lg/pagination:hidden">
 				<ol class="sequence flex items-center justify-center">
 					{@render sequence(MAX_PAGES_SM)}
 				</ol>
 			</li>
 			<!-- md sequence -->
-			<li class="hidden sm:flex">
+			<li class="hidden @lg/pagination:flex">
 				<ol class="sequence flex items-center justify-center">
 					{@render sequence(MAX_PAGES_MD)}
 				</ol>

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -288,126 +288,125 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 					{/each}
 				</div>
 			{/if}
-			<footer
-				class="card-footer @container mt-1 flex flex-col-reverse flex-wrap md:flex-row"
-				id={footerId}
-			>
-				{#if item.selectTypeStr}
-					<span class="text-body font-medium">{item.selectTypeStr}</span>
-					<!-- eslint-disable-next-line svelte/no-useless-mustaches -->
-					<span class="hidden whitespace-pre-wrap md:inline">{' · '}</span>
-				{/if}
-				<span>
-					{#each item[LensType.WebCardFooter]?._display as obj, index (index)}
-						{#if 'hasInstance' in obj}
-							{@const instances = getInstanceData(obj.hasInstance)}
-							{#if instances?.years}
-								{#if instances.count > 1}
-									{instances?.count}
-									{page.data.t('search.editions')}
-									{`(${instances.years})`}
-								{:else}
-									{instances.years}
-								{/if}
-							{/if}
-							{#if instances?.count === 1}
-								<!-- eslint-disable-next-line svelte/no-useless-mustaches -->
-								<span class="divider">{' · '}</span>
-								{#each obj.hasInstance._display as obj2, index (index)}
-									<!-- FIXME we need publication for year, but don't want to show it again with the year -->
-									{#if !obj2.publication}
-										<DecoratedData
-											data={obj2}
-											showLabels={ShowLabelsOptions.Never}
-											{allowLinks}
-											{allowPopovers}
-										/>
-									{/if}
-								{/each}
-							{/if}
-						{:else}
-							<span>
-								<DecoratedData
-									data={obj}
-									showLabels={ShowLabelsOptions.Never}
-									{allowLinks}
-									{allowPopovers}
-								/>
-							</span>
-						{/if}
-					{/each}
-				</span>
-			</footer>
-			{#if allowActions}
-				<div class="card-actions flex gap-1 self-end pt-3 @lg/card:pt-0">
-					{#if firstMediaLink}
-						{#snippet mediaLinksPopover()}
-							<DecoratedData
-								data={item.mediaLinks as ResourceData}
-								showLabels={ShowLabelsOptions.Never}
-								allowPopovers={false}
-								block
-							/>
-						{/snippet}
-						<a
-							class="btn btn-primary h-7 rounded-full md:h-8"
-							href={firstMediaLink}
-							target="_blank"
-							use:popover={{
-								onFocus: false,
-								snippet: mediaLinksPopover
-							}}
-						>
-							<BiBoxArrowUpRight class="text-neutral-400" />
-							<span>{page.data.t('search.freeOnline')}</span>
-						</a>
-					{/if}
-					{#if isInstanceCard}
-						<a
-							aria-labelledby={`cite-${id} ${titleId}`}
-							class="btn btn-primary h-7 min-w-22.5 rounded-full md:h-8"
-							href={getCiteLink(page.url, id)}
-							onclick={(event) => handleClickCite(event, page.state, id)}
-						>
-							<BiQuote aria-hidden="true" class="size-4 text-neutral-400" />
-							<span id={`cite-${id}`}> {page.data.t('citations.cite')}</span>
-						</a>
-					{/if}
-					{#if isLibraryCard(item)}
-						{@const userSettings = getUserSettings()}
-						{@const alreadyAdded =
-							userSettings.myLibraries &&
-							Object.keys(userSettings.myLibraries).includes(item.libraryId)}
-						<button
-							class="btn btn-primary h-7 rounded-full md:h-8"
-							type="button"
-							onclick={() =>
-								alreadyAdded
-									? userSettings.removeLibrary(item.libraryId)
-									: userSettings.addLibrary(item.libraryId, item.displayStr)}
-						>
-							{#if alreadyAdded}
-								<BiHeartFill aria-hidden="true" class="text-primary-600" />
-								<span
-									aria-label={`${page.data.t('general.remove')} ${page.data.t('myPages.favouriteLibrary')}`}
-								>
-									{page.data.t('general.remove')}</span
-								>
-							{:else}
-								<BiHeart aria-hidden="true" class="text-primary-600" />
-								<span
-									aria-label={`${page.data.t('general.add')} ${page.data.t('myPages.favouriteLibrary')}`}
-								>
-									{page.data.t('general.add')}</span
-								>
-							{/if}
-						</button>
-					{/if}
-					{@render holdingsButton()}
-				</div>
-			{/if}
 		</div>
-
+		<footer
+			class="card-footer @container mt-1 flex flex-col-reverse flex-wrap md:flex-row"
+			id={footerId}
+		>
+			{#if item.selectTypeStr}
+				<span class="text-body font-medium">{item.selectTypeStr}</span>
+				<!-- eslint-disable-next-line svelte/no-useless-mustaches -->
+				<span class="hidden whitespace-pre-wrap md:inline">{' · '}</span>
+			{/if}
+			<span>
+				{#each item[LensType.WebCardFooter]?._display as obj, index (index)}
+					{#if 'hasInstance' in obj}
+						{@const instances = getInstanceData(obj.hasInstance)}
+						{#if instances?.years}
+							{#if instances.count > 1}
+								{instances?.count}
+								{page.data.t('search.editions')}
+								{`(${instances.years})`}
+							{:else}
+								{instances.years}
+							{/if}
+						{/if}
+						{#if instances?.count === 1}
+							<!-- eslint-disable-next-line svelte/no-useless-mustaches -->
+							<span class="divider">{' · '}</span>
+							{#each obj.hasInstance._display as obj2, index (index)}
+								<!-- FIXME we need publication for year, but don't want to show it again with the year -->
+								{#if !obj2.publication}
+									<DecoratedData
+										data={obj2}
+										showLabels={ShowLabelsOptions.Never}
+										{allowLinks}
+										{allowPopovers}
+									/>
+								{/if}
+							{/each}
+						{/if}
+					{:else}
+						<span>
+							<DecoratedData
+								data={obj}
+								showLabels={ShowLabelsOptions.Never}
+								{allowLinks}
+								{allowPopovers}
+							/>
+						</span>
+					{/if}
+				{/each}
+			</span>
+		</footer>
+		{#if allowActions}
+			<div class="card-actions flex gap-1 self-end pt-3">
+				{#if firstMediaLink}
+					{#snippet mediaLinksPopover()}
+						<DecoratedData
+							data={item.mediaLinks as ResourceData}
+							showLabels={ShowLabelsOptions.Never}
+							allowPopovers={false}
+							block
+						/>
+					{/snippet}
+					<a
+						class="btn btn-primary h-7 rounded-full md:h-8"
+						href={firstMediaLink}
+						target="_blank"
+						use:popover={{
+							onFocus: false,
+							snippet: mediaLinksPopover
+						}}
+					>
+						<BiBoxArrowUpRight class="text-neutral-400" />
+						<span>{page.data.t('search.freeOnline')}</span>
+					</a>
+				{/if}
+				{#if isInstanceCard}
+					<a
+						aria-labelledby={`cite-${id} ${titleId}`}
+						class="btn btn-primary h-7 min-w-22.5 rounded-full md:h-8"
+						href={getCiteLink(page.url, id)}
+						onclick={(event) => handleClickCite(event, page.state, id)}
+					>
+						<BiQuote aria-hidden="true" class="size-4 text-neutral-400" />
+						<span id={`cite-${id}`}> {page.data.t('citations.cite')}</span>
+					</a>
+				{/if}
+				{#if isLibraryCard(item)}
+					{@const userSettings = getUserSettings()}
+					{@const alreadyAdded =
+						userSettings.myLibraries &&
+						Object.keys(userSettings.myLibraries).includes(item.libraryId)}
+					<button
+						class="btn btn-primary h-7 rounded-full md:h-8"
+						type="button"
+						onclick={() =>
+							alreadyAdded
+								? userSettings.removeLibrary(item.libraryId)
+								: userSettings.addLibrary(item.libraryId, item.displayStr)}
+					>
+						{#if alreadyAdded}
+							<BiHeartFill aria-hidden="true" class="text-primary-600" />
+							<span
+								aria-label={`${page.data.t('general.remove')} ${page.data.t('myPages.favouriteLibrary')}`}
+							>
+								{page.data.t('general.remove')}</span
+							>
+						{:else}
+							<BiHeart aria-hidden="true" class="text-primary-600" />
+							<span
+								aria-label={`${page.data.t('general.add')} ${page.data.t('myPages.favouriteLibrary')}`}
+							>
+								{page.data.t('general.add')}</span
+							>
+						{/if}
+					</button>
+				{/if}
+				{@render holdingsButton()}
+			</div>
+		{/if}
 		{#if item._debug}
 			{#key item._debug}
 				<div class="card-debug z-20 self-start text-left select-text">
@@ -457,13 +456,28 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 
 	.search-card {
 		grid-template-areas:
-			'image content'
-			'debug .';
-		grid-template-columns: 64px 1fr;
+			'image content content'
+			'image footer footer'
+			'actions actions actions'
+			'debug . .';
+
+		grid-template-columns: 64px 1fr auto;
 
 		@container card (min-width: 768px) {
+			grid-template-columns: 72px 1fr auto;
 			@apply gap-x-6 px-6 py-4;
-			grid-template-columns: 72px 1fr;
+		}
+
+		@container card (min-width: 640px) {
+			grid-template-areas:
+				'image content content'
+				'image content content'
+				'image footer actions'
+				'debug . .';
+
+			& .card-actions {
+				padding-top: calc(var(--spacing) * 1);
+			}
 		}
 
 		& :global(.contribution-role) {
@@ -480,19 +494,8 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 		grid-area: content;
 
 		grid-template-areas:
-			'header header'
-			'body body'
-			'footer footer'
-			'actions actions';
-
-		grid-template-columns: 1fr auto;
-
-		@container card (min-width: 30rem) {
-			grid-template-areas:
-				'header header'
-				'body actions'
-				'footer actions';
-		}
+			'header'
+			'body';
 	}
 
 	.card-debug {

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -136,7 +136,7 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 {#snippet holdingsButton()}
 	{#if id && item.numberOfHolders >= 0}
 		<a
-			class="btn btn-primary h-7 rounded-full md:h-8"
+			class="btn btn-primary h-7 min-w-28 rounded-full md:h-8"
 			href={page.data.localizeHref(getHoldingsLink(page.url, id))}
 			data-sveltekit-preload-data={isInstanceCard ? 'false' : ''}
 			data-sveltekit-noscroll
@@ -339,7 +339,7 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 				</span>
 			</footer>
 			{#if allowActions}
-				<div class="card-actions flex gap-1 self-end pt-1">
+				<div class="card-actions flex gap-1 self-end pt-3 @lg/card:pt-0">
 					{#if firstMediaLink}
 						{#snippet mediaLinksPopover()}
 							<DecoratedData
@@ -365,7 +365,7 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 					{#if isInstanceCard}
 						<a
 							aria-labelledby={`cite-${id} ${titleId}`}
-							class="btn btn-primary h-7 rounded-full md:h-8"
+							class="btn btn-primary h-7 min-w-22.5 rounded-full md:h-8"
 							href={getCiteLink(page.url, id)}
 							onclick={(event) => handleClickCite(event, page.state, id)}
 						>

--- a/lxl-web/src/lib/utils/holdings.server.ts
+++ b/lxl-web/src/lib/utils/holdings.server.ts
@@ -32,9 +32,19 @@ export function getHoldersByType(holdingsByType: HoldingsByType): HoldersByType 
 	);
 }
 
-export function getHoldingsByType(mainEntity: HoldingMainEntity): HoldingsByType {
-	const instances = mainEntity[JsonLd.REVERSE]?.instanceOf;
-	if (!instances) return {};
+export function getHoldingsByType(mainEntity: HoldingMainEntity | HoldingInstance): HoldingsByType {
+	let instances = null;
+	if (!mainEntity[JsonLd.REVERSE]) return {};
+	if ('instanceOf' in mainEntity[JsonLd.REVERSE]) {
+		instances = mainEntity[JsonLd.REVERSE].instanceOf;
+	}
+	if ('itemOf' in mainEntity[JsonLd.REVERSE]) {
+		instances = [mainEntity] as HoldingInstance[];
+	}
+
+	if (!instances) {
+		return {};
+	}
 
 	const result: HoldingsByType = {};
 

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -359,8 +359,8 @@ function asItemDebugInfo(i: ApiItemDebugInfo, maxScores: Record<string, number>)
 
 function getHeldByMyLibraries(item: FramedData, myLibraries: MyLibrariesType) {
 	const orgs = getRefinedOrgs(myLibraries);
-	const holdingsByType = getHoldersByType(getHoldingsByType(item));
-	return getMyLibsFromHoldings(myLibraries, holdingsByType, orgs);
+	const holdersByType = getHoldersByType(getHoldingsByType(item));
+	return getMyLibsFromHoldings(myLibraries, holdersByType, orgs);
 }
 
 function isFreeTextQuery(property: unknown): boolean {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -102,7 +102,7 @@
 					</ol>
 					<Pagination data={searchResult} />
 				</main>
-				<aside class="search-result-aside min-w-[300px]">
+				<aside class="search-result-aside min-w-75">
 					<div class="hidden @5xl/content:block">
 						<Toolbar />
 					</div>


### PR DESCRIPTION
## Description
### Solves

* Make `getHoldingsByType` handle more diverse data to fix the issue where myLibraries indicator not working correctly for instance cards.

<img width="791" height="401" alt="Skärmavbild 2026-03-12 kl  14 27 46" src="https://github.com/user-attachments/assets/6f89a3a3-a877-4f50-bbc9-072734597c02" />
VS
<img width="791" height="410" alt="Skärmavbild 2026-03-12 kl  14 27 54" src="https://github.com/user-attachments/assets/c660d158-b5d4-4633-836b-07414142d386" />

* Add min-width to library button to achieve button alignment in search result
<img width="791" height="416" alt="Skärmavbild 2026-03-12 kl  14 31 00" src="https://github.com/user-attachments/assets/dc2c054a-023f-4259-8260-85d4d3f3f8fd" />

* Re-organize `SearchCard` grid to allow card-actions (buttons) take up a row below the image on small screens. Prevents the case of three buttons looking horrible on small screens
<img width="222" height="379" alt="Skärmavbild 2026-03-12 kl  12 45 29" src="https://github.com/user-attachments/assets/9d50e794-ef93-4a0a-aad2-06b6e289b2bd" />
<img width="222" height="379" alt="Skärmavbild 2026-03-12 kl  12 45 23" src="https://github.com/user-attachments/assets/f992bdb0-9a92-45bc-8641-21e34a8ce658" />

* Use container queries for pagination component to prevent page overflow when pane is resized