### PR TITLE
feat(lxl-web/filters): Display/hide filter label based on vocab

### DIFF
--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -24,7 +24,17 @@
 >
 	{#each mapping as m, i (`outer-${i}-${depth}`)}
 		{#if !MAPPING_IGNORE_VARIABLE.some((v) => v === m.variable)}
-			{@const { children, operator, up, variable, displayStr, label, display, invalid } = m}
+			{@const {
+				children,
+				operator,
+				up,
+				variable,
+				displayStr,
+				label,
+				display,
+				isRedundantKeyLabel,
+				invalid
+			} = m}
 			{#if displayStr || label}
 				{@const isLinked = !!display?.['@id']}
 				<li
@@ -34,7 +44,7 @@
 					]}
 				>
 					<span class="atomic truncate">
-						{#if label}
+						{#if label && !isRedundantKeyLabel}
 							<span class="lxl-qualifier-key h-full content-center whitespace-nowrap">
 								{#if invalid}
 									{invalid}
@@ -43,7 +53,7 @@
 								{/if}
 							</span>
 						{/if}
-						{#if operator && operator !== 'none'}
+						{#if operator && operator !== 'none' && !isRedundantKeyLabel}
 							<span
 								class="lxl-qualifier-operator h-full content-center pr-1.5 {operator ===
 									'existence' && 'pl-1.5'}">{getRelationSymbol(m.operator)}</span

--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -7,7 +7,16 @@
 		onclick?: () => void;
 	}
 
-	const { key, keyLabel, operator, value, valueLabel, removeLink, onclick }: Props = $props();
+	const {
+		key,
+		keyLabel,
+		operator,
+		value,
+		valueLabel,
+		removeLink,
+		isRedundantKeyLabel,
+		onclick
+	}: Props = $props();
 
 	const pillText = $derived(`${keyLabel || ''}${operator} ${valueLabel || ''}`);
 
@@ -20,7 +29,7 @@
 {#if keyLabel}
 	<span
 		data-qualifier-key={key}
-		class="lxl-qualifier-key cursor-text"
+		class={['lxl-qualifier-key cursor-text', isRedundantKeyLabel && 'redundant-label']}
 		role="button"
 		tabindex="-1"
 		{onclick}
@@ -31,7 +40,7 @@
 {/if}
 {#if operator}
 	<span
-		class="lxl-qualifier-operator cursor-text"
+		class={['lxl-qualifier-operator cursor-text', isRedundantKeyLabel && 'redundant-label']}
 		data-qualifier-operator={operator}
 		role="button"
 		tabindex="-1"

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -86,6 +86,7 @@ export default {
 	facet: {
 		q: 'Free text search',
 		'librissearch:findCategory': 'Category',
+		'librissearch:identifyCategory': 'Category',
 		'librissearch:hasInstanceCategory': 'Format',
 		'@reverse.itemOf.heldBy.@id': 'Has holding',
 		'instanceOf.@type': 'Type of work',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -86,6 +86,7 @@ export default {
 	facet: {
 		q: 'Fritextsökning',
 		'librissearch:findCategory': 'Kategori',
+		'librissearch:identifyCategory': 'Kategori',
 		'librissearch:hasInstanceCategory': 'Format',
 		'@reverse.itemOf.heldBy.@id': 'Har bestånd',
 		'instanceOf.@type': 'Verkstyp',

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -146,7 +146,6 @@
 }
 
 /* hide key and operator for linked values in supersearch */
-.codemirror-container .atomic .lxl-qualifier-key:has(~ .lxl-qualifier-value),
-.codemirror-container .atomic .lxl-qualifier-operator:has(~ .lxl-qualifier-value) {
+.codemirror-container .atomic .redundant-label:has(~ .lxl-qualifier-value) {
 	display: none;
 }

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -116,6 +116,7 @@ export interface DisplayMapping {
 	variable?: string;
 	_key?: string;
 	_value?: string;
+	isRedundantKeyLabel?: boolean;
 }
 
 export interface PartialCollectionView {
@@ -198,12 +199,15 @@ export interface SearchMapping extends MappingObj {
 }
 
 interface ObjectProperty {
+	'@type': 'ObjectProperty';
 	'@id'?: string;
+	category?: Link[];
 }
 
 export interface DatatypeProperty {
 	'@type': 'DataTypeProperty';
 	'@id': string;
+	category?: Link[];
 }
 
 interface InvalidProperty {

--- a/lxl-web/src/lib/types/xl.ts
+++ b/lxl-web/src/lib/types/xl.ts
@@ -57,7 +57,7 @@ export enum Concepts {
 export enum Platform {
 	integral = 'integral',
 	searchfilter = 'searchfilter',
-	mainfilterforrange = 'mainfilterforrange',
+	impliedByObject = 'impliedByObject',
 	composite = 'https://id.kb.se/ns/librissearch/composite',
 	meta = 'meta'
 }

--- a/lxl-web/src/lib/types/xl.ts
+++ b/lxl-web/src/lib/types/xl.ts
@@ -57,6 +57,7 @@ export enum Concepts {
 export enum Platform {
 	integral = 'integral',
 	searchfilter = 'searchfilter',
+	mainfilterforrange = 'mainfilterforrange',
 	composite = 'https://id.kb.se/ns/librissearch/composite',
 	meta = 'meta'
 }

--- a/lxl-web/src/lib/utils/displayMappingToString.ts
+++ b/lxl-web/src/lib/utils/displayMappingToString.ts
@@ -8,10 +8,11 @@ export function displayMappingToString(mapping: DisplayMapping[]): string {
 
 		function _iterate(mapping: DisplayMapping) {
 			if (MAPPING_IGNORE_VARIABLE.some((v) => v === mapping.variable)) return;
-			const { children, operator, variable, displayStr, label, _key, _value } = mapping;
+			const { children, operator, variable, displayStr, label, _key, _value, isRedundantKeyLabel } =
+				mapping;
 			if (displayStr || label) {
-				if (!_key && !_value && displayStr) {
-					// don't show 'free text search' label
+				const isFreeText = !_key && !_value;
+				if ((isFreeText || isRedundantKeyLabel) && displayStr) {
 					result.push(displayStr);
 				} else {
 					result.push(

--- a/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
+++ b/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
@@ -17,6 +17,7 @@ function getLabelFromMappings(
 	const valueLabel = suggestLabels.valueLabel || pageLabels.valueLabel;
 	let invalid = suggestLabels.invalid !== false && pageLabels.invalid !== false;
 	const removeLink = suggestLabels.removeLink || pageLabels.removeLink;
+	const isRedundantKeyLabel = pageLabels?.isRedundantKeyLabel || suggestLabels?.isRedundantKeyLabel;
 
 	if (suggestMapping?.length) {
 		// save latest mapping as fallback for error responses etc
@@ -28,7 +29,7 @@ function getLabelFromMappings(
 		invalid = false;
 	}
 
-	return { key, value, keyLabel, valueLabel, removeLink, invalid };
+	return { key, value, keyLabel, valueLabel, removeLink, invalid, isRedundantKeyLabel };
 }
 
 function iterateMapping(
@@ -40,6 +41,7 @@ function iterateMapping(
 	let valueLabel: string | undefined;
 	let removeLink: string | undefined;
 	let invalid: boolean | undefined;
+	let isRedundantKeyLabel: boolean | undefined;
 
 	if (mapping && Array.isArray(mapping)) {
 		_iterate(mapping);
@@ -61,6 +63,7 @@ function iterateMapping(
 						valueLabel = el.displayStr;
 						removeLink = el.up?.['@id'];
 					}
+					isRedundantKeyLabel = el.isRedundantKeyLabel;
 				} else if (!key && value === el?._value && el?.displayStr) {
 					// ...unless a filter alias (no key, only value)
 					valueLabel = el.displayStr;
@@ -69,7 +72,7 @@ function iterateMapping(
 			});
 		}
 	}
-	return { keyLabel, valueLabel, removeLink, invalid };
+	return { keyLabel, valueLabel, removeLink, invalid, isRedundantKeyLabel };
 }
 
 export default getLabelFromMappings;

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -200,7 +200,7 @@ export function displayMappings(
 				}
 
 				const redundantLabel = asArray(m.property?.category).some(
-					(c) => getUriSlug(c[JsonLd.ID]) === Platform.mainfilterforrange
+					(c) => getUriSlug(c[JsonLd.ID]) === Platform.impliedByObject
 				);
 
 				return {

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -14,7 +14,8 @@ import {
 	JsonLd,
 	LensType,
 	type Link,
-	Owl
+	Owl,
+	Platform
 } from '$lib/types/xl';
 
 import {
@@ -198,6 +199,10 @@ export function displayMappings(
 							m._key;
 				}
 
+				const redundantLabel = asArray(m.property?.category).some(
+					(c) => getUriSlug(c[JsonLd.ID]) === Platform.mainfilterforrange
+				);
+
 				return {
 					...(isObject(m.property) && { [JsonLd.ID]: m.property[JsonLd.ID] }),
 					display: displayUtil.lensAndFormat(value, LensType.Chip, locale),
@@ -208,7 +213,8 @@ export function displayMappings(
 					...('up' in m && { up: replacePath(m.up as Link, usePath) }),
 					...('variable' in m && { variable: m.variable }),
 					_key: m._key,
-					_value: m._value
+					_value: m._value,
+					...(redundantLabel && { isRedundantKeyLabel: true })
 				} as DisplayMapping;
 			} else if (operator && operator in m) {
 				const mappingArr = Array.isArray(m[operator]) ? m[operator] : [m[operator]];

--- a/lxl-web/tests/find.mobile.spec.ts
+++ b/lxl-web/tests/find.mobile.spec.ts
@@ -42,7 +42,7 @@ test('mapping displays the correct search query', async ({ page }) => {
 	await page.goto('/find?_q=språk%3A"lang%3Aswe"+sommar');
 	await page.getByRole('link', { name: 'Sökfilter' }).click();
 	const mapping = page.getByRole('navigation', { name: 'Valda filter' });
-	await expect(mapping).toHaveText('and Språk : Svenska and Fritextsökning : sommar Rensa', {
+	await expect(mapping).toHaveText('and   Svenska and Fritextsökning : sommar   Rensa', {
 		ignoreCase: true
 	});
 });
@@ -54,7 +54,7 @@ test('mapping displays the correct search query 2', async ({ page }) => {
 	await page.getByRole('link', { name: 'Sökfilter' }).click();
 	const mapping = await page.getByRole('navigation', { name: 'Valda filter' });
 	const innerText =
-		'and or Medverkan och funktion ∃  or and Kategori : Litteratur and not Titel : "pirater"    and   Har omslags-/miniatyrbild   Rensa';
+		'and or Medverkan och funktion ∃  or and   Litteratur and not Titel : \\"pirater\\"    and   Har omslags-/miniatyrbild   Rensa';
 	await expect(mapping).toHaveText(innerText, { ignoreCase: true });
 });
 
@@ -65,7 +65,7 @@ test('mapping displays the correct search query 3', async ({ page }) => {
 	await page.getByRole('link', { name: 'Sökfilter' }).click();
 	const mapping = page.getByRole('navigation', { name: 'Valda filter' });
 	const mappingText =
-		'and Titel : "pippi långstrump" and or Språk : Engelska or and Språk : Franska and not Språk : tyska and Fritextsökning : lindgren Rensa';
+		'and Titel : \\"pippi långstrump\\" and or   Engelska or and   Franska and not   tyska    and Fritextsökning : lindgren   Rensa';
 	await expect(mapping).toHaveText(mappingText, { ignoreCase: true });
 });
 

--- a/lxl-web/tests/find.mobile.spec.ts
+++ b/lxl-web/tests/find.mobile.spec.ts
@@ -54,7 +54,7 @@ test('mapping displays the correct search query 2', async ({ page }) => {
 	await page.getByRole('link', { name: 'Sökfilter' }).click();
 	const mapping = await page.getByRole('navigation', { name: 'Valda filter' });
 	const innerText =
-		'and or Medverkan och funktion ∃  or and   Litteratur and not Titel : \\"pirater\\"    and   Har omslags-/miniatyrbild   Rensa';
+		'and or Medverkan och funktion ∃  or and   Litteratur and not Titel : "pirater"    and   Har omslags-/miniatyrbild   Rensa';
 	await expect(mapping).toHaveText(innerText, { ignoreCase: true });
 });
 
@@ -65,7 +65,7 @@ test('mapping displays the correct search query 3', async ({ page }) => {
 	await page.getByRole('link', { name: 'Sökfilter' }).click();
 	const mapping = page.getByRole('navigation', { name: 'Valda filter' });
 	const mappingText =
-		'and Titel : \\"pippi långstrump\\" and or   Engelska or and   Franska and not   tyska    and Fritextsökning : lindgren   Rensa';
+		'and Titel : "pippi långstrump" and or   Engelska or and   Franska and not   tyska    and Fritextsökning : lindgren   Rensa';
 	await expect(mapping).toHaveText(mappingText, { ignoreCase: true });
 });
 

--- a/packages/supersearch/src/lib/types/lxlQualifierPlugin.ts
+++ b/packages/supersearch/src/lib/types/lxlQualifierPlugin.ts
@@ -40,6 +40,7 @@ export type QualifierRendererProps = {
 	value?: string;
 	valueLabel?: string;
 	removeLink?: string;
+	isRedundantKeyLabel?: boolean;
 };
 
 export type QualifierRenderer = (


### PR DESCRIPTION
Depends on https://github.com/libris/definitions/pull/566

## Description
Hide labels for filters only where the filter is obvious from the value.
For now this is just a simple `:category` on the filter definition. (naming TBD!)
That is, the label for specific property/filter is always visible or not when it has a linked value.
Never show "language", always show "orginal language"

I started sketching a solution where this was dependent on the type of the value. 
e.g something like `:subject :impliedByValueOfType :Topic`
But I'm not sure that is necessary. I think `subject` is the one filter that is on the fence here.

Example:
<img width="666" height="66" alt="Skärmbild från 2026-03-12 13-22-34" src="https://github.com/user-attachments/assets/049ea81a-7550-474d-a693-2321e21b7190" />

Also here:
<img width="486" height="63" alt="bild" src="https://github.com/user-attachments/assets/40651a3c-8af2-47bc-9cdc-c1aa729ea57b" />
<img width="378" height="170" alt="Skärmbild från 2026-03-12 16-52-00" src="https://github.com/user-attachments/assets/71c7ac9a-d69f-436c-9256-380a337ca093" />
<img width="333" height="60" alt="Skärmbild från 2026-03-12 16-52-41" src="https://github.com/user-attachments/assets/d012fe14-9433-4a5d-9a82-98852ce34bef" />
