### PR TITLE
fix(lxlweb): fix IOS Safari input zoom

### DIFF
--- a/lxl-web/src/lib/components/Holder.svelte
+++ b/lxl-web/src/lib/components/Holder.svelte
@@ -92,7 +92,7 @@
 				</a>
 			{:else if numInstances > 1 && hasSomeItemLink}
 				<button
-					class="text-link ml-2 whitespace-nowrap"
+					class="text-link ml-2 text-sm whitespace-nowrap"
 					type="button"
 					onclick={() => (expanded = !expanded)}
 				>

--- a/lxl-web/src/lib/components/HoldingsNearMeBtn.svelte
+++ b/lxl-web/src/lib/components/HoldingsNearMeBtn.svelte
@@ -98,7 +98,7 @@
 		type="button"
 		role="switch"
 		aria-checked={!!userLocation}
-		class="btn btn-ghost gap-2"
+		class="btn btn-ghost gap-2 text-sm sm:text-xs"
 		onclick={toggleNearMe}
 	>
 		<span>

--- a/lxl-web/src/lib/components/HoldingsPanel.svelte
+++ b/lxl-web/src/lib/components/HoldingsPanel.svelte
@@ -180,7 +180,7 @@
 		bind:value={searchPhrase}
 		placeholder={page.data.t('holdings.findLibrary')}
 		aria-label={page.data.t('holdings.findLibrary')}
-		class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-sm"
+		class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-base sm:text-sm"
 		type="search"
 		name={page.data.t('holdings.findLibrary')}
 	/>

--- a/lxl-web/src/lib/components/find/FacetRange.svelte
+++ b/lxl-web/src/lib/components/find/FacetRange.svelte
@@ -42,7 +42,7 @@
 	<div class="flex flex-col gap-1">
 		<label class="sr-only" for="facet-range-from">{page.data.t('general.from')}</label>
 		<input
-			class="bg-input h-8 rounded-sm border border-neutral-300 px-2 py-1"
+			class="bg-input h-8 rounded-sm border border-neutral-300 px-2 py-1 text-base sm:text-sm"
 			id="facet-range-from"
 			type="number"
 			min="1000"
@@ -55,7 +55,7 @@
 	<div class="flex flex-col gap-1">
 		<label class="sr-only" for="facet-range-to">{page.data.t('general.to')}</label>
 		<input
-			class="bg-input h-8 rounded-sm border border-neutral-300 px-2 py-1"
+			class="bg-input h-8 rounded-sm border border-neutral-300 px-2 py-1 text-base sm:text-sm"
 			id="facet-range-to"
 			type="number"
 			min="1000"

--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -37,7 +37,7 @@
 					bind:value={searchPhrase}
 					placeholder={page.data.t('search.findFilter')}
 					aria-label={page.data.t('search.findFilter')}
-					class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-sm"
+					class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-base sm:text-sm"
 					type="search"
 					name={page.data.t('search.findFilter')}
 				/>

--- a/lxl-web/src/lib/components/my-pages/Libraries.svelte
+++ b/lxl-web/src/lib/components/my-pages/Libraries.svelte
@@ -92,13 +92,13 @@
 				id="my-libraries-search"
 				bind:value={searchPhrase}
 				placeholder={page.data.t('myPages.findLibrary')}
-				class="bg-input h-9 w-full max-w-xl rounded-sm border border-neutral-300 pr-2 pl-8 text-sm"
+				class="bg-input h-9 w-full max-w-xl rounded-sm border border-neutral-300 pr-2 pl-8 text-base sm:text-sm"
 				oninput={handleInputChange}
 				type="search"
 			/>
 			<BiSearch class="text-subtle absolute top-0 left-2.5 h-9 text-sm" />
 		</div>
-		<span class="my-3 block text-sm" role="status">
+		<span class="mt-4 mb-2 block text-sm" role="status">
 			{#if search.isLoading}
 				{page.data.t('search.loading')}
 			{:else if search.error && !search.data}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -455,7 +455,7 @@
 						aria-label={page.data.t('general.close')}
 						class={[
 							'action text-subtle flex size-11 items-center justify-center -outline-offset-2 sm:hidden',
-							expanded && 'h-14 w-13'
+							expanded && 'mr-1 h-14 w-13'
 						]}
 						onclick={onclickClose}
 					>
@@ -525,7 +525,7 @@
 						{page.data.t('supersearch.addQualifiers')}
 					</div>
 					<div role="rowgroup" aria-labelledby="supersearch-add-qualifier-key-label" class="mb-1">
-						<div role="row" class="flex flex-wrap items-center gap-2 py-2 pl-4">
+						<div role="row" class="flex flex-wrap items-center gap-2 px-4 py-2">
 							{#each filteredQualifierSuggestions as { key, label }, cellIndex (key)}
 								<button
 									type="button"
@@ -547,7 +547,7 @@
 									type="button"
 									id={getCellId(1, filteredQualifierSuggestions.length + 1)}
 									class={[
-										'text-2xs link-subtle ml-1',
+										'link-subtle ml-1 text-sm sm:text-xs',
 										isFocusedCell(1, filteredQualifierSuggestions.length + 1) &&
 											'focused-cell outline-2'
 									]}
@@ -562,7 +562,7 @@
 										href={resolve(page.data.localizeHref('/help/filters'))}
 										id={getCellId(1, filteredQualifierSuggestions.length + 2)}
 										class={[
-											'text-2xs link-subtle ml-1',
+											'link-subtle ml-1 text-sm sm:text-xs',
 											isFocusedCell(1, filteredQualifierSuggestions.length + 2) &&
 												'focused-cell outline-2'
 										]}
@@ -614,7 +614,7 @@
 	.supersearch-input {
 		height: 100%;
 		min-height: var(--search-input-height);
-		font-size: var(--text-sm);
+		font-size: var(--text-base);
 		border-radius: var(--radius-md);
 		box-shadow: 0 0 0 1px var(--color-primary-400);
 
@@ -631,6 +631,10 @@
 			&:focus-within {
 				outline: 4px solid var(--color-primary-200);
 			}
+		}
+
+		@variant sm {
+			font-size: var(--text-sm);
 		}
 
 		@variant @5xl {
@@ -911,7 +915,7 @@
 	}
 
 	:global(.codemirror-container .cm-placeholder) {
-		font-size: var(--text-xs);
+		font-size: var(--text-base);
 		color: var(--color-placeholder);
 		margin-top: 1px;
 

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -7,8 +7,12 @@
 	border-radius: var(--radius-md);
 	transition: background-color 0.1s ease;
 	z-index: 1;
-	font-size: var(--text-sm);
+	font-size: var(--text-base);
 	/* pointer-events: none; */
+
+	@media screen and (min-width: 640px) {
+		font-size: var(--text-sm);
+	}
 }
 
 .lxl-qualifier.editing {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
@@ -60,7 +60,7 @@
 			aria-label={ariaLabel}
 			aria-describedby={ariaDescribedBy}
 			bind:this={fallbackInputElement}
-			class="placeholder:text-placeholder w-full pl-11 text-base focus:outline-none sm:px-3 sm:text-sm @5xl:text-[0.9375rem]"
+			class="placeholder:text-placeholder w-full pl-11 text-base focus:outline-none sm:px-3 sm:text-sm sm:@3xl:pl-4 @5xl:text-[0.9375rem]"
 		/>
 		<button
 			type="submit"

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
@@ -60,7 +60,7 @@
 			aria-label={ariaLabel}
 			aria-describedby={ariaDescribedBy}
 			bind:this={fallbackInputElement}
-			class="placeholder:text-placeholder w-full pl-11 focus:outline-none sm:px-3 sm:@3xl:pl-4 @5xl:text-[0.9375rem]"
+			class="placeholder:text-placeholder w-full pl-11 text-base focus:outline-none sm:px-3 sm:text-sm sm:@3xl:pl-4"
 		/>
 		<button
 			type="submit"

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
@@ -60,7 +60,7 @@
 			aria-label={ariaLabel}
 			aria-describedby={ariaDescribedBy}
 			bind:this={fallbackInputElement}
-			class="placeholder:text-placeholder w-full pl-11 text-base focus:outline-none sm:px-3 sm:text-sm sm:@3xl:pl-4"
+			class="placeholder:text-placeholder w-full pl-11 text-base focus:outline-none sm:px-3 sm:text-sm @5xl:text-[0.9375rem]"
 		/>
 		<button
 			type="submit"


### PR DESCRIPTION
## Description
### Solves

IOS Safari zooms in when putting the cursor in an input field in a very disturbing way. Apparently, this is an "accessibility feature" - when Safari thinks the font size in an input is too small, it zooms it in for better visibility. "Too small" being below 16px.

I think the correct fix here is not to hack around it but to actually increase the font-size, it looks better and seems standard.

adding `text-base sm:text-sm` for all our inputs. Tested it on real mobile using dev:host and it works.

Also some other minor fixes, mostly increased sizes that looks too small in comparison with the new input size.

### Summary of changes

* input `text-sm` -> `text-base`
