### PR TITLE
fix(lxlweb): Use QualifierPill for SearchMapping

### DIFF
--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -30,10 +30,10 @@
 			{@const { children, operator, up, variable, displayStr, label, isRedundantKeyLabel } = m}
 			{#if displayStr || label}
 				<li class={['lxl-qualifier inline-block', variable && `variable-${variable}`]}>
-					{#if m._key}
+					{#if m._key || m._value}
 						<span class="atomic truncate">
 							<QualifierPill
-								key={m._key}
+								key={m._key || ''}
 								keyLabel={label}
 								operator={getRelationSymbol(m.operator)}
 								value={m._value}

--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -79,7 +79,7 @@
 					{#if up && variable}
 						<a
 							href={m.up?.['@id']}
-							class="btn btn-ghost h-7 rounded-sm text-sm"
+							class="search-mapping-clear btn btn-ghost h-7 rounded-sm text-sm"
 							aria-label={page.data.t('search.clearAllFilters')}
 						>
 							<BiTrash aria-hidden="true" />

--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -37,7 +37,7 @@
 								keyLabel={label}
 								operator={getRelationSymbol(m.operator)}
 								value={m._value}
-								valueLabel={displayStr}
+								valueLabel={displayStr || m._value}
 								removeLink={up?.['@id']}
 								type={m.display?.[JsonLd.TYPE]}
 								id={m.display[JsonLd.ID]}

--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
+	import { JsonLd } from '$lib/types/xl';
+	import type { DisplayMapping } from '$lib/types/search';
 	import { MAPPING_IGNORE_VARIABLE } from '$lib/constants/mapping';
 	import { getRelationSymbol } from '$lib/utils/getRelationSymbol';
 	import SearchMapping from './SearchMapping.svelte';
-	import type { DisplayMapping } from '$lib/types/search';
-	import { page } from '$app/state';
-	import BiXLg from '~icons/bi/x-lg';
+	import QualifierPill from '../supersearch/QualifierPill.svelte';
+	import IconClose from '~icons/bi/x-lg';
 	import BiTrash from '~icons/bi/trash';
 
 	interface Props {
@@ -17,70 +20,43 @@
 
 <ul
 	class={[
-		'max-w-full',
+		'max-w-full leading-7.5',
 		depth === 0 ? 'search-mapping flex-col-reverse gap-2' : 'flex-col',
 		'flex items-start text-xs'
 	]}
 >
 	{#each mapping as m, i (`outer-${i}-${depth}`)}
 		{#if !MAPPING_IGNORE_VARIABLE.some((v) => v === m.variable)}
-			{@const {
-				children,
-				operator,
-				up,
-				variable,
-				displayStr,
-				label,
-				display,
-				isRedundantKeyLabel,
-				invalid
-			} = m}
+			{@const { children, operator, up, variable, displayStr, label, isRedundantKeyLabel } = m}
 			{#if displayStr || label}
-				{@const isLinked = !!display?.['@id']}
-				<li
-					class={[
-						'lxl-qualifier pill bg-neutral flex h-8 max-w-full items-center rounded-sm',
-						variable && `variable-${variable}`
-					]}
-				>
-					<span class="atomic truncate">
-						{#if label && !isRedundantKeyLabel}
-							<span class="lxl-qualifier-key h-full content-center whitespace-nowrap">
-								{#if invalid}
-									{invalid}
-								{:else}
-									{label}
-								{/if}
-							</span>
-						{/if}
-						{#if operator && operator !== 'none' && !isRedundantKeyLabel}
-							<span
-								class="lxl-qualifier-operator h-full content-center pr-1.5 {operator ===
-									'existence' && 'pl-1.5'}">{getRelationSymbol(m.operator)}</span
-							>
-						{/if}
-						{#if displayStr}
-							<span
-								class={[
-									'h-full content-center overflow-hidden',
-									operator === 'none' ? 'lxl-qualifier-alias' : 'lxl-qualifier-value',
-									isLinked && 'atomic'
-								]}
-							>
-								<span class="block truncate">{displayStr}</span>
-							</span>
-						{/if}
-						{#if up}
-							{@const pillText = `${label || ''}${getRelationSymbol(m.operator)} ${displayStr || ''}`}
+				<li class={['lxl-qualifier inline-block', variable && `variable-${variable}`]}>
+					{#if m._key}
+						<span class="atomic truncate">
+							<QualifierPill
+								key={m._key}
+								keyLabel={label}
+								operator={getRelationSymbol(m.operator)}
+								value={m._value}
+								valueLabel={displayStr}
+								removeLink={up?.['@id']}
+								type={m.display?.[JsonLd.TYPE]}
+								id={m.display[JsonLd.ID]}
+								{isRedundantKeyLabel}
+							/>
+						</span>
+					{:else}
+						<!-- free text search -->
+						<span class="flex h-full items-center gap-1 pl-1.5">
+							<span>{displayStr}</span>
 							<a
-								class="lxl-qualifier-remove atomic h-8 transition-colors"
-								href={m.up?.['@id']}
-								aria-label={`${page.data.t('search.removeFilter')} ${pillText}`}
+								href={resolve(page.data.localizeHref(up?.['@id']))}
+								class="lxl-qualifier-remove"
+								aria-label={`${page.data.t('search.removeFilter')} ${displayStr}`}
 							>
-								<BiXLg aria-hidden="true" fill="currentColor" />
+								<IconClose aria-hidden="true" />
 							</a>
-						{/if}
-					</span>
+						</span>
+					{/if}
 				</li>
 			{:else if children && variable !== 'defaultSiteFilters'}
 				<li
@@ -88,20 +64,22 @@
 						'group flex max-w-full flex-wrap items-center gap-1.5',
 						`group-${operator}`,
 						`${operator === 'not' && 'lxl-not-term'}`,
-						variable ? `variable-${variable}` : `${children.length > 1 ? 'group-inner' : ''}`
+						variable
+							? `variable-${variable}`
+							: `${children.length > 1 ? 'group-inner text-sm' : ''}`
 					]}
 				>
 					{#each children as child, i (`${i}-${depth}`)}
 						{@const _child = Array.isArray(child) ? child : [child]}
 						{#if operator}
-							<span class="operator-{operator} text-2xs uppercase">{operator}</span>
+							<span class="operator-{operator} text-sm uppercase">{operator}</span>
 						{/if}
 						<SearchMapping depth={depth + 1} mapping={_child} />
 					{/each}
 					{#if up && variable}
 						<a
 							href={m.up?.['@id']}
-							class="btn btn-primary"
+							class="btn btn-ghost h-7 rounded-sm text-sm"
 							aria-label={page.data.t('search.clearAllFilters')}
 						>
 							<BiTrash aria-hidden="true" />
@@ -126,8 +104,8 @@
 	}
 
 	/* we can give _r pills a special styling if we want */
-	.variable-_r .pill,
-	.variable-_r.pill {
+	.variable-_r .lxl-qualifier,
+	.variable-_r.lxl-qualifier {
 	}
 
 	.group-inner::after {

--- a/lxl-web/src/lib/components/find/SearchResultToolbar.svelte
+++ b/lxl-web/src/lib/components/find/SearchResultToolbar.svelte
@@ -20,7 +20,8 @@
 
 	let showFiltersModal = $state(false);
 	const numHits = $derived(searchResult.totalItems);
-	const filterCount = $derived(getFiltersCount(searchResult.mapping));
+	const mapping = $derived(searchResult.mapping.filter((m) => m.variable === '_q'));
+	const filterCount = $derived(getFiltersCount(mapping));
 
 	function getFiltersCount(mapping: DisplayMapping[]) {
 		const root = mapping.filter(
@@ -95,6 +96,6 @@
 				{numHits == 1 ? page.data.t('search.hitsOne') : page.data.t('search.hits')})
 			</span>
 		{/snippet}
-		<Filters facets={searchResult.facets || []} mapping={searchResult.mapping} />
+		<Filters facets={searchResult.facets || []} {mapping} />
 	</Modal>
 {/if}

--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
-	import { resolve } from '$app/paths';
 	import type { QualifierRendererProps } from 'supersearch';
 	import { relativizeUrl, stripAnchor, trimSlashes } from '$lib/utils/http';
 	import { getPersonImage } from '$lib/utils/getPersonImage';
@@ -57,7 +56,6 @@
 	>
 		{keyLabel}
 	</span>
-	<span class="sr-only">{keyLabel}</span>
 {/if}
 {#if operator}
 	<span
@@ -110,7 +108,7 @@
 {/if}
 {#if valueLabel && removeLink}
 	<a
-		href={resolve(page.data.localizeHref(removeLink))}
+		href={page.data.localizeHref(removeLink)}
 		class="lxl-qualifier-remove"
 		aria-label={`${page.data.t('search.removeFilter')} ${pillText}`}
 	>

--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -12,15 +12,15 @@
 		onclick?: () => void;
 	}
 
-  const {
+	const {
 		key,
 		keyLabel,
 		operator,
 		value,
 		valueLabel,
 		removeLink,
-    type, 
-    id, 
+		type,
+		id,
 		isRedundantKeyLabel,
 		onclick
 	}: Props = $props();
@@ -61,7 +61,10 @@
 {/if}
 {#if operator}
 	<span
-		class={['lxl-qualifier-operator cursor-text', (isRedundantKeyLabel || operator === ':') && 'hidden']}
+		class={[
+			'lxl-qualifier-operator cursor-text',
+			(isRedundantKeyLabel || operator === ':') && 'hidden'
+		]}
 		data-qualifier-operator={operator}
 		role="button"
 		tabindex="-1"
@@ -92,7 +95,7 @@
 
 		{#if image || type}
 			<span
-				class="icon-wrapper mr-0.5 mb-1 inline-flex size-5 items-center justify-center align-middle"
+				class="icon-wrapper my-1.25 inline-flex size-5 items-center justify-center align-bottom"
 				aria-hidden="true"
 			>
 				{#if image}
@@ -102,7 +105,7 @@
 				{/if}
 			</span>
 		{/if}
-		{valueLabel}
+		<span>{valueLabel}</span>
 	</span>
 {/if}
 {#if valueLabel && removeLink}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -204,9 +204,22 @@
 
 	const showAddQualifiers = $derived(filteredQualifierSuggestions.length > 0);
 
+	const NO_WILDCARD_AFTER_CHAR = [')', '"', '*', '?'];
+	const NO_WILDCARD_AFTER_WORD = ['AND', 'OR', 'NOT'];
+
+	const lastWordBeforeCursor = $derived.by(() => {
+		const before = q.slice(0, cursor);
+		const match = before.match(/(\S+)$/);
+		return match ? match[1] : '';
+	});
+
 	const isValidWildcardPosition = $derived.by(() => {
 		// a valid wildcard position is at end of word (inside group, not inside quote)
-		if (hasCharBefore && ![')', '"', '*'].includes(q.charAt(cursor - 1))) {
+		if (
+			hasCharBefore &&
+			!NO_WILDCARD_AFTER_CHAR.includes(q.charAt(cursor - 1)) &&
+			!NO_WILDCARD_AFTER_WORD.includes(lastWordBeforeCursor)
+		) {
 			if (!hasCharAfter || q.charAt(cursor) === ')') {
 				return true;
 			}

--- a/lxl-web/src/lib/i18n/locales.ts
+++ b/lxl-web/src/lib/i18n/locales.ts
@@ -40,7 +40,7 @@ function localizeHref(
 
 	// hijacking this function to pass on 'r' param to all links,
 	// should we rename this function?
-	if (currentUrl.searchParams.get('_r') && !url.searchParams.get('_r')) {
+	if (currentUrl.searchParams.get('_r') && !url.searchParams.has('_r')) {
 		url.searchParams.set('_r', currentUrl.searchParams?.get('_r') || '');
 	}
 

--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -19,6 +19,7 @@
 }
 
 .lxl-qualifier-key {
+	position: relative;
 	padding-left: calc(var(--spacing) * 1.5);
 	padding-right: calc(var(--spacing) * 1.5);
 }
@@ -89,15 +90,11 @@
 	white-space: nowrap;
 }
 
-.lxl-qualifier-key:not(.redundant-label) ~ .lxl-qualifier-value {
-	padding-left: 0;
-}
-
 .atomic .lxl-qualifier-operator {
 	padding-right: calc(var(--spacing) * 1.5);
 }
 
-.atomic .lxl-qualifier-operator::after {
+.atomic .lxl-qualifier-key::after {
 	content: '';
 	position: absolute;
 	top: 0px;
@@ -117,11 +114,6 @@
 	text-underline-offset: 2px;
 }
 
-.lxl-not-term {
-	color: var(--color-severe-600);
-	color: var(--color-body);
-}
-
 .lxl-not-term .atomic {
 	background-color: var(--color-severe-50);
 }
@@ -134,7 +126,7 @@
 	background-color: var(--color-severe-100);
 }
 
-.lxl-not-term .atomic .lxl-qualifier-operator::after {
+.lxl-not-term .atomic .lxl-qualifier-key::after {
 	background-color: var(--color-severe-200);
 }
 
@@ -154,7 +146,7 @@
 	background-color: transparent;
 }
 
-/* hide key and operator for linked values in supersearch */
-.codemirror-container .atomic .redundant-label:has(~ .lxl-qualifier-value) {
+/* hide key and operator for linked values */
+.atomic .redundant-label:has(~ .lxl-qualifier-value) {
 	display: none;
 }

--- a/lxl-web/src/lib/utils/getRelationSymbol.ts
+++ b/lxl-web/src/lib/utils/getRelationSymbol.ts
@@ -3,6 +3,7 @@ import type { SearchOperators } from '$lib/types/search';
 export function getRelationSymbol(operator: keyof typeof SearchOperators): string {
 	switch (operator) {
 		case 'equals':
+		case 'existence':
 			return ':';
 		case 'not':
 			return '≠';
@@ -14,8 +15,6 @@ export function getRelationSymbol(operator: keyof typeof SearchOperators): strin
 			return '＜';
 		case 'lessThanOrEquals':
 			return '⩽';
-		case 'existence':
-			return '∃';
 		case 'notExistence':
 			return '∄';
 		default:

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -695,6 +695,10 @@
 		max-width: none;
 	}
 
+	.subset-container :global(.search-mapping-clear) {
+		display: none;
+	}
+
 	.subset-container::after {
 		content: '';
 		position: absolute;

--- a/lxl-web/tests/find.mobile.spec.ts
+++ b/lxl-web/tests/find.mobile.spec.ts
@@ -54,7 +54,7 @@ test('mapping displays the correct search query 2', async ({ page }) => {
 	await page.getByRole('link', { name: 'Sökfilter' }).click();
 	const mapping = await page.getByRole('navigation', { name: 'Valda filter' });
 	const innerText =
-		'and or Medverkan och funktion ∃  or and Kategori :  Litteratur and not Titel :  "pirater"    and Har omslags-/miniatyrbild   Rensa';
+		'and or Medverkan och funktion :  * or and Kategori :  Litteratur and not Titel :  "pirater"    and Har omslags-/miniatyrbild   Rensa';
 	await expect(mapping).toHaveText(innerText, { ignoreCase: true });
 });
 

--- a/lxl-web/tests/find.mobile.spec.ts
+++ b/lxl-web/tests/find.mobile.spec.ts
@@ -42,7 +42,7 @@ test('mapping displays the correct search query', async ({ page }) => {
 	await page.goto('/find?_q=språk%3A"lang%3Aswe"+sommar');
 	await page.getByRole('link', { name: 'Sökfilter' }).click();
 	const mapping = page.getByRole('navigation', { name: 'Valda filter' });
-	await expect(mapping).toHaveText('and   Svenska and Fritextsökning : sommar   Rensa', {
+	await expect(mapping).toHaveText('and Språk :  Svenska and sommar   Rensa', {
 		ignoreCase: true
 	});
 });
@@ -54,7 +54,7 @@ test('mapping displays the correct search query 2', async ({ page }) => {
 	await page.getByRole('link', { name: 'Sökfilter' }).click();
 	const mapping = await page.getByRole('navigation', { name: 'Valda filter' });
 	const innerText =
-		'and or Medverkan och funktion ∃  or and   Litteratur and not Titel : "pirater"    and   Har omslags-/miniatyrbild   Rensa';
+		'and or Medverkan och funktion ∃  or and Kategori :  Litteratur and not Titel :  "pirater"    and Har omslags-/miniatyrbild   Rensa';
 	await expect(mapping).toHaveText(innerText, { ignoreCase: true });
 });
 
@@ -65,7 +65,7 @@ test('mapping displays the correct search query 3', async ({ page }) => {
 	await page.getByRole('link', { name: 'Sökfilter' }).click();
 	const mapping = page.getByRole('navigation', { name: 'Valda filter' });
 	const mappingText =
-		'and Titel : "pippi långstrump" and or   Engelska or and   Franska and not   tyska    and Fritextsökning : lindgren   Rensa';
+		'and Titel :  "pippi långstrump" and or Språk :  Engelska or and Språk :  Franska and not Språk :  tyska    and lindgren   Rensa';
 	await expect(mapping).toHaveText(mappingText, { ignoreCase: true });
 });
 


### PR DESCRIPTION
## Description
### Solves

* I was about to fix so that the `SearchMapping` component renders icons etc just like the supersearch pills. Then realized we should just render the `QualifierPill` component directly. Less code - one source of truth.
<img width="1006" height="138" alt="Skärmavbild 2026-03-13 kl  16 11 17" src="https://github.com/user-attachments/assets/ebd1dd4c-a0d6-4378-a7cb-17b05ba2dcf0" />

* Also tweaked the pills a bit (re-inserted the divider line for example)

* Filter out `_r` filters (finally) from the modal filter display

* Plus a fix for the automatically inserted wildcard, so that we don't insert it after operator. 

### Summary of changes

* Use `QualifierPill` in `SearchMapping`
* add `NO_WILDCARD_AFTER_WORD`
