### PR TITLE
feat(lxlweb): Library subset tweaks

### DIFF
--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -8,6 +8,7 @@ import { DebugFlags, type MyLibrariesType, type UserSettings } from '$lib/types/
 import displayWeb from '$lib/assets/json/display-web.json';
 import { DisplayUtil, VocabUtil } from '$lib/utils/xl';
 import { startRefreshLibraries } from '$lib/utils/getLibraries.server';
+import { getSubsetMapping } from '$lib/utils/subsetCache.server';
 
 type Util = [VocabUtil, DisplayUtil];
 let utilCache: Util | undefined;
@@ -86,6 +87,11 @@ export const handle = async ({ event, resolve }) => {
 
 	// set data-theme defined in themes.css
 	const dataTheme = site?.themeName || 'libris';
+
+	// get subset mapping
+	const _r = event.url.searchParams.get('_r');
+	const subsetMapping = await getSubsetMapping(_r, event.locals, lang);
+	event.locals.subsetMapping = subsetMapping;
 
 	return resolve(event, {
 		transformPageChunk: ({ html }) => html.replace('%lang%', lang).replace('%theme%', dataTheme)

--- a/lxl-web/src/lib/components/HoldingsPanel.svelte
+++ b/lxl-web/src/lib/components/HoldingsPanel.svelte
@@ -3,7 +3,7 @@
 	import { getUserSettings } from '$lib/contexts/userSettings';
 	import type { LibraryWithLinksAndInstances, OrgId, UnknownLibrary } from '$lib/types/holdings';
 	import { JsonLd } from '$lib/types/xl';
-	import { getMyLibsFromHoldings, isLibraryOrg } from '$lib/utils/holdings';
+	import { getLibsFromHoldings, isLibraryOrg } from '$lib/utils/holdings';
 	import { getLibraryIdsFromMapping } from '$lib/utils/getLibraryIdsFromMapping';
 	import { sortByDistance, userLocation } from '$lib/utils/geolocation.svelte';
 	import HoldingsNearMeBtn from './HoldingsNearMeBtn.svelte';
@@ -53,7 +53,7 @@
 	const myLibsHolders = $derived.by(() => {
 		if (!myLibraries) return [];
 		const holderIds = holders.map((holder) => holder[JsonLd.ID]);
-		const ids = getMyLibsFromHoldings(myLibraries, holderIds, libOrgs);
+		const ids = getLibsFromHoldings(myLibraries, holderIds, libOrgs);
 		return buildNestedLibraries(ids, myLibraries, holders);
 	});
 

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -79,7 +79,7 @@
 
 	const uidPrefix = $derived(uid ? `${uid}-` : ''); // used for prefixing id's when resource is rendered inside panes
 
-	let searchMapping = $derived(searchResult?.mapping);
+	let searchMapping = $derived(searchResult?.mapping.filter((m) => m.variable === '_q'));
 	let filteredInstances = $derived(searchResult?.items);
 
 	const derivedFilteredInstances = $derived.by(() => {

--- a/lxl-web/src/lib/components/ResourceHoldings.svelte
+++ b/lxl-web/src/lib/components/ResourceHoldings.svelte
@@ -5,9 +5,10 @@
 	import type { HoldingsData } from '$lib/types/holdings';
 	import type { SearchResultItem } from '$lib/types/search';
 	import type { ResourceData } from '$lib/types/resourceData';
+	import { LxlLens } from '$lib/types/display';
+	import { getLibraryIdsFromMapping } from '$lib/utils/getLibraryIdsFromMapping';
 	import { getHoldingsLink, getLibsFromHoldings, handleClickHoldings } from '$lib/utils/holdings';
 	import MyLibsHoldingIndicator from '$lib/components/MyLibsHoldingIndicator.svelte';
-	import { LxlLens } from '$lib/types/display';
 
 	interface Props {
 		instances: SearchResultItem[] | ResourceData[];
@@ -16,6 +17,9 @@
 
 	let { holdings, instances }: Props = $props();
 	const { myLibraries } = getUserSettings();
+	const subsetLibraries = $derived(
+		getLibraryIdsFromMapping([page.data.subsetMapping]) || undefined
+	);
 
 	function getLocalizedType(type: string) {
 		const found = instances.find((instanceItem) => type === instanceItem[JsonLd.TYPE]);
@@ -32,9 +36,20 @@
 			holdings.byType[type],
 			page.data.refinedOrgs
 		)}
+		{@const subsetHoldingByType = getLibsFromHoldings(
+			subsetLibraries,
+			holdings.byType[type],
+			page.data.refinedOrgs
+		)}
 		<li class="@md:self-center">
+			<!-- use regular btn if subset library but no holding for type -->
 			<a
-				class="btn btn-cta @md:max-w-sm"
+				class={[
+					'btn @md:max-w-sm',
+					!subsetLibraries || (subsetLibraries && subsetHoldingByType)
+						? 'btn-cta'
+						: 'btn-primary h-10 rounded-full text-sm'
+				]}
 				href={page.data.localizeHref(getHoldingsLink(page.url, type))}
 				data-sveltekit-preload-data="false"
 				data-testid="holding-link"
@@ -48,10 +63,16 @@
 				<span class="text-nowrap">{getLocalizedType(type)}</span>
 				<span class="truncate font-normal opacity-90">
 					{' · '}
-					{holdings.byType[type].length}
-					{holdings.byType[type].length === 1
-						? page.data.t('holdings.library')
-						: page.data.t('holdings.libraries')}
+					{#if subsetLibraries && subsetHoldingByType}
+						<span>{page.data.t('holdings.findTitle')}</span>
+					{:else}
+						<span>
+							{holdings.byType[type].length}
+							{holdings.byType[type].length === 1
+								? page.data.t('holdings.library')
+								: page.data.t('holdings.libraries')}
+						</span>
+					{/if}
 				</span>
 			</a>
 		</li>

--- a/lxl-web/src/lib/components/ResourceHoldings.svelte
+++ b/lxl-web/src/lib/components/ResourceHoldings.svelte
@@ -5,7 +5,7 @@
 	import type { HoldingsData } from '$lib/types/holdings';
 	import type { SearchResultItem } from '$lib/types/search';
 	import type { ResourceData } from '$lib/types/resourceData';
-	import { getHoldingsLink, getMyLibsFromHoldings, handleClickHoldings } from '$lib/utils/holdings';
+	import { getHoldingsLink, getLibsFromHoldings, handleClickHoldings } from '$lib/utils/holdings';
 	import MyLibsHoldingIndicator from '$lib/components/MyLibsHoldingIndicator.svelte';
 	import { LxlLens } from '$lib/types/display';
 
@@ -27,7 +27,7 @@
 
 <ul class="@container flex flex-col gap-2">
 	{#each Object.keys(holdings.byType) as type (type)}
-		{@const myLibsHoldingByType = getMyLibsFromHoldings(
+		{@const myLibsHoldingByType = getLibsFromHoldings(
 			myLibraries,
 			holdings.byType[type],
 			page.data.refinedOrgs

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -150,11 +150,15 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 					<BiHouse class="text-neutral-400" />
 				{/if}
 			</span>
-			<span class="sr-only">{`${page.data.t('holdings.availableAt')}`}</span>
-			<span>
-				{item.numberOfHolders}
-				{page.data.t('search.libraries')}
-			</span>
+			{#if item.heldBySubset}
+				<span>{page.data.t('holdings.findTitle')}</span>
+			{:else}
+				<span class="sr-only">{`${page.data.t('holdings.availableAt')}`}</span>
+				<span>
+					{item.numberOfHolders}
+					{page.data.t('search.libraries')}
+				</span>
+			{/if}
 		</a>
 	{/if}
 {/snippet}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -704,6 +704,19 @@
 		}
 	}
 
+	/* adjust combobox for navbar with subset filter */
+	:global(.with-subset .supersearch-combobox) {
+		&:has(.expanded) {
+			@variant lg {
+				margin-inline: calc(var(--spacing) * 1.25);
+			}
+
+			@media screen and (min-width: 1380px) {
+				margin-inline: calc(var(--spacing) * 1.75);
+			}
+		}
+	}
+
 	.action {
 		&:hover {
 			background: var(--color-accent-50);

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -943,6 +943,7 @@
 	:global(.codemirror-container .cm-placeholder) {
 		font-size: var(--text-base);
 		color: var(--color-placeholder);
+		white-space: nowrap;
 		margin-top: 1px;
 
 		@variant sm {

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -300,7 +300,8 @@ export default {
 		showFewer: 'Show fewer editions',
 		myLoans: 'My loans',
 		applyForCard: 'Apply for library card',
-		refinedLibraries: 'Refined libraries'
+		refinedLibraries: 'Refined libraries',
+		findTitle: 'Find the title'
 	},
 	filterAlias: {
 		'alias-myLibraries': 'My Libraries'

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -300,7 +300,8 @@ export default {
 		showFewer: 'Visa färre utgåvor',
 		myLoans: 'Mina lån',
 		applyForCard: 'Ansök om lånekort',
-		refinedLibraries: 'Avgränsade bibliotek'
+		refinedLibraries: 'Avgränsade bibliotek',
+		findTitle: 'Hitta titeln'
 	},
 	filterAlias: {
 		'alias-myLibraries': 'Mina bibliotek'

--- a/lxl-web/src/lib/remotes/searchResult.remote.ts
+++ b/lxl-web/src/lib/remotes/searchResult.remote.ts
@@ -12,11 +12,16 @@ import { SearchResultsSchema } from '$lib/schemas/searchResult';
 import { asAdjecentSearchResult } from '$lib/utils/adjecentSearchResult';
 
 export const getSearchResults = query(SearchResultsSchema, async (params) => {
-	const { fetch, locals, params: routeParams } = getRequestEvent();
+	const { fetch, locals, params: routeParams, url } = getRequestEvent();
 	const searchParams = new URLSearchParams(Object.entries(params));
 
 	if (locals.userSettings?.debug?.includes(DebugFlags.ES_SCORE)) {
 		searchParams.set('_debug', 'true');
+	}
+
+	const _r = url.searchParams.get('_r');
+	if (_r) {
+		searchParams.set('_r', _r);
 	}
 
 	const res = await fetch(`${env.API_URL}/find.jsonld?${searchParams.toString()}`);

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -58,7 +58,8 @@ export interface SearchResultItem {
 	typeStr: string;
 	selectTypeStr: string; // FIXME
 	mediaLinks: DisplayDecorated | null;
-	heldByMyLibraries?: (LibraryId | OrgId)[] | null;
+	heldByMyLibraries?: (LibraryId | OrgId)[];
+	heldBySubset?: (LibraryId | OrgId)[];
 	numberOfHolders: number;
 	_debug?: ItemDebugInfo;
 }

--- a/lxl-web/src/lib/utils/getRefinedOrgs.server.ts
+++ b/lxl-web/src/lib/utils/getRefinedOrgs.server.ts
@@ -9,13 +9,13 @@ import { isLibraryOrg } from './holdings';
  * Get orgs and its members currently in search mapping and/or myLibraries
  */
 export function getRefinedOrgs(
-	myLibraries?: MyLibrariesType,
+	libraries?: MyLibrariesType,
 	mapping: (DisplayMapping[] | undefined)[] = []
 ): Record<OrgId, LibraryId[]> {
 	const mappingIds = getLibraryIdsFromMapping(mapping) ?? {};
 
 	const mappingOrgs = Object.keys(mappingIds).filter(isLibraryOrg);
-	const myLibsOrgs = Object.keys(myLibraries ?? {}).filter(isLibraryOrg);
+	const myLibsOrgs = Object.keys(libraries ?? {}).filter(isLibraryOrg);
 
 	const orgIds = new Set([...mappingOrgs, ...myLibsOrgs]);
 

--- a/lxl-web/src/lib/utils/holdings.test.ts
+++ b/lxl-web/src/lib/utils/holdings.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getBibIdsByInstanceId, getHoldersByType, getHoldingsByType } from './holdings.server';
-import { getMyLibsFromHoldings } from './holdings';
+import { getLibsFromHoldings } from './holdings';
 import mainEntity from '$lib/assets/json/test-data/main-entity.json';
 import record from '$lib/assets/json/test-data/record.json';
 import { UserSettings } from './userSettings.svelte';
@@ -29,20 +29,20 @@ describe('getBibIdsByInstanceId', () => {
 	});
 });
 
-describe('getMyLibsFromHoldings', () => {
+describe('getLibsFromHoldings', () => {
 	it('Returns favourite library present in the holdings list', () => {
 		const userSettings = new UserSettings({});
 		userSettings.addLibrary('https://libris.kb.se/library/S', 'Kungliga biblioteket');
 		userSettings.addLibrary('https://libris.kb.se/library/foo', 'Mitt bibliotek');
 		const byType = getHoldersByType(getHoldingsByType(workCenteredMainEntity));
 
-		expect(getMyLibsFromHoldings(userSettings.myLibraries, byType)).toStrictEqual([
+		expect(getLibsFromHoldings(userSettings.myLibraries, byType)).toStrictEqual([
 			'https://libris.kb.se/library/S'
 		]);
 
 		userSettings.addLibrary('https://libris.kb.se/library/H', 'Frescatibilbioteket');
 
-		expect(getMyLibsFromHoldings(userSettings.myLibraries, byType)).toStrictEqual([
+		expect(getLibsFromHoldings(userSettings.myLibraries, byType)).toStrictEqual([
 			'https://libris.kb.se/library/S',
 			'https://libris.kb.se/library/H'
 		]);

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -146,15 +146,15 @@ export function isLibraryOrg(id: LibraryId): boolean {
 }
 
 /**
- * Get myLibraries id:s that are holders of a resource -
+ * Get Library id:s that are holders of a resource -
  * orgs will be included if passed (with its members) as argument
  */
-export function getMyLibsFromHoldings(
+export function getLibsFromHoldings(
 	myLibraries: MyLibrariesType | undefined,
 	holdings: string[] | HoldersByType | HoldersByType[string],
 	orgs?: Record<string, string[]>
-): (LibraryId | OrgId)[] | null {
-	if (!myLibraries) return null;
+): (LibraryId | OrgId)[] | undefined {
+	if (!myLibraries) return undefined;
 
 	const holdingIds = Array.isArray(holdings) ? holdings : Object.values(holdings).flat();
 
@@ -184,5 +184,5 @@ export function getMyLibsFromHoldings(
 		}
 	}
 
-	return result.size ? [...result] : null;
+	return result.size ? [...result] : undefined;
 }

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -48,7 +48,7 @@ import { isLibraryOrg } from '$lib/utils/holdings';
 import { getRefinedOrgs } from '$lib/utils/getRefinedOrgs.server';
 import { copyMediaLinksToWork } from '$lib/utils/copyMediaLinksToWork';
 import { getHoldersByType, getHoldersCount, getHoldingsByType } from '$lib/utils/holdings.server';
-import { getMyLibsFromHoldings } from '$lib/utils/holdings';
+import { getLibsFromHoldings } from '$lib/utils/holdings';
 import getTypeLike, { getTypeForIcon, toTypes, type TypeLike } from '$lib/utils/getTypeLike';
 import capitalize from '$lib/utils/capitalize';
 import { ACCESS_FILTERS, MY_LIBRARIES_FILTER_ALIAS } from '$lib/constants/facets';
@@ -60,7 +60,8 @@ export async function asResult(
 	locale: LangCode,
 	auxdSecret: string,
 	usePath?: string,
-	myLibraries?: MyLibrariesType
+	myLibraries?: MyLibrariesType,
+	subsetLibraries?: MyLibrariesType
 ): Promise<SearchResult> {
 	const translate = await getTranslator(locale);
 
@@ -87,6 +88,7 @@ export async function asResult(
 			locale,
 			auxdSecret,
 			myLibraries,
+			subsetLibraries,
 			maxScores
 		),
 		...('stats' in view && {
@@ -111,13 +113,17 @@ export function asSearchResultItem(
 	locale: LangCode,
 	auxdSecret: string,
 	myLibraries?: MyLibrariesType,
+	subsetLibraries?: MyLibrariesType,
 	maxScores?: Record<string, number>
 ): SearchResultItem[] {
 	return items
 		?.map((i) => cleanUpItem(i))
 		.map((i) => ({
 			...(myLibraries && {
-				heldByMyLibraries: getHeldByMyLibraries(i, myLibraries)
+				heldByMyLibraries: getHeldByLibraries(i, myLibraries)
+			}),
+			...(subsetLibraries && {
+				heldBySubset: getHeldByLibraries(i, subsetLibraries)
 			}),
 			...('_debug' in i && {
 				_debug: asItemDebugInfo(i['_debug'] as ApiItemDebugInfo, maxScores)
@@ -363,10 +369,10 @@ function asItemDebugInfo(i: ApiItemDebugInfo, maxScores: Record<string, number>)
 	};
 }
 
-function getHeldByMyLibraries(item: FramedData, myLibraries: MyLibrariesType) {
-	const orgs = getRefinedOrgs(myLibraries);
+function getHeldByLibraries(item: FramedData, libraries: MyLibrariesType) {
+	const orgs = getRefinedOrgs(libraries);
 	const holdersByType = getHoldersByType(getHoldingsByType(item));
-	return getMyLibsFromHoldings(myLibraries, holdersByType, orgs);
+	return getLibsFromHoldings(libraries, holdersByType, orgs);
 }
 
 function isFreeTextQuery(property: unknown): boolean {

--- a/lxl-web/src/lib/utils/subsetCache.server.ts
+++ b/lxl-web/src/lib/utils/subsetCache.server.ts
@@ -1,0 +1,73 @@
+import { env } from '$env/dynamic/private';
+import type { DisplayMapping, MappingsOnlyPartialCollectionView } from '$lib/types/search';
+import { getTranslator } from '$lib/i18n';
+import { getSupportedLocale } from '$lib/i18n/locales';
+import { displayMappings } from './search';
+
+const cache = new Map<string, DisplayMapping[]>();
+const pending = new Map<string, Promise<MappingsOnlyPartialCollectionView | null>>();
+const MAX_SIZE = 500;
+
+function deleteOldest() {
+	if (cache.size <= MAX_SIZE) return;
+	// delete oldest entry if exceding max size
+	const first = cache.keys().next().value;
+	if (first) cache.delete(first);
+}
+
+async function fetchMapping(r: string) {
+	const res = await fetch(
+		`${env.API_URL}/find.jsonld?${new URLSearchParams({
+			_r: r,
+			_q: '',
+			_mappingOnly: 'true'
+		}).toString()}`
+	);
+
+	if (!res.ok) {
+		console.warn('Failed to get _r mappings');
+		return null;
+	}
+
+	return (await res.json()) as MappingsOnlyPartialCollectionView;
+}
+
+export async function getSubsetMapping(r: string | null, locals: App.Locals, lang: string) {
+	if (!r || r === '*') {
+		return undefined;
+	}
+
+	const cached = cache.get(r);
+	if (cached) {
+		return cached;
+	}
+
+	// deduplicate concurrent fetches
+	let dataPromise = pending.get(r);
+	if (!dataPromise) {
+		dataPromise = fetchMapping(r).finally(() => pending.delete(r));
+		pending.set(r, dataPromise);
+	}
+
+	const data = await dataPromise;
+
+	if (data) {
+		deleteOldest();
+		const rMapping = await formatMapping(data, locals, lang);
+		cache.set(r, rMapping);
+		return rMapping;
+	} else {
+		return undefined;
+	}
+}
+
+async function formatMapping(
+	data: MappingsOnlyPartialCollectionView,
+	locals: App.Locals,
+	lang: string
+): Promise<DisplayMapping[]> {
+	const locale = getSupportedLocale(lang);
+	const translator = await getTranslator(locale);
+	const mappings = displayMappings(data, locals.display, locale, translator);
+	return mappings.filter((m) => m.variable === '_r');
+}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
@@ -22,7 +22,7 @@
 {#each page.data.featuredSearches as featured, index (featured.heading)}
 	{@const id = `${uid}-featured-search-${index + 1}`}
 	<section
-		class="my-3 flex flex-col gap-3 last-of-type:pb-6 @lg:gap-4.5 @5xl:gap-4.5 @5xl:first-of-type:mt-8 @5xl:last-of-type:pb-10 @min-[110rem]:gap-6"
+		class="featured-preview-section my-3 flex flex-col gap-3 last-of-type:pb-6 @lg:gap-4.5 @5xl:gap-4.5 @5xl:first-of-type:mt-8 @5xl:last-of-type:pb-10 @min-[110rem]:gap-6"
 	>
 		<header class="flex justify-between px-3 @sm:px-6 @5xl:px-20">
 			<h2
@@ -101,5 +101,10 @@
 				}
 			}
 		}
+	}
+
+	/* hide empty sections */
+	.featured-preview-section:global(:has(.featured-previews.empty)) {
+		display: none;
 	}
 </style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -672,15 +672,26 @@
 
 	/* subset in header */
 	.with-subset {
-		--search-grid-template-columns: minmax(300px, 1fr) minmax(0, 3fr) calc(var(--spacing) * 40);
+		--search-grid-template-columns: minmax(0, auto) minmax(0, auto)
+			minmax(0, calc(var(--spacing) * 22));
 
 		.leading-actions {
 			position: static;
+		}
+
+		@variant lg {
+			--search-grid-template-columns: minmax(calc(var(--spacing) * 75), 1fr) minmax(0, 3fr)
+				minmax(0, calc(var(--spacing) * 40));
 		}
 	}
 
 	:global(.home .with-subset .leading-actions) {
 		position: fixed;
+
+		/* hide the subset pill on the front page for now */
+		& .subset-container {
+			display: none;
+		}
 	}
 
 	.app-bar :global(.search-mapping) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -669,13 +669,18 @@
 	.shadow-app-bar {
 		box-shadow: var(--app-bar-shadows);
 	}
+
 	/* subset in header */
 	.with-subset {
-		--search-grid-template-columns: minmax(auto, 400px) minmax(0, 3fr) calc(var(--spacing) * 22);
-		@variant lg {
-			--search-grid-template-columns: minmax(auto, 400px) minmax(0, 3fr) calc(var(--spacing) * 30);
+		--search-grid-template-columns: minmax(300px, 1fr) minmax(0, 3fr) calc(var(--spacing) * 40);
+
+		.leading-actions {
+			position: static;
 		}
-		grid-template-columns: var(--search-grid-template-columns);
+	}
+
+	:global(.home .with-subset .leading-actions) {
+		position: fixed;
 	}
 
 	.app-bar :global(.search-mapping) {
@@ -687,11 +692,6 @@
 
 	.app-bar :global(.search-mapping .group) {
 		flex-wrap: nowrap;
-		max-width: none;
-	}
-
-	.app-bar :global(.search-mapping .pill),
-	.subset-container :global(ul) {
 		max-width: none;
 	}
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/FeaturedPreviewList.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/FeaturedPreviewList.svelte
@@ -87,7 +87,7 @@
 	</div>
 {/snippet}
 
-<div class="featured-previews contents">
+<div class={['featured-previews contents', previews?.totalItems === 0 && 'empty']}>
 	<SearchResultList
 		items={previews?.items || []}
 		type="horizontal"

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -29,12 +29,16 @@ import { getRefinedOrgs } from '$lib/utils/getRefinedOrgs.server';
 import { getSearchResults } from '$lib/remotes/searchResult.remote';
 import { SearchResultsSchema } from '$lib/schemas/searchResult';
 import { copyMediaLinksToWork } from '$lib/utils/copyMediaLinksToWork';
+import { getLibraryIdsFromMapping } from '$lib/utils/getLibraryIdsFromMapping.js';
 
 export const load = async ({ params, locals, fetch, url }) => {
 	const displayUtil = locals.display;
 	const vocabUtil = locals.vocab;
 	const locale = getSupportedLocale(params?.lang);
 	const translate = await getTranslator(locale);
+
+	const subsetMapping = locals?.subsetMapping;
+	const subsetLibraries = getLibraryIdsFromMapping([subsetMapping]) || undefined;
 	const myLibraries = locals.userSettings?.myLibraries;
 
 	let resourceId: null | string = null;
@@ -76,8 +80,7 @@ export const load = async ({ params, locals, fetch, url }) => {
 			vocabUtil,
 			locale,
 			env.AUXD_SECRET,
-			myLibraries,
-			undefined
+			myLibraries
 		)[0];
 	} else if (resource.mainEntity.instanceOf) {
 		// instance - fetch work card
@@ -163,7 +166,7 @@ export const load = async ({ params, locals, fetch, url }) => {
 			locale,
 			env.AUXD_SECRET,
 			myLibraries,
-			undefined
+			subsetLibraries
 		);
 	}
 
@@ -307,7 +310,6 @@ export const load = async ({ params, locals, fetch, url }) => {
 		holdingLibraries: getHoldingLibraries(byType)
 	};
 
-	const subsetMapping = locals?.subsetMapping;
 	const refinedOrgs = getRefinedOrgs(myLibraries, [subsetMapping, searchResult?.mapping]);
 
 	return {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
@@ -1,7 +1,6 @@
 import { redirect, error } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { getSupportedLocale } from '$lib/i18n/locales.js';
-
 import { type ApiError } from '$lib/types/api.js';
 import type { PartialCollectionView } from '$lib/types/search.js';
 import { appendMyLibrariesParam, asResult } from '$lib/utils/search';
@@ -9,6 +8,7 @@ import { DebugFlags } from '$lib/types/userSettings';
 import { displayMappingToString } from '$lib/utils/displayMappingToString.js';
 import getPageTitle from '$lib/utils/getPageTitle';
 import { getRefinedOrgs } from '$lib/utils/getRefinedOrgs.server.js';
+import { getLibraryIdsFromMapping } from '$lib/utils/getLibraryIdsFromMapping.js';
 
 export const load = async ({ params, url, locals, fetch }) => {
 	const displayUtil = locals.display;
@@ -16,6 +16,8 @@ export const load = async ({ params, url, locals, fetch }) => {
 	const locale = getSupportedLocale(params?.lang);
 
 	const debug = locals.userSettings?.debug?.includes(DebugFlags.ES_SCORE) ? '&_debug=esScore' : '';
+	const subsetMapping = locals?.subsetMapping;
+	const subsetLibraries = getLibraryIdsFromMapping([subsetMapping]) || undefined;
 	const myLibraries = locals.userSettings?.myLibraries;
 
 	const searchParams = new URLSearchParams();
@@ -85,12 +87,11 @@ export const load = async ({ params, url, locals, fetch }) => {
 		locale,
 		env.AUXD_SECRET,
 		`${params?.lang ? `/${params.lang}` : ''}/find`, // avoid creating a dependency to url.pathName!
-		myLibraries
+		myLibraries,
+		subsetLibraries
 	);
 
 	const pageTitle = getPageTitle(displayMappingToString(searchResult.mapping), locals.site?.name);
-
-	const subsetMapping = locals?.subsetMapping;
 	const refinedOrgs = getRefinedOrgs(myLibraries, [subsetMapping, searchResult?.mapping]);
 
 	return { searchResult, pageTitle, refinedOrgs };

--- a/lxl-web/src/routes/+layout.server.ts
+++ b/lxl-web/src/routes/+layout.server.ts
@@ -1,42 +1,17 @@
-import { env } from '$env/dynamic/private';
-import type { MappingsOnlyPartialCollectionView, QualifierSuggestion2 } from '$lib/types/search';
-import { getTranslator } from '$lib/i18n/index.js';
+import type { QualifierSuggestion2 } from '$lib/types/search';
 import { getSupportedLocale, type LocaleCode, otherLocales } from '$lib/i18n/locales.js';
-import { displayMappings } from '$lib/utils/search';
 import { type FramedData, JsonLd, LensType, Platform } from '$lib/types/xl';
 import { asArray, type DisplayUtil, toString, VocabUtil } from '$lib/utils/xl';
 import { getUriSlug } from '$lib/utils/http';
 
-export async function load({ locals, url, params, fetch }) {
+export async function load({ locals, url, params }) {
 	const userSettings = locals.userSettings;
-	let subsetMapping;
-	const r = url.searchParams.get('_r');
-	// get the label for a subset filter on any page
-	if (r && r !== '*') {
-		const res = await fetch(
-			`${env.API_URL}/find.jsonld?${new URLSearchParams({
-				_r: r,
-				_q: '',
-				_mappingOnly: 'true'
-			}).toString()}`
-		);
 
-		if (res.ok) {
-			const data = (await res.json()) as MappingsOnlyPartialCollectionView;
-
-			const locale = getSupportedLocale(params?.lang);
-			const translator = await getTranslator(locale);
-			const mappings = displayMappings(data, locals.display, locale, translator, url.pathname);
-			subsetMapping = mappings.filter((m) => m.variable === '_r');
-			// add to locals for access in other load functions
-			locals.subsetMapping = subsetMapping;
-		} else {
-			console.warn('Failed to get _r mappings');
-		}
-	}
+	// create dependency to react to _r changes
+	url.searchParams.get('_r');
+	const subsetMapping = locals.subsetMapping;
 
 	const siteName = locals.site?.name;
-
 	const locale = getSupportedLocale(params?.lang);
 	const qualifierSuggestions = getQualifierSuggestions(locale, locals.vocab, locals.display);
 

--- a/lxl-web/src/routes/api/[[lang=lang]]/[fnurgel=fnurgel]/+server.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/[fnurgel=fnurgel]/+server.ts
@@ -23,9 +23,7 @@ export async function GET({ params, locals }) {
 		displayUtil,
 		vocabUtil,
 		getSupportedLocale(params?.lang),
-		env.AUXD_SECRET,
-		undefined,
-		undefined
+		env.AUXD_SECRET
 	)[0];
 
 	return json(searchCard, {

--- a/lxl-web/tests/help.filters.spec.ts
+++ b/lxl-web/tests/help.filters.spec.ts
@@ -14,10 +14,10 @@ test('should not have any detectable a11y issues', async ({ page }) => {
 
 test('qualifier keys can be added from filter list', async ({ page }) => {
 	await page.getByRole('main').getByRole('button').getByText('Bibliografi').click();
-	await expect(page.getByRole('combobox').first()).toContainText('Bibliografi');
-	await expect(page.getByRole('combobox').last()).toContainText('Bibliografi');
+	await expect(page.getByRole('combobox').first()).toContainText('Ingår i bibliografi');
+	await expect(page.getByRole('combobox').last()).toContainText('Ingår i bibliografi');
 	await page.keyboard.press('Escape');
 	await page.getByRole('main').getByRole('button').getByText('Biblioteksorganisation').click();
-	await expect(page.getByRole('combobox').first()).toContainText('Bibliografi');
+	await expect(page.getByRole('combobox').first()).toContainText('Ingår i bibliografi');
 	await expect(page.getByRole('combobox').first()).toContainText(' Biblioteksorganisation');
 });

--- a/lxl-web/tests/subsets.spec.ts
+++ b/lxl-web/tests/subsets.spec.ts
@@ -35,3 +35,22 @@ test('A subset filter can be removed and preserves lang', async ({ page }) => {
 	await page.waitForLoadState('networkidle');
 	await expect(page).toHaveURL('/en/find?_q=&_r=');
 });
+
+test('Holding button changes text when using a library subset filter', async ({ page }) => {
+	await page.goto('/find?_q=&_r=itemHeldByOrg:%22sigel:org/ARKM%22');
+	await expect(page.getByTestId('holding-link').first()).toHaveText('Hitta titeln');
+});
+
+test('Holding button does not change text when subset filter is not a library', async ({
+	page
+}) => {
+	await page.goto('/find?_q=&_r=language:"lang:swe"');
+	await expect(page.getByTestId('holding-link').first()).not.toHaveText('Hitta titeln');
+});
+
+test('Holdings panel highlights the library subset holding', async ({ page }) => {
+	await page.goto('/find?_q=&_r=itemHeldByOrg:%22sigel:org/ARKM%22');
+	await page.getByTestId('holding-link').first().click();
+	await expect(page.locator('.special-section')).toContainText('Avgränsade bibliotek');
+	await expect(page.locator('.special-section')).toContainText('ArkDes');
+});


### PR DESCRIPTION
## Description
### Solves

A few improvements when using a library as a subset filter, in these examples [ArkDes](http://localhost:5173/?_r=itemHeldByOrg%3A%22sigel%3Aorg%2FARKM%22).

The biggest change under the hood is the way to fetch subset mappings. Earlier, they were fetched in the root layout file and passed as page data to the client. Now we need access to the subset mappings in other server `load` functions (and we don't want to rely on `await parent()`). The new solution is to fetch the mappings in the `hooks.server` file and add it to `event.locals`. The hooks file is delicate and needs to be performant, so i've implemented a util that caches `_r` with their mappings to avoid any unnecessary fetches. This data should be safe to share between users on the server, but feel free to express any concerns with this approach.

Visual changes:

1) Front page now takes `_r` into account when fetching previews. Preview sections without any items are now hidden.
<img width="1114" height="540" alt="Skärmavbild 2026-03-19 kl  12 47 46" src="https://github.com/user-attachments/assets/acb9eba8-a4ba-43b0-aff0-b6304181d79f" />

2) When using a library as a subset filter, the text of the holdings button changes.
<img width="849" height="322" alt="Skärmavbild 2026-03-19 kl  12 50 52" src="https://github.com/user-attachments/assets/cee2734b-31c9-4bc2-9942-af5e88e7bdc8" />

Same thing with instances on resource pages (instances not held by subset display the same as before)
<img width="839" height="289" alt="Skärmavbild 2026-03-19 kl  12 53 33" src="https://github.com/user-attachments/assets/3520a254-699d-40ee-93c6-f992158942ff" />

3) "Holdings by type" buttons keep their CTA look only if subset has holdings, others get a more neutral look (we could also hide them completely, but that would mean you can't access the modal if somehow entering a resource without "the right" holding).
<img width="310" height="412" alt="Skärmavbild 2026-03-19 kl  12 56 22" src="https://github.com/user-attachments/assets/81144359-ce60-4b1a-9466-ec7cbd4a9cd5" />

4) Fixed regression in navbar + subset pill. Now fade + sidescroll if pill reaches its maximal width.
<img width="943" height="81" alt="Skärmavbild 2026-03-19 kl  13 09 09" src="https://github.com/user-attachments/assets/2654cf01-c811-42db-bb29-df92006d722e" />


### Summary of changes
* Add `subsetCache.server` + update root `+layout.server`, `hooks.server.ts`
* Add `heldBySubset` to `SearchResultItem`
* rename `getMyLibsFromHoldings` -> `getLibsFromHoldings`, `getHeldByMyLibraries` -> `getHeldByLibraries`
* modified `SearchCard` and `ResourceHoldings` with `conditional` text
* Account for `_r` in `searchResult.remote` (start page fetch)
* Update `AppBar` CSS
* Add a few tests to cover cases in this PR