### PR TITLE
fix(lxlweb) bib/org icons

### DIFF
--- a/lxl-web/src/lib/components/TypeIcon.svelte
+++ b/lxl-web/src/lib/components/TypeIcon.svelte
@@ -20,7 +20,8 @@
 	import BiVectorPen from '~icons/bi/vector-pen';
 	import BiTag from '~icons/bi/tag';
 	import BiGlobe from '~icons/bi/globe';
-	import BiHouseHeart from '~icons/bi/house-heart';
+	import BiHouse from '~icons/bi/house';
+	import BiHouses from '~icons/bi/houses';
 	import BiAlphabet from '~icons/bi/alphabet-uppercase';
 	import BiGeoAlt from '~icons/bi/geo-alt';
 	import BiClockHistory from '~icons/bi/clock-history';
@@ -39,7 +40,8 @@
 		GenreForm: BiTag,
 		Geographic: BiGeoAlt,
 		Language: BiGlobe,
-		Library: BiHouseHeart,
+		Library: BiHouse,
+		'bibdb:Organization': BiHouses,
 		Organization: BiBank,
 		Person: BiPerson,
 		Temporal: BiClockHistory,

--- a/lxl-web/src/lib/utils/getTypeLike.ts
+++ b/lxl-web/src/lib/utils/getTypeLike.ts
@@ -236,9 +236,7 @@ const PRIORITIZED_ICONS = [
 export function getTypeForIcon(typeLike: TypeLike) {
 	for (const t of typeLike.identify.concat(typeLike.find)) {
 		if (t) {
-			const slugStr = slug(
-				((typeLike.find?.[0]?.[JsonLd.ID] as string) || '').replace('/bibdb/', '/bibdb:')
-			);
+			const slugStr = slug((slug(t[JsonLd.ID] as string) || '').replace('/bibdb/', '/bibdb:'));
 			if (slugStr && PRIORITIZED_ICONS.includes(slugStr)) {
 				return slugStr;
 			}
@@ -246,7 +244,7 @@ export function getTypeForIcon(typeLike: TypeLike) {
 	}
 
 	return typeLike.find.length > 0 && typeLike.find[0] !== undefined
-		? slug(((typeLike.find?.[0]?.[JsonLd.ID] as string) || '').replace('/bibdb/', '/bibdb:'))
+		? slug(((typeLike.find[0][JsonLd.ID] as string) || '').replace('/bibdb/', '/bibdb:'))
 		: '';
 }
 

--- a/lxl-web/src/lib/utils/getTypeLike.ts
+++ b/lxl-web/src/lib/utils/getTypeLike.ts
@@ -236,7 +236,9 @@ const PRIORITIZED_ICONS = [
 export function getTypeForIcon(typeLike: TypeLike) {
 	for (const t of typeLike.identify.concat(typeLike.find)) {
 		if (t) {
-			const slugStr = slug(t[JsonLd.ID]);
+			const slugStr = slug(
+				((typeLike.find?.[0]?.[JsonLd.ID] as string) || '').replace('/bibdb/', '/bibdb:')
+			);
 			if (slugStr && PRIORITIZED_ICONS.includes(slugStr)) {
 				return slugStr;
 			}
@@ -244,7 +246,7 @@ export function getTypeForIcon(typeLike: TypeLike) {
 	}
 
 	return typeLike.find.length > 0 && typeLike.find[0] !== undefined
-		? slug(typeLike.find[0][JsonLd.ID])
+		? slug(((typeLike.find?.[0]?.[JsonLd.ID] as string) || '').replace('/bibdb/', '/bibdb:'))
 		: '';
 }
 

--- a/lxl-web/src/lib/utils/getTypeLike.ts
+++ b/lxl-web/src/lib/utils/getTypeLike.ts
@@ -236,7 +236,7 @@ const PRIORITIZED_ICONS = [
 export function getTypeForIcon(typeLike: TypeLike) {
 	for (const t of typeLike.identify.concat(typeLike.find)) {
 		if (t) {
-			const slugStr = slug((slug(t[JsonLd.ID] as string) || '').replace('/bibdb/', '/bibdb:'));
+			const slugStr = slug((t[JsonLd.ID] as string) || ''.replace('/bibdb/', '/bibdb:'));
 			if (slugStr && PRIORITIZED_ICONS.includes(slugStr)) {
 				return slugStr;
 			}
@@ -244,7 +244,7 @@ export function getTypeForIcon(typeLike: TypeLike) {
 	}
 
 	return typeLike.find.length > 0 && typeLike.find[0] !== undefined
-		? slug(((typeLike.find[0][JsonLd.ID] as string) || '').replace('/bibdb/', '/bibdb:'))
+		? slug((typeLike.find[0][JsonLd.ID] as string) || ''.replace('/bibdb/', '/bibdb:'))
 		: '';
 }
 


### PR DESCRIPTION
## Description
### Solves

Icon tweak
<img width="874" height="63" alt="Skärmavbild 2026-03-20 kl  13 48 20" src="https://github.com/user-attachments/assets/e728ca57-0221-4e3a-af5f-303d030e4089" />

Prevent `slug()` from turning `id.kb.se/bibdb/Organization` into `Organization`
