### PR TITLE
fix(lxl-web): Missing person image url

### DIFF
--- a/lxl-web/src/lib/utils/getPersonImage.ts
+++ b/lxl-web/src/lib/utils/getPersonImage.ts
@@ -17,9 +17,9 @@ export async function getPersonImage(id: string) {
 		}
 
 		const data = await res.json();
-		const image = data.image.url;
+		const image = data.image?.url;
 
-		images.set(id, image);
+		if (image) images.set(id, image);
 		pending.delete(id);
 
 		return image;


### PR DESCRIPTION
### Solves

Fixes issue with `TypeError: can't access property "url", data.image is undefined` in `getPersonImage`

### Summary of changes

- Fix missing person image url
