### PR TITLE
fix(lxl-web, supersearch): Fix issue with qualifier pills not appearing due to nbsp chars

### DIFF
--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
@@ -35,6 +35,8 @@ const lxlQualifierPlugin = (validateFn: QualifierValidator, renderFn?: Qualifier
 		{
 			decorations: (instance) => instance.decorations,
 			provide: () => [
+				EditorState.transactionFilter.of(replaceNbspWithSpace),
+
 				qualifierStateField,
 				stopEditingOnEnterOrEsc,
 				qualifierValidatorFacet.of(validateFn),
@@ -51,8 +53,7 @@ const lxlQualifierPlugin = (validateFn: QualifierValidator, renderFn?: Qualifier
 				EditorState.transactionFilter.of(balanceInnerParens),
 				// <--
 
-				EditorState.transactionFilter.of(insertSpaceAroundQualifier),
-				EditorState.transactionFilter.of(replaceNbspWithSpace)
+				EditorState.transactionFilter.of(insertSpaceAroundQualifier)
 			]
 		}
 	);

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/index.ts
@@ -13,6 +13,7 @@ import {
 	removeGhostGroup
 } from './ghostGroup.js';
 import insertSpaceAroundQualifier from './insertSpaceAroundQualifier.js';
+import replaceNbspWithSpace from './replaceNbspWithSpace.js';
 
 const lxlQualifierPlugin = (validateFn: QualifierValidator, renderFn?: QualifierRenderer) => {
 	return ViewPlugin.fromClass(
@@ -50,7 +51,8 @@ const lxlQualifierPlugin = (validateFn: QualifierValidator, renderFn?: Qualifier
 				EditorState.transactionFilter.of(balanceInnerParens),
 				// <--
 
-				EditorState.transactionFilter.of(insertSpaceAroundQualifier)
+				EditorState.transactionFilter.of(insertSpaceAroundQualifier),
+				EditorState.transactionFilter.of(replaceNbspWithSpace)
 			]
 		}
 	);

--- a/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/replaceNbspWithSpace.ts
+++ b/packages/supersearch/src/lib/extensions/lxlQualifierPlugin/replaceNbspWithSpace.ts
@@ -1,0 +1,39 @@
+import { Transaction } from '@codemirror/state';
+
+/**
+ * This is (a not so elegant) fix for the issue with nbsp characters appearing after qualifiers, (resulting in following pills after the first to not appear)
+ */
+export const replaceNbspWithSpace = (tr: Transaction) => {
+	if (!tr.annotation(Transaction.userEvent)) {
+		return tr;
+	}
+	if (
+		!tr.docChanged ||
+		tr.isUserEvent('select') ||
+		tr.isUserEvent('undo') ||
+		tr.isUserEvent('redo')
+	) {
+		return tr;
+	}
+
+	const doc = tr.newDoc.toString();
+	const docWithoutNbsp = doc.replaceAll(/\u00A0/g, ' ');
+
+	return [
+		tr,
+		{
+			changes: [
+				{
+					from: 0,
+					to: doc.length,
+					insert: docWithoutNbsp
+				}
+			],
+			selection: tr.newSelection,
+			sequential: true,
+			userEvent: 'input'
+		}
+	];
+};
+
+export default replaceNbspWithSpace;


### PR DESCRIPTION
### Solves

A (not-so-elegant) fix to the issue with qualifier pills not appearing because of strange `nbsp` chars.

I'm not sure where the non-breaking spaces come from; I have tried searching through the entire front-end codebase for nbsp characters without any luck.

### Summary of changes

- Add extenstion to replace all nbsp chars with spaces
