### PR TITLE
fix(lxlweb): HTML validation warnings/errors

### DIFF
--- a/lxl-web/maintenance.html
+++ b/lxl-web/maintenance.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Underhållsarbete</title>
 <style>
 	body {

--- a/lxl-web/src/app.html
+++ b/lxl-web/src/app.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="%lang%" data-theme="%theme%">
 	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" type="image/png" />
-		<link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta charset="utf-8">
+		<link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml">
+		<link rel="icon" href="%sveltekit.assets%/favicon.png" type="image/png">
+		<link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -180,7 +180,7 @@
 				<svelte:element
 					this={getElementType(data)}
 					href={getLink(data)}
-					target={hasStyle(data, 'ext-link') ? '_blank' : null}
+					target={getLink(data) && hasStyle(data, 'ext-link') ? '_blank' : null}
 					data-type={data['@type']}
 					class={getStyleClasses(data)}
 					use:conditionalPopover={data}

--- a/lxl-web/src/lib/components/TableOfContents.svelte
+++ b/lxl-web/src/lib/components/TableOfContents.svelte
@@ -158,6 +158,7 @@
 					aria-label={openOnMobile
 						? page.data.t('tableOfContents.hide')
 						: page.data.t('tableOfContents.show')}
+					aria-expanded={openOnMobile}
 					aria-controls={`${uidPrefix}toc-items`}
 					class="h-0 appearance-none focus:outline-0"
 					onkeydown={handleCheckboxKeydown}

--- a/lxl-web/src/lib/components/TableOfContents.svelte
+++ b/lxl-web/src/lib/components/TableOfContents.svelte
@@ -143,13 +143,14 @@
 
 <div bind:this={tocElement} class="contents">
 	{#if mobile}
+		<h2 class="sr-only">{page.data.t('tableOfContents.onThisPage')}</h2>
 		<div class="border-b-neutral border-b p-1 text-xs sm:text-sm">
 			<label
 				id={`${uidPrefix}toc-label`}
 				class="bg-page text-subtle flex min-h-8 cursor-pointer items-center gap-1.5 px-2 has-checked:[&+nav]:block"
 			>
 				<IconToC class="size-4" />
-				<h2>{page.data.t('tableOfContents.onThisPage')}</h2>
+				<span>{page.data.t('tableOfContents.onThisPage')}</span>
 				<input
 					type="checkbox"
 					role="switch"
@@ -157,7 +158,6 @@
 					aria-label={openOnMobile
 						? page.data.t('tableOfContents.hide')
 						: page.data.t('tableOfContents.show')}
-					aria-expanded={openOnMobile}
 					aria-controls={`${uidPrefix}toc-items`}
 					class="h-0 appearance-none focus:outline-0"
 					onkeydown={handleCheckboxKeydown}

--- a/lxl-web/src/lib/components/find/FacetGroup.svelte
+++ b/lxl-web/src/lib/components/find/FacetGroup.svelte
@@ -227,8 +227,7 @@
 				data-testid={`facet-sort-${data.dimension}`}
 			>
 				{#each sortOptions as option (option.value)}
-					<option selected={option.value == currentSort} value={option.value}>{option.label}</option
-					>
+					<option value={option.value}>{option.label}</option>
 				{/each}
 			</select>
 			<BiSortDown class="pointer-events-none absolute top-0 right-0 m-2 text-base" />

--- a/lxl-web/src/lib/components/find/FacetRange.svelte
+++ b/lxl-web/src/lib/components/find/FacetRange.svelte
@@ -36,7 +36,6 @@
 
 <form
 	class="[&_label]:text-subtle grid grid-cols-[1fr_1fr_auto] items-end gap-2 p-2"
-	action=""
 	onsubmit={handleSubmit}
 >
 	<div class="flex flex-col gap-1">

--- a/lxl-web/src/lib/components/find/SearchResultSort.svelte
+++ b/lxl-web/src/lib/components/find/SearchResultSort.svelte
@@ -45,7 +45,7 @@
 		<select
 			id="search-sort"
 			class="btn btn-primary w-px sm:w-auto"
-			form="search"
+			form="search-form"
 			onchange={handleSortChange}
 		>
 			{#each sortOptions as option (option.value)}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -152,7 +152,7 @@
 	});
 
 	const IDs = {
-		search: 'search',
+		search: 'app-bar-search',
 		appBarMenu: 'app-bar-menu',
 		appBarMenuLabel: 'app-bar-menu-label',
 		appBarSearchLabel: 'app-bar-search-label',
@@ -296,7 +296,7 @@
 					'hidden target:flex has-[dialog:open]:h-0 lg:flex lg:has-[dialog:open]:h-fit' // enable toggling using target/anchor (so it also works when JavaScript is disabled)
 			]}
 		>
-			<form action={findActionUrl} class="mx-auto w-full min-w-0">
+			<form id="search-form" action={findActionUrl} class="mx-auto w-full min-w-0">
 				{#if isHomeRoute}
 					<hgroup
 						class="absolute my-3 px-3 leading-snug @xl:mt-6 lg:@xl:my-3 lg:@xl:px-3 @3xl:leading-normal lg:@3xl:my-3 lg:@3xl:px-4 @5xl:my-4"
@@ -323,7 +323,7 @@
 					</hgroup>
 				{/if}
 				<AppSearch
-					id="search"
+					id="app-search"
 					name="_q"
 					--page-y-offset={pageYOffset}
 					bind:this={appSearchComponent}
@@ -399,7 +399,7 @@
 			height="100"
 			alt=""
 			class="pointer-events-none h-full w-full  select-none"
-		/>
+		>
 		<figcaption class="text-3xs absolute right-3 bottom-3 opacity-50">
 			Namn Namnsson, Lorem ipsum dolor (1924). Foto: Namn Namnsson
 		</figcaption>

--- a/packages/supersearch/src/app.html
+++ b/packages/supersearch/src/app.html
@@ -1,9 +1,9 @@
 <!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta charset="utf-8">
+		<link rel="icon" href="%sveltekit.assets%/favicon.png">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
## Description

### Solves

Ran some pages through the [W3C markup validation](https://validator.w3.org/) and tried to fix the stuff it reported. I think this needs to be done in iterations...

### Summary of changes
* Remove self-closing of void elements, like `<link>`, `<meta>`, `<input>`, `<img>` (not required, but recommended)
* Fix duplicate id `”search”`
* Remove manual `selected` for `<select>` when it is also bound (resulting in duplicate `selected=""`)
* Remove invalid empty form `action`
* The `form` attribute of the sort-select did not refer to a form element. Add `search-form` to both.
* `<h2>` is not allowed as a child of `<label>`. Added sr-only `<h2>` outside of the toc-mobile toggle to preserve page semantics.
* Remove `aria-expanded` for input element:  "Attribute aria-expanded not allowed on element [input] at this point"
* Prevent `<span>` from getting `target=”_blank”` in `decoratedData`
