### PR TITLE
feat(lxl-web, supersearch): Add search help link

### DIFF
--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -538,7 +538,7 @@
 			</div>
 		{/snippet}
 		{#snippet expandedContent({ resultsCount, resultsSnippet, getCellId, isFocusedCell })}
-			<nav class="mt-3 mb-2 lg:mt-4">
+			<nav class="mt-3 lg:mt-4">
 				{#if showAddQualifiers}
 					<div
 						id="supersearch-add-qualifier-key-label"
@@ -620,6 +620,17 @@
 						{@render resultsSnippet({ rowOffset: showAddQualifiers ? 2 : 1 })}
 					</div>
 				{/if}
+				<div role="row" class="border-neutral mt-2 flex justify-end gap-4 border-t px-4 text-sm">
+					<!-- TODO: Add keyboard interaction help here -->
+					<a
+						href={resolve(page.data.localizeHref('/help'))}
+						class={[
+							'text-link flex min-h-14 items-center justify-end overflow-hidden px-4 hover:underline focus:underline'
+						]}
+					>
+						{page.data.t('supersearch.searchHelp')}
+					</a>
+				</div>
 			</nav>
 		{/snippet}
 		{#snippet resultItemRow({ resultItem, getCellId, isFocusedCell })}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -538,6 +538,7 @@
 			</div>
 		{/snippet}
 		{#snippet expandedContent({ resultsCount, resultsSnippet, getCellId, isFocusedCell })}
+			{@const searchHelpRowIndex = (showAddQualifiers ? 1 : 0) + (resultsCount || 0) + 1}
 			<nav class="mt-3 lg:mt-4">
 				{#if showAddQualifiers}
 					<div
@@ -620,12 +621,18 @@
 						{@render resultsSnippet({ rowOffset: showAddQualifiers ? 2 : 1 })}
 					</div>
 				{/if}
-				<div role="row" class="border-neutral mt-2 flex justify-end gap-4 border-t px-4 text-sm">
+				<div
+					role="row"
+					data-skip-row-on-arrow-key
+					class="border-neutral mt-2 flex justify-end gap-4 border-t px-4 text-sm"
+				>
 					<!-- TODO: Add keyboard interaction help here -->
 					<a
 						href={resolve(page.data.localizeHref('/help'))}
+						id={getCellId(searchHelpRowIndex, 0)}
 						class={[
-							'text-link flex min-h-14 items-center justify-end overflow-hidden px-4 hover:underline focus:underline'
+							'text-link flex min-h-14 items-center justify-end overflow-hidden px-4 hover:underline',
+							isFocusedCell(searchHelpRowIndex, 0) && 'underline'
 						]}
 					>
 						{page.data.t('supersearch.searchHelp')}

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -199,7 +199,8 @@ export default {
 		addQualifiers: 'Add filter',
 		loading: 'Loading...',
 		suggestions: 'Suggestions',
-		showAll: 'Show search results'
+		showAll: 'Show search results',
+		searchHelp: 'Search help'
 	},
 	sort: {
 		sort: 'Sort',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -198,7 +198,8 @@ export default {
 		addQualifiers: 'Lägg till filter',
 		loading: 'Laddar...',
 		suggestions: 'Förslag',
-		showAll: 'Visa sökresultat'
+		showAll: 'Visa sökresultat',
+		searchHelp: 'Sökhjälp'
 	},
 	sort: {
 		sort: 'Sortera',

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -471,7 +471,14 @@
 			event.key === 'ArrowRight' ||
 			event.key === 'Tab'
 		) {
-			const rows = Array.from(dialog?.querySelectorAll(':scope [role=row]') || []);
+			const arrowKeyRows = Array.from(
+				dialog?.querySelectorAll(':scope [role=row]:not([data-skip-row-on-arrow-key])') || []
+			);
+
+			const rows =
+				event.key === 'Tab'
+					? Array.from(dialog?.querySelectorAll(':scope [role=row]') || [])
+					: arrowKeyRows;
 
 			const getColsInInputRow = () => {
 				return comboboxElement
@@ -527,7 +534,7 @@
 						hideExpandedSearch();
 					} else {
 						if (wrappingArrowKeyNavigation && activeRowIndex === 0) {
-							activeRowIndex = rows.length;
+							activeRowIndex = arrowKeyRows.length;
 							activeColIndex = 0;
 						} else if (activeRowIndex >= 1) {
 							activeRowIndex--;
@@ -549,10 +556,10 @@
 					}
 					break;
 				case 'ArrowDown':
-					if (wrappingArrowKeyNavigation && activeRowIndex === rows.length) {
+					if (wrappingArrowKeyNavigation && activeRowIndex === arrowKeyRows.length) {
 						activeRowIndex = 0;
 						activeColIndex = defaultInputCol;
-					} else if (activeRowIndex < rows.length) {
+					} else if (activeRowIndex < arrowKeyRows.length) {
 						activeRowIndex++;
 						const cols = getColsInRow(activeRowIndex - 1);
 						if (activeRowIndex === 1) {


### PR DESCRIPTION
## Description

### Solves

Adds a search help link in the expanded combobox.

It currently looks quite lonely in the bottom but the intention is to add keyboard navigation tips on the other side.

### Summary of changes

- Add search help shortcut in combobox
- Allow search help link to be tabbable but not navigable using arrow keys (using new `data-skip-row-on-arrow-key` attribute)