### PR TITLE
fix(lxl-web): resource summary and toc width

### DIFF
--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -500,9 +500,11 @@
 		}
 
 		& :global(.summary) {
-			display: inline-block;
-			/*max-width: 60ch;*/
-			text-align: justify;
+			max-width: 60ch;
+		}
+
+		& :global(div[data-property='tableOfContents']) {
+			max-width: 60ch;
 		}
 
 		& :global(div[data-property='tableOfContents'] > span[data-type='TableOfContents']) {


### PR DESCRIPTION
Summary and table of contents on resource page 
* max width. `60ch` seems to give ~70 characters 
* left justify

TODO
Split unstructured MARC style tocs with `--` to rows