### PR TITLE
feat(lxweb): stream stats

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -468,7 +468,7 @@
 }
 
 @utility skeleton {
-	@apply rounded-lg bg-neutral-100;
+	@apply animate-pulse rounded-lg bg-neutral-100;
 }
 
 /* OLD THEME */

--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -1,19 +1,49 @@
 <script lang="ts">
-	import { page, navigating } from '$app/state';
-	import { getModalContext } from '$lib/contexts/modal';
-	import { displayMappingToString } from '$lib/utils/displayMappingToString';
-	import type { DisplayMapping, Facet } from '$lib/types/search';
+	import { navigating, page } from '$app/state';
 	import FacetGroup from '$lib/components/find/FacetGroup.svelte';
-	import SearchMapping from './SearchMapping.svelte';
-	import BiSearch from '~icons/bi/search';
 	import { DEFAULT_FACETS_EXPANDED } from '$lib/constants/facets';
+	import { getModalContext } from '$lib/contexts/modal';
+	import type { DisplayMapping, Facet } from '$lib/types/search';
+	import { displayMappingToString } from '$lib/utils/displayMappingToString';
+	import BiSearch from '~icons/bi/search';
+	import SearchMapping from './SearchMapping.svelte';
 
 	type Props = {
-		facets: Facet[];
+		facets: Promise<Facet[]>;
 		mapping?: DisplayMapping[];
 	};
 
 	const { facets, mapping }: Props = $props();
+	let data = $state<Facet[] | null>(null);
+	let loading = $state(true);
+	let error = $state<unknown>(null);
+
+	let current = 0;
+
+	$effect(() => {
+		if (!facets) return;
+
+		const id = ++current;
+		loading = true;
+		error = null;
+
+		Promise.resolve(facets)
+			.then((resolved) => {
+				if (id === current) {
+					data = resolved;
+				}
+			})
+			.catch((e) => {
+				if (id === current) {
+					error = e;
+				}
+			})
+			.finally(() => {
+				if (id === current) {
+					loading = false;
+				}
+			});
+	});
 
 	function shouldShowMapping(m: DisplayMapping[]) {
 		return !!displayMappingToString(m).trim();
@@ -30,40 +60,57 @@
 			<SearchMapping {mapping} />
 		</nav>
 	{/if}
-	{#if facets?.length}
-		<nav class="facet-nav" aria-label={page.data.t('search.filters')} data-testid="facets">
-			<div class="relative mx-3 mt-3">
-				<input
-					bind:value={searchPhrase}
-					placeholder={page.data.t('search.findFilter')}
-					aria-label={page.data.t('search.findFilter')}
-					class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-base sm:text-sm"
-					type="search"
-					name={page.data.t('search.findFilter')}
-				/>
-				<BiSearch class="text-subtle absolute top-0 left-2.5 h-9 text-sm" />
-			</div>
-			<ul
-				aria-labelledby={'tab-filters'}
-				class={[
-					'text-sm',
-					navigating.to &&
-						navigating.from?.url.pathname === navigating.to?.url.pathname &&
-						'pointer-events-none opacity-50'
-				]}
+	{#if data}
+		{#if data?.length}
+			<nav
+				class="facet-nav"
+				aria-label={page.data.t('search.filters')}
+				data-testid="facets"
+				aria-busy={loading}
 			>
-				{#each facets as facet, index (facet.dimension)}
-					<li>
-						<FacetGroup
-							data={facet}
-							level={1}
-							{searchPhrase}
-							isDefaultExpanded={index < DEFAULT_FACETS_EXPANDED}
-						/>
-					</li>
-				{/each}
-			</ul>
-		</nav>
+				<div class="relative mx-3 mt-3">
+					<input
+						bind:value={searchPhrase}
+						placeholder={page.data.t('search.findFilter')}
+						aria-label={page.data.t('search.findFilter')}
+						class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-base sm:text-sm"
+						type="search"
+						name={page.data.t('search.findFilter')}
+					/>
+					<BiSearch class="text-subtle absolute top-0 left-2.5 h-9 text-sm" />
+				</div>
+				<ul
+					aria-labelledby={'tab-filters'}
+					class={[
+						'text-sm',
+						((navigating.to && navigating.from?.url.pathname === navigating.to?.url.pathname) ||
+							loading) &&
+							'pointer-events-none opacity-50'
+					]}
+				>
+					{#each data as facet, index (facet.dimension)}
+						<li>
+							<FacetGroup
+								data={facet}
+								level={1}
+								{searchPhrase}
+								isDefaultExpanded={index < DEFAULT_FACETS_EXPANDED}
+							/>
+						</li>
+					{/each}
+				</ul>
+			</nav>
+		{/if}
+	{:else if loading}
+		<div aria-busy="true" class="skeleton-container flex flex-col gap-2 overflow-hidden p-4">
+			{#each new Array(10)}
+				<div class="skeleton bg-neutral min-h-3 w-full"></div>
+				<div class="skeleton bg-neutral min-h-2 w-3/4"></div>
+				<div class="skeleton bg-neutral mb-2 min-h-2 w-5/6"></div>
+			{/each}
+		</div>
+	{:else if error}
+		<p>{error}</p>
 	{/if}
 </div>
 
@@ -71,5 +118,11 @@
 	:global(dialog .facet-nav) {
 		margin-right: calc(var(--spacing) * -4);
 		margin-left: calc(var(--spacing) * -4);
+	}
+
+	.skeleton-container {
+		max-height: calc(
+			100vh - var(--app-bar-height) - var(--banner-height, 0) - var(--toolbar-height, 0)
+		);
 	}
 </style>

--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -9,7 +9,7 @@
 	import SearchMapping from './SearchMapping.svelte';
 
 	type Props = {
-		facets: Promise<Facet[]>;
+		facets: Promise<Facet[]> | null;
 		mapping?: DisplayMapping[];
 	};
 
@@ -21,7 +21,10 @@
 	let current = 0;
 
 	$effect(() => {
-		if (!facets) return;
+		if (!facets) {
+			if (!data) loading = true;
+			return;
+		}
 
 		const id = ++current;
 		loading = true;

--- a/lxl-web/src/lib/components/find/Filters.svelte
+++ b/lxl-web/src/lib/components/find/Filters.svelte
@@ -9,43 +9,25 @@
 	import SearchMapping from './SearchMapping.svelte';
 
 	type Props = {
-		facets: Promise<Facet[]> | null;
+		facets: Promise<Facet[]>;
 		mapping?: DisplayMapping[];
 	};
 
 	const { facets, mapping }: Props = $props();
-	let data = $state<Facet[] | null>(null);
-	let loading = $state(true);
-	let error = $state<unknown>(null);
 
+	let prevData: Facet[] | null = $state(null);
 	let current = 0;
 
 	$effect(() => {
-		if (!facets) {
-			if (!data) loading = true;
-			return;
-		}
-
+		if (!facets) return;
 		const id = ++current;
-		loading = true;
-		error = null;
 
-		Promise.resolve(facets)
-			.then((resolved) => {
-				if (id === current) {
-					data = resolved;
-				}
-			})
-			.catch((e) => {
-				if (id === current) {
-					error = e;
-				}
-			})
-			.finally(() => {
-				if (id === current) {
-					loading = false;
-				}
-			});
+		Promise.resolve(facets).then((resolved) => {
+			if (id === current) {
+				// cache data to display (disabled) when loading next time
+				prevData = resolved;
+			}
+		});
 	});
 
 	function shouldShowMapping(m: DisplayMapping[]) {
@@ -57,64 +39,82 @@
 	let searchPhrase = $state('');
 </script>
 
+{#snippet facetSnippet(data: Facet[], loading: boolean = false)}
+	{#if data?.length}
+		<nav
+			class="facet-nav"
+			aria-label={page.data.t('search.filters')}
+			data-testid="facets"
+			aria-busy={loading}
+		>
+			<div class="relative mx-3 mt-3">
+				<input
+					bind:value={searchPhrase}
+					placeholder={page.data.t('search.findFilter')}
+					aria-label={page.data.t('search.findFilter')}
+					class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-base sm:text-sm"
+					type="search"
+					name={page.data.t('search.findFilter')}
+				/>
+				<BiSearch class="text-subtle absolute top-0 left-2.5 h-9 text-sm" />
+			</div>
+			<ul
+				aria-labelledby={'tab-filters'}
+				class={[
+					'text-sm',
+					((navigating.to && navigating.from?.url.pathname === navigating.to?.url.pathname) ||
+						loading) &&
+						'pointer-events-none opacity-50'
+				]}
+			>
+				{#each data as facet, index (facet.dimension)}
+					<li>
+						<FacetGroup
+							data={facet}
+							level={1}
+							{searchPhrase}
+							isDefaultExpanded={index < DEFAULT_FACETS_EXPANDED}
+						/>
+					</li>
+				{/each}
+			</ul>
+		</nav>
+	{/if}
+{/snippet}
+
+{#snippet skeleton()}
+	<div aria-busy="true" class="skeleton-container flex flex-col gap-2 overflow-hidden p-4">
+		{#each new Array(10)}
+			<div class="skeleton bg-neutral min-h-3 w-full"></div>
+			<div class="skeleton bg-neutral min-h-2 w-3/4"></div>
+			<div class="skeleton bg-neutral mb-2 min-h-2 w-5/6"></div>
+		{/each}
+	</div>
+{/snippet}
+
 <div class="flex flex-col gap-4">
 	{#if mapping && inModal && shouldShowMapping(mapping)}
 		<nav aria-label={page.data.t('search.selectedFilters')}>
 			<SearchMapping {mapping} />
 		</nav>
 	{/if}
-	{#if data}
-		{#if data?.length}
-			<nav
-				class="facet-nav"
-				aria-label={page.data.t('search.filters')}
-				data-testid="facets"
-				aria-busy={loading}
-			>
-				<div class="relative mx-3 mt-3">
-					<input
-						bind:value={searchPhrase}
-						placeholder={page.data.t('search.findFilter')}
-						aria-label={page.data.t('search.findFilter')}
-						class="bg-input h-9 w-full rounded-sm border border-neutral-300 pr-2 pl-8 text-base sm:text-sm"
-						type="search"
-						name={page.data.t('search.findFilter')}
-					/>
-					<BiSearch class="text-subtle absolute top-0 left-2.5 h-9 text-sm" />
-				</div>
-				<ul
-					aria-labelledby={'tab-filters'}
-					class={[
-						'text-sm',
-						((navigating.to && navigating.from?.url.pathname === navigating.to?.url.pathname) ||
-							loading) &&
-							'pointer-events-none opacity-50'
-					]}
-				>
-					{#each data as facet, index (facet.dimension)}
-						<li>
-							<FacetGroup
-								data={facet}
-								level={1}
-								{searchPhrase}
-								isDefaultExpanded={index < DEFAULT_FACETS_EXPANDED}
-							/>
-						</li>
-					{/each}
-				</ul>
-			</nav>
+	{#await facets}
+		{#if prevData}
+			{@render facetSnippet(prevData, true)}
+		{:else}
+			{@render skeleton()}
 		{/if}
-	{:else if loading}
-		<div aria-busy="true" class="skeleton-container flex flex-col gap-2 overflow-hidden p-4">
-			{#each new Array(10)}
-				<div class="skeleton bg-neutral min-h-3 w-full"></div>
-				<div class="skeleton bg-neutral min-h-2 w-3/4"></div>
-				<div class="skeleton bg-neutral mb-2 min-h-2 w-5/6"></div>
-			{/each}
-		</div>
-	{:else if error}
-		<p>{error}</p>
-	{/if}
+	{:then resolvedFacets}
+		{#if resolvedFacets}
+			{@render facetSnippet(resolvedFacets)}
+		{:else if page.url.searchParams.has('holdings') && prevData}
+			{@render facetSnippet(prevData)}
+		{:else if page.url.searchParams.has('holdings') && !prevData}
+			{@render skeleton()}
+		{/if}
+	{:catch error}
+		<p class="text-severe-700">{error.message}</p>
+	{/await}
 </div>
 
 <style lang="postcss">

--- a/lxl-web/src/lib/components/find/SearchResultSort.svelte
+++ b/lxl-web/src/lib/components/find/SearchResultSort.svelte
@@ -30,7 +30,7 @@
 		if (searchParams.has('_offset')) {
 			searchParams.set('_offset', '0');
 		}
-		goto(`${page.url.pathname}?${searchParams.toString()}`, { invalidateAll: true });
+		goto(`${page.url.pathname}?${searchParams.toString()}`, { invalidate: ['app:search'] });
 	}
 </script>
 

--- a/lxl-web/src/lib/components/find/SearchResultToolbar.svelte
+++ b/lxl-web/src/lib/components/find/SearchResultToolbar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import type { DisplayMapping, SearchResult } from '$lib/types/search';
+	import type { DisplayMapping, Facet, SearchResult } from '$lib/types/search';
 	import { getUserSettings } from '$lib/contexts/userSettings';
 	import { MAPPING_IGNORE_VARIABLE } from '$lib/constants/mapping';
 	import { fade } from 'svelte/transition';
@@ -22,6 +22,7 @@
 	const numHits = $derived(searchResult.totalItems);
 	const mapping = $derived(searchResult.mapping.filter((m) => m.variable === '_q'));
 	const filterCount = $derived(getFiltersCount(mapping));
+	const facets: Promise<Facet[]> = $derived(page.data.facets);
 
 	function getFiltersCount(mapping: DisplayMapping[]) {
 		const root = mapping.filter(
@@ -96,6 +97,6 @@
 				{numHits == 1 ? page.data.t('search.hitsOne') : page.data.t('search.hits')})
 			</span>
 		{/snippet}
-		<Filters facets={searchResult.facets || []} {mapping} />
+		<Filters {facets} {mapping} />
 	</Modal>
 {/if}

--- a/lxl-web/src/lib/remotes/searchResult.remote.ts
+++ b/lxl-web/src/lib/remotes/searchResult.remote.ts
@@ -24,6 +24,8 @@ export const getSearchResults = query(SearchResultsSchema, async (params) => {
 		searchParams.set('_r', _r);
 	}
 
+	searchParams.set('_stats', 'falseThisRequest');
+
 	const res = await fetch(`${env.API_URL}/find.jsonld?${searchParams.toString()}`);
 
 	if (!res.ok) {
@@ -52,6 +54,7 @@ export const getSearchResults = query(SearchResultsSchema, async (params) => {
 export const getAdjecentSearchResult = query(v.string(), async (viewId) => {
 	const { fetch, url } = getRequestEvent();
 	const searchParams = new URL(url.origin + viewId).searchParams;
+	searchParams.set('_stats', 'falseThisRequest');
 	const res = await fetch(`${env.API_URL}/find.jsonld?${searchParams.toString()}`);
 
 	if (!res.ok) {

--- a/lxl-web/src/lib/utils/relations.ts
+++ b/lxl-web/src/lib/utils/relations.ts
@@ -76,6 +76,7 @@ export async function getRelations(
 						_q: `${qualifierKey}${op}${qualifierValue}`,
 						_limit: '10',
 						_spell: 'false',
+						_stats: 'falseThisRequest',
 						...(subsetFilter && { _r: subsetFilter }),
 						...(searchSite && { _site: searchSite })
 					})

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -385,7 +385,7 @@ function isDatatypeProperty(data: unknown): data is DatatypeProperty {
 	return isObject(data) && data['@type'] === 'DatatypeProperty';
 }
 
-function displayFacets(
+export function displayFacets(
 	view: PartialCollectionView,
 	displayUtil: DisplayUtil,
 	locale: LangCode,

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+layout.server.ts
@@ -5,15 +5,10 @@ import { getTranslator } from '$lib/i18n';
 import { appendMyLibrariesParam, displayFacets } from '$lib/utils/search.js';
 import type { PartialCollectionView } from '$lib/types/search';
 
-export const load = async ({ url, params, fetch, locals }) => {
+export const load = async ({ url, params, fetch, locals, isDataRequest }) => {
 	const locale = getSupportedLocale(params?.lang);
 	const displayUtil = locals.display;
 	const myLibraries = locals.userSettings?.myLibraries;
-
-	// makes load function run on every navigation
-	// if (!url.searchParams.size) {
-	// 	redirect(303, `/`); // redirect to home page if no search params are given
-	// }
 
 	const searchParams = new URLSearchParams();
 
@@ -45,8 +40,12 @@ export const load = async ({ url, params, fetch, locals }) => {
 	}
 
 	if (holdingsParam) {
-		return { holdings: getHoldings(holdingsParam || ''), facets: null };
+		// support javascript disabled by fully SSR if "true" http request
+		return {
+			holdings: isDataRequest ? getHoldings(holdingsParam) : await getHoldings(holdingsParam),
+			facets: null
+		};
 	} else {
-		return { facets: getFacets() };
+		return { facets: isDataRequest ? getFacets() : await getFacets() };
 	}
 };

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+layout.server.ts
@@ -1,15 +1,29 @@
+import { env } from '$env/dynamic/private';
 import { getSupportedLocale } from '$lib/i18n/locales';
 import type { HoldingsData } from '$lib/types/holdings.js';
-import { redirect } from '@sveltejs/kit';
+import { getTranslator } from '$lib/i18n';
+import { appendMyLibrariesParam, displayFacets } from '$lib/utils/search.js';
+import type { PartialCollectionView } from '$lib/types/search';
 
-export const load = async ({ url, params, fetch }) => {
-	// makes load function run on every navigation
-	if (!url.searchParams.size) {
-		redirect(303, `/`); // redirect to home page if no search params are given
-	}
-
-	const holdingParam = url.searchParams.get('holdings');
+export const load = async ({ url, params, fetch, locals }) => {
 	const locale = getSupportedLocale(params?.lang);
+	const displayUtil = locals.display;
+	const myLibraries = locals.userSettings?.myLibraries;
+
+	// makes load function run on every navigation
+	// if (!url.searchParams.size) {
+	// 	redirect(303, `/`); // redirect to home page if no search params are given
+	// }
+
+	const searchParams = new URLSearchParams();
+
+	// reruns on change in these params:
+	const _q = url.searchParams.get('_q');
+	const _r = url.searchParams.get('_r');
+	const holdingsParam = url.searchParams.get('holdings');
+
+	searchParams.set('_q', _q || '');
+	if (_r) searchParams.set('_r', _r);
 
 	async function getHoldings(fnurgel: string): Promise<HoldingsData> {
 		const res = await fetch(`/api/${locale}/${fnurgel}/holdings`);
@@ -17,9 +31,22 @@ export const load = async ({ url, params, fetch }) => {
 		return holdings;
 	}
 
-	if (holdingParam) {
-		return { holdings: getHoldings(holdingParam) };
+	async function getFacets() {
+		searchParams.set('_stats', 'true');
+		searchParams.set('_limit', '0');
+
+		const recordsRes = await fetch(
+			`${env.API_URL}/find.jsonld?${appendMyLibrariesParam(searchParams, myLibraries).toString()}`
+		);
+		const view = (await recordsRes.json()) as PartialCollectionView;
+
+		const translate = await getTranslator(locale);
+		return displayFacets(view, displayUtil, locale, translate, '');
+	}
+
+	if (holdingsParam) {
+		return { holdings: getHoldings(holdingsParam || ''), facets: null };
 	} else {
-		return {};
+		return { facets: getFacets() };
 	}
 };

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
@@ -28,8 +28,9 @@ export const load = async ({ params, url, locals, fetch, depends }) => {
 	// reruns on change in these params:
 	const reactiveParams = ['_q', '_limit', '_offset', '_sort', '_r'];
 	reactiveParams.forEach((p) => {
-		const param = url.searchParams.get(p);
-		searchParams.set(p, param || '');
+		if (url.searchParams.has(p) || p === '_q') {
+			searchParams.set(p, url.searchParams.get(p) || '');
+		}
 	});
 
 	// fetch facets separately in layout

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
@@ -3,14 +3,15 @@ import { env } from '$env/dynamic/private';
 import { getSupportedLocale } from '$lib/i18n/locales.js';
 import { type ApiError } from '$lib/types/api.js';
 import type { PartialCollectionView } from '$lib/types/search.js';
-import { appendMyLibrariesParam, asResult } from '$lib/utils/search';
+import { appendMyLibrariesParam, asResult, displayFacets } from '$lib/utils/search';
 import { DebugFlags } from '$lib/types/userSettings';
 import { displayMappingToString } from '$lib/utils/displayMappingToString.js';
 import getPageTitle from '$lib/utils/getPageTitle';
 import { getRefinedOrgs } from '$lib/utils/getRefinedOrgs.server.js';
 import { getLibraryIdsFromMapping } from '$lib/utils/getLibraryIdsFromMapping.js';
+import { getTranslator } from '$lib/i18n';
 
-export const load = async ({ params, url, locals, fetch }) => {
+export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 	const displayUtil = locals.display;
 	const vocabUtil = locals.vocab;
 	const locale = getSupportedLocale(params?.lang);
@@ -33,6 +34,8 @@ export const load = async ({ params, url, locals, fetch }) => {
 	if (locals.site?.searchSite) {
 		searchParams.set('_site', locals.site?.searchSite);
 	}
+
+	searchParams.set('_stats', 'falseThisRequest');
 
 	const recordsRes = await fetch(
 		`${env.API_URL}/find.jsonld?${appendMyLibrariesParam(searchParams, myLibraries).toString()}${debug}`,
@@ -94,5 +97,28 @@ export const load = async ({ params, url, locals, fetch }) => {
 	const pageTitle = getPageTitle(displayMappingToString(searchResult.mapping), locals.site?.name);
 	const refinedOrgs = getRefinedOrgs(myLibraries, [subsetMapping, searchResult?.mapping]);
 
-	return { searchResult, pageTitle, refinedOrgs };
+	async function getFacets() {
+		const paramsMappingOnly = new URLSearchParams(searchParams);
+		paramsMappingOnly.set('_stats', 'true');
+		paramsMappingOnly.set('_limit', '0');
+		const recordsRes = await fetch(
+			`${env.API_URL}/find.jsonld?${appendMyLibrariesParam(paramsMappingOnly, myLibraries).toString()}${debug}`
+		);
+		const view = (await recordsRes.json()) as PartialCollectionView;
+
+		const translate = await getTranslator(locale);
+
+		return displayFacets(view, displayUtil, locale, translate, '');
+	}
+
+	const facetsPromise = getFacets();
+
+	return {
+		searchResult,
+		pageTitle,
+		refinedOrgs,
+		streamed: {
+			facets: isDataRequest ? facetsPromise : await facetsPromise
+		}
+	};
 };

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
@@ -3,15 +3,14 @@ import { env } from '$env/dynamic/private';
 import { getSupportedLocale } from '$lib/i18n/locales.js';
 import { type ApiError } from '$lib/types/api.js';
 import type { PartialCollectionView } from '$lib/types/search.js';
-import { appendMyLibrariesParam, asResult, displayFacets } from '$lib/utils/search';
+import { appendMyLibrariesParam, asResult } from '$lib/utils/search';
 import { DebugFlags } from '$lib/types/userSettings';
 import { displayMappingToString } from '$lib/utils/displayMappingToString.js';
 import getPageTitle from '$lib/utils/getPageTitle';
 import { getRefinedOrgs } from '$lib/utils/getRefinedOrgs.server.js';
 import { getLibraryIdsFromMapping } from '$lib/utils/getLibraryIdsFromMapping.js';
-import { getTranslator } from '$lib/i18n';
 
-export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
+export const load = async ({ params, url, locals, fetch, depends }) => {
 	const displayUtil = locals.display;
 	const vocabUtil = locals.vocab;
 	const locale = getSupportedLocale(params?.lang);
@@ -23,19 +22,22 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 
 	const searchParams = new URLSearchParams();
 
-	// find page load function reloads on change in these params:
-	const reactiveParams = ['_q', '_limit', '_offset', '_sort', '_spell', '_r'];
+	// used by sort to invalidate search results
+	depends('app:search');
+
+	// reruns on change in these params:
+	const reactiveParams = ['_q', '_limit', '_offset', '_sort', '_r'];
 	reactiveParams.forEach((p) => {
-		if (url.searchParams.has(p)) {
-			searchParams.set(p, url.searchParams.get(p) || '');
-		}
+		const param = url.searchParams.get(p);
+		searchParams.set(p, param || '');
 	});
+
+	// fetch facets separately in layout
+	searchParams.set('_stats', 'falseThisRequest');
 
 	if (locals.site?.searchSite) {
 		searchParams.set('_site', locals.site?.searchSite);
 	}
-
-	searchParams.set('_stats', 'falseThisRequest');
 
 	const recordsRes = await fetch(
 		`${env.API_URL}/find.jsonld?${appendMyLibrariesParam(searchParams, myLibraries).toString()}${debug}`,
@@ -97,28 +99,9 @@ export const load = async ({ params, url, locals, fetch, isDataRequest }) => {
 	const pageTitle = getPageTitle(displayMappingToString(searchResult.mapping), locals.site?.name);
 	const refinedOrgs = getRefinedOrgs(myLibraries, [subsetMapping, searchResult?.mapping]);
 
-	async function getFacets() {
-		const paramsMappingOnly = new URLSearchParams(searchParams);
-		paramsMappingOnly.set('_stats', 'true');
-		paramsMappingOnly.set('_limit', '0');
-		const recordsRes = await fetch(
-			`${env.API_URL}/find.jsonld?${appendMyLibrariesParam(paramsMappingOnly, myLibraries).toString()}${debug}`
-		);
-		const view = (await recordsRes.json()) as PartialCollectionView;
-
-		const translate = await getTranslator(locale);
-
-		return displayFacets(view, displayUtil, locale, translate, '');
-	}
-
-	const facetsPromise = getFacets();
-
 	return {
 		searchResult,
 		pageTitle,
-		refinedOrgs,
-		streamed: {
-			facets: isDataRequest ? facetsPromise : await facetsPromise
-		}
+		refinedOrgs
 	};
 };

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -22,7 +22,7 @@
 	import getPageTitle from '$lib/utils/getPageTitle';
 
 	const searchResult: SearchResult = $derived(page.data.searchResult);
-	const facets: Promise<Facet[]> = $derived(page.data.streamed.facets);
+	const facets: Promise<Facet[]> = $derived(page.data.facets);
 
 	const siteName = $derived(getPageTitle(undefined, page.data.siteName));
 	const searchQuery = $derived(page.url.searchParams.get('q') || page.url.searchParams.get('_q'));
@@ -85,7 +85,7 @@
 	>
 		<LeadingPane>
 			<div id="panel-filters" role="tabpanel" aria-labelledby="tab-filters">
-				<Filters facets={facets || []} />
+				<Filters {facets} />
 			</div>
 		</LeadingPane>
 		<div class="search-result-content @container/content flex flex-1 flex-col">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state';
 	import { afterNavigate, goto } from '$app/navigation';
 	import { MediaQuery, SvelteURLSearchParams } from 'svelte/reactivity';
-	import type { SearchResult } from '$lib/types/search';
+	import type { Facet, SearchResult } from '$lib/types/search';
 	import type { HoldingsData } from '$lib/types/holdings';
 	import SiteFooter from '../SiteFooter.svelte';
 	import { USE_HOLDING_PANE } from '$lib/constants/panels';
@@ -22,6 +22,7 @@
 	import getPageTitle from '$lib/utils/getPageTitle';
 
 	const searchResult: SearchResult = $derived(page.data.searchResult);
+	const facets: Promise<Facet[]> = $derived(page.data.streamed.facets);
 
 	const siteName = $derived(getPageTitle(undefined, page.data.siteName));
 	const searchQuery = $derived(page.url.searchParams.get('q') || page.url.searchParams.get('_q'));
@@ -84,7 +85,7 @@
 	>
 		<LeadingPane>
 			<div id="panel-filters" role="tabpanel" aria-labelledby="tab-filters">
-				<Filters facets={searchResult.facets || []} />
+				<Filters facets={facets || []} />
 			</div>
 		</LeadingPane>
 		<div class="search-result-content @container/content flex flex-1 flex-col">

--- a/lxl-web/src/routes/api/[[lang=lang]]/my-pages/+server.ts
+++ b/lxl-web/src/routes/api/[[lang=lang]]/my-pages/+server.ts
@@ -21,6 +21,7 @@ export const GET: RequestHandler = async ({ url, params, locals }) => {
 	}
 
 	const newSearchParams = new URLSearchParams([...Array.from(url.searchParams.entries())]);
+	newSearchParams.set('_stats', 'falseThisRequest');
 	const findRes = await fetch(`${env.API_URL}/find?${newSearchParams.toString()}`);
 
 	if (!findRes.ok) {


### PR DESCRIPTION
## Description

### Solves
With `_stats=falseThisRequest` we can omit stats from the response without any trace in the output links. That means we can fetch the **search results** and the **facets** separately and let the facets stream in when done.

I chose to put the stats fetch in the `+layout.server` file because we want to run it as seldom as possible. I.e when paginating or sorting, the stats are the same (and by not having the layout load function dependent on those, we can reuse the data instead).

Some additional features:
* We cache the old facet data in the component to display (if available) while waiting. That means the "disabled" look lasts from navigation start until we have new data. If no cached data, we display a "skeleton" instead. 
* To ensure users with javascript disabled can still access the filters, we await the data when the request is not coming from server side navigation (`isDataRequest`).

All and all, the site will hopefully feel a lot faster. Compare it to the beta :)

### Summary of changes

Summary of changes
* add `getFacets` to /find `+layout.server`
* Refactor `Filters` component
* Add '_stats', 'falseThisRequest' to some other fetches where stats are not needed.