### PR TITLE
fix(lxlweb): fix hydration mismatch

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -29,7 +29,6 @@
 	let expandedMenu = $state(page.url.hash === '#menu');
 	let dismissableBanner: boolean = $state(false);
 	let dismissedBanner: boolean = $state(false);
-	let pageYOffset: number | undefined = $state();
 
 	const otherLangCode = $derived(
 		Object.keys(Locales).find((locale) => locale !== page.data.locale) as LocaleCode
@@ -322,12 +321,7 @@
 						</p>
 					</hgroup>
 				{/if}
-				<AppSearch
-					id="app-search"
-					name="_q"
-					--page-y-offset={pageYOffset}
-					bind:this={appSearchComponent}
-				/>
+				<AppSearch id="app-search" name="_q" bind:this={appSearchComponent} />
 			</form>
 		</search>
 		<ul class="trailing-actions z-42 flex w-full items-center justify-end lg:gap-2">


### PR DESCRIPTION
## Description
### Solves

We get a hydration mismatch warning on every page
<img width="775" height="48" alt="Skärmavbild 2026-03-31 kl  11 49 46" src="https://github.com/user-attachments/assets/2be57fe6-6533-4561-bb1a-fe796281a37c" />

The culprit seems to be `--page-y-offset={pageYOffset}`
Removing it fixes the problem. 
I can't really detect the value it's supposed to set. Removing it makes no visible difference to me.
Maybe it has some function that i missed?

### Summary of changes

* remove `--page-y-offset={pageYOffset}`
