### PR TITLE
fix(lxlweb): fix zotero tag

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -78,7 +78,9 @@
 <div data-testid="resource-page" class="contents">
 	<!-- Zotero tag -->
 	{#if data.instances?.length}
-		<abbr class="unapi-id hidden" title={data.uri}></abbr>
+		{#each data.instances as instance (instance[JsonLd.ID])}
+			<abbr class="unapi-id hidden" title={instance[JsonLd.ID]}></abbr>
+		{/each}
 	{/if}
 	<Resource
 		fnurgel={page.params.fnurgel}

--- a/lxl-web/tests/cite.spec.ts
+++ b/lxl-web/tests/cite.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Zotero support', async () => {
+	const id = 'z7p0lb61wvsdl3x7';
+	test('A resource page should have a script tag with unapi link', async ({ page }) => {
+		await page.goto(`/${id}`);
+		const link = page.locator('link[rel="unapi-server"]');
+		await expect(link).toHaveAttribute('type', 'application/xml');
+		await expect(link).toHaveAttribute('href', '/api/sv/cite');
+	});
+
+	test('A resource page should have a <abbr> tag containing the resource id', async ({ page }) => {
+		await page.goto(`/${id}`);
+		const abbr = page.locator('abbr.unapi-id');
+		await expect(abbr).toHaveCount(1);
+		await expect(abbr).toHaveAttribute('title', new RegExp(`.+/${id}$`));
+	});
+});

--- a/lxl-web/tests/cite.spec.ts
+++ b/lxl-web/tests/cite.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Zotero support', async () => {
 	const id = 'z7p0lb61wvsdl3x7';
-	test('A resource page should have a script tag with unapi link', async ({ page }) => {
+	test('A resource page should have a link tag to unapi server', async ({ page }) => {
 		await page.goto(`/${id}`);
 		const link = page.locator('link[rel="unapi-server"]');
 		await expect(link).toHaveAttribute('type', 'application/xml');


### PR DESCRIPTION
## Description

### Solves

Page data from resource pages must have changed along the way with `resourceId` replacing `uri` (that now includes `#it`) silently breaking the zotero api call.

However, we should probably use `instance.@id`s instead, allowing all the instances to be listed for works (this was the case in the past, can't remember how that worked with the old code)

Anyway, also wrote a couple of tests so this can never happen again 😉 

### Summary of changes

* Fix `<abbr>` tag
* Write tests
