### PR TITLE
feat(lxlweb): more item details pt 1 

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -338,11 +338,23 @@
 						}
 					]
 				},
+				"Item": {
+					"@id": "Item-chips",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "Item",
+					"showProperties": ["heldBy", "itemOf"]
+				},
 				"Library": {
 					"@id": "Library-chips",
 					"@type": "fresnel:Lens",
 					"showProperties": ["name", "qualifier", "sigel"],
 					"classLensDomain": "Library"
+				},
+				"ItemAvailability": {
+					"@id": "ItemAvailability-chips",
+					"@type": "fresnel:Lens",
+					"showProperties": ["label"],
+					"classLensDomain": "ItemAvailability"
 				},
 				"Bibliography": {
 					"@id": "Bibliography-chips",
@@ -635,21 +647,6 @@
 						"isPartOf",
 						"part"
 					]
-				},
-				"Item": {
-					"@id": "Item-web-card",
-					"@type": "fresnel:Lens",
-					"classLensDomain": "Item",
-					"showProperties": [
-						"hasComponent",
-						"physicalLocation",
-						"shelfMark",
-						"shelfControlNumber",
-						"immediateAcquisition",
-						"availability",
-						{ "inverseOf": "itemUsed" },
-						{ "inverseOf": "hasComponent" }
-					]
 				}
 			}
 		},
@@ -875,6 +872,41 @@
 						"continuedInPartBy",
 						"relatedTo",
 						"accompaniedBy"
+					]
+				},
+				"Item": {
+					"@id": "Item-web-overview2",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "Item",
+					"showProperties": [
+						"shelfLabel",
+						"physicalLocation",
+						"shelfMark",
+						"shelfControlNumber",
+						"availability",
+						"hasNote",
+						"hasComponent",
+						"immediateAcquisition"
+					]
+				}
+			}
+		},
+		"web-overview-footer": {
+			"@id": "web-overview-footer",
+			"@type": "fresnel:Group",
+			"lenses": {
+				"Item": {
+					"@id": "Item-web-overview-footer",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "Item",
+					"showProperties": [
+						"cataloguersNote",
+						"custodialHistory",
+						"summary",
+						"appliesTo",
+						"marc:hasCopyAndVersionIdentificationNote",
+						"marc:hasBindingInformation",
+						"marc:hasTextualHoldingsBasicBibliographicUnit"
 					]
 				}
 			}

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -1446,6 +1446,7 @@
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Item"],
 			"fresnel:propertyFormatDomain": ["hasNote"],
+			"fresnel:propertyStyle": [""],
 			"fresnel:propertyFormat": {
 				"fresnel:contentBefore": " (",
 				"fresnel:contentAfter": ")"

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -840,6 +840,12 @@
 						"_select"
 					]
 				},
+				"Item": {
+					"@id": "Item-web-overview",
+					"@type": "fresnel:Lens",
+					"classLensDomain": "Item",
+					"showProperties": ["associatedMedia", "isPrimaryTopicOf"]
+				},
 				"Bibliography": {
 					"@id": "Bibliography-web-overview",
 					"@type": "fresnel:Lens",

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -1441,6 +1441,16 @@
 			"fresnel:propertyFormatDomain": ["hasNote"],
 			"fresnel:propertyStyle": ["hasNote"]
 		},
+		"Item-hasNote-format": {
+			"@id": "Item-hasNote-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Item"],
+			"fresnel:propertyFormatDomain": ["hasNote"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": " (",
+				"fresnel:contentAfter": ")"
+			}
+		},
 		"Classification-format": {
 			"@id": "Classification-format",
 			"@type": "fresnel:Format",

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -890,8 +890,8 @@
 						"shelfMark",
 						"shelfControlNumber",
 						"availability",
-						"hasNote",
 						"hasComponent",
+						"hasNote",
 						"immediateAcquisition"
 					]
 				}
@@ -907,11 +907,8 @@
 					"classLensDomain": "Item",
 					"showProperties": [
 						"cataloguersNote",
-						"custodialHistory",
 						"summary",
 						"appliesTo",
-						"marc:hasCopyAndVersionIdentificationNote",
-						"marc:hasBindingInformation",
 						"marc:hasTextualHoldingsBasicBibliographicUnit"
 					]
 				}

--- a/lxl-web/src/lib/components/Holder.svelte
+++ b/lxl-web/src/lib/components/Holder.svelte
@@ -215,11 +215,6 @@
 									{page.data.t('holdings.applyForCard')}
 								</a>
 							{/if}
-							<!-- {#if numInstances === 1 && instances?.[0].linkResolver}
-								<a href={instances[0].linkResolver.uri} target="_blank" class="ext-link"
-									>{instances[0].linkResolver.label}</a
-								>
-							{/if} -->
 						</div>
 					</li>
 				{/if}

--- a/lxl-web/src/lib/components/Holder.svelte
+++ b/lxl-web/src/lib/components/Holder.svelte
@@ -55,7 +55,9 @@
 				instance?.linksToItem.length ||
 				instance?.loanReserveLink.length ||
 				instance?.itemStatus?.length ||
-				instance?.shelfData
+				instance?.shelfData?._display?.length ||
+				instance?.itemNoteData?._display?.length ||
+				instance?.itemMedia?._display?.length
 		)
 	);
 

--- a/lxl-web/src/lib/components/Holder.svelte
+++ b/lxl-web/src/lib/components/Holder.svelte
@@ -77,24 +77,6 @@
 </script>
 
 {#snippet ItemSnippet(instance: InstanceWithLinks, bestLink?: string)}
-	{#if instance.shelfData}
-		<!-- shelfData -->
-		<li>
-			<p>
-				<span class="text-subtle">{page.data.t('holdings.shelfMark')}: </span>
-				<DecoratedData data={instance.shelfData} showLabels={ShowLabelsOptions.Never} />
-			</p>
-		</li>
-	{/if}
-	{#if instance.itemNoteData?._display?.length}
-		<!-- Item notes -->
-		<li>
-			<p>
-				<span class="text-subtle">{page.data.t('holdings.itemNote')}: </span>
-				<DecoratedData data={instance.itemNoteData} showLabels={ShowLabelsOptions.Never} />
-			</p>
-		</li>
-	{/if}
 	{#if bestLink || instance.linkResolver}
 		<li class="flex gap-2">
 			<!-- instance best link -->
@@ -115,6 +97,33 @@
 					{instance.linkResolver.label}
 				</a>
 			{/if}
+		</li>
+	{/if}
+	{#if instance.shelfData}
+		<!-- shelf data -->
+		<li>
+			<p>
+				<span class="text-subtle">{page.data.t('holdings.shelfMark')}: </span>
+				<DecoratedData data={instance.shelfData} showLabels={ShowLabelsOptions.Never} />
+			</p>
+		</li>
+	{/if}
+	{#if instance.itemMedia}
+		<!-- item media -->
+		<li>
+			<p>
+				<span class="text-subtle">{page.data.t('holdings.itemMedia')}: </span>
+				<DecoratedData data={instance.itemMedia} showLabels={ShowLabelsOptions.Never} />
+			</p>
+		</li>
+	{/if}
+	{#if instance.itemNoteData?._display?.length}
+		<!-- Item notes -->
+		<li>
+			<p>
+				<span class="text-subtle">{page.data.t('holdings.itemNote')}: </span>
+				<DecoratedData data={instance.itemNoteData} showLabels={ShowLabelsOptions.Never} />
+			</p>
 		</li>
 	{/if}
 	{#if instance.itemStatus?.[0]}

--- a/lxl-web/src/lib/components/Holder.svelte
+++ b/lxl-web/src/lib/components/Holder.svelte
@@ -99,8 +99,8 @@
 			{/if}
 		</li>
 	{/if}
-	{#if instance.shelfData}
-		<!-- shelf data -->
+	<!-- shelf data -->
+	{#if instance.shelfData?._display?.length}
 		<li>
 			<p>
 				<span class="text-subtle">{page.data.t('holdings.shelfMark')}: </span>
@@ -108,8 +108,8 @@
 			</p>
 		</li>
 	{/if}
-	{#if instance.itemMedia}
-		<!-- item media -->
+	<!-- item media -->
+	{#if instance.itemMedia?._display?.length}
 		<li>
 			<p>
 				<span class="text-subtle">{page.data.t('holdings.itemMedia')}: </span>
@@ -117,8 +117,8 @@
 			</p>
 		</li>
 	{/if}
+	<!-- Item notes -->
 	{#if instance.itemNoteData?._display?.length}
-		<!-- Item notes -->
 		<li>
 			<p>
 				<span class="text-subtle">{page.data.t('holdings.itemNote')}: </span>

--- a/lxl-web/src/lib/components/Holder.svelte
+++ b/lxl-web/src/lib/components/Holder.svelte
@@ -8,10 +8,12 @@
 		UnknownLibrary
 	} from '$lib/types/holdings';
 	import { JsonLd } from '$lib/types/xl';
-	import BiChevronRight from '~icons/bi/chevron-right';
-	import BiBoxArrowUpRight from '~icons/bi/box-arrow-up-right';
+	import { ShowLabelsOptions } from '$lib/types/decoratedData';
 	import { createHoldingLinks } from '$lib/utils/holdings';
 	import LoanStatus from './LoanStatus.svelte';
+	import DecoratedData from './DecoratedData.svelte';
+	import BiChevronRight from '~icons/bi/chevron-right';
+	import BiBoxArrowUpRight from '~icons/bi/box-arrow-up-right';
 
 	type Props = {
 		holder: LibraryWithLinksAndInstances | UnknownLibrary;
@@ -53,7 +55,7 @@
 				instance?.linksToItem.length ||
 				instance?.loanReserveLink.length ||
 				instance?.itemStatus?.length ||
-				instance?.itemStr
+				instance?.shelfData
 		)
 	);
 
@@ -73,6 +75,54 @@
 		return link;
 	}
 </script>
+
+{#snippet ItemSnippet(instance: InstanceWithLinks, bestLink?: string)}
+	{#if instance.shelfData}
+		<!-- shelfData -->
+		<li>
+			<p>
+				<span class="text-subtle">{page.data.t('holdings.shelfMark')}: </span>
+				<DecoratedData data={instance.shelfData} showLabels={ShowLabelsOptions.Never} />
+			</p>
+		</li>
+	{/if}
+	{#if instance.itemNoteData?._display?.length}
+		<!-- Item notes -->
+		<li>
+			<p>
+				<span class="text-subtle">{page.data.t('holdings.itemNote')}: </span>
+				<DecoratedData data={instance.itemNoteData} showLabels={ShowLabelsOptions.Never} />
+			</p>
+		</li>
+	{/if}
+	{#if bestLink || instance.linkResolver}
+		<li class="flex gap-2">
+			<!-- instance best link -->
+			{#if bestLink}
+				<a
+					href={getBestLink(instance)}
+					target="_blank"
+					class="ext-link"
+					aria-label={page.data.t('holdings.findAtLibrary')}
+					aria-describedby={`holder-${holder[JsonLd.ID]}`}
+				>
+					{page.data.t('holdings.linkToLocal')}
+				</a>
+			{/if}
+			<!-- instance linkserver link -->
+			{#if instance.linkResolver}
+				<a href={instance.linkResolver.uri} target="_blank" class="ext-link">
+					{instance.linkResolver.label}
+				</a>
+			{/if}
+		</li>
+	{/if}
+	{#if instance.itemStatus?.[0]}
+		<li>
+			<LoanStatus sigel={holder.sigel} bibIdObj={instance} />
+		</li>
+	{/if}
+{/snippet}
 
 <li class={['holder', hidden && 'hidden']}>
 	<article class="border-neutral bg-page flex flex-col rounded-sm border-b p-3">
@@ -106,7 +156,7 @@
 				<p>{page.data.t('errors.notAvailable')}</p>
 			</div>
 		{:else}
-			<ul class="flex flex-col gap-0.5 text-sm sm:text-xs">
+			<ul class="mt-1 flex flex-col gap-1 text-sm sm:text-xs">
 				{#if numInstances > 1 && expanded}
 					<!-- multiple instances list -->
 					{#each shownInstances as instance (instance.bibId)}
@@ -115,39 +165,7 @@
 							<h4 class="mb-1 font-medium">{instance.publicationStr || '-'}</h4>
 							<!-- instance item data -->
 							<ul class="flex flex-col gap-0.5">
-								{#if instance.itemStr}
-									<li>
-										<p>
-											<span class="text-subtle">{page.data.t('holdings.shelfMark')}: </span>
-											<span>{instance.itemStr}</span>
-										</p>
-									</li>
-								{/if}
-								<li class="flex gap-2">
-									<!-- instance best link -->
-									{#if bestLink}
-										<a
-											href={getBestLink(instance)}
-											target="_blank"
-											class="ext-link"
-											aria-label={page.data.t('holdings.findAtLibrary')}
-											aria-describedby={`holder-${holder[JsonLd.ID]}`}
-										>
-											{page.data.t('holdings.linkToLocal')}
-										</a>
-									{/if}
-									<!-- instance linkserver link -->
-									{#if instance.linkResolver}
-										<a href={instance.linkResolver.uri} target="_blank" class="ext-link">
-											{instance.linkResolver.label}
-										</a>
-									{/if}
-								</li>
-								{#if instance.itemStatus?.[0]}
-									<li>
-										<LoanStatus sigel={holder.sigel} bibIdObj={instance} />
-									</li>
-								{/if}
+								{@render ItemSnippet(instance, bestLink)}
 							</ul>
 						</li>
 					{/each}
@@ -172,21 +190,11 @@
 				<!-- single instance item data & loan status -->
 				{#if numInstances === 1}
 					{@const singleInstance = instances[0]}
-					{#if singleInstance.itemStr}
-						<li class="my-0.5">
-							<span class="text-subtle">{page.data.t('holdings.shelfMark')}: </span>
-							<span>{singleInstance.itemStr}</span>
-						</li>
-					{/if}
-					{#if singleInstance.itemStatus?.[0]}
-						<li class="mt-1">
-							<LoanStatus sigel={holder.sigel} bibIdObj={singleInstance} />
-						</li>
-					{/if}
+					{@render ItemSnippet(singleInstance)}
 				{/if}
 				<!-- Lopac general links / single instance linkserver link -->
-				{#if holder._links.myLoansLink || holder._links.registrationLink || instances[0].linkResolver}
-					<li class="mt-1">
+				{#if holder._links.myLoansLink || holder._links.registrationLink}
+					<li>
 						<div class="ml-4 flex flex-row gap-2">
 							{#if holder._links.myLoansLink}
 								<a target="_blank" class="ext-link" href={holder._links.myLoansLink}>
@@ -198,17 +206,17 @@
 									{page.data.t('holdings.applyForCard')}
 								</a>
 							{/if}
-							{#if numInstances === 1 && instances?.[0].linkResolver}
+							<!-- {#if numInstances === 1 && instances?.[0].linkResolver}
 								<a href={instances[0].linkResolver.uri} target="_blank" class="ext-link"
 									>{instances[0].linkResolver.label}</a
 								>
-							{/if}
+							{/if} -->
 						</div>
 					</li>
 				{/if}
 				<!-- opening hours / adress -->
 				{#if hasOpeningHoursEtc}
-					<li class="mt-1">
+					<li>
 						<details class="w-full">
 							<summary class="link-subtle flex cursor-pointer items-center gap-1">
 								<span

--- a/lxl-web/src/lib/components/HoldingsContent.svelte
+++ b/lxl-web/src/lib/components/HoldingsContent.svelte
@@ -70,7 +70,8 @@
 				libraries[libraryId][instanceId] = {
 					...bibIdData[instanceId],
 					shelfData: lib.shelfData,
-					itemNoteData: lib.itemNoteData
+					itemNoteData: lib.itemNoteData,
+					itemMedia: lib.itemMedia
 				};
 			}
 		}

--- a/lxl-web/src/lib/components/HoldingsContent.svelte
+++ b/lxl-web/src/lib/components/HoldingsContent.svelte
@@ -29,8 +29,8 @@
 
 	function getSelectionKind(selection?: string): SelectionKind {
 		if (!selection) return 'all';
-		if (byInstanceId[selection]) return 'instance';
-		if (byType[selection]) return 'type';
+		if (byInstanceId?.[selection]) return 'instance';
+		if (byType?.[selection]) return 'type';
 		if (isFnurgel(selection)) return 'work';
 		return 'all';
 	}
@@ -67,7 +67,11 @@
 				if (!libraries[libraryId]) {
 					libraries[libraryId] = {};
 				}
-				libraries[libraryId][instanceId] = { ...bibIdData[instanceId], itemStr: lib.itemStr };
+				libraries[libraryId][instanceId] = {
+					...bibIdData[instanceId],
+					shelfData: lib.shelfData,
+					itemNoteData: lib.itemNoteData
+				};
 			}
 		}
 

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -253,6 +253,8 @@
 						<DecoratedData
 							data={decoratedData.overviewFooter}
 							block
+							showLabels={ShowLabelsOptions.DefaultOn}
+							allowFindLinks={true}
 							limit={{ contribution: 5, hasVariant: 10, hasPart: 10 }}
 						/>
 					</div>

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -284,6 +284,7 @@ export default {
 		DigitalResource: 'Digital resource',
 		shelfMark: 'Shelf mark',
 		itemNote: 'Item note',
+		itemMedia: 'Related link',
 		location: 'Location',
 		shelf: 'Shelf',
 		status: 'Status',

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -283,6 +283,7 @@ export default {
 		PhysicalResource: 'Physical resource',
 		DigitalResource: 'Digital resource',
 		shelfMark: 'Shelf mark',
+		itemNote: 'Item note',
 		location: 'Location',
 		shelf: 'Shelf',
 		status: 'Status',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -284,6 +284,7 @@ export default {
 		DigitalResource: 'Digital',
 		shelfMark: 'Placering',
 		itemNote: 'Bestånd',
+		itemMedia: 'Relaterad länk',
 		location: 'Placering',
 		shelf: 'Hylla',
 		loanPolicy: 'Lånepolitik',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -283,6 +283,7 @@ export default {
 		PhysicalResource: 'Fysisk',
 		DigitalResource: 'Digital',
 		shelfMark: 'Placering',
+		itemNote: 'Bestånd',
 		location: 'Placering',
 		shelf: 'Hylla',
 		loanPolicy: 'Lånepolitik',

--- a/lxl-web/src/lib/types/holdings.ts
+++ b/lxl-web/src/lib/types/holdings.ts
@@ -1,4 +1,4 @@
-import type { BibDb, FramedData, JsonLd } from './xl';
+import type { BibDb, DisplayDecorated, FramedData, JsonLd } from './xl';
 
 export type HoldingMainEntity = {
 	[JsonLd.REVERSE]?: {
@@ -97,7 +97,8 @@ export type BibIdObj = {
 	issn: string[];
 	publicationStr: string;
 	titleStr: string;
-	itemStr: string | undefined;
+	shelfData: DisplayDecorated | undefined;
+	itemNoteData: DisplayDecorated | undefined;
 };
 
 export type BibIdData = { [instanceId: string]: BibIdObj };
@@ -105,7 +106,8 @@ export type BibIdData = { [instanceId: string]: BibIdObj };
 export type HoldersByInstanceId = {
 	[id: LibraryId]: {
 		[JsonLd.ID]: string;
-		itemStr?: string;
+		shelfData?: DisplayDecorated;
+		itemNoteData?: DisplayDecorated;
 	}[];
 };
 

--- a/lxl-web/src/lib/types/holdings.ts
+++ b/lxl-web/src/lib/types/holdings.ts
@@ -99,6 +99,7 @@ export type BibIdObj = {
 	titleStr: string;
 	shelfData: DisplayDecorated | undefined;
 	itemNoteData: DisplayDecorated | undefined;
+	itemMedia: DisplayDecorated | undefined;
 };
 
 export type BibIdData = { [instanceId: string]: BibIdObj };
@@ -108,6 +109,7 @@ export type HoldersByInstanceId = {
 		[JsonLd.ID]: string;
 		shelfData?: DisplayDecorated;
 		itemNoteData?: DisplayDecorated;
+		itemMedia?: DisplayDecorated;
 	}[];
 };
 

--- a/lxl-web/src/lib/types/xl.ts
+++ b/lxl-web/src/lib/types/xl.ts
@@ -202,6 +202,7 @@ export enum LensType {
 	WebCard = 'web-card',
 	WebOverview = 'web-overview',
 	WebOverview2 = 'web-overview2',
+	WebOverviewFooter = 'web-overview-footer',
 	WebDetails = 'web-details',
 	WebCardFooter = 'web-card-footer',
 	WebCardHeaderTop = 'web-card-header-top',

--- a/lxl-web/src/lib/utils/holdings.server.ts
+++ b/lxl-web/src/lib/utils/holdings.server.ts
@@ -81,16 +81,13 @@ export function getHoldingsByInstanceId(
 		result[id] = items.map((item) => {
 			return {
 				[JsonLd.ID]: item.heldBy[JsonLd.ID],
-				itemStr: getItemStr(item, displayUtil)
+				shelfData: displayUtil.lensAndFormat(item, LensType.WebOverview2, ''),
+				itemNoteData: displayUtil.lensAndFormat(item, LensType.WebOverviewFooter, '')
 			};
 		});
 	}
 
 	return result;
-}
-
-function getItemStr(item: FramedData, displayUtil: DisplayUtil) {
-	return toString(displayUtil.lensAndFormat(item, LensType.WebCard, ''));
 }
 
 export function getBibIdsByInstanceId(
@@ -135,7 +132,8 @@ export function getBibIdsByInstanceId(
 			issn,
 			publicationStr,
 			titleStr,
-			itemStr: undefined // append real item data per holder in component
+			shelfData: undefined, // append real item data per holder in component,
+			itemNoteData: undefined
 		};
 	}
 	return result;

--- a/lxl-web/src/lib/utils/holdings.server.ts
+++ b/lxl-web/src/lib/utils/holdings.server.ts
@@ -81,6 +81,7 @@ export function getHoldingsByInstanceId(
 		result[id] = items.map((item) => {
 			return {
 				[JsonLd.ID]: item.heldBy[JsonLd.ID],
+				itemMedia: displayUtil.lensAndFormat(item, LensType.WebOverview, ''),
 				shelfData: displayUtil.lensAndFormat(item, LensType.WebOverview2, ''),
 				itemNoteData: displayUtil.lensAndFormat(item, LensType.WebOverviewFooter, '')
 			};
@@ -133,7 +134,8 @@ export function getBibIdsByInstanceId(
 			publicationStr,
 			titleStr,
 			shelfData: undefined, // append real item data per holder in component,
-			itemNoteData: undefined
+			itemNoteData: undefined,
+			itemMedia: undefined
 		};
 	}
 	return result;

--- a/lxl-web/src/lib/utils/holdings.test.ts
+++ b/lxl-web/src/lib/utils/holdings.test.ts
@@ -24,7 +24,8 @@ describe('getBibIdsByInstanceId', () => {
 				publicationStr: publicationStr,
 				titleStr: publicationStr,
 				shelfData: undefined,
-				itemNoteData: undefined
+				itemNoteData: undefined,
+				itemMedia: undefined
 			}
 		});
 	});

--- a/lxl-web/src/lib/utils/holdings.test.ts
+++ b/lxl-web/src/lib/utils/holdings.test.ts
@@ -23,7 +23,8 @@ describe('getBibIdsByInstanceId', () => {
 				issn: [],
 				publicationStr: publicationStr,
 				titleStr: publicationStr,
-				itemStr: undefined
+				shelfData: undefined,
+				itemNoteData: undefined
 			}
 		});
 	});

--- a/lxl-web/src/lib/utils/xl.ts
+++ b/lxl-web/src/lib/utils/xl.ts
@@ -182,6 +182,7 @@ export class DisplayUtil {
 			case LensType.WebCardHeaderExtra:
 			case LensType.WebOverview:
 			case LensType.WebOverview2:
+			case LensType.WebOverviewFooter:
 			case LensType.WebDetails:
 				return LensType.Chip;
 			case LensType.WebCardFooter:

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -145,6 +145,8 @@ export const load = async ({ params, locals, fetch, url }) => {
 			: [])
 	];
 
+	const overviewFooter = displayUtil.lensAndFormat(mainEntity, LensType.WebOverviewFooter, locale);
+
 	const details = [
 		displayUtil.lensAndFormat(mainEntity, LensType.WebDetails, locale),
 		...(_instances.length === 1
@@ -329,7 +331,7 @@ export const load = async ({ params, locals, fetch, url }) => {
 			headingExtra: headingExtra,
 			overview: overview,
 			overview2: overview2,
-			overviewFooter: {},
+			overviewFooter: overviewFooter,
 			summary: summary,
 			resourceTableOfContents: resourceTableOfContents,
 			details: details,


### PR DESCRIPTION
## Description
### Solves

Add more data under three labels in the holdings panel; _placering_, _bestånd_, _relaterad länk_ (in line with old Libris)

Old Libris uses `fresnel:mergeProperties` to squash all relevant properties under a new namespace. We don't support that (yet), so the hack around that is to recreate these as `Item` lenses for our custom lens groups. i.e:

`Item-web-overview` -> _relaterad länk_
`Item-web-overview2` -> _placering_
`web-overview-footer` -> _bestånd_

example _placering_ & _bestånd_ ([link](http://localhost:5173/l3wgvwhx1q80cv2?holdings=PhysicalResource)):
Before:
<img width="460" height="111" alt="Skärmavbild 2026-04-09 kl  16 55 04" src="https://github.com/user-attachments/assets/056dd45e-7394-4cac-aa0f-f3401dfc0292" />
Now:
<img width="460" height="111" alt="Skärmavbild 2026-04-09 kl  16 55 54" src="https://github.com/user-attachments/assets/bff61eac-5587-4d6e-853d-d9a347ce027c" />
Old:
<img width="460" height="111" alt="Skärmavbild 2026-04-09 kl  16 56 45" src="https://github.com/user-attachments/assets/fbfea513-a04a-4135-aaf5-78b2d8c7d840" />

----
example _relaterad länk_ (`associatedMedia` & `isPrimaryTopicOf`)

Now ([link](http://localhost:5173/m5z9j7xz1d01cbv?holdings=DigitalResource)):
<img width="453" height="118" alt="Skärmavbild 2026-04-13 kl  15 26 31" src="https://github.com/user-attachments/assets/81302d8b-ed39-4a3f-9d00-01412cfea7b3" />

Old:
<img width="460" height="111" alt="Skärmavbild 2026-04-09 kl  17 00 24" src="https://github.com/user-attachments/assets/9cb116b5-3613-4780-88cd-cdfa3023c530" />


Now ([link](http://localhost:5173/cvn9gpgp123cj65?holdings=PhysicalResource)):
<img width="460" height="129" alt="Skärmavbild 2026-04-13 kl  15 30 17" src="https://github.com/user-attachments/assets/038cd073-ae30-4479-8775-fb87d02a25ee" />

Old:
<img width="533" height="118" alt="Skärmavbild 2026-04-13 kl  15 29 49" src="https://github.com/user-attachments/assets/bd7cddad-73b8-460b-8c65-c086298982fc" />

----

Of course the old site thought of everything, and I found a case that I can't solve (there are maybe more).
The property `copyNumber` gets some kind of special treatment, but I can't even find a mention in the display file.

([link](http://localhost:5173/l3wl4jtx4xg6p25?holdings=PhysicalResource))

<img width="460" height="153" alt="Skärmavbild 2026-04-13 kl  15 36 11" src="https://github.com/user-attachments/assets/e1848b78-4ae1-4215-abac-6ea9931863c0" />

<img width="492" height="111" alt="Skärmavbild 2026-04-09 kl  17 08 17" src="https://github.com/user-attachments/assets/cb274eb3-b855-44b9-8bcb-d8436543cebf" />


----

**TODO**: part 2 which is to list all item `subject`, `classification` etc among resource details.

### Summary of changes

Summary of changes
