### PR TITLE
fix(supersearch, lxl-web): Cancel debounced fetching timeouts

### DIFF
--- a/packages/supersearch/src/lib/utils/debounce.ts
+++ b/packages/supersearch/src/lib/utils/debounce.ts
@@ -2,13 +2,19 @@
 function debounce(callback: Function, wait: number | ((...args: any[]) => number | null) = 300) {
 	let timeout: ReturnType<typeof setTimeout>;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	return (...args: any[]) => {
+	const debounced = (...args: any[]) => {
 		clearTimeout(timeout);
 		const resolvedWait = typeof wait === 'function' ? wait(...args) : wait;
 		if (resolvedWait !== null) {
 			timeout = setTimeout(() => callback(...args), resolvedWait);
 		}
 	};
+
+	debounced.cancel = () => {
+		clearTimeout(timeout);
+	};
+
+	return debounced;
 }
 
 export default debounce;

--- a/packages/supersearch/src/lib/utils/useSearchRequest.svelte.ts
+++ b/packages/supersearch/src/lib/utils/useSearchRequest.svelte.ts
@@ -58,6 +58,9 @@ export function useSearchRequest({
 			return _data;
 		} catch (err) {
 			if (err instanceof Error) {
+				if (err.name === 'AbortError') {
+					return; // don't set an error message when intentionally aborting fetch
+				}
 				error = 'Failed to fetch data: ' + err.message;
 			} else {
 				error = 'Failed to fetch data';

--- a/packages/supersearch/src/lib/utils/useSearchRequest.svelte.ts
+++ b/packages/supersearch/src/lib/utils/useSearchRequest.svelte.ts
@@ -89,6 +89,8 @@ export function useSearchRequest({
 	}
 
 	function resetData() {
+		controller?.abort();
+		debouncedFetchData?.cancel();
 		data = undefined;
 		paginatedData = undefined;
 		moreSearchParams = undefined;


### PR DESCRIPTION
## Description

### Solves

The debounced fetching in the supersearch component had a tendency to show the results of unfinished fetch requests started _before_ resetting data – this fix ensures that the timeouts are cancelled/cleared when calling `resetData`.

(The problem is more apparent when the expanded search open is kept open (coming in a upcoming PR)).

### Summary of changes

- Clear debounced timeouts when resetting data
- Skip intentional `AbortError` messages
