### PR TITLE
perf(lxl-web): Compute qualiferSuggestions once

### DIFF
--- a/lxl-web/src/app.d.ts
+++ b/lxl-web/src/app.d.ts
@@ -4,7 +4,7 @@ import type { CitationsType } from '$lib/types/citation';
 import type { MatomoTracker } from '$lib/types/matomo';
 import type { UserSettings } from '$lib/types/userSettings';
 import type { DisplayUtil, VocabUtil } from '$lib/utils/xl';
-import type { AdjecentSearchResult, DisplayMapping } from '$lib/types/search';
+import type { AdjecentSearchResult, DisplayMapping, QualifierSuggestion2 } from '$lib/types/search';
 import 'unplugin-icons/types/svelte';
 import type { Site } from '$lib/types/site';
 
@@ -19,6 +19,7 @@ declare global {
 			userSettings: UserSettings;
 			site?: Site;
 			subsetMapping?: DisplayMapping[];
+			qualifierSuggestions: QualifierSuggestion2[];
 		}
 		interface LayoutData {
 			locale: import('$lib/i18n/locales').LocaleCode;

--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import type { RequestEvent } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
-import { defaultLocale, Locales } from '$lib/i18n/locales';
+import { defaultLocale, getSupportedLocale, Locales } from '$lib/i18n/locales';
 import { DERIVED_LENSES } from '$lib/types/display';
 import type { Site } from '$lib/types/site';
 import { DebugFlags, type MyLibrariesType, type UserSettings } from '$lib/types/userSettings';
@@ -9,13 +9,14 @@ import displayWeb from '$lib/assets/json/display-web.json';
 import { DisplayUtil, VocabUtil } from '$lib/utils/xl';
 import { startRefreshLibraries } from '$lib/utils/getLibraries.server';
 import { getSubsetMapping } from '$lib/utils/subsetCache.server';
+import { getQualifierSuggestions } from '$lib/utils/getQualifierSuggestions';
 
-type Util = [VocabUtil, DisplayUtil];
+type Util = [VocabUtil, DisplayUtil, Record<keyof Locales, (QualifierSuggestion2 | null)[]>];
 let utilCache: Util | undefined;
 let initLibraries: boolean = false;
 
 export const handle = async ({ event, resolve }) => {
-	const [vocabUtil, displayUtil] = await loadUtilCached();
+	const [vocabUtil, displayUtil, qualifierSuggestionsByLocale] = await loadUtilCached();
 
 	if (!initLibraries) {
 		initLibraries = true;
@@ -93,6 +94,8 @@ export const handle = async ({ event, resolve }) => {
 	const subsetMapping = await getSubsetMapping(_r, event.locals, lang);
 	event.locals.subsetMapping = subsetMapping;
 
+	event.locals.qualifierSuggestions = qualifierSuggestionsByLocale[getSupportedLocale(lang)];
+
 	return resolve(event, {
 		transformPageChunk: ({ html }) => html.replace('%lang%', lang).replace('%theme%', dataTheme)
 	});
@@ -156,7 +159,13 @@ async function loadUtil(): Promise<Util> {
 
 	DERIVED_LENSES.forEach((l) => displayUtil.registerDerivedLens(l));
 
-	return [vocabUtil, displayUtil];
+	const qualifierSuggestionsByLocale: Record<keyof Locales, (QualifierSuggestion2 | null)[]> = {};
+	Object.keys(Locales).forEach((locale) => {
+		qualifierSuggestionsByLocale[locale] = getQualifierSuggestions(locale, vocabUtil, displayUtil);
+	});
+	console.info('Loaded qualifierSuggestionsByLocale');
+
+	return [vocabUtil, displayUtil, qualifierSuggestionsByLocale];
 }
 
 function getSite(event: RequestEvent): Site | null {

--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -3,6 +3,7 @@ import type { RequestEvent } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { defaultLocale, getSupportedLocale, Locales } from '$lib/i18n/locales';
 import { DERIVED_LENSES } from '$lib/types/display';
+import type { QualifierSuggestion2 } from '$lib/types/search';
 import type { Site } from '$lib/types/site';
 import { DebugFlags, type MyLibrariesType, type UserSettings } from '$lib/types/userSettings';
 import displayWeb from '$lib/assets/json/display-web.json';
@@ -11,7 +12,8 @@ import { startRefreshLibraries } from '$lib/utils/getLibraries.server';
 import { getSubsetMapping } from '$lib/utils/subsetCache.server';
 import { getQualifierSuggestions } from '$lib/utils/getQualifierSuggestions';
 
-type Util = [VocabUtil, DisplayUtil, Record<keyof Locales, (QualifierSuggestion2 | null)[]>];
+type QualifierSuggestionsByLocale = Record<keyof typeof Locales, QualifierSuggestion2[]>;
+type Util = [VocabUtil, DisplayUtil, QualifierSuggestionsByLocale];
 let utilCache: Util | undefined;
 let initLibraries: boolean = false;
 
@@ -159,8 +161,8 @@ async function loadUtil(): Promise<Util> {
 
 	DERIVED_LENSES.forEach((l) => displayUtil.registerDerivedLens(l));
 
-	const qualifierSuggestionsByLocale: Record<keyof Locales, (QualifierSuggestion2 | null)[]> = {};
-	Object.keys(Locales).forEach((locale) => {
+	const qualifierSuggestionsByLocale = {} as QualifierSuggestionsByLocale;
+	(Object.keys(Locales) as Array<keyof typeof Locales>).forEach((locale) => {
 		qualifierSuggestionsByLocale[locale] = getQualifierSuggestions(locale, vocabUtil, displayUtil);
 	});
 	console.info('Loaded qualifierSuggestionsByLocale');

--- a/lxl-web/src/lib/utils/getQualifierSuggestions.ts
+++ b/lxl-web/src/lib/utils/getQualifierSuggestions.ts
@@ -34,9 +34,9 @@ export function getQualifierSuggestions(
 
 function mapSearchFilterDefinition(
 	def: FramedData,
-	locale,
+	locale: LocaleCode,
 	display: DisplayUtil,
-	compare
+	compare: (x: string, y: string) => number
 ): QualifierSuggestion2 | null {
 	try {
 		const otherLangLabels = otherLocales(locale).map((l) =>

--- a/lxl-web/src/lib/utils/getQualifierSuggestions.ts
+++ b/lxl-web/src/lib/utils/getQualifierSuggestions.ts
@@ -1,0 +1,72 @@
+import { type LocaleCode, otherLocales } from '$lib/i18n/locales';
+import { asArray, type DisplayUtil, toString, VocabUtil } from '$lib/utils/xl';
+import { type FramedData, JsonLd, LensType, Platform } from '$lib/types/xl';
+import type { QualifierSuggestion2 } from '$lib/types/search';
+import { getUriSlug } from '$lib/utils/http';
+
+export function getQualifierSuggestions(
+	locale: LocaleCode,
+	vocab: VocabUtil,
+	display: DisplayUtil
+) {
+	const compare = new Intl.Collator(locale).compare;
+
+	return vocab
+		.getPropertiesByCategory(Platform.searchfilter)
+		.map((p) => mapSearchFilterDefinition(p, locale, display, compare))
+		.filter((p) => p !== null)
+		.sort((a, b) => compare(a?.label, b?.label))
+		.sort((a, b) => {
+			const aIx = CURATED_ORDER.get(a.key);
+			const bIx = CURATED_ORDER.get(b.key);
+			if (aIx !== undefined && bIx !== undefined) {
+				return aIx - bIx;
+			}
+			if (aIx !== undefined) {
+				return -1;
+			}
+			if (bIx !== undefined) {
+				return 1;
+			}
+			return 0;
+		});
+}
+
+function mapSearchFilterDefinition(
+	def: FramedData,
+	locale,
+	display: DisplayUtil,
+	compare
+): QualifierSuggestion2 | null {
+	try {
+		const otherLangLabels = otherLocales(locale).map((l) =>
+			toString(display.lensAndFormat(def, LensType.Chip, l))
+		);
+		const key = getUriSlug(def[JsonLd.ID]) as string;
+
+		return {
+			// FIXME???,
+			key: key,
+			label: toString(display.lensAndFormat(def, LensType.Chip, locale)),
+			queryCodes: ((asArray(def['librisQueryCode']) || []) as string[]).sort((a, b) =>
+				compare(a, b)
+			),
+			altLabels: otherLangLabels,
+			...(CURATED_QUALIFIERS.includes(key) && { curated: true })
+		};
+	} catch (error) {
+		console.warn('Error mapping filter definition', error);
+		return null;
+	}
+}
+
+// TODO where do we specify this?
+const CURATED_QUALIFIERS = [
+	'contributor',
+	'title',
+	'language',
+	'yearPublished',
+	'subject',
+	'originalLanguage'
+];
+const CURATED_ORDER = new Map(CURATED_QUALIFIERS.map((value, index) => [value, index]));

--- a/lxl-web/src/routes/+layout.server.ts
+++ b/lxl-web/src/routes/+layout.server.ts
@@ -1,10 +1,4 @@
-import type { QualifierSuggestion2 } from '$lib/types/search';
-import { getSupportedLocale, type LocaleCode, otherLocales } from '$lib/i18n/locales.js';
-import { type FramedData, JsonLd, LensType, Platform } from '$lib/types/xl';
-import { asArray, type DisplayUtil, toString, VocabUtil } from '$lib/utils/xl';
-import { getUriSlug } from '$lib/utils/http';
-
-export async function load({ locals, url, params }) {
+export async function load({ locals, url }) {
 	const userSettings = locals.userSettings;
 
 	// create dependency to react to _r changes
@@ -12,8 +6,7 @@ export async function load({ locals, url, params }) {
 	const subsetMapping = locals.subsetMapping;
 
 	const siteName = locals.site?.name;
-	const locale = getSupportedLocale(params?.lang);
-	const qualifierSuggestions = getQualifierSuggestions(locale, locals.vocab, locals.display);
+	const qualifierSuggestions = locals.qualifierSuggestions;
 
 	return {
 		userSettings,
@@ -22,67 +15,3 @@ export async function load({ locals, url, params }) {
 		qualifierSuggestions
 	};
 }
-
-function getQualifierSuggestions(locale: LocaleCode, vocab: VocabUtil, display: DisplayUtil) {
-	const compare = new Intl.Collator(locale).compare;
-
-	return vocab
-		.getPropertiesByCategory(Platform.searchfilter)
-		.map((p) => mapSearchFilterDefinition(p, locale, display, compare))
-		.filter((p) => p !== null)
-		.sort((a, b) => compare(a?.label, b?.label))
-		.sort((a, b) => {
-			const aIx = CURATED_ORDER.get(a.key);
-			const bIx = CURATED_ORDER.get(b.key);
-			if (aIx !== undefined && bIx !== undefined) {
-				return aIx - bIx;
-			}
-			if (aIx !== undefined) {
-				return -1;
-			}
-			if (bIx !== undefined) {
-				return 1;
-			}
-			return 0;
-		});
-}
-
-function mapSearchFilterDefinition(
-	def: FramedData,
-	locale,
-	display: DisplayUtil,
-	compare
-): QualifierSuggestion2 | null {
-	try {
-		const otherLangLabels = otherLocales(locale).map((l) =>
-			toString(display.lensAndFormat(def, LensType.Chip, l))
-		);
-		const key = getUriSlug(def[JsonLd.ID]) as string;
-
-		return {
-			// FIXME???,
-			key: key,
-			label: toString(display.lensAndFormat(def, LensType.Chip, locale)),
-			queryCodes: ((asArray(def['librisQueryCode']) || []) as string[]).sort((a, b) =>
-				compare(a, b)
-			),
-			altLabels: otherLangLabels,
-			...(CURATED_QUALIFIERS.includes(key) && { curated: true })
-		};
-	} catch (error) {
-		console.warn('Error mapping filter definition', error);
-		return null;
-	}
-}
-
-// TODO where do we specify this?
-const CURATED_QUALIFIERS = [
-	'contributor',
-	'title',
-	'language',
-	'yearPublished',
-	'subject',
-	'originalLanguage'
-];
-
-const CURATED_ORDER = new Map(CURATED_QUALIFIERS.map((value, index) => [value, index]));


### PR DESCRIPTION
Compute qualiferSuggestions once instead of on every request.
They are static in relation to vocab.

took ~14% cpu when profiling locally with stress_search2_api_simple.py

- Move `getQualifierSuggestions()` to separate file
- Call once in hooks.server.ts `loadUtilCached()`

Before:
<img width="1814" height="669" alt="Skärmbild från 2026-04-13 16-41-46" src="https://github.com/user-attachments/assets/c5e9d63e-e710-48bd-b84e-27bb29c88eb1" />
