### PR TITLE
fix(lxlweb): avoid squeezed pills

### DIFF
--- a/lxl-web/src/lib/styles/lxlquery.css
+++ b/lxl-web/src/lib/styles/lxlquery.css
@@ -51,6 +51,10 @@
 	background-color: var(--color-accent-50);
 }
 
+.lxl-qualifier-value:not(:has(.lxl-ghost-paren)) {
+	padding-inline: calc(var(--spacing) * 1.5);
+}
+
 .atomic .lxl-qualifier-value {
 	border-radius: 0;
 }


### PR DESCRIPTION
## Description

### Solves

The only left-right padding of an unlinked pill value is now the (hidden) parenthesis. But sometimes the generated queries don't include them, resulting in 
<img width="451" height="63" alt="Skärmavbild 2026-04-14 kl  12 02 56" src="https://github.com/user-attachments/assets/aa6b56bc-09cf-42ac-9834-b39b19dd11ea" />

How about we add padding when the value does not contain `lxl-ghost-paren`?

<img width="451" height="63" alt="Skärmavbild 2026-04-14 kl  12 02 47" src="https://github.com/user-attachments/assets/4980f20a-a830-4a03-bb5b-e0d3e6efd82d" />