### PR TITLE
fix(lxlweb): resolve() causing broken links

### DIFF
--- a/lxl-web/src/lib/components/supersearch/Suggestion.svelte
+++ b/lxl-web/src/lib/components/supersearch/Suggestion.svelte
@@ -138,11 +138,11 @@
 						menuItems: [
 							...item.qualifiers.map((qualifier) => ({
 								label: `${page.data.t('search.addAs')} ${qualifier.label.toLocaleLowerCase()}`,
-								href: resolve(qualifier._q)
+								href: qualifier._q
 							})),
 							{
 								label: `${page.data.t('search.goToResource')}`,
-								href: resolve(resourceId || '')
+								href: resourceId || ''
 							}
 						],
 						placeAsSibling: true

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -420,7 +420,7 @@
 							{#each await getCategoryShortcuts(page.data.locale) as category (category.id)}
 								<li>
 									<a
-										href={resolve(page.data.localizeHref(category.href))}
+										href={page.data.localizeHref(category.href)}
 										id={category.id}
 										aria-labelledby="search-for {category.id}"
 										class="btn-outlined text-primary-900 border-primary-600/75 focus-visible:bg-primary-200 hover:bg-primary-200/50 min-w-12 px-2 py-1.5 text-center whitespace-nowrap @xl:px-3 @xl:py-2 @3xl:min-w-14 @5xl:min-h-10 @5xl:min-w-16"


### PR DESCRIPTION
## Description
### Solves

Both these:

<img width="500" height="478" alt="Skärmavbild 2026-04-15 kl  09 40 50" src="https://github.com/user-attachments/assets/8e8fcc85-96a4-424d-94e8-0c71b7b07c23" />
<img width="428" height="368" alt="Skärmavbild 2026-04-15 kl  09 40 15" src="https://github.com/user-attachments/assets/f8a5ccc9-23d1-4438-a981-f2a6accb8550" />

Is because `resolve()` cant handle links with uri:s in their params. I've encountered it before...

### Summary of changes

* Remove `resolve()`
