### PR TITLE
feat(lxl-web): Add keyboard interaction help

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -455,6 +455,19 @@
 		color: var(--color-page);
 		background-color: var(--color-accent);
 	}
+
+	/* keyboard input denotations */
+	.key {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border: 1px solid var(--color-neutral-300);
+		border-radius: var(--radius-md);
+		color: var(--color-placeholder);
+		background-color: none;
+		width: 1.75em;
+		height: 1.75em;
+	}
 }
 
 @custom-variant wide (&:where(.prefers-wide-layout, .prefers-wide-layout *));

--- a/lxl-web/src/lib/components/supersearch/SuperSearchFooterRow.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchFooterRow.svelte
@@ -70,7 +70,7 @@
 				<IconReturnKey class="absolute mt-0.5 size-3" aria-hidden="true" />
 				<span class="text-transparent">↵</span>
 			</kbd>
-			{returnKeyLabel}
+			<span data-testid="supersearch-return-key-label">{returnKeyLabel}</span>
 		</li>
 	</ul>
 	<a

--- a/lxl-web/src/lib/components/supersearch/SuperSearchFooterRow.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchFooterRow.svelte
@@ -1,14 +1,43 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
+	import IconArrowUpKey from '~icons/bi/arrow-up-short';
+	import IconArrowDownKey from '~icons/bi/arrow-right-short';
+	import IconArrowLeftKey from '~icons/bi/arrow-left-short';
+	import IconArrowRightKey from '~icons/bi/arrow-right-short';
+	import IconReturnKey from '~icons/bi/arrow-return-left';
 
 	type Props = {
+		inputRowIndex: number;
+		qualifiersRowIndex: number;
 		footerRowIndex: number;
 		getCellId: (rowIndex: number, cellIndex: number) => string | undefined;
+		isFocusedRow: (rowIndex: number) => boolean | undefined;
 		isFocusedCell: (rowIndex: number, cellIndex: number) => boolean | undefined;
 	};
 
-	let { footerRowIndex, getCellId, isFocusedCell }: Props = $props();
+	let {
+		inputRowIndex,
+		qualifiersRowIndex,
+		footerRowIndex,
+		getCellId,
+		isFocusedRow,
+		isFocusedCell
+	}: Props = $props();
+
+	/* The return key label is context-aware depending on what the user has focused */
+	const returnKeyLabel = $derived.by(() => {
+		if (isFocusedCell(inputRowIndex, 1)) {
+			return page.data.t('supersearch.clear');
+		}
+		if (isFocusedRow(inputRowIndex)) {
+			return page.data.t('supersearch.search');
+		}
+		if (isFocusedRow(qualifiersRowIndex)) {
+			return page.data.t('supersearch.add');
+		}
+		return page.data.t('supersearch.select');
+	});
 </script>
 
 <div
@@ -16,6 +45,34 @@
 	data-skip-row-on-arrow-key
 	class="border-neutral flex min-h-14 items-center justify-between gap-4 pl-4 text-sm sm:border-t"
 >
+	<ul class="text-placeholder hidden cursor-default items-center gap-4 sm:flex">
+		<li>
+			<kbd class="key" title={page.data.t('supersearch.arrowUpKey')}>
+				<IconArrowUpKey class="absolute size-4" aria-hidden="true" />
+				<span class="text-transparent">↑</span>
+			</kbd>
+			<kbd class="key" title={page.data.t('supersearch.arrowDownKey')}>
+				<IconArrowDownKey class="absolute size-4" aria-hidden="true" />
+				<span class="text-transparent">↓</span>
+			</kbd>
+			<kbd class="key" title={page.data.t('supersearch.arrowLeftKey')}>
+				<IconArrowLeftKey class="absolute size-4" aria-hidden="true" />
+				<span class="text-transparent">←</span>
+			</kbd>
+			<kbd class="key" title={page.data.t('supersearch.arrowRightKey')}>
+				<IconArrowRightKey class="absolute size-4" aria-hidden="true" />
+				<span class="text-transparent">→</span>
+			</kbd>
+			{page.data.t('supersearch.navigate')}
+		</li>
+		<li>
+			<kbd class="key" title={page.data.t('supersearch.returnKey')}>
+				<IconReturnKey class="absolute mt-0.5 size-3" aria-hidden="true" />
+				<span class="text-transparent">↵</span>
+			</kbd>
+			{returnKeyLabel}
+		</li>
+	</ul>
 	<a
 		href={resolve(page.data.localizeHref('/help'))}
 		id={getCellId(footerRowIndex, 0)}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchFooterRow.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchFooterRow.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
+
+	type Props = {
+		footerRowIndex: number;
+		getCellId: (rowIndex: number, cellIndex: number) => string | undefined;
+		isFocusedCell: (rowIndex: number, cellIndex: number) => boolean | undefined;
+	};
+
+	let { footerRowIndex, getCellId, isFocusedCell }: Props = $props();
+</script>
+
+<div
+	role="row"
+	data-skip-row-on-arrow-key
+	class="border-neutral flex min-h-14 items-center justify-between gap-4 pl-4 text-sm sm:border-t"
+>
+	<a
+		href={resolve(page.data.localizeHref('/help'))}
+		id={getCellId(footerRowIndex, 0)}
+		class={[
+			'text-link mr-4 justify-end hover:underline',
+			isFocusedCell(footerRowIndex, 0) && 'underline outline-2 -outline-offset-2'
+		]}
+	>
+		{page.data.t('supersearch.searchHelp')}
+	</a>
+</div>

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -13,6 +13,7 @@
 		type DebouncedWaitFunction,
 		type ExpandEvent
 	} from 'supersearch';
+	import SuperSearchFooterRow from './SuperSearchFooterRow.svelte';
 	import QualifierPill from './QualifierPill.svelte';
 	import Suggestion from './Suggestion.svelte';
 	import getLabelFromMappings from '$lib/utils/getLabelsFromMapping.svelte';
@@ -538,7 +539,7 @@
 			</div>
 		{/snippet}
 		{#snippet expandedContent({ resultsCount, resultsSnippet, getCellId, isFocusedCell })}
-			{@const searchHelpRowIndex = (showAddQualifiers ? 1 : 0) + (resultsCount || 0) + 1}
+			{@const footerRowIndex = (showAddQualifiers ? 1 : 0) + (resultsCount || 0) + 1}
 			<nav class="mt-3 lg:mt-4">
 				{#if showAddQualifiers}
 					<div
@@ -621,23 +622,7 @@
 						{@render resultsSnippet({ rowOffset: showAddQualifiers ? 2 : 1 })}
 					</div>
 				{/if}
-				<div
-					role="row"
-					data-skip-row-on-arrow-key
-					class="border-neutral mt-2 flex justify-end gap-4 border-t px-4 text-sm"
-				>
-					<!-- TODO: Add keyboard interaction help here -->
-					<a
-						href={resolve(page.data.localizeHref('/help'))}
-						id={getCellId(searchHelpRowIndex, 0)}
-						class={[
-							'text-link flex min-h-14 items-center justify-end overflow-hidden px-4 hover:underline',
-							isFocusedCell(searchHelpRowIndex, 0) && 'underline'
-						]}
-					>
-						{page.data.t('supersearch.searchHelp')}
-					</a>
-				</div>
+				<SuperSearchFooterRow {footerRowIndex} {getCellId} {isFocusedCell} />
 			</nav>
 		{/snippet}
 		{#snippet resultItemRow({ resultItem, getCellId, isFocusedCell })}

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -538,7 +538,15 @@
 				</button>
 			</div>
 		{/snippet}
-		{#snippet expandedContent({ resultsCount, resultsSnippet, getCellId, isFocusedCell })}
+		{#snippet expandedContent({
+			resultsCount,
+			resultsSnippet,
+			getCellId,
+			isFocusedRow,
+			isFocusedCell
+		})}
+			{@const inputRowIndex = 0}
+			{@const qualifiersRowIndex = showAddQualifiers ? 1 : -1}
 			{@const footerRowIndex = (showAddQualifiers ? 1 : 0) + (resultsCount || 0) + 1}
 			<nav class="mt-3 lg:mt-4">
 				{#if showAddQualifiers}
@@ -622,7 +630,14 @@
 						{@render resultsSnippet({ rowOffset: showAddQualifiers ? 2 : 1 })}
 					</div>
 				{/if}
-				<SuperSearchFooterRow {footerRowIndex} {getCellId} {isFocusedCell} />
+				<SuperSearchFooterRow
+					{inputRowIndex}
+					{qualifiersRowIndex}
+					{footerRowIndex}
+					{getCellId}
+					{isFocusedRow}
+					{isFocusedCell}
+				/>
 			</nav>
 		{/snippet}
 		{#snippet resultItemRow({ resultItem, getCellId, isFocusedCell })}

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -198,6 +198,15 @@ export default {
 		loading: 'Loading...',
 		suggestions: 'Suggestions',
 		showAll: 'Show search results',
+		arrowUpKey: 'Arrow Up key',
+		arrowRightKey: 'Arrow Right key',
+		arrowDownKey: 'Arrow Down key',
+		arrowLeftKey: 'Arrow Left key',
+		returnKey: 'Return key',
+		navigate: 'Navigate',
+		select: 'Select',
+		clear: 'Clear',
+		add: 'Add',
 		searchHelp: 'Search help'
 	},
 	sort: {

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -197,6 +197,15 @@ export default {
 		loading: 'Laddar...',
 		suggestions: 'Förslag',
 		showAll: 'Visa sökresultat',
+		arrowUpKey: 'Piltangent uppåt',
+		arrowRightKey: 'Piltangent höger',
+		arrowDownKey: 'Piltangent neråt',
+		arrowLeftKey: 'Piltangent vänster',
+		returnKey: 'Returtangent',
+		navigate: 'Navigera',
+		select: 'Välj',
+		clear: 'Rensa',
+		add: 'Lägg till',
 		searchHelp: 'Sökhjälp'
 	},
 	sort: {

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -301,6 +301,10 @@ test('return key label is context-aware', async ({ page }) => {
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.getByTestId('supersearch').getByRole('dialog').getByRole('combobox').fill('a');
 	await page.keyboard.press('Tab');
+	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
+		'aria-activedescendant',
+		'supersearch-item-0x1'
+	);
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Rensa');
 	await page.keyboard.press('Backspace');
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
@@ -309,5 +313,9 @@ test('return key label is context-aware', async ({ page }) => {
 	await page.keyboard.press('ArrowUp');
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('Shift+Tab');
+	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
+		'aria-activedescendant',
+		'supersearch-item-2x0'
+	);
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Välj');
 });

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -295,3 +295,16 @@ test('qualifier keys can be added using keyboard only', async ({ page, context }
 		'arrow key navigation works as intended after adding qualifier key'
 	).toBe('c contributor:(a)b');
 });
+
+test('return key label is context-aware', async ({ page }) => {
+	await page.getByTestId('supersearch').getByRole('combobox').click();
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	await page.getByTestId('supersearch').getByRole('dialog').getByRole('combobox').fill('a');
+	await page.keyboard.press('Tab');
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Rensa');
+	await page.keyboard.press('Enter');
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	await page.keyboard.press('ArrowUp');
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
+	// TODO: Add test for 'Välj' label
+});

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -302,9 +302,12 @@ test('return key label is context-aware', async ({ page }) => {
 	await page.getByTestId('supersearch').getByRole('dialog').getByRole('combobox').fill('a');
 	await page.keyboard.press('Tab');
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Rensa');
-	await page.keyboard.press('Enter');
+	await page.keyboard.press('Backspace');
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
-	await page.keyboard.press('ArrowUp');
+	await page.keyboard.press('ArrowDown');
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
-	// TODO: Add test for 'Välj' label
+	await page.keyboard.press('ArrowUp');
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	await page.keyboard.press('Shift+Tab');
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Välj');
 });


### PR DESCRIPTION
## Description

### Solves

Adds keyboard interaction help in the expanded search component.

<img width="949" height="250" alt="Skärmavbild 2026-04-15 kl  15 06 00" src="https://github.com/user-attachments/assets/5986bbde-85df-4c3e-9368-cd64299fdfe8" />

### Summary of changes

- Add keyboard interaction help
- Add tailwind component class for keyboard input denotations
- Add component for supersearch footer row
- Add test for context-aware return key label
