### PR TITLE
feat(supersearch): Add wrapping left/right navigation

### DIFF
--- a/packages/supersearch/e2e/supersearch.spec.ts
+++ b/packages/supersearch/e2e/supersearch.spec.ts
@@ -175,6 +175,18 @@ test('supports keyboard navigation between rows and columns/cells', async ({ pag
 	).not.toHaveAttribute('aria-activedescendant', /.+/);
 	await page.keyboard.press('ArrowDown');
 	await expect(comboboxElement).toHaveAttribute('aria-activedescendant', 'supersearch-item-1x0');
+	await page.keyboard.press('ArrowDown');
+	await expect(comboboxElement).toHaveAttribute('aria-activedescendant', 'supersearch-item-2x0');
+	await page.keyboard.press('ArrowLeft');
+	await expect(
+		comboboxElement,
+		'user can jump from first col to last by pressing arrow left if wrappingArrowKeyNavigation is enabled'
+	).toHaveAttribute('aria-activedescendant', 'supersearch-item-2x2');
+	await page.keyboard.press('ArrowRight');
+	await expect(
+		comboboxElement,
+		'user can jump from last col to first by pressing arrow right if wrappingArrowKeyNavigation is enabled'
+	).toHaveAttribute('aria-activedescendant', 'supersearch-item-2x0');
 });
 
 test('user can toggle expanded search using alt key + arrow up or down (without moving cursor) ', async ({

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -556,7 +556,7 @@
 					}
 					break;
 				case 'ArrowDown':
-					if (wrappingArrowKeyNavigation && activeRowIndex === arrowKeyRows.length) {
+					if (wrappingArrowKeyNavigation && activeRowIndex >= arrowKeyRows.length) {
 						activeRowIndex = 0;
 						activeColIndex = defaultInputCol;
 					} else if (activeRowIndex < arrowKeyRows.length) {

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -574,12 +574,23 @@
 					}
 					break;
 				case 'ArrowLeft':
-					if (activeRowIndex >= 1 && activeColIndex > 0) {
+					if (wrappingArrowKeyNavigation && activeRowIndex >= 1 && activeColIndex === 0) {
+						activeColIndex = Math.max(0, getColsInRow(activeRowIndex - 1).length - 1);
+					} else if (activeRowIndex >= 1 && activeColIndex > 0) {
 						activeColIndex = getColIndexBefore(activeRowIndex - 1, activeColIndex);
 					}
 					break;
 				case 'ArrowRight':
-					if (activeRowIndex >= 1 && activeColIndex < getColsInRow(activeRowIndex - 1).length - 1) {
+					if (
+						wrappingArrowKeyNavigation &&
+						activeRowIndex >= 1 &&
+						activeColIndex === getColsInRow(activeRowIndex - 1).length - 1
+					) {
+						activeColIndex = 0;
+					} else if (
+						activeRowIndex >= 1 &&
+						activeColIndex < getColsInRow(activeRowIndex - 1).length - 1
+					) {
 						activeColIndex = getColIndexAfter(activeRowIndex - 1, activeColIndex);
 					}
 


### PR DESCRIPTION
## Description

### Solves

Adds horizontal wrapping when the supersearch component using left/right arrow keys (if `wrappingArrowKeyNavigation` is enabled).

This is useful for further improvements of the expanded search in `lxl-web` (running `npm run prebuild-local-dependencies` is then required).

### Summary of changes

- Add wrapping left/right arrow key navigation
- Fix wrapping down arrow key navigation on last row
- Add test for left/right wrapping arrow key navigation