### PR TITLE
fix(cataloging,idkbse,lxl-web): add Anubis cookies to cookie consent info + fix language bug

### DIFF
--- a/cataloging/src/settings.js
+++ b/cataloging/src/settings.js
@@ -557,6 +557,16 @@ export default {
                       name: "cc_cookie",
                       description: "Används för att spara dina kakinställningar.",
                       duration: "6 månader"
+                    },
+                    {
+                      name: "techaro.lol-anubis-auth",
+                      description: "Sparas när din webbläsare klarat en säkerhetskontroll som skyddar mot automatiserade bottar. Den gör att du slipper genomgå kontrollen på nytt vid varje sidbesök.",
+                      duration: "1 vecka"
+                    },
+                    {
+                      name: "techaro.lol-anubis-cookie-verification",
+                      description: "Används för att kontrollera att din webbläsare accepterar kakor, vilket krävs för att säkerhetskontrollen ska fungera.",
+                      duration: "30 minuter"
                     }
                   ]
                 }

--- a/idkbse/src/plugins/cookieConsent.js
+++ b/idkbse/src/plugins/cookieConsent.js
@@ -40,7 +40,27 @@ const cookieConsentConfig = {
               title: 'Nödvändiga kakor',
               description:
                 'Dessa krävs för att tjänsten ska vara säker och fungera som den ska.',
-              linkedCategory: 'necessary'
+              linkedCategory: 'necessary',
+              cookieTable: {
+                title: "Lista över kakor",
+                headers: {
+                  name: "Namn",
+                  description: "Beskrivning",
+                  duration: "Varaktighet"
+                },
+                body: [
+                  {
+                    name: "techaro.lol-anubis-auth",
+                    description: "Sparas när din webbläsare klarat en säkerhetskontroll som skyddar mot automatiserade bottar. Den gör att du slipper genomgå kontrollen på nytt vid varje sidbesök.",
+                    duration: "1 vecka"
+                  },
+                  {
+                    name: "techaro.lol-anubis-cookie-verification",
+                    description: "Används för att kontrollera att din webbläsare accepterar kakor, vilket krävs för att säkerhetskontrollen ska fungera.",
+                    duration: "30 minuter"
+                  }
+                ]
+              }
             },
             {
               title: 'Analytiska kakor',

--- a/lxl-web/src/lib/components/CookieConsent.svelte
+++ b/lxl-web/src/lib/components/CookieConsent.svelte
@@ -59,4 +59,8 @@
 	onMount(() => {
 		CookieConsent.run(config);
 	});
+
+	$effect(() => {
+		CookieConsent.setLanguage(page.data.locale);
+	});
 </script>

--- a/lxl-web/src/lib/i18n/cookieConsent/en.js
+++ b/lxl-web/src/lib/i18n/cookieConsent/en.js
@@ -23,7 +23,29 @@ export default {
 				title: 'Necessary cookies',
 				description:
 					'These cookies are essential for the proper functioning of the website and cannot be disabled.',
-				linkedCategory: 'necessary'
+				linkedCategory: 'necessary',
+				cookieTable: {
+					title: 'Lista över kakor',
+					headers: {
+						name: 'Namn',
+						description: 'Beskrivning',
+						duration: 'Varaktighet'
+					},
+					body: [
+						{
+							name: 'techaro.lol-anubis-auth',
+							description:
+								"Saved when your browser has passed a security check against automated bots. It means you don't have to go through the check again on each page visit.",
+							duration: '1 week'
+						},
+						{
+							name: 'techaro.lol-anubis-cookie-verification',
+							description:
+								'Used to check that your browser accepts cookies, which is required for the security check to work.',
+							duration: '30 minutes'
+						}
+					]
+				}
 			},
 			{
 				title: 'Analytical cookies',

--- a/lxl-web/src/lib/i18n/cookieConsent/sv.js
+++ b/lxl-web/src/lib/i18n/cookieConsent/sv.js
@@ -24,7 +24,29 @@ export default {
 				title: 'Nödvändiga kakor',
 				description:
 					'Dessa kakor krävs för att tjänsten ska vara säker och fungera som den ska. Därför går de inte att inaktivera.',
-				linkedCategory: 'necessary'
+				linkedCategory: 'necessary',
+				cookieTable: {
+					title: 'Lista över kakor',
+					headers: {
+						name: 'Namn',
+						description: 'Beskrivning',
+						duration: 'Varaktighet'
+					},
+					body: [
+						{
+							name: 'techaro.lol-anubis-auth',
+							description:
+								'Sparas när din webbläsare klarat en säkerhetskontroll som skyddar mot automatiserade bottar. Den gör att du slipper genomgå kontrollen på nytt vid varje sidbesök.',
+							duration: '1 vecka'
+						},
+						{
+							name: 'techaro.lol-anubis-cookie-verification',
+							description:
+								'Används för att kontrollera att din webbläsare accepterar kakor, vilket krävs för att säkerhetskontrollen ska fungera.',
+							duration: '30 minuter'
+						}
+					]
+				}
 			},
 			{
 				title: 'Analytiska kakor',


### PR DESCRIPTION
Adds info about Anubis cookies to the cookie consent modals.

Also fixes the bug where if you used the language switcher on Libris sök, the cookie consent modal language wouldn't change.