### PR TITLE
fix(lxlweb): avoid pointless truncation

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
@@ -66,20 +66,27 @@ export const load = async ({ params, url, locals, fetch, depends }) => {
 
 	const result = (await recordsRes.json()) as PartialCollectionView;
 
-	// zero hits -> redirect to a search with wildcard at cursor position
-	if (
-		result.totalItems === 0 &&
-		url.searchParams.get('_cursor') &&
-		!url.searchParams.has('_relaxed')
-	) {
-		const cursor = url.searchParams.get('_cursor');
+	// zero hits -> try truncating the search
+	if (result.totalItems === 0) {
+		const _cursor = url.searchParams.get('_cursor');
+		const _relaxed = url.searchParams.has('_relaxed');
 		const retryParams = new URLSearchParams(url.searchParams);
 		const _q = retryParams.get('_q');
 
-		if (cursor && _q) {
-			const _qWithWildCard = _q.slice(0, parseInt(cursor)) + '*' + _q.slice(parseInt(cursor));
-			retryParams.set('_q', _qWithWildCard);
+		if (_cursor && _q && !_relaxed) {
+			// add wildcard
+			const _qWithWildcard = _q.slice(0, parseInt(_cursor)) + '*' + _q.slice(parseInt(_cursor));
+			retryParams.set('_q', _qWithWildcard);
 			retryParams.set('_relaxed', 'true');
+
+			redirect(302, `${url.pathname}?${retryParams.toString()}`);
+		}
+
+		if (_cursor && _q && _relaxed && _q.slice(parseInt(_cursor)).startsWith('*')) {
+			// tried it, still no hits -> remove wildcard
+			const _qWithoutWildcard = _q.slice(0, parseInt(_cursor)) + _q.slice(parseInt(_cursor) + 1);
+			retryParams.set('_q', _qWithoutWildcard);
+			retryParams.delete('_relaxed');
 			retryParams.delete('_cursor');
 
 			redirect(302, `${url.pathname}?${retryParams.toString()}`);


### PR DESCRIPTION
## Description

### Solves

The automatic truncation is great when it's helping:

<img width="687" height="244" alt="Skärmavbild 2026-04-16 kl  16 34 22" src="https://github.com/user-attachments/assets/34c34806-2914-4555-ad20-0920a413d0fb" />

But confusing when it's not helping:

<img width="687" height="244" alt="Skärmavbild 2026-04-16 kl  16 35 55" src="https://github.com/user-attachments/assets/d8b28c49-825d-4fbb-85cc-11be65d76b56" />

The user might think "maybe i got zero hits because of that weird char I didn't even type" and try removing it and it can't be done 🙈 

This _redirects back_ to the original query when the truncation was pointless. I thought the double redirect would take too much time but turns out it doesn't. This feels like much better UX.

<img width="687" height="244" alt="Skärmavbild 2026-04-16 kl  16 39 07" src="https://github.com/user-attachments/assets/904578fb-344a-4e43-9ff1-3ee4c632a2f5" />

### Summary of changes

* Redirect back when `_relaxed` and still 0 hits
