### PR TITLE
feat(lxl-web): Prevent lost value and selection when loading supersearch

### DIFF
--- a/lxl-web/src/lib/components/supersearch/SuperSearchFallback.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchFallback.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import IconSearch from '~icons/bi/search';
+	import IconClear from '~icons/bi/x-circle';
+
+	interface Props {
+		placeholder: string;
+		ariaLabelledBy?: string;
+		ariaLabel?: string;
+	}
+
+	let { placeholder, ariaLabel, ariaLabelledBy }: Props = $props();
+
+	let fallbackInputElement: HTMLInputElement | undefined = $state();
+
+	let value = $derived(page.url.searchParams.get('_q'));
+
+	$effect(() => {
+		if (page.url.hash === `#search`) {
+			fallbackInputElement?.focus();
+		}
+	});
+</script>
+
+<div class="fallback-search relative">
+	<span class="text-subtle absolute flex h-full w-11 items-center justify-center sm:hidden">
+		<IconSearch class="size-4 lg:mt-px" aria-hidden="true" />
+	</span>
+	<input
+		type="search"
+		name="_q"
+		{placeholder}
+		{value}
+		aria-labelledby={ariaLabelledBy}
+		aria-label={ariaLabel}
+		bind:this={fallbackInputElement}
+		class="placeholder:text-placeholder w-full pl-11 text-base focus:outline-none sm:pl-3 lg:text-[0.9375rem] sm:@3xl:pl-4"
+	/>
+	<button
+		type="reset"
+		aria-label={page.data.t('search.clear')}
+		title={page.data.t('search.clear')}
+		class="action text-subtle hidden h-full w-full max-w-11 items-center justify-center -outline-offset-2 lg:max-w-12"
+	>
+		<IconClear aria-hidden="true" class="size-4.5 sm:size-4" />
+	</button>
+
+	<button
+		type="submit"
+		class={[
+			'hover:bg-primary-50 hidden h-full w-full max-w-11 items-center justify-center rounded-r-md border-l border-l-neutral-300 sm:flex lg:max-w-12'
+		]}
+		aria-label={page.data.t('supersearch.search')}
+	>
+		<IconSearch aria-hidden="true" class={['flex size-4.5']} />
+	</button>
+</div>
+
+<style lang="postcss">
+	@reference 'tailwindcss';
+
+	.fallback-search {
+		display: flex;
+		width: 100%;
+		height: var(--search-input-height);
+		background: var(--color-input);
+		box-shadow: 0 0 0 1px var(--color-primary-400);
+		border-radius: var(--radius-md);
+		font-size: var(--text-xs);
+		@variant sm {
+			font-size: var(--text-sm);
+		}
+
+		&:not(:has([type='submit']:focus)) {
+			&:has(:focus) {
+				box-shadow: 0 0 0 2px var(--color-accent-500);
+				outline: 4px solid var(--color-accent-100);
+				outline-offset: 2px;
+			}
+		}
+	}
+
+	input:not(:placeholder-shown) + [type='reset'] {
+		display: flex;
+	}
+
+	.action {
+		&:hover {
+			background: var(--color-accent-50);
+		}
+
+		&:focus {
+			background: var(--color-accent-100);
+		}
+	}
+</style>

--- a/lxl-web/src/lib/components/supersearch/SuperSearchFallback.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchFallback.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { getSearchContext } from '$lib/contexts/search';
 	import IconSearch from '~icons/bi/search';
 	import IconClear from '~icons/bi/x-circle';
 
@@ -7,10 +8,12 @@
 		placeholder: string;
 		ariaLabelledBy?: string;
 		ariaLabel?: string;
+		autofocus?: boolean;
 	}
 
-	let { placeholder, ariaLabel, ariaLabelledBy }: Props = $props();
+	let { placeholder, ariaLabel, ariaLabelledBy, autofocus }: Props = $props();
 
+	const searchContext = getSearchContext();
 	let fallbackInputElement: HTMLInputElement | undefined = $state();
 
 	let value = $derived(page.url.searchParams.get('_q'));
@@ -20,6 +23,33 @@
 			fallbackInputElement?.focus();
 		}
 	});
+
+	function getSelectionOnTeardown(): { anchor: number | null; head: number | null } | undefined {
+		if (fallbackInputElement?.selectionStart || fallbackInputElement?.selectionEnd) {
+			if (fallbackInputElement.selectionDirection === 'backward') {
+				return {
+					anchor: fallbackInputElement?.selectionEnd,
+					head: fallbackInputElement?.selectionStart
+				};
+			}
+			return {
+				anchor: fallbackInputElement?.selectionStart,
+				head: fallbackInputElement?.selectionEnd
+			};
+		}
+	}
+
+	$effect(() => {
+		return () => {
+			// Use teardown function to save state before mounting SuperSearchWrapper.svelte (so selection and value is kept...)
+			if (fallbackInputElement) {
+				searchContext.initialStateBeforeMount = {
+					value: fallbackInputElement.value,
+					selection: getSelectionOnTeardown()
+				};
+			}
+		};
+	});
 </script>
 
 <div class="fallback-search relative">
@@ -27,12 +57,14 @@
 		<IconSearch class="size-4 lg:mt-px" aria-hidden="true" />
 	</span>
 	<input
+		id="search-fallback"
 		type="search"
 		name="_q"
 		{placeholder}
 		{value}
 		aria-labelledby={ariaLabelledBy}
 		aria-label={ariaLabel}
+		{autofocus}
 		bind:this={fallbackInputElement}
 		class="placeholder:text-placeholder w-full pl-11 text-base focus:outline-none sm:pl-3 lg:text-[0.9375rem] sm:@3xl:pl-4"
 	/>

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -123,11 +123,11 @@
 
 			pageMapping = page.data.searchResult?.mapping || pageMapping; // use previous page mapping if there is no new page mapping
 
-			superSearch?.hideExpandedSearch();
+			hideExpandedSearch();
 			fetchOnExpand = true;
 
 			if (userClearedSearch) {
-				superSearch?.showExpandedSearch();
+				showExpandedSearch();
 				userClearedSearch = false;
 			} else if (isHomeRoute) {
 				superSearch?.focus(); // focus input on start page
@@ -282,7 +282,7 @@
 		return data;
 	}
 
-	export function changeQuery(params: ChangeQueryParams) {
+	function changeQuery(params: ChangeQueryParams) {
 		const { insert } = params;
 		const from = params.from || q.length;
 		const to = params.to || q.length;
@@ -303,7 +303,7 @@
 
 	function addQualifierKey(qualifierKey: string) {
 		superSearch?.resetData();
-		superSearch?.showExpandedSearch(); // keep dialog open (since 'regular' search is hidden on mobile)
+		showExpandedSearch(); // keep dialog open (since 'regular' search is hidden on mobile)
 
 		if (qualifierSuggestionNeedle.word.length > 0) {
 			// TODO don't need this if we can check qualifier editing state?
@@ -370,8 +370,12 @@
 		return lxlQualifierPlugin(getLabels, renderer);
 	});
 
-	export function showExpandedSearch(options?: ShowExpandedSearchOptions) {
+	function showExpandedSearch(options?: ShowExpandedSearchOptions) {
 		superSearch?.showExpandedSearch(options);
+	}
+
+	function hideExpandedSearch() {
+		superSearch?.hideExpandedSearch();
 	}
 
 	function handleOnChange() {
@@ -411,7 +415,10 @@
 	});
 
 	onMount(() => {
+		searchContext.showExpandedSearch = showExpandedSearch;
+		searchContext.hideExpandedSearch = hideExpandedSearch;
 		searchContext.changeQuery = changeQuery;
+		searchContext.isMounted = true;
 	});
 </script>
 

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { mount, onMount, unmount } from 'svelte';
+	import { mount, onMount, onDestroy, unmount } from 'svelte';
 	import { page } from '$app/state';
 	import { afterNavigate } from '$app/navigation';
 	import { resolve } from '$app/paths';
@@ -37,9 +37,16 @@
 		expandedAriaDescribedBy?: string;
 		onCursorChange: (cursor: number | null) => void;
 		qualifierSuggestions: QualifierSuggestion2[];
+		autofocus?: boolean;
 	}
 
-	export type ChangeQueryParams = { insert: string; from?: number; to?: number };
+	export type ChangeQueryParams = {
+		change: { insert: string; from?: number; to?: number };
+		selection?: {
+			anchor?: number | null;
+			head?: number | null;
+		};
+	};
 
 	let {
 		placeholder,
@@ -50,12 +57,13 @@
 		expandedAriaLabel,
 		expandedAriaDescribedBy,
 		onCursorChange,
-		qualifierSuggestions
+		qualifierSuggestions,
+		autofocus
 	}: Props = $props();
 
 	const searchContext = getSearchContext();
 
-	let q = $state(addSpaceIfEndingQualifier(page.url.searchParams.get('_q')?.trim() || ''));
+	let q = $state(addSpaceIfEndingQualifier(page.url.searchParams.get('_q') || ''));
 	let selection: Selection | undefined = $state();
 
 	let isLoading: boolean | undefined = $state();
@@ -118,7 +126,7 @@
 			if (isHomeRoute) {
 				q = ''; // reset query if navigating to start/index page
 			} else if (to.url.searchParams.has('_q')) {
-				q = addSpaceIfEndingQualifier(to.url.searchParams.get('_q')?.trim() || '');
+				q = addSpaceIfEndingQualifier(to.url.searchParams.get('_q') || '');
 			}
 
 			pageMapping = page.data.searchResult?.mapping || pageMapping; // use previous page mapping if there is no new page mapping
@@ -282,20 +290,25 @@
 		return data;
 	}
 
-	function changeQuery(params: ChangeQueryParams) {
-		const { insert } = params;
-		const from = params.from || q.length;
-		const to = params.to || q.length;
-		const before = q.slice(0, from);
+	function changeQuery({ change, selection }: ChangeQueryParams) {
+		const from = typeof change.from === 'number' ? change.from : q.length;
+		const to = typeof change.to === 'number' ? change.to : q.length;
+
 		superSearch?.dispatchChange({
 			change: {
 				from,
 				to,
-				insert
+				insert: change.insert
 			},
 			selection: {
-				anchor: (before + insert).length,
-				head: (before + insert).length
+				anchor:
+					selection && typeof selection.anchor === 'number'
+						? selection.anchor
+						: (q.slice(0, from) + change.insert).length,
+				head:
+					selection && typeof selection.head === 'number'
+						? selection.head
+						: (q.slice(0, from) + change.insert).length
 			},
 			userEvent: 'input'
 		});
@@ -415,10 +428,24 @@
 	});
 
 	onMount(() => {
+		if (searchContext.initialStateBeforeMount?.value) {
+			changeQuery({
+				change: { insert: searchContext.initialStateBeforeMount.value, from: 0, to: q.length },
+				selection: {
+					anchor: searchContext.initialStateBeforeMount.selection?.anchor,
+					head: searchContext.initialStateBeforeMount.selection?.head
+				}
+			});
+		}
 		searchContext.showExpandedSearch = showExpandedSearch;
 		searchContext.hideExpandedSearch = hideExpandedSearch;
 		searchContext.changeQuery = changeQuery;
 		searchContext.isMounted = true;
+	});
+
+	onDestroy(() => {
+		if (timeout) clearTimeout(timeout); // ensure timeout is cleared to prevent memory leaks
+		searchContext.initialStateBeforeMount = undefined;
 	});
 </script>
 
@@ -438,7 +465,7 @@
 		{expandedAriaLabel}
 		{expandedAriaDescribedBy}
 		collapsedAriaKeyshortcuts={`Shift+7 ${navigator.userAgent.includes('Mac OS X') ? 'Meta+K' : 'Control+K'}`}
-		autofocus={isHomeRoute ? true : undefined}
+		{autofocus}
 		endpoint={`/api/${page.data.locale}/supersearch`}
 		queryFn={(query, cursor) => {
 			return new URLSearchParams({

--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -696,14 +696,11 @@
 			box-shadow: 0 0 0 1px var(--color-primary-600);
 		}
 
-		&:focus-within {
-			outline: 3px solid var(--color-primary-100);
-			outline-offset: 1px;
-		}
-
-		@variant lg {
-			&:focus-within {
-				outline: 4px solid var(--color-primary-200);
+		@variant sm {
+			&:focus-within:not(:has(button:focus)) {
+				box-shadow: 0 0 0 6px var(--color-accent-100);
+				outline: 2px solid var(--color-outline);
+				outline-offset: 0;
 			}
 		}
 
@@ -730,11 +727,6 @@
 
 			&:hover {
 				box-shadow: 0 0 0 1px var(--color-neutral-600);
-			}
-			&.focused-row:not(:has(:global(.focused-cell))) {
-				box-shadow: 0 0 0 6px var(--color-accent-100);
-				outline: 2px solid var(--color-outline);
-				outline-offset: 0;
 			}
 		}
 

--- a/lxl-web/src/lib/contexts/search.ts
+++ b/lxl-web/src/lib/contexts/search.ts
@@ -1,6 +1,10 @@
 import { createContext } from 'svelte';
+import type { ShowExpandedSearchOptions } from 'supersearch';
 import type { ChangeQueryParams } from '$lib/components/supersearch/SuperSearchWrapper.svelte';
 
 export const [getSearchContext, setSearchContext] = createContext<{
-	changeQuery?: (params: ChangeQueryParams) => void;
+	showExpandedSearch: (options: ShowExpandedSearchOptions) => void;
+	hideExpandedSearch: () => void;
+	changeQuery: (params: ChangeQueryParams) => void;
+	isMounted: boolean;
 }>();

--- a/lxl-web/src/lib/contexts/search.ts
+++ b/lxl-web/src/lib/contexts/search.ts
@@ -6,5 +6,9 @@ export const [getSearchContext, setSearchContext] = createContext<{
 	showExpandedSearch: (options: ShowExpandedSearchOptions) => void;
 	hideExpandedSearch: () => void;
 	changeQuery: (params: ChangeQueryParams) => void;
+	initialStateBeforeMount?: {
+		value: string;
+		selection?: { anchor: number | null | undefined; head: number | null | undefined };
+	};
 	isMounted: boolean;
 }>();

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
@@ -17,14 +17,16 @@
 
 	setHomepageContext(homepageCache);
 
-	// Search context is later updated in the onMount lifecycle hook of SuperSearchWrapper.svelte (which is lazy-loaded)
-	setSearchContext({
+	let searchContext = $state({
 		showExpandedSearch: () => {},
 		hideExpandedSearch: () => {},
 		changeQuery: () => {},
 		initialStateBeforeMount: undefined,
 		isMounted: false
 	});
+
+	// Search context is later updated in the onMount lifecycle hook of SuperSearchWrapper.svelte (which is lazy-loaded)
+	setSearchContext(searchContext);
 </script>
 
 <svelte:head>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
@@ -19,10 +19,11 @@
 
 	// Search context is later updated in the onMount lifecycle hook of SuperSearchWrapper.svelte (which is lazy-loaded)
 	setSearchContext({
-		isMounted: false,
 		showExpandedSearch: () => {},
 		hideExpandedSearch: () => {},
-		changeQuery: () => {}
+		changeQuery: () => {},
+		initialStateBeforeMount: undefined,
+		isMounted: false
 	});
 </script>
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+layout.svelte
@@ -16,7 +16,14 @@
 	});
 
 	setHomepageContext(homepageCache);
-	setSearchContext({});
+
+	// Search context is later updated in the onMount lifecycle hook of SuperSearchWrapper.svelte (which is lazy-loaded)
+	setSearchContext({
+		isMounted: false,
+		showExpandedSearch: () => {},
+		hideExpandedSearch: () => {},
+		changeQuery: () => {}
+	});
 </script>
 
 <svelte:head>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -323,7 +323,7 @@
 						</p>
 					</hgroup>
 				{/if}
-				<AppSearch id="app-search" name="_q" />
+				<AppSearch />
 			</form>
 		</search>
 		<ul class="trailing-actions z-42 flex w-full items-center justify-end lg:gap-2">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -5,6 +5,7 @@
 	import { baseLocale, type LocaleCode, Locales } from '$lib/i18n/locales';
 	import { page } from '$app/state';
 	import { beforeNavigate } from '$app/navigation';
+	import { getSearchContext } from '$lib/contexts/search';
 	import librisLogo from '$lib/assets/img/libris-logo.svg';
 	import AppSearch from './AppSearch.svelte';
 	import IconMenu from '~icons/bi/list';
@@ -18,6 +19,8 @@
 	import SearchMapping from '$lib/components/find/SearchMapping.svelte';
 	import { getCategoryShortcuts } from '$lib/remotes/homepage.remote';
 
+	const searchContext = getSearchContext();
+
 	let mounted: boolean = $state(false);
 	let menuToggleElement: HTMLButtonElement | HTMLAnchorElement | undefined = $state();
 	let menuDialogElement: HTMLDialogElement | undefined = $state();
@@ -25,7 +28,6 @@
 	let backgroundObserver: IntersectionObserver | undefined = $state();
 	let shadowSentinelElement: HTMLElement | undefined = $state();
 	let shadowObserver: IntersectionObserver | undefined = $state();
-	let appSearchComponent: AppSearch | undefined = $state();
 	let expandedMenu = $state(page.url.hash === '#menu');
 	let dismissableBanner: boolean = $state(false);
 	let dismissedBanner: boolean = $state(false);
@@ -82,17 +84,17 @@
 
 	function handleClickPageTitle() {
 		if (window.getSelection()?.type === 'Caret') {
-			appSearchComponent?.showExpandedSearch({ cursorAtEnd: true });
+			searchContext.showExpandedSearch({ cursorAtEnd: true });
 		}
 	}
 
 	function handleClickSearchAction(event: MouseEvent) {
 		event.preventDefault();
-		appSearchComponent?.showExpandedSearch({ cursorAtEnd: true });
+		searchContext.showExpandedSearch({ cursorAtEnd: true });
 	}
 
 	function handleClickAddFilter() {
-		appSearchComponent?.showExpandedSearch({ cursorAtEnd: true, focusRow: 1 });
+		searchContext.showExpandedSearch({ cursorAtEnd: true, focusRow: 1 });
 	}
 
 	function handleBackgroundObserve(entries: IntersectionObserverEntry[]) {
@@ -321,7 +323,7 @@
 						</p>
 					</hgroup>
 				{/if}
-				<AppSearch id="app-search" name="_q" bind:this={appSearchComponent} />
+				<AppSearch id="app-search" name="_q" />
 			</form>
 		</search>
 		<ul class="trailing-actions z-42 flex w-full items-center justify-end lg:gap-2">

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
@@ -16,6 +16,7 @@
 			? `${page.data.t('header.searchSubsetPlaceholder')}: ${displayMappingToString(page.data.subsetMapping)}`
 			: page.data.t('header.searchPlaceholder')
 	);
+	const autofocus = $derived(isHomeRoute ? true : undefined);
 
 	const pageParams = $derived.by(() => {
 		let p = getSortedSearchParams(addDefaultSearchParams(page.url.searchParams));
@@ -33,7 +34,7 @@
 </script>
 
 {#snippet fallbackInput()}
-	<SuperSearchFallback {placeholder} {ariaLabelledBy} {ariaLabel} />
+	<SuperSearchFallback {placeholder} {ariaLabelledBy} {ariaLabel} {autofocus} />
 {/snippet}
 
 {#await import('$lib/components/supersearch/SuperSearchWrapper.svelte')}
@@ -47,6 +48,7 @@
 			expandedAriaLabel={page.data.t('header.search')}
 			onCursorChange={(value) => (cursor = value)}
 			qualifierSuggestions={page.data.qualifierSuggestions || []}
+			{autofocus}
 		/>
 	</div>
 {:catch}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-	import { type SvelteComponent } from 'svelte';
 	import { page } from '$app/state';
 	import addDefaultSearchParams from '$lib/utils/addDefaultSearchParams';
 	import getSortedSearchParams from '$lib/utils/getSortedSearchParams';
 	import IconSearch from '~icons/bi/search';
-	import type { ShowExpandedSearchOptions } from 'supersearch';
 	import { displayMappingToString } from '$lib/utils/displayMappingToString';
 
 	type Props = {
@@ -15,7 +13,6 @@
 	let { id, name }: Props = $props();
 
 	let fallbackInputElement: HTMLInputElement | undefined = $state();
-	let superSearchWrapperComponent: SvelteComponent | undefined = $state();
 	let cursor: number | null = $state(null);
 
 	const isHomeRoute = $derived(page.route.id === '/(app)/[[lang=lang]]');
@@ -44,10 +41,6 @@
 			fallbackInputElement?.focus();
 		}
 	});
-
-	export function showExpandedSearch(options?: ShowExpandedSearchOptions) {
-		superSearchWrapperComponent?.showExpandedSearch(options);
-	}
 </script>
 
 {#snippet fallbackInput()}
@@ -86,7 +79,6 @@
 			collapsedAriaLabelledBy={isHomeRoute ? 'page-title' : undefined}
 			collapsedAriaLabel={!isHomeRoute ? page.data.t('header.search') : undefined}
 			expandedAriaLabel={page.data.t('header.search')}
-			bind:this={superSearchWrapperComponent}
 			onCursorChange={(value) => (cursor = value)}
 			qualifierSuggestions={page.data.qualifierSuggestions || []}
 		/>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
@@ -1,22 +1,17 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import SuperSearchFallback from '$lib/components/supersearch/SuperSearchFallback.svelte';
 	import addDefaultSearchParams from '$lib/utils/addDefaultSearchParams';
 	import getSortedSearchParams from '$lib/utils/getSortedSearchParams';
-	import IconSearch from '~icons/bi/search';
 	import { displayMappingToString } from '$lib/utils/displayMappingToString';
 
-	type Props = {
-		id?: string;
-		name: string;
-	};
-
-	let { id, name }: Props = $props();
-
-	let fallbackInputElement: HTMLInputElement | undefined = $state();
 	let cursor: number | null = $state(null);
 
 	const isHomeRoute = $derived(page.route.id === '/(app)/[[lang=lang]]');
-	const placeholder = $derived(
+
+	const ariaLabelledBy = $derived(isHomeRoute ? 'page-title' : undefined);
+	const ariaLabel = $derived(!isHomeRoute ? page.data.t('header.search') : undefined);
+	const placeholder: string = $derived(
 		page.data.subsetMapping
 			? `${page.data.t('header.searchSubsetPlaceholder')}: ${displayMappingToString(page.data.subsetMapping)}`
 			: page.data.t('header.searchPlaceholder')
@@ -35,39 +30,10 @@
 		}
 		return p;
 	});
-
-	$effect(() => {
-		if (page.url.hash === `#${id}`) {
-			fallbackInputElement?.focus();
-		}
-	});
 </script>
 
 {#snippet fallbackInput()}
-	<div class="fallback-search relative">
-		<span class="text-subtle absolute flex h-full w-11 items-center justify-center sm:hidden">
-			<IconSearch class="size-4 lg:mt-px" aria-hidden="true" />
-		</span>
-		<input
-			type="search"
-			{id}
-			{name}
-			{placeholder}
-			aria-labelledby={isHomeRoute ? 'page-title' : undefined}
-			aria-label={!isHomeRoute ? page.data.t('header.search') : undefined}
-			bind:this={fallbackInputElement}
-			class="placeholder:text-placeholder w-full pl-11 text-base focus:outline-none sm:px-3 lg:text-[0.9375rem] sm:@3xl:pl-4"
-		/>
-		<button
-			type="submit"
-			class={[
-				'hover:bg-primary-50 hidden h-full w-full max-w-11 items-center justify-center rounded-r-md border-l border-l-neutral-300 sm:flex lg:max-w-12'
-			]}
-			aria-label={page.data.t('supersearch.search')}
-		>
-			<IconSearch aria-hidden="true" class={['flex size-4.5']} />
-		</button>
-	</div>
+	<SuperSearchFallback {placeholder} {ariaLabelledBy} {ariaLabel} />
 {/snippet}
 
 {#await import('$lib/components/supersearch/SuperSearchWrapper.svelte')}
@@ -76,8 +42,8 @@
 	<div class="contents" data-testid="supersearch">
 		<SuperSearchWrapper
 			{placeholder}
-			collapsedAriaLabelledBy={isHomeRoute ? 'page-title' : undefined}
-			collapsedAriaLabel={!isHomeRoute ? page.data.t('header.search') : undefined}
+			collapsedAriaLabelledBy={ariaLabelledBy}
+			collapsedAriaLabel={ariaLabel}
 			expandedAriaLabel={page.data.t('header.search')}
 			onCursorChange={(value) => (cursor = value)}
 			qualifierSuggestions={page.data.qualifierSuggestions || []}
@@ -91,29 +57,3 @@
 		<input type="hidden" {name} {value} />
 	{/if}
 {/each}
-
-<style lang="postcss">
-	@reference 'tailwindcss';
-	@reference "../../../app.css";
-
-	.fallback-search {
-		display: flex;
-		width: 100%;
-		height: var(--search-input-height);
-		background: var(--color-input);
-		box-shadow: 0 0 0 1px var(--color-primary-400);
-		border-radius: var(--radius-md);
-		font-size: var(--text-xs);
-		@variant sm {
-			font-size: var(--text-sm);
-		}
-
-		&:not(:has([type='submit']:focus)) {
-			&:has(:focus) {
-				box-shadow: 0 0 0 2px var(--color-accent-500);
-				outline: 4px solid var(--color-accent-100);
-				outline-offset: 2px;
-			}
-		}
-	}
-</style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-	import { type SvelteComponent } from 'svelte';
 	import { page } from '$app/state';
 	import addDefaultSearchParams from '$lib/utils/addDefaultSearchParams';
 	import getSortedSearchParams from '$lib/utils/getSortedSearchParams';
 	import IconSearch from '~icons/bi/search';
-	import type { ShowExpandedSearchOptions } from 'supersearch';
 	import { displayMappingToString } from '$lib/utils/displayMappingToString';
 
 	type Props = {
@@ -15,7 +13,6 @@
 	let { id, name }: Props = $props();
 
 	let fallbackInputElement: HTMLInputElement | undefined = $state();
-	let superSearchWrapperComponent: SvelteComponent | undefined = $state();
 	let cursor: number | null = $state(null);
 
 	const isHomeRoute = $derived(page.route.id === '/(app)/[[lang=lang]]');
@@ -43,10 +40,6 @@
 			fallbackInputElement?.focus();
 		}
 	});
-
-	export function showExpandedSearch(options?: ShowExpandedSearchOptions) {
-		superSearchWrapperComponent?.showExpandedSearch(options);
-	}
 </script>
 
 {#snippet fallbackInput()}
@@ -85,7 +78,6 @@
 			collapsedAriaLabelledBy={isHomeRoute ? 'page-title' : undefined}
 			collapsedAriaLabel={!isHomeRoute ? page.data.t('header.search') : undefined}
 			expandedAriaLabel={page.data.t('header.search')}
-			bind:this={superSearchWrapperComponent}
 			onCursorChange={(value) => (cursor = value)}
 			qualifierSuggestions={page.data.qualifierSuggestions || []}
 		/>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
@@ -14,6 +14,7 @@
 		(page.data.subsetMapping && displayMappingToString(page.data.subsetMapping)) ||
 			page.data.t('header.searchPlaceholder')
 	);
+	const autofocus = $derived(isHomeRoute ? true : undefined);
 
 	const pageParams = $derived.by(() => {
 		let p = getSortedSearchParams(addDefaultSearchParams(page.url.searchParams));
@@ -31,7 +32,7 @@
 </script>
 
 {#snippet fallbackInput()}
-	<SuperSearchFallback {placeholder} {ariaLabelledBy} {ariaLabel} />
+	<SuperSearchFallback {placeholder} {ariaLabelledBy} {ariaLabel} {autofocus} />
 {/snippet}
 
 {#await import('$lib/components/supersearch/SuperSearchWrapper.svelte')}
@@ -45,6 +46,7 @@
 			expandedAriaLabel={page.data.t('header.search')}
 			onCursorChange={(value) => (cursor = value)}
 			qualifierSuggestions={page.data.qualifierSuggestions || []}
+			{autofocus}
 		/>
 	</div>
 {:catch}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
@@ -1,22 +1,16 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import SuperSearchFallback from '$lib/components/supersearch/SuperSearchFallback.svelte';
 	import addDefaultSearchParams from '$lib/utils/addDefaultSearchParams';
 	import getSortedSearchParams from '$lib/utils/getSortedSearchParams';
-	import IconSearch from '~icons/bi/search';
 	import { displayMappingToString } from '$lib/utils/displayMappingToString';
 
-	type Props = {
-		id?: string;
-		name: string;
-	};
-
-	let { id, name }: Props = $props();
-
-	let fallbackInputElement: HTMLInputElement | undefined = $state();
 	let cursor: number | null = $state(null);
 
 	const isHomeRoute = $derived(page.route.id === '/(app)/[[lang=lang]]');
-	const placeholder = $derived(
+	const ariaLabelledBy = $derived(isHomeRoute ? 'page-title' : undefined);
+	const ariaLabel = $derived(!isHomeRoute ? page.data.t('header.search') : undefined);
+	const placeholder: string = $derived(
 		(page.data.subsetMapping && displayMappingToString(page.data.subsetMapping)) ||
 			page.data.t('header.searchPlaceholder')
 	);
@@ -34,39 +28,10 @@
 		}
 		return p;
 	});
-
-	$effect(() => {
-		if (page.url.hash === `#${id}`) {
-			fallbackInputElement?.focus();
-		}
-	});
 </script>
 
 {#snippet fallbackInput()}
-	<div class="fallback-search relative">
-		<span class="text-subtle absolute flex h-full w-11 items-center justify-center sm:hidden">
-			<IconSearch class="size-4 lg:mt-px" aria-hidden="true" />
-		</span>
-		<input
-			type="search"
-			{id}
-			{name}
-			{placeholder}
-			aria-labelledby={isHomeRoute ? 'page-title' : undefined}
-			aria-label={!isHomeRoute ? page.data.t('header.search') : undefined}
-			bind:this={fallbackInputElement}
-			class="placeholder:text-placeholder w-full pl-11 text-base focus:outline-none sm:px-3 lg:text-[0.9375rem] sm:@3xl:pl-4"
-		/>
-		<button
-			type="submit"
-			class={[
-				'hover:bg-primary-50 hidden h-full w-full max-w-11 items-center justify-center rounded-r-md border-l border-l-neutral-300 sm:flex lg:max-w-12'
-			]}
-			aria-label={page.data.t('supersearch.search')}
-		>
-			<IconSearch aria-hidden="true" class={['flex size-4.5']} />
-		</button>
-	</div>
+	<SuperSearchFallback {placeholder} {ariaLabelledBy} {ariaLabel} />
 {/snippet}
 
 {#await import('$lib/components/supersearch/SuperSearchWrapper.svelte')}
@@ -75,8 +40,8 @@
 	<div class="contents" data-testid="supersearch">
 		<SuperSearchWrapper
 			{placeholder}
-			collapsedAriaLabelledBy={isHomeRoute ? 'page-title' : undefined}
-			collapsedAriaLabel={!isHomeRoute ? page.data.t('header.search') : undefined}
+			collapsedAriaLabelledBy={ariaLabelledBy}
+			collapsedAriaLabel={ariaLabel}
 			expandedAriaLabel={page.data.t('header.search')}
 			onCursorChange={(value) => (cursor = value)}
 			qualifierSuggestions={page.data.qualifierSuggestions || []}
@@ -90,29 +55,3 @@
 		<input type="hidden" {name} {value} />
 	{/if}
 {/each}
-
-<style lang="postcss">
-	@reference 'tailwindcss';
-	@reference "../../../app.css";
-
-	.fallback-search {
-		display: flex;
-		width: 100%;
-		height: var(--search-input-height);
-		background: var(--color-input);
-		box-shadow: 0 0 0 1px var(--color-primary-400);
-		border-radius: var(--radius-md);
-		font-size: var(--text-xs);
-		@variant sm {
-			font-size: var(--text-sm);
-		}
-
-		&:not(:has([type='submit']:focus)) {
-			&:has(:focus) {
-				box-shadow: 0 0 0 2px var(--color-accent-500);
-				outline: 4px solid var(--color-accent-100);
-				outline-offset: 2px;
-			}
-		}
-	}
-</style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/filters/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/filters/+page.svelte
@@ -42,7 +42,7 @@
 					<td>
 						<button
 							class="qualifier text-body bg-accent-50 text-2xs hover:bg-accent-100 inline-block min-h-8 min-w-9 shrink-0 rounded-md px-1.5 font-medium whitespace-nowrap first-letter:capitalize"
-							onclick={() => searchContext.changeQuery?.({ insert: ` ${f.key}:` })}
+							onclick={() => searchContext.changeQuery({ insert: ` ${f.key}:` })}
 						>
 							{f.label}
 						</button>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/filters/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/filters/+page.svelte
@@ -42,7 +42,7 @@
 					<td>
 						<button
 							class="qualifier text-body bg-accent-50 text-2xs hover:bg-accent-100 inline-block min-h-8 min-w-9 shrink-0 rounded-md px-1.5 font-medium whitespace-nowrap first-letter:capitalize"
-							onclick={() => searchContext.changeQuery({ insert: ` ${f.key}:` })}
+							onclick={() => searchContext.changeQuery({ change: { insert: ` ${f.key}:` } })}
 						>
 							{f.label}
 						</button>

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -301,6 +301,7 @@ test('return key label is context-aware', async ({ page }) => {
 	await page.getByTestId('supersearch').getByRole('combobox').click();
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.getByTestId('supersearch').getByRole('dialog').getByRole('combobox').fill('a');
+	await expect(page.getByRole('combobox').first()).toHaveText('a');
 	await page.keyboard.press('Tab');
 	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
 		'aria-activedescendant',

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -309,6 +309,10 @@ test('return key label is context-aware', async ({ page }) => {
 	await page.keyboard.press('Backspace');
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('ArrowDown');
+	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
+		'aria-activedescendant',
+		'supersearch-item-1x0'
+	);
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
 	await page.keyboard.press('ArrowUp');
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -42,7 +42,7 @@ test('expanded content shows persistant items and results', async ({ page }) => 
 		page.getByRole('dialog').getByLabel('Förslag').getByRole('link'),
 		'search results are shown after typing'
 	).toHaveCount(5);
-	await page.goto('/find?_limit=20&_offset=0&_q=language:"lang:swe"+&_sort=&_spell=true');
+	await page.goto('/find?_limit=20&_offset=0&_q=language%3A"lang%3Aswe"&_sort=&_spell=true');
 	await page.getByTestId('supersearch').click();
 
 	await page.waitForResponse(
@@ -59,7 +59,6 @@ test('expanded content shows persistant items and results', async ({ page }) => 
 		page.getByRole('combobox').first().locator('.lxl-qualifier-key'),
 		'query is kept when navigating from find routes...'
 	).toContainText('Språk');
-	await page.waitForLoadState('networkidle');
 	await expect(page.getByRole('combobox').locator('.lxl-qualifier-value')).toContainText('Svenska');
 	await page.getByTestId('home').click(); // click on home link
 	await page.waitForURL('/'); // fnurgel route
@@ -299,29 +298,24 @@ test('qualifier keys can be added using keyboard only', async ({ page, context }
 
 test('return key label is context-aware', async ({ page }) => {
 	await page.getByTestId('supersearch').getByRole('combobox').click();
-	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.getByTestId('supersearch').getByRole('dialog').getByRole('combobox').fill('a');
-	await expect(page.getByRole('combobox').first()).toHaveText('a');
 	await page.keyboard.press('Tab');
 	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
 		'aria-activedescendant',
 		'supersearch-item-0x1'
 	);
-	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Rensa');
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Rensa');
 	await page.keyboard.press('Backspace');
-	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('ArrowDown');
-	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
-		'aria-activedescendant',
-		'supersearch-item-1x0'
-	);
-	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
 	await page.keyboard.press('ArrowUp');
-	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('Shift+Tab');
 	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
 		'aria-activedescendant',
 		'supersearch-item-2x0'
 	);
-	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Välj');
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Välj');
 });

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -42,7 +42,7 @@ test('expanded content shows persistant items and results', async ({ page }) => 
 		page.getByRole('dialog').getByLabel('Förslag').getByRole('link'),
 		'search results are shown after typing'
 	).toHaveCount(5);
-	await page.goto('/find?_limit=20&_offset=0&_q=language:"lang:swe"+&_sort=&_spell=true');
+	await page.goto('/find?_limit=20&_offset=0&_q=language%3A"lang%3Aswe"&_sort=&_spell=true');
 	await page.getByTestId('supersearch').click();
 
 	await page.waitForResponse(
@@ -59,7 +59,6 @@ test('expanded content shows persistant items and results', async ({ page }) => 
 		page.getByRole('combobox').first().locator('.lxl-qualifier-key'),
 		'query is kept when navigating from find routes...'
 	).toContainText('Språk');
-	await page.waitForLoadState('networkidle');
 	await expect(page.getByRole('combobox').locator('.lxl-qualifier-value')).toContainText('Svenska');
 	await page.getByTestId('home').click(); // click on home link
 	await page.waitForURL('/'); // fnurgel route
@@ -301,7 +300,6 @@ test('return key label is context-aware', async ({ page }) => {
 	await page.getByTestId('supersearch').getByRole('combobox').click();
 	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.getByTestId('supersearch').getByRole('dialog').getByRole('combobox').fill('a');
-	await expect(page.getByRole('combobox').first()).toHaveText('a');
 	await page.keyboard.press('Tab');
 	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
 		'aria-activedescendant',
@@ -311,13 +309,9 @@ test('return key label is context-aware', async ({ page }) => {
 	await page.keyboard.press('Backspace');
 	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('ArrowDown');
-	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
-		'aria-activedescendant',
-		'supersearch-item-1x0'
-	);
-	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
+	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
 	await page.keyboard.press('ArrowUp');
-	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('Shift+Tab');
 	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
 		'aria-activedescendant',

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -309,7 +309,11 @@ test('return key label is context-aware', async ({ page }) => {
 	await page.keyboard.press('Backspace');
 	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('ArrowDown');
-	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
+	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
+		'aria-activedescendant',
+		'supersearch-item-1x0'
+	);
+	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
 	await page.keyboard.press('ArrowUp');
 	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('Shift+Tab');

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -315,9 +315,9 @@ test('return key label is context-aware', async ({ page }) => {
 		'aria-activedescendant',
 		'supersearch-item-1x0'
 	);
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
+	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
 	await page.keyboard.press('ArrowUp');
-	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('Shift+Tab');
 	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
 		'aria-activedescendant',

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -42,7 +42,7 @@ test('expanded content shows persistant items and results', async ({ page }) => 
 		page.getByRole('dialog').getByLabel('Förslag').getByRole('link'),
 		'search results are shown after typing'
 	).toHaveCount(5);
-	await page.goto('/find?_limit=20&_offset=0&_q=language%3A"lang%3Aswe"&_sort=&_spell=true');
+	await page.goto('/find?_limit=20&_offset=0&_q=language:"lang:swe"+&_sort=&_spell=true');
 	await page.getByTestId('supersearch').click();
 
 	await page.waitForResponse(

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -301,6 +301,7 @@ test('return key label is context-aware', async ({ page }) => {
 	await page.getByTestId('supersearch').getByRole('combobox').click();
 	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.getByTestId('supersearch').getByRole('dialog').getByRole('combobox').fill('a');
+	await expect(page.getByRole('combobox').first()).toHaveText('a');
 	await page.keyboard.press('Tab');
 	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
 		'aria-activedescendant',

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -299,7 +299,7 @@ test('qualifier keys can be added using keyboard only', async ({ page, context }
 
 test('return key label is context-aware', async ({ page }) => {
 	await page.getByTestId('supersearch').getByRole('combobox').click();
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.getByTestId('supersearch').getByRole('dialog').getByRole('combobox').fill('a');
 	await expect(page.getByRole('combobox').first()).toHaveText('a');
 	await page.keyboard.press('Tab');
@@ -307,21 +307,21 @@ test('return key label is context-aware', async ({ page }) => {
 		'aria-activedescendant',
 		'supersearch-item-0x1'
 	);
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Rensa');
+	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Rensa');
 	await page.keyboard.press('Backspace');
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('ArrowDown');
 	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
 		'aria-activedescendant',
 		'supersearch-item-1x0'
 	);
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
+	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
 	await page.keyboard.press('ArrowUp');
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('Shift+Tab');
 	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
 		'aria-activedescendant',
 		'supersearch-item-2x0'
 	);
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Välj');
+	await expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Välj');
 });

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -59,6 +59,7 @@ test('expanded content shows persistant items and results', async ({ page }) => 
 		page.getByRole('combobox').first().locator('.lxl-qualifier-key'),
 		'query is kept when navigating from find routes...'
 	).toContainText('Språk');
+	await page.waitForLoadState('networkidle');
 	await expect(page.getByRole('combobox').locator('.lxl-qualifier-value')).toContainText('Svenska');
 	await page.getByTestId('home').click(); // click on home link
 	await page.waitForURL('/'); // fnurgel route


### PR DESCRIPTION
## Description

### Solves

When loading the site on slow connections (e.g. on trains) users could start editing the fallback input before the lazy-loaded supersearch component has finished loading. The contents added (as well as the selection) would then be reset when mounting the lazy-loaded component which can be frustrating. This PR solves this by passing along the current value and selection.

Further improvements can later be made where so the selection is placed directly after pills when selecting qualifiers before mount (as this requires parsing the syntax grammer).

The PR also further implements context usage for controlling the component from outside instead of using component binding.

### Summary of changes

- Use searchContext to control SuperSearch from outside
- Move fallback search input to separate component
- Pass along current value and selection when mounting SuperSearchWrapper
- Use same focus styling on collapsed and expanded state
