### PR TITLE
feat(lxl-web): Add keyboard shortcut help for expanding search

### DIFF
--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -524,6 +524,19 @@
 					>
 						<IconClear aria-hidden="true" class="size-4.5 sm:size-4" />
 					</svelte:element>
+				{:else if !expanded}
+					<button
+						type="button"
+						onclick={() => showExpandedSearch()}
+						tabindex={-1}
+						class="hidden size-11 cursor-text items-center justify-center select-none sm:flex lg:size-12"
+					>
+						<kbd
+							class="key pointer-events-auto h-[1.75em] w-[1.75em] text-sm"
+							title={`${page.data.t('supersearch.expandSearch')} (Shift+7 ${page.data.t('supersearch.or')} ${navigator.userAgent.includes('Mac OS X') ? 'Meta+K' : 'Control+K'})`}
+							>/</kbd
+						>
+					</button>
 				{/if}
 				<button
 					type="submit"

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -209,7 +209,9 @@ export default {
 		select: 'Select',
 		clear: 'Clear',
 		add: 'Add',
-		searchHelp: 'Search help'
+		searchHelp: 'Search help',
+		expandSearch: 'Expand search',
+		or: 'or'
 	},
 	sort: {
 		sort: 'Sort',

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -210,7 +210,7 @@ export default {
 		clear: 'Clear',
 		add: 'Add',
 		searchHelp: 'Search help',
-		expandSearch: 'Expand search',
+		expandSearch: 'Go to search',
 		or: 'or'
 	},
 	sort: {

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -208,7 +208,9 @@ export default {
 		select: 'Välj',
 		clear: 'Rensa',
 		add: 'Lägg till',
-		searchHelp: 'Sökhjälp'
+		searchHelp: 'Sökhjälp',
+		expandSearch: 'Expandera sök',
+		or: 'or'
 	},
 	sort: {
 		sort: 'Sortera',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -209,7 +209,7 @@ export default {
 		clear: 'Rensa',
 		add: 'Lägg till',
 		searchHelp: 'Sökhjälp',
-		expandSearch: 'Expandera sök',
+		expandSearch: 'Gå till sökruta',
 		or: 'eller'
 	},
 	sort: {

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -210,7 +210,7 @@ export default {
 		add: 'Lägg till',
 		searchHelp: 'Sökhjälp',
 		expandSearch: 'Expandera sök',
-		or: 'or'
+		or: 'eller'
 	},
 	sort: {
 		sort: 'Sortera',

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -310,6 +310,10 @@ test('return key label is context-aware', async ({ page }) => {
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('ArrowDown');
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
+	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
+		'aria-activedescendant',
+		'supersearch-item-1x0'
+	);
 	await page.keyboard.press('ArrowUp');
 	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('Shift+Tab');


### PR DESCRIPTION
## Description

### Solves

Add keyboard shortcut help for expanding search.

<img width="757" height="101" alt="Skärmavbild 2026-04-20 kl  11 23 43" src="https://github.com/user-attachments/assets/636852a5-f7f9-43c9-a65d-5cc10879fd82" />

### Summary of changes

- Add keyboard shortcut help for expanding search 
