### PR TITLE
feat(lxl-web): Holdings button in main column

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -817,13 +817,7 @@
 					"@id": "Work-web-overview",
 					"@type": "fresnel:Lens",
 					"classLensDomain": "Work",
-					"showProperties": [
-						"contribution",
-						"category",
-						"hasPart",
-						"relationship",
-						"intendedAudience"
-					]
+					"showProperties": ["contribution", "hasPart", "relationship", "intendedAudience"]
 				},
 				"Instance": {
 					"@id": "Instance-web-overview",
@@ -864,7 +858,7 @@
 					"@id": "Work-web-overview2",
 					"@type": "fresnel:Lens",
 					"classLensDomain": "Work",
-					"showProperties": ["subject", "associatedMedia"]
+					"showProperties": ["category", "subject", "associatedMedia"]
 				},
 				"Instance": {
 					"@id": "Instance-web-overview2",
@@ -1391,7 +1385,7 @@
 		"needs-label-format": {
 			"@id": "Subject-format",
 			"@type": "fresnel:Format",
-			"fresnel:propertyFormatDomain": ["subject", "seriesMembership", "isPartOf"],
+			"fresnel:propertyFormatDomain": ["category", "subject", "seriesMembership", "isPartOf"],
 			"fresnel:propertyStyle": ["label"]
 		},
 		"Work-hasPart-format": {

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -300,32 +300,6 @@
 		width: fit-content;
 	}
 
-	/* resource property-specific styles */
-	.genre-form {
-		display: flex;
-		flex-wrap: wrap;
-		gap: calc(var(--spacing) * 1.5);
-		font-size: var(--text-xs);
-
-		/* pill */
-		& > * {
-			border: 1px solid var(--color-neutral-200);
-			border-radius: calc(infinity * 1px);
-			padding-block: calc(var(--spacing) * 1.5);
-			padding-inline: calc(var(--spacing) * 3);
-			text-decoration: none;
-			white-space: nowrap;
-		}
-
-		& > a {
-			border-color: var(--color-accent-200);
-
-			&:hover {
-				background-color: var(--color-primary-100);
-			}
-		}
-	}
-
 	.transliteration {
 		font-style: italic;
 	}

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -113,6 +113,10 @@
 	const showTabs = $derived(
 		derivedFilteredInstances?.length && derivedFilteredInstances?.length !== instances?.length
 	);
+
+	const hasHoldingsBtn = $derived(
+		holdings.byType && Object.keys(holdings.byType).length && instances
+	);
 </script>
 
 {#snippet panelMatchingInstances()}
@@ -178,12 +182,6 @@
 					thumbnailTargetWidth={ImageWidth.MEDIUM}
 					linkToFull
 				/>
-				{#if holdings.byType && Object.keys(holdings.byType).length && instances}
-					<section class="mt-5">
-						<h2 class="sr-only">{page.data.t('holdings.availabilityByType')}</h2>
-						<ResourceHoldings {holdings} {instances} />
-					</section>
-				{/if}
 			</div>
 		</div>
 		<div class="wide:max-w-screen mx-auto flex w-full max-w-4xl flex-col gap-3 @sm:gap-6 @3xl:py-6">
@@ -234,8 +232,12 @@
 						</div>
 					{/each}
 				</div>
+				{#if hasHoldingsBtn}
+					<h2 class="sr-only">{page.data.t('holdings.availabilityByType')}</h2>
+					<ResourceHoldings {holdings} {instances} />
+				{/if}
 				<div class="decorated-data-section decorated-spacious">
-					{#if decoratedData.overview.some((o) => o._display?.length > 0) && decoratedData.overview2.some((o) => o._display?.length > 0)}
+					{#if !hasHoldingsBtn && decoratedData.overview.some((o) => o._display?.length > 0) && decoratedData.overview2.some((o) => o._display?.length > 0)}
 						<div class="border-b-neutral mb-2 border-b"></div>
 					{/if}
 					{#each decoratedData.overview2 as overview2 (overview2)}

--- a/lxl-web/src/lib/components/ResourceHoldings.svelte
+++ b/lxl-web/src/lib/components/ResourceHoldings.svelte
@@ -29,7 +29,7 @@
 	}
 </script>
 
-<ul class="@container flex flex-col gap-2">
+<ul class="@container my-4 flex flex-wrap gap-2">
 	{#each Object.keys(holdings.byType) as type (type)}
 		{@const myLibsHoldingByType = getLibsFromHoldings(
 			myLibraries,


### PR DESCRIPTION
- Move holdings button in main content area on resource page
- Make category regular links instead of pills. So that they clash less with all buttons visually
    - Maybe the difference between subject and category is more pedagogical now that they're side by side and labelled.

<img width="1058" height="794" alt="Skärmbild från 2026-04-20 13-16-06" src="https://github.com/user-attachments/assets/1a183615-c026-4baa-ab56-24cce2cb3fa9" />



Different button widths on mobile does not look great but ok for now?
<img width="376" height="674" alt="bild" src="https://github.com/user-attachments/assets/4986ec57-ad6a-4262-b255-275273ba604b" />


