### PR TITLE
fix(lxlweb): restore subset look

### DIFF
--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -20,7 +20,7 @@
 
 <ul
 	class={[
-		'max-w-full leading-7.5',
+		'max-w-full py-px leading-7.5',
 		depth === 0 ? 'search-mapping flex-col-reverse gap-2' : 'flex-col',
 		'flex items-start text-xs'
 	]}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -675,9 +675,8 @@
 	:global(.home .with-subset .leading-actions) {
 		position: fixed;
 
-		/* hide the subset pill on the front page for now */
-		& .subset-container {
-			display: none;
+		& + #app-bar-search {
+			background-color: var(--color-app-bar);
 		}
 	}
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
@@ -20,8 +20,9 @@
 
 	const isHomeRoute = $derived(page.route.id === '/(app)/[[lang=lang]]');
 	const placeholder = $derived(
-		(page.data.subsetMapping && displayMappingToString(page.data.subsetMapping)) ||
-			page.data.t('header.searchPlaceholder')
+		page.data.subsetMapping
+			? `${page.data.t('header.searchSubsetPlaceholder')}: ${displayMappingToString(page.data.subsetMapping)}`
+			: page.data.t('header.searchPlaceholder')
 	);
 
 	const pageParams = $derived.by(() => {


### PR DESCRIPTION
## Description
### Solves

<img width="1345" height="358" alt="Skärmavbild 2026-04-21 kl  15 14 23" src="https://github.com/user-attachments/assets/863d9d5d-b50f-420b-abdf-9c0aff46bb9c" />

Does not look great at some scroll positions, but hard to fix due fixed positions etc on start page.

### Summary of changes

* Re-add subset placeholder text
* Unhide subset pills on start page
