### PR TITLE
fix(lxlweb): hopefully fix 'return key label is context-aware' test

### DIFF
--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -268,7 +268,7 @@ test('qualifier keys can be added', async ({ page, context }) => {
 	await page.keyboard.press('ControlOrMeta+A');
 	await page.keyboard.press('ControlOrMeta+C');
 	const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());
-	await expect(clipboardContent).toBe('contributor:(a)');
+	expect(clipboardContent).toBe('contributor:(a)');
 });
 
 test('qualifier keys can be added using keyboard only', async ({ page, context }) => {
@@ -290,7 +290,7 @@ test('qualifier keys can be added using keyboard only', async ({ page, context }
 	await page.keyboard.press('ControlOrMeta+A');
 	await page.keyboard.press('ControlOrMeta+C');
 	const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());
-	await expect(
+	expect(
 		clipboardContent,
 		'arrow key navigation works as intended after adding qualifier key'
 	).toBe('c contributor:(a)b');
@@ -317,5 +317,5 @@ test('return key label is context-aware', async ({ page }) => {
 		'aria-activedescendant',
 		'supersearch-item-2x0'
 	);
-	expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Välj');
+	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Välj');
 });

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -298,24 +298,24 @@ test('qualifier keys can be added using keyboard only', async ({ page, context }
 
 test('return key label is context-aware', async ({ page }) => {
 	await page.getByTestId('supersearch').getByRole('combobox').click();
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.getByTestId('supersearch').getByRole('dialog').getByRole('combobox').fill('a');
 	await page.keyboard.press('Tab');
 	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
 		'aria-activedescendant',
 		'supersearch-item-0x1'
 	);
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Rensa');
+	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Rensa');
 	await page.keyboard.press('Backspace');
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('ArrowDown');
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
+	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Lägg till');
 	await page.keyboard.press('ArrowUp');
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
+	await expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Sök');
 	await page.keyboard.press('Shift+Tab');
 	await expect(page.getByRole('dialog').getByRole('combobox')).toHaveAttribute(
 		'aria-activedescendant',
 		'supersearch-item-2x0'
 	);
-	expect(await page.getByTestId('supersearch-return-key-label')).toHaveText('Välj');
+	expect(page.getByTestId('supersearch-return-key-label')).toHaveText('Välj');
 });


### PR DESCRIPTION
## Description
### Solves

Let's see if this fixes the infamous test

### Summary of changes

* Move `await` in 'return key label is context-aware' test
