### PR TITLE
fix(lxlweb): repair library stuff

### DIFF
--- a/lxl-web/src/lib/components/HoldingsPanel.svelte
+++ b/lxl-web/src/lib/components/HoldingsPanel.svelte
@@ -11,7 +11,7 @@
 	import BiSearch from '~icons/bi/search';
 	// import BiHouseHeart from '~icons/bi/house-heart';
 	import IconChevron from '~icons/bi/chevron-down';
-	import BiBank from '~icons/bi/bank';
+	import BiHouses from '~icons/bi/houses';
 
 	type Props = {
 		holders: (LibraryWithLinksAndInstances | UnknownLibrary)[];
@@ -156,7 +156,7 @@
 						<li>
 							<h3 class="mb-3 flex items-center gap-2">
 								<span aria-hidden="true" class="text-subtle text-base">
-									<BiBank class="text-subtle size-3" />
+									<BiHouses class="text-subtle size-3" />
 								</span>
 								<span>{holder._orgLabel}</span>
 							</h3>

--- a/lxl-web/src/lib/utils/getLibraryIdsFromMapping.test.ts
+++ b/lxl-web/src/lib/utils/getLibraryIdsFromMapping.test.ts
@@ -5,20 +5,20 @@ import { getLibraryIdsFromMapping } from './getLibraryIdsFromMapping';
 describe('getLibraryIdsFromMapping', () => {
 	it('it returns an object of sigels and labels included in mapping', () => {
 		expect(getLibraryIdsFromMapping([mappingOneLib])).toStrictEqual({
-			'https://libris.kb.se/library/Alve': 'Alvesta bibliotek · Alve'
+			'https://libris.kb.se/library/Alve': 'Alvesta bibliotek'
 		});
 	});
 
 	it('it returns an object of sigels and labels included in mapping 2', () => {
 		expect(getLibraryIdsFromMapping([mappingTwoLibs])).toStrictEqual({
-			'https://libris.kb.se/library/Boln': 'Bollnäs bibliotek · Boln',
-			'https://libris.kb.se/library/Hagf': 'Hagfors bibliotek · Hagf'
+			'https://libris.kb.se/library/Boln': 'Bollnäs bibliotek',
+			'https://libris.kb.se/library/Hagf': 'Hagfors bibliotek'
 		});
 	});
 
 	it('does not include explicitly excluded libraries', () => {
 		expect(getLibraryIdsFromMapping([mappingExcludedLib])).toStrictEqual({
-			'https://libris.kb.se/library/Boln': 'Bollnäs bibliotek · Boln'
+			'https://libris.kb.se/library/Boln': 'Bollnäs bibliotek'
 		});
 	});
 
@@ -32,11 +32,12 @@ describe('getLibraryIdsFromMapping', () => {
 	});
 });
 
+// library:"sigel:Alve" hej
 const mappingOneLib: DisplayMapping[] = [
 	{
 		children: [
 			{
-				'@id': 'https://id.kb.se/vocab/itemHeldBy',
+				'@id': 'https://id.kb.se/ns/librissearch/library',
 				display: {
 					'@id': 'https://libris.kb.se/library/Alve',
 					'@type': 'Library',
@@ -44,24 +45,20 @@ const mappingOneLib: DisplayMapping[] = [
 						{
 							name: 'Alvesta bibliotek',
 							_label: 'namn'
-						},
-						{
-							_contentBefore: ' · ',
-							sigel: 'Alve',
-							_label: 'sigel'
 						}
 					],
-					_style: ['link'],
+					_style: ['link', 'block'],
 					_label: 'Bibliotek'
 				},
-				displayStr: 'Alvesta bibliotek · Alve',
+				displayStr: 'Alvesta bibliotek',
 				label: 'Bibliotek',
 				operator: 'equals',
 				up: {
 					'@id': '/find?_q=hej'
 				},
-				_key: 'itemHeldBy',
-				_value: '"sigel:Alve"'
+				_key: 'library',
+				_value: '"sigel:Alve"',
+				isRedundantKeyLabel: true
 			},
 			{
 				'@id': 'https://id.kb.se/vocab/textQuery',
@@ -70,18 +67,19 @@ const mappingOneLib: DisplayMapping[] = [
 				label: 'Fritextsökning',
 				operator: 'equals',
 				up: {
-					'@id': '/find?_q=itemHeldBy:%22sigel:Alve%22'
+					'@id': '/find?_q=library:%22sigel:Alve%22'
 				}
 			}
 		],
 		operator: 'and',
 		up: {
-			'@id': '/find?_q=*'
+			'@id': '/find?_q='
 		},
 		variable: '_q'
 	}
 ];
 
+// språk:"lang:swe" library:"sigel:Boln" library:"sigel:Hagf"
 const mappingTwoLibs: DisplayMapping[] = [
 	{
 		children: [
@@ -102,84 +100,70 @@ const mappingTwoLibs: DisplayMapping[] = [
 				label: 'Språk',
 				operator: 'equals',
 				up: {
-					'@id': '/find?_q=itemHeldBy:%22sigel:Boln%22+OR+itemHeldBy:%22sigel:Hagf%22'
+					'@id': '/find?_q=library:%22sigel:Boln%22+library:%22sigel:Hagf%22'
 				},
 				_key: 'språk',
-				_value: '"lang:swe"'
+				_value: '"lang:swe"',
+				isRedundantKeyLabel: true
 			},
 			{
-				children: [
-					{
-						'@id': 'https://id.kb.se/vocab/itemHeldBy',
-						display: {
-							'@id': 'https://libris.kb.se/library/Boln',
-							'@type': 'Library',
-							_display: [
-								{
-									name: 'Bollnäs bibliotek',
-									_label: 'namn'
-								},
-								{
-									_contentBefore: ' · ',
-									sigel: 'Boln',
-									_label: 'sigel'
-								}
-							],
-							_style: ['link'],
-							_label: 'Bibliotek'
-						},
-						displayStr: 'Bollnäs bibliotek · Boln',
-						label: 'Bibliotek',
-						operator: 'equals',
-						up: {
-							'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+itemHeldBy:%22sigel:Hagf%22'
-						},
-						_key: 'itemHeldBy',
-						_value: '"sigel:Boln"'
-					},
-					{
-						'@id': 'https://id.kb.se/vocab/itemHeldBy',
-						display: {
-							'@id': 'https://libris.kb.se/library/Hagf',
-							'@type': 'Library',
-							_display: [
-								{
-									name: 'Hagfors bibliotek',
-									_label: 'namn'
-								},
-								{
-									_contentBefore: ' · ',
-									sigel: 'Hagf',
-									_label: 'sigel'
-								}
-							],
-							_style: ['link'],
-							_label: 'Bibliotek'
-						},
-						displayStr: 'Hagfors bibliotek · Hagf',
-						label: 'Bibliotek',
-						operator: 'equals',
-						up: {
-							'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+itemHeldBy:%22sigel:Boln%22'
-						},
-						_key: 'itemHeldBy',
-						_value: '"sigel:Hagf"'
-					}
-				],
-				operator: 'or',
+				'@id': 'https://id.kb.se/ns/librissearch/library',
+				display: {
+					'@id': 'https://libris.kb.se/library/Boln',
+					'@type': 'Library',
+					_display: [
+						{
+							name: 'Bollnäs bibliotek',
+							_label: 'namn'
+						}
+					],
+					_style: ['link', 'block'],
+					_label: 'Bibliotek'
+				},
+				displayStr: 'Bollnäs bibliotek',
+				label: 'Bibliotek',
+				operator: 'equals',
 				up: {
-					'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22'
-				}
+					'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+library:%22sigel:Hagf%22'
+				},
+				_key: 'library',
+				_value: '"sigel:Boln"',
+				isRedundantKeyLabel: true
+			},
+			{
+				'@id': 'https://id.kb.se/ns/librissearch/library',
+				display: {
+					'@id': 'https://libris.kb.se/library/Hagf',
+					'@type': 'Library',
+					_display: [
+						{
+							name: 'Hagfors bibliotek',
+							_label: 'namn'
+						}
+					],
+					_style: ['link', 'block'],
+					_label: 'Bibliotek'
+				},
+				displayStr: 'Hagfors bibliotek',
+				label: 'Bibliotek',
+				operator: 'equals',
+				up: {
+					'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+library:%22sigel:Boln%22'
+				},
+				_key: 'library',
+				_value: '"sigel:Hagf"',
+				isRedundantKeyLabel: true
 			}
 		],
 		operator: 'and',
 		up: {
-			'@id': '/find?_q=*'
+			'@id': '/find?_q='
 		},
 		variable: '_q'
 	}
 ];
 
+// språk:"lang:swe" library:"sigel:Boln" NOT library:"sigel:Hagf"
 const mappingExcludedLib: DisplayMapping[] = [
 	{
 		children: [
@@ -200,13 +184,14 @@ const mappingExcludedLib: DisplayMapping[] = [
 				label: 'Språk',
 				operator: 'equals',
 				up: {
-					'@id': '/find?_q=itemHeldBy:%22sigel:Boln%22+NOT+itemHeldBy:%22sigel:Hagf%22'
+					'@id': '/find?_q=library:%22sigel:Boln%22+NOT+library:%22sigel:Hagf%22'
 				},
 				_key: 'språk',
-				_value: '"lang:swe"'
+				_value: '"lang:swe"',
+				isRedundantKeyLabel: true
 			},
 			{
-				'@id': 'https://id.kb.se/vocab/itemHeldBy',
+				'@id': 'https://id.kb.se/ns/librissearch/library',
 				display: {
 					'@id': 'https://libris.kb.se/library/Boln',
 					'@type': 'Library',
@@ -214,29 +199,25 @@ const mappingExcludedLib: DisplayMapping[] = [
 						{
 							name: 'Bollnäs bibliotek',
 							_label: 'namn'
-						},
-						{
-							_contentBefore: ' · ',
-							sigel: 'Boln',
-							_label: 'sigel'
 						}
 					],
-					_style: ['link'],
+					_style: ['link', 'block'],
 					_label: 'Bibliotek'
 				},
-				displayStr: 'Bollnäs bibliotek · Boln',
+				displayStr: 'Bollnäs bibliotek',
 				label: 'Bibliotek',
 				operator: 'equals',
 				up: {
-					'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+NOT+itemHeldBy:%22sigel:Hagf%22'
+					'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+NOT+library:%22sigel:Hagf%22'
 				},
-				_key: 'itemHeldBy',
-				_value: '"sigel:Boln"'
+				_key: 'library',
+				_value: '"sigel:Boln"',
+				isRedundantKeyLabel: true
 			},
 			{
 				children: [
 					{
-						'@id': 'https://id.kb.se/vocab/itemHeldBy',
+						'@id': 'https://id.kb.se/ns/librissearch/library',
 						display: {
 							'@id': 'https://libris.kb.se/library/Hagf',
 							'@type': 'Library',
@@ -244,40 +225,37 @@ const mappingExcludedLib: DisplayMapping[] = [
 								{
 									name: 'Hagfors bibliotek',
 									_label: 'namn'
-								},
-								{
-									_contentBefore: ' · ',
-									sigel: 'Hagf',
-									_label: 'sigel'
 								}
 							],
-							_style: ['link'],
+							_style: ['link', 'block'],
 							_label: 'Bibliotek'
 						},
-						displayStr: 'Hagfors bibliotek · Hagf',
+						displayStr: 'Hagfors bibliotek',
 						label: 'Bibliotek',
 						operator: 'equals',
 						up: {
-							'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+itemHeldBy:%22sigel:Boln%22'
+							'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+library:%22sigel:Boln%22'
 						},
-						_key: 'itemHeldBy',
-						_value: '"sigel:Hagf"'
+						_key: 'library',
+						_value: '"sigel:Hagf"',
+						isRedundantKeyLabel: true
 					}
 				],
 				operator: 'not',
 				up: {
-					'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+itemHeldBy:%22sigel:Boln%22'
+					'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+library:%22sigel:Boln%22'
 				}
 			}
 		],
 		operator: 'and',
 		up: {
-			'@id': '/find?_q=*'
+			'@id': '/find?_q='
 		},
 		variable: '_q'
 	}
 ];
 
+// språk:"lang:swe" NOT library:"sigel:Hagf" instanceType:DigitalResource
 const mappingNoLibs: DisplayMapping[] = [
 	{
 		children: [
@@ -298,15 +276,16 @@ const mappingNoLibs: DisplayMapping[] = [
 				label: 'Språk',
 				operator: 'equals',
 				up: {
-					'@id': '/find?_q=NOT+itemHeldBy:%22sigel:Hagf%22+hasInstanceType:DigitalResource+hagfors'
+					'@id': '/find?_q=NOT+library:%22sigel:Hagf%22+instanceType:DigitalResource'
 				},
 				_key: 'språk',
-				_value: '"lang:swe"'
+				_value: '"lang:swe"',
+				isRedundantKeyLabel: true
 			},
 			{
 				children: [
 					{
-						'@id': 'https://id.kb.se/vocab/itemHeldBy',
+						'@id': 'https://id.kb.se/ns/librissearch/library',
 						display: {
 							'@id': 'https://libris.kb.se/library/Hagf',
 							'@type': 'Library',
@@ -314,33 +293,29 @@ const mappingNoLibs: DisplayMapping[] = [
 								{
 									name: 'Hagfors bibliotek',
 									_label: 'namn'
-								},
-								{
-									_contentBefore: ' · ',
-									sigel: 'Hagf',
-									_label: 'sigel'
 								}
 							],
-							_style: ['link'],
+							_style: ['link', 'block'],
 							_label: 'Bibliotek'
 						},
-						displayStr: 'Hagfors bibliotek · Hagf',
+						displayStr: 'Hagfors bibliotek',
 						label: 'Bibliotek',
 						operator: 'equals',
 						up: {
-							'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+hasInstanceType:DigitalResource+hagfors'
+							'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+instanceType:DigitalResource'
 						},
-						_key: 'itemHeldBy',
-						_value: '"sigel:Hagf"'
+						_key: 'library',
+						_value: '"sigel:Hagf"',
+						isRedundantKeyLabel: true
 					}
 				],
 				operator: 'not',
 				up: {
-					'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+hasInstanceType:DigitalResource+hagfors'
+					'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+instanceType:DigitalResource'
 				}
 			},
 			{
-				'@id': 'https://id.kb.se/vocab/hasInstanceType',
+				'@id': 'https://id.kb.se/ns/librissearch/instanceType',
 				display: {
 					'@id': 'https://id.kb.se/vocab/DigitalResource',
 					'@type': 'Class',
@@ -353,29 +328,19 @@ const mappingNoLibs: DisplayMapping[] = [
 					_label: 'Klass'
 				},
 				displayStr: 'Digital resurs',
-				label: 'Format',
+				label: 'https://id.kb.se/ns/librissearch/instanceType',
 				operator: 'equals',
 				up: {
-					'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+NOT+itemHeldBy:%22sigel:Hagf%22+hagfors'
+					'@id': '/find?_q=spr%C3%A5k:%22lang:swe%22+NOT+library:%22sigel:Hagf%22'
 				},
-				_key: 'hasInstanceType',
-				_value: 'DigitalResource'
-			},
-			{
-				'@id': 'https://id.kb.se/vocab/textQuery',
-				display: 'hagfors',
-				displayStr: 'hagfors',
-				label: 'Fritextsökning',
-				operator: 'equals',
-				up: {
-					'@id':
-						'/find?_q=spr%C3%A5k:%22lang:swe%22+NOT+itemHeldBy:%22sigel:Hagf%22+hasInstanceType:DigitalResource'
-				}
+				_key: 'instanceType',
+				_value: 'DigitalResource',
+				isRedundantKeyLabel: true
 			}
 		],
 		operator: 'and',
 		up: {
-			'@id': '/find?_q=*'
+			'@id': '/find?_q='
 		},
 		variable: '_q'
 	}

--- a/lxl-web/src/lib/utils/getLibraryIdsFromMapping.ts
+++ b/lxl-web/src/lib/utils/getLibraryIdsFromMapping.ts
@@ -10,7 +10,7 @@ export function getLibraryIdsFromMapping(
 	mappings: (DisplayMapping[] | undefined)[]
 ): Record<LibraryId | OrgId, string> | null {
 	const result: Record<string, string> = {};
-	const validKeys = new Set(['itemHeldBy', 'itemHeldByOrg']);
+	const libraryId = 'https://id.kb.se/ns/librissearch/library';
 	for (const mapping of mappings) {
 		if (mapping) {
 			for (const m of mapping) {
@@ -27,7 +27,7 @@ export function getLibraryIdsFromMapping(
 			return;
 		}
 
-		if (mapping._key && validKeys.has(mapping._key)) {
+		if (mapping[JsonLd.ID] && mapping[JsonLd.ID] === libraryId) {
 			const id = mapping.display[JsonLd.ID];
 			// as long as we don't fetch & cache library organizations
 			// we need to store the labels for reuse too

--- a/lxl-web/src/lib/utils/getTypeLike.ts
+++ b/lxl-web/src/lib/utils/getTypeLike.ts
@@ -236,7 +236,7 @@ const PRIORITIZED_ICONS = [
 export function getTypeForIcon(typeLike: TypeLike) {
 	for (const t of typeLike.identify.concat(typeLike.find)) {
 		if (t) {
-			const slugStr = slug((t[JsonLd.ID] as string) || ''.replace('/bibdb/', '/bibdb:'));
+			const slugStr = slug(((t[JsonLd.ID] as string) || '').replace('/bibdb/', '/bibdb:'));
 			if (slugStr && PRIORITIZED_ICONS.includes(slugStr)) {
 				return slugStr;
 			}
@@ -244,7 +244,7 @@ export function getTypeForIcon(typeLike: TypeLike) {
 	}
 
 	return typeLike.find.length > 0 && typeLike.find[0] !== undefined
-		? slug((typeLike.find[0][JsonLd.ID] as string) || ''.replace('/bibdb/', '/bibdb:'))
+		? slug(((typeLike.find[0][JsonLd.ID] as string) || '').replace('/bibdb/', '/bibdb:'))
 		: '';
 }
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/search/en.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/search/en.md
@@ -91,7 +91,7 @@ See our [API-documentation](https://libris.kb.se/api/docs/) for information abou
 
 It’s easy to copy searches (including filters) by selecting the contents of the search box and copying it as if it were plain text.
 
-- Example: [A search for computer games held by Bergslagsbibblan](/find?_q=category:"saogf:Datorspel"+itemHeldByOrg:"sigel:org/BER"), which has been created by clicking suggested search filters, can be transformed to its text representation (`category:"saogf:Datorspel" itemHeldByOrg:"sigel:org/BER"`) by marking and copying it.
+- Example: [A search for computer games held by Bergslagsbibblan](/find?_q=category:"saogf:Datorspel"+library:"sigel:org/BER"), which has been created by clicking suggested search filters, can be transformed to its text representation (`category:"saogf:Datorspel" library:"sigel:org/BER"`) by marking and copying it.
 
 ### Empty filters -- required a specific property to be present
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/search/sv.md
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/search/sv.md
@@ -93,7 +93,7 @@ Här kan du också läsa om hur du gör anrop för att skapa integrationer mot a
 
 Det går enkelt att kopiera sökningar (inklusive filter) genom att markera innehållet i sökrutan och kopiera det som om det vore vanlig text.
 
-- Exempel: [En sökning på datorspel som finns på Bergslagsbibblan](/find?_q=category:"saogf:Datorspel"+itemHeldByOrg:"sigel:org/BER"), som klickats fram från föreslagna filter, kan omvandlas till dess textrepresentation (`category:"saogf:Datorspel" itemHeldByOrg:"sigel:org/BER"`) genom att markera och kopiera den.
+- Exempel: [En sökning på datorspel som finns på Bergslagsbibblan](/find?_q=category:"saogf:Datorspel"+library:"sigel:org/BER"), som klickats fram från föreslagna filter, kan omvandlas till dess textrepresentation (`category:"saogf:Datorspel" library:"sigel:org/BER"`) genom att markera och kopiera den.
 
 ### Tomma filter – kräv att en egenskap ska finnas
 

--- a/lxl-web/tests/help.filters.spec.ts
+++ b/lxl-web/tests/help.filters.spec.ts
@@ -13,11 +13,11 @@ test('should not have any detectable a11y issues', async ({ page }) => {
 */
 
 test('qualifier keys can be added from filter list', async ({ page }) => {
-	await page.getByRole('main').getByRole('button').getByText('Bibliografi').click();
+	await page.getByRole('main').getByRole('button').getByText('Ingår i bibliografi').click();
 	await expect(page.getByRole('combobox').first()).toContainText('Ingår i bibliografi');
 	await expect(page.getByRole('combobox').last()).toContainText('Ingår i bibliografi');
 	await page.keyboard.press('Escape');
-	await page.getByRole('main').getByRole('button').getByText('Biblioteksorganisation').click();
+	await page.getByRole('main').getByRole('button').getByText('Bibliotek').click();
 	await expect(page.getByRole('combobox').first()).toContainText('Ingår i bibliografi');
-	await expect(page.getByRole('combobox').first()).toContainText(' Biblioteksorganisation');
+	await expect(page.getByRole('combobox').first()).toContainText(' Bibliotek');
 });

--- a/lxl-web/tests/subsets.spec.ts
+++ b/lxl-web/tests/subsets.spec.ts
@@ -1,25 +1,25 @@
 import { expect, test } from '@playwright/test';
 
 test('A subset filter can display on any page', async ({ page }) => {
-	await page.goto('/help/search?_r=itemHeldBy%3A"sigel%3AArkm"');
+	await page.goto('/help/search?_r=library%3A"sigel%3AArkm"');
 	await expect(page.locator('.subset-container').getByText('ArkDes')).toBeVisible();
 });
 
 test('The search placeholder is replaced when using a subset', async ({ page }) => {
-	await page.goto('my-pages?_r=itemHeldBy%3A"sigel%3AArkm"');
+	await page.goto('my-pages?_r=library%3A"sigel%3AArkm"');
 	await expect(page.getByRole('combobox', { name: 'Sök' }).getByText('ArkDes')).toBeVisible();
 });
 
 test('_r param is preserved when navigating around the app', async ({ page }) => {
-	await page.goto('/find?_q=a&_offset=0&_limit=20&_r=itemHeldBy%3A%22sigel%3AArkm%22');
+	await page.goto('/find?_q=a&_offset=0&_limit=20&_r=library%3A%22sigel%3AArkm%22');
 	await page.getByRole('main').getByRole('article').getByRole('link').first().click();
-	await expect(page).toHaveURL(/_r=itemHeldBy%3A%22sigel%3AArkm%22/);
+	await expect(page).toHaveURL(/_r=library%3A%22sigel%3AArkm%22/);
 	await page.getByRole('main').getByRole('link').getByText('Nästa').click();
-	await expect(page).toHaveURL(/_r=itemHeldBy%3A%22sigel%3AArkm%22/);
+	await expect(page).toHaveURL(/_r=library%3A%22sigel%3AArkm%22/);
 	await page.getByRole('main').getByRole('link').getByText('Visa i träfflista').click();
-	await expect(page).toHaveURL(/_r=itemHeldBy%3A%22sigel%3AArkm%22/);
+	await expect(page).toHaveURL(/_r=library%3A%22sigel%3AArkm%22/);
 	await page.getByRole('link', { name: 'Mina sidor' }).click();
-	await expect(page).toHaveURL(/my-pages\?_r=itemHeldBy%3A%22sigel%3AArkm%22/);
+	await expect(page).toHaveURL(/my-pages\?_r=library%3A%22sigel%3AArkm%22/);
 });
 
 test('A subset filter can be removed', async ({ page }) => {
@@ -37,7 +37,7 @@ test('A subset filter can be removed and preserves lang', async ({ page }) => {
 });
 
 test('Holding button changes text when using a library subset filter', async ({ page }) => {
-	await page.goto('/find?_q=&_r=itemHeldByOrg:%22sigel:org/ARKM%22');
+	await page.goto('/find?_q=&_r=library:%22sigel:org/ARKM%22');
 	await expect(page.getByTestId('holding-link').first()).toHaveText('Hitta titeln');
 });
 
@@ -49,7 +49,7 @@ test('Holding button does not change text when subset filter is not a library', 
 });
 
 test('Holdings panel highlights the library subset holding', async ({ page }) => {
-	await page.goto('/find?_q=&_r=itemHeldByOrg:%22sigel:org/ARKM%22');
+	await page.goto('/find?_q=&_r=library:%22sigel:org/ARKM%22');
 	await page.getByTestId('holding-link').first().click();
 	await expect(page.locator('.special-section')).toContainText('Avgränsade bibliotek');
 	await expect(page.locator('.special-section')).toContainText('ArkDes');


### PR DESCRIPTION
## Description
### Solves

`itemHeldBy`/`itemHeldByOrg` --> `library`

### Summary of changes

* Repair refined libraries: `getLibraryIdsFromMapping`: check `@id` instead of `_key`
* update `getLibraryIdsFromMapping` unit test with new mapping data
* Fix e2e test: don't click on "Biblioteksorganisation"
* Update example search in help page
* Remove references to `itemHeldBy` 
* Fix library org icons (not related but domain-related :))
