### PR TITLE
Use preformatted _q string from API response for relation search

### DIFF
--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -170,6 +170,7 @@ export interface Slice {
 export interface Observation {
 	totalItems: number;
 	view: Link;
+	predicate?: FramedData;
 	object: FramedData;
 	_selected?: boolean;
 	sliceByDimension: Record<FacetId, Slice>;

--- a/lxl-web/src/lib/utils/relations.ts
+++ b/lxl-web/src/lib/utils/relations.ts
@@ -5,7 +5,6 @@ import type { PartialCollectionView } from '$lib/types/search';
 import { Base, JsonLd, Platform } from '$lib/types/xl';
 import addDefaultSearchParams from '$lib/utils/addDefaultSearchParams';
 import getSortedSearchParams from '$lib/utils/getSortedSearchParams';
-import prefixesByNamespace from '$lib/assets/json/prefixesByNamespace.json';
 import capitalize from '$lib/utils/capitalize';
 import { type ApiError } from '$lib/types/api.js';
 import getAtPath from '$lib/utils/getAtPath';
@@ -53,19 +52,18 @@ export async function getRelations(
 
 	if (data.stats?._predicates) {
 		return data.stats._predicates.map((p) => {
-			const qualifierKey = new URLSearchParams(p.view[JsonLd.ID]).get('_p') as string;
-			const qualifierValue = getQualifierValue(resourceId);
-			const label = capitalize(
-				vocabUtil.getLabelByLang(qualifierKey as string, locale) || qualifierKey
-			);
-			const preferLike: boolean = getAtPath(p.object, [Base.category, '*', JsonLd.ID])
+			const params = p.view[JsonLd.ID].split('?')[1];
+			const q = new URLSearchParams(params).get('_q') as string;
+			const predicateIri = p.predicate[JsonLd.ID] as string;
+			const qualifierKey = getUriSlug(predicateIri);
+			const label = capitalize(vocabUtil.getLabelByLang(predicateIri, locale) || qualifierKey);
+			const preferLike: boolean = getAtPath(p.predicate, [Base.category, '*', JsonLd.ID])
 				.map(getUriSlug)
 				.some((c) => c === Platform.preferLike);
-			const op = preferLike ? '~' : ':';
 			const findUrl = `/find?${getSortedSearchParams(
 				addDefaultSearchParams(
 					new URLSearchParams({
-						_q: `${qualifierKey}${op}${qualifierValue}`,
+						_q: q,
 						_spell: 'false'
 					})
 				)
@@ -73,7 +71,7 @@ export async function getRelations(
 			const previewUrl = `${env.API_URL}/find.jsonld?${getSortedSearchParams(
 				addDefaultSearchParams(
 					new URLSearchParams({
-						_q: `${qualifierKey}${op}${qualifierValue}`,
+						_q: q,
 						_limit: '10',
 						_spell: 'false',
 						_stats: 'falseThisRequest',
@@ -95,35 +93,4 @@ export async function getRelations(
 	}
 
 	return [];
-}
-
-function getQualifierValue(id: string) {
-	const prefix = getPrefix(id);
-	const qId = id.split('/').pop();
-
-	if (prefix && qId) {
-		return '"' + prefix + qId + '"';
-	}
-	if (looksLikeUri(id)) {
-		return '"' + id + '"';
-	}
-	return id;
-}
-
-function looksLikeUri(id: string) {
-	return id.startsWith('https://') || id.startsWith('http://');
-}
-
-function getPrefix(id: string) {
-	const prefixFromNamespace = Object.entries(prefixesByNamespace).find(([ns]) =>
-		id.includes(ns)
-	)?.[1];
-
-	if (prefixFromNamespace) {
-		return prefixFromNamespace;
-	}
-	if (id.includes(env.API_URL)) {
-		return 'libris:';
-	}
-	return '';
 }


### PR DESCRIPTION
Fixes bad query formatting in relation search.

Before:
<img width="1382" height="541" alt="bild" src="https://github.com/user-attachments/assets/31e4d2ef-961a-48e6-ad4d-88a6e83a503e" />

After:
<img width="1370" height="501" alt="bild" src="https://github.com/user-attachments/assets/9bba70f9-3d74-4bd6-a94f-18e7a27d21fb" />

Depends on https://github.com/libris/librisxl/pull/1756

The code can likely be be simplified even more now that backend provides all the required data. Feel free to step in :slightly_smiling_face: 