### PR TITLE
fix(lxl-web): instance/work/uniform title

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -574,6 +574,8 @@
 						"legalDate",
 						"version",
 						"marc:arrangedStatementForMusic",
+						"musicMedium",
+						"musicKey",
 						"originDate"
 					]
 				},
@@ -1659,6 +1661,12 @@
 			"@type": "fresnel:Format",
 			"fresnel:propertyFormatDomain": ["summary"],
 			"fresnel:propertyStyle": ["nolabel", "summary"]
+		},
+		"marc:arrangedStatementForMusic-format": {
+			"@id": "marc:arrangedStatementForMusic-format",
+			"@type": "fresnel:Format",
+			"fresnel:propertyFormatDomain": ["marc:arrangedStatementForMusic"],
+			"fresnel:propertyStyle": ["nolabel"]
 		},
 		"Work-language-format": {
 			"@id": "Work-language-format",

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -720,9 +720,7 @@
 						{
 							"alternateProperties": [{ "subPropertyOf": "hasTitle", "range": "KeyTitle" }]
 						},
-						{
-							"alternateProperties": ["translationOf", "_uniformTitle"]
-						}
+						"translationOf"
 					]
 				},
 				"Instance": {

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -312,9 +312,9 @@
 						"translationOf",
 						"legalDate",
 						"version",
-						"marc:arrangedStatementForMusic",
 						"musicMedium",
 						"musicKey",
+						"marc:arrangedStatementForMusic",
 						"originDate",
 						"language",
 						{
@@ -573,9 +573,9 @@
 						},
 						"legalDate",
 						"version",
-						"marc:arrangedStatementForMusic",
 						"musicMedium",
 						"musicKey",
+						"marc:arrangedStatementForMusic",
 						"originDate"
 					]
 				},
@@ -1426,7 +1426,20 @@
 			"fresnel:propertyFormat": {
 				"fresnel:contentBefore": " ",
 				"fresnel:contentFirst": ""
-			}
+			},
+			"fresnel:propertyStyle": ["nolabel"]
+		},
+		"musicMedium-format": {
+			"@id": "musicMedium-format",
+			"@type": "fresnel:Format",
+			"fresnel:propertyFormatDomain": ["musicMedium"],
+			"fresnel:propertyStyle": ["nolabel"]
+		},
+		"musicKey-format": {
+			"@id": "musicKey-format",
+			"@type": "fresnel:Format",
+			"fresnel:propertyFormatDomain": ["musicKey"],
+			"fresnel:propertyStyle": ["nolabel"]
 		},
 		"marc:formSubheading-format": {
 			"@id": "marc:formSubheading-format",
@@ -1661,12 +1674,6 @@
 			"@type": "fresnel:Format",
 			"fresnel:propertyFormatDomain": ["summary"],
 			"fresnel:propertyStyle": ["nolabel", "summary"]
-		},
-		"marc:arrangedStatementForMusic-format": {
-			"@id": "marc:arrangedStatementForMusic-format",
-			"@type": "fresnel:Format",
-			"fresnel:propertyFormatDomain": ["marc:arrangedStatementForMusic"],
-			"fresnel:propertyStyle": ["nolabel"]
 		},
 		"Work-language-format": {
 			"@id": "Work-language-format",

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -42,6 +42,7 @@
 			headingTop: DisplayDecorated;
 			heading: DisplayDecorated;
 			headingExtra: DisplayDecorated;
+			_workTitle2?: DisplayDecorated;
 			overview: DisplayDecorated[];
 			overview2: DisplayDecorated[];
 			overviewFooter: DisplayDecorated;
@@ -216,6 +217,16 @@
 									showLabels={ShowLabelsOptions.DefaultOn}
 								/>
 							</p>
+							{#if decoratedData['_workTitle2']?._display}
+								<p
+									class="decorated-heading-extra text-subtle flex items-center gap-1 text-sm font-medium"
+								>
+									<DecoratedData
+										data={decoratedData._workTitle2}
+										showLabels={ShowLabelsOptions.DefaultOff}
+									/>
+								</p>
+							{/if}
 						</hgroup>
 					</header>
 				</div>

--- a/lxl-web/src/lib/components/SearchResultItem.svelte
+++ b/lxl-web/src/lib/components/SearchResultItem.svelte
@@ -113,7 +113,7 @@
 					<p class="decorated-card-heading-extra text-subtle mt-0.5 truncate text-xs">
 						{#each data['_workTitle2']?._display as displayObj, index (index)}
 							<span>
-								<DecoratedData data={displayObj} showLabels="defaultOn" />
+								<DecoratedData data={displayObj} showLabels="defaultOff" />
 							</span>
 						{/each}
 					</p>

--- a/lxl-web/src/lib/components/SearchResultItem.svelte
+++ b/lxl-web/src/lib/components/SearchResultItem.svelte
@@ -7,6 +7,7 @@
 	import getInstanceData from '$lib/utils/getInstanceData';
 	import TypeIcon from './TypeIcon.svelte';
 	import { bookAspectRatio } from '$lib/utils/getTypeLike';
+	import { LensType } from '$lib/types/xl';
 
 	type Props = {
 		data: SearchResultItem;
@@ -99,9 +100,18 @@
 				>
 					<DecoratedData data={data['card-heading']} showLabels="never" />
 				</h2>
-				{#if data['web-card-header-extra']?._display && data['web-card-header-extra']?._display.length}
+				{#if data[LensType.WebCardHeaderExtra]?._display && data[LensType.WebCardHeaderExtra]?._display.length}
 					<p class="decorated-card-heading-extra text-subtle mt-0.5 truncate text-xs">
-						{#each data['web-card-header-extra']?._display as displayObj, index (index)}
+						{#each data[LensType.WebCardHeaderExtra]?._display as displayObj, index (index)}
+							<span>
+								<DecoratedData data={displayObj} showLabels="defaultOn" />
+							</span>
+						{/each}
+					</p>
+				{/if}
+				{#if data['_workTitle2']?._display && data['_workTitle2']?._display.length}
+					<p class="decorated-card-heading-extra text-subtle mt-0.5 truncate text-xs">
+						{#each data['_workTitle2']?._display as displayObj, index (index)}
 							<span>
 								<DecoratedData data={displayObj} showLabels="defaultOn" />
 							</span>

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -290,6 +290,20 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 						{/each}
 					</p>
 				{/if}
+				{#if item['_workTitle2']?._display}
+					<p class="card-header-extra">
+						{#each item['_workTitle2']?._display as obj, index (index)}
+							<span>
+								<DecoratedData
+									data={obj}
+									showLabels={ShowLabelsOptions.DefaultOn}
+									{allowLinks}
+									{allowPopovers}
+								/>
+							</span>
+						{/each}
+					</p>
+				{/if}
 			</header>
 			{#if item[LxlLens.CardBody]?._display}
 				<div class="card-body mt-1 text-sm" id={bodyId}>

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -51,6 +51,7 @@ export interface SearchResultItem {
 	[LxlLens.CardHeading]: DisplayDecorated;
 	[LxlLens.CardBody]: DisplayDecorated;
 	[LensType.WebCardHeaderExtra]: DisplayDecorated;
+	_workTitle2?: DisplayDecorated;
 	[LensType.WebCardHeaderTop]: DisplayDecorated;
 	[LensType.WebCardFooter]: DisplayDecorated;
 	image: SecureImageResolution | undefined;

--- a/lxl-web/src/lib/utils/centerOnWork.ts
+++ b/lxl-web/src/lib/utils/centerOnWork.ts
@@ -8,9 +8,6 @@ export function centerOnWork(mainEntity: FramedData): FramedData {
 		result['@reverse'] = { instanceOf: [mainEntity] };
 		if (!result.hasTitle && mainEntity.hasTitle) {
 			result.hasTitle = mainEntity.hasTitle;
-		} else if (result.hasTitle && mainEntity.hasTitle) {
-			result._uniformTitle = result.hasTitle;
-			result.hasTitle = mainEntity.hasTitle;
 		}
 		return result;
 	} else {

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -117,7 +117,7 @@ export function asSearchResultItem(
 	maxScores?: Record<string, number>
 ): SearchResultItem[] {
 	return items?.map((i) => {
-		const isWorkSingleInstance = getAtPath(i, ['@reverse', 'instanceOf', '*']).length === 1;
+		const isWorkSingleInstance = (i?.['@reverse']?.instanceOf || []).length === 1;
 		i = cleanUpItem(i, isWorkSingleInstance);
 
 		const headerThing = isWorkSingleInstance ? (i['@reverse']['instanceOf'][0] as FramedData) : i;
@@ -151,7 +151,7 @@ export function asSearchResultItem(
 				locale
 			),
 			...(hasWorkTitle && {
-				_workTitle2: displayUtil.lensAndFormat(i, LxlLens.CardHeading, locale)
+				_workTitle2: workTitle
 			}),
 			[LensType.WebCardFooter]: displayUtil.lensAndFormat(i, LensType.WebCardFooter, locale),
 			image: toSecure(bestSize(bestImage(i, locale), Width.SMALL), auxdSecret),

--- a/lxl-web/src/lib/utils/search.ts
+++ b/lxl-web/src/lib/utils/search.ts
@@ -116,9 +116,21 @@ export function asSearchResultItem(
 	subsetLibraries?: MyLibrariesType,
 	maxScores?: Record<string, number>
 ): SearchResultItem[] {
-	return items
-		?.map((i) => cleanUpItem(i))
-		.map((i) => ({
+	return items?.map((i) => {
+		const isWorkSingleInstance = getAtPath(i, ['@reverse', 'instanceOf', '*']).length === 1;
+		i = cleanUpItem(i, isWorkSingleInstance);
+
+		const headerThing = isWorkSingleInstance ? (i['@reverse']['instanceOf'][0] as FramedData) : i;
+
+		const heading = displayUtil.lensAndFormat(headerThing, LxlLens.CardHeading, locale);
+
+		const workTitle = isWorkSingleInstance
+			? displayUtil.lensAndFormat(i, LxlLens.CardHeading, locale)
+			: undefined;
+
+		const hasWorkTitle = isWorkSingleInstance && toString(heading) !== toString(workTitle);
+
+		return {
 			...(myLibraries && {
 				heldByMyLibraries: getHeldByLibraries(i, myLibraries)
 			}),
@@ -130,7 +142,7 @@ export function asSearchResultItem(
 			}),
 			[JsonLd.ID]: i.meta[JsonLd.ID] as string,
 			[JsonLd.TYPE]: i[JsonLd.TYPE] as string,
-			[LxlLens.CardHeading]: displayUtil.lensAndFormat(i, LxlLens.CardHeading, locale),
+			[LxlLens.CardHeading]: heading,
 			[LxlLens.CardBody]: displayUtil.lensAndFormat(i, LxlLens.CardBody, locale),
 			[LensType.WebCardHeaderTop]: displayUtil.lensAndFormat(i, LensType.WebCardHeaderTop, locale),
 			[LensType.WebCardHeaderExtra]: displayUtil.lensAndFormat(
@@ -138,6 +150,9 @@ export function asSearchResultItem(
 				LensType.WebCardHeaderExtra,
 				locale
 			),
+			...(hasWorkTitle && {
+				_workTitle2: displayUtil.lensAndFormat(i, LxlLens.CardHeading, locale)
+			}),
 			[LensType.WebCardFooter]: displayUtil.lensAndFormat(i, LensType.WebCardFooter, locale),
 			image: toSecure(bestSize(bestImage(i, locale), Width.SMALL), auxdSecret),
 			typeStr: typeStr(getTypeLike(i, vocabUtil), displayUtil, locale),
@@ -155,7 +170,8 @@ export function asSearchResultItem(
 					i?.reverseLinks?.totalItemsByRelation?.['meta.bibliography'] ||
 					(undefined as number | undefined)
 			})
-		}));
+		};
+	});
 }
 
 function typeStr(typeLike: TypeLike, displayUtil: DisplayUtil, locale: LangCode): string {
@@ -288,7 +304,7 @@ export function displayMappings(
 	}
 }
 
-function cleanUpItem(item: FramedData): FramedData {
+function cleanUpItem(item: FramedData, isWorkSingleInstance: boolean): FramedData {
 	if (isSerial(item)) {
 		const FILTER_ROLES = [
 			'https://id.kb.se/relator/publishingDirector',
@@ -312,7 +328,7 @@ function cleanUpItem(item: FramedData): FramedData {
 	});
 
 	// TODO: don't copy these from the instance when we have fresnel:fslselector (path) support in lenses
-	if (getAtPath(item, ['@reverse', 'instanceOf', '*']).length === 1) {
+	if (isWorkSingleInstance) {
 		const instanceIsPartOf = asArray(
 			getAtPath(item, ['@reverse', 'instanceOf', '*', 'isPartOf', '*'])
 		);

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -123,7 +123,19 @@ export const load = async ({ params, locals, fetch, url }) => {
 		_instances[0]['_select'] = typeLike.select;
 	}
 
-	const heading = displayUtil.lensAndFormat(mainEntity, LxlLens.PageHeading, locale);
+	const isWorkSingleInstance = _instances.length == 1;
+
+	const headingThing = isWorkSingleInstance
+		? (mainEntity['@reverse']['instanceOf'][0] as FramedData)
+		: mainEntity;
+
+	const workTitle = isWorkSingleInstance
+		? displayUtil.lensAndFormat(mainEntity, LxlLens.CardHeading, locale)
+		: undefined;
+
+	const heading = displayUtil.lensAndFormat(headingThing, LxlLens.PageHeading, locale);
+	const hasWorkTitle = isWorkSingleInstance && toString(heading) !== toString(workTitle);
+
 	const headingExtra = displayUtil.lensAndFormat(mainEntity, LensType.WebCardHeaderExtra, locale);
 	const overview = [
 		displayUtil.lensAndFormat(mainEntity, LensType.WebOverview, locale),
@@ -330,6 +342,7 @@ export const load = async ({ params, locals, fetch, url }) => {
 			headingTop: types,
 			heading: heading,
 			headingExtra: headingExtra,
+			...(hasWorkTitle && { _workTitle2: workTitle }),
 			overview: overview,
 			overview2: overview2,
 			overviewFooter: overviewFooter,


### PR DESCRIPTION
Hit list shows the wrong title when both instance and work has a title.

------------

example p43kq57bmnnj86c0
<img width="555" height="120" alt="Skärmbild från 2026-04-28 17-01-33" src="https://github.com/user-attachments/assets/cecbe49d-c5f2-4e67-9436-229e385cdbef" />

before
<img width="614" height="182" alt="Skärmbild från 2026-04-28 17-02-04" src="https://github.com/user-attachments/assets/654db7ae-e3db-4978-869e-78fdb4c6f44d" />

after
<img width="618" height="172" alt="Skärmbild från 2026-04-28 17-13-01" src="https://github.com/user-attachments/assets/faee03fc-8ecc-4e48-b680-63e192fd89cf" />
(musicMedium and musicKey "violin, orkester arrangemang" is missing in index/result. Broken when type normalization removed `NotatedMusic`. Fixed in https://github.com/libris/definitions/commit/431eaa39fa28c4bd7b2f36f36496aa0738746c76 )

------------
Resource page almost does the right thing, but mixes up some music related details-  "violin, orkester arrangemang" in this example. ~Will fix in a follow up PR.~ Fixed in [ace8150](https://github.com/libris/lxlviewer/pull/1578/commits/ace81507118d621e4fcf5149a0fe9fd3e4886985)
<img width="652" height="145" alt="Skärmbild från 2026-04-28 17-06-14" src="https://github.com/user-attachments/assets/6cab0e5c-db23-42cf-9289-461db425bc77" />

------------
example fxgd9wg3crz3nrgr

before:
<img width="619" height="180" alt="Skärmbild från 2026-04-28 16-50-50" src="https://github.com/user-attachments/assets/f8a600af-d750-409c-bcc8-92d9e402ff2c" />

after:
<img width="615" height="239" alt="Skärmbild från 2026-04-28 16-50-13" src="https://github.com/user-attachments/assets/1f8c2217-4662-4691-a7d2-1e5487dbcf49" />

------------
example tc55fgl526cbls2

before:
<img width="613" height="176" alt="Skärmbild från 2026-04-28 17-23-23" src="https://github.com/user-attachments/assets/ada9f8f8-2cba-41ff-ad5a-2e374d478e26" />

after:
<img width="620" height="195" alt="Skärmbild från 2026-04-28 17-23-13" src="https://github.com/user-attachments/assets/3dd93417-16bb-4b19-aa39-28f6d852ae2d" />


