### PR TITLE
feat(lxlweb): featured categories component

### DIFF
--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -141,6 +141,7 @@ export default {
 		search: 'Search',
 		searchResults: 'Search results',
 		searchFor: 'Search for',
+		exploreCategories: 'Explore categories',
 		loading: 'Loading...',
 		filter: 'Filter',
 		findFilter: 'Find filter',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -140,6 +140,7 @@ export default {
 		search: 'Sök',
 		searchResults: 'Sökresultat',
 		searchFor: 'Sök efter',
+		exploreCategories: 'Utforska kategorier',
 		loading: 'Laddar...',
 		filter: 'Filter',
 		findFilter: 'Hitta filter',

--- a/lxl-web/src/lib/remotes/homepage.remote.ts
+++ b/lxl-web/src/lib/remotes/homepage.remote.ts
@@ -79,14 +79,6 @@ const CATEGORY_SHORTCUTS: {
 	labelByLang: Record<LocaleCode, string>;
 }[] = [
 	{
-		id: 'all-categories',
-		href: '/find?_q=',
-		labelByLang: {
-			sv: 'Allt',
-			en: 'All'
-		}
-	},
-	{
 		id: 'fiction-category',
 		href: '/find?_q=category:"saogf:Sk%25C3%25B6nlitteratur"',
 		labelByLang: {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/+page.svelte
@@ -5,6 +5,7 @@
 	import { page } from '$app/state';
 	import IconArrowRight from '~icons/bi/arrow-right';
 	import FeaturedPreviewList from './FeaturedPreviewList.svelte';
+	import FeaturedCategories from './FeaturedCategories.svelte';
 
 	const uid = $props.id();
 	const featuredSearches: FeaturedSearch[] = $derived(page.data.featuredSearches);
@@ -82,7 +83,7 @@
 		{/if}
 	</section>
 {/snippet}
-
+<FeaturedCategories />
 {#each featuredSearches as featured, index (featured.heading)}
 	{@render featuredSearch(featured, index)}
 {/each}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/FeaturedCategories.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/FeaturedCategories.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { getCategoryShortcuts } from '$lib/remotes/homepage.remote';
+</script>
+
+<section
+	class="bg-primary-100 border-y-primary-200 flex flex-col items-center border-y px-3 py-3 @5xl:px-20"
+>
+	<h3 class="text-subtle px-3 font-serif text-base italic lg:text-lg @3xl:max-w-max @5xl:text-xl">
+		<strong class="font-normal">Libris</strong>
+		{page.data.t('home.pageHeadingDescription')}
+	</h3>
+	<div class="w-full">
+		<nav class="pt-2 pb-4 @5xl:pt-3 @5xl:pb-5" aria-label={page.data.t('home.searchShortcuts')}>
+			<div class="flex w-full items-center justify-center">
+				<div
+					tabindex="-1"
+					class="filters-scroller scrollbar-hidden flex items-center overflow-x-scroll px-3 py-1 @3xl:px-4"
+				>
+					<h4
+						id="search-for"
+						class="mr-3 hidden font-serif font-medium whitespace-nowrap @xl:block @5xl:text-[1.0625rem]"
+					>
+						{page.data.t('search.exploreCategories')}
+					</h4>
+					<ul class="flex gap-2 pr-3 text-xs @3xl:text-sm @5xl:text-[0.9375rem]">
+						{#each await getCategoryShortcuts(page.data.locale) as category (category.id)}
+							<li>
+								<a
+									href={page.data.localizeHref(category.href)}
+									id={category.id}
+									aria-labelledby="search-for {category.id}"
+									class="btn-outlined text-primary-900 border-primary-600/75 focus-visible:bg-primary-200 hover:bg-primary-200/50 min-w-12 px-2 py-1.5 text-center whitespace-nowrap @xl:px-3 @xl:py-2 @3xl:min-w-14 @5xl:min-h-10 @5xl:min-w-16"
+								>
+									{category.label}
+								</a>
+							</li>
+						{/each}
+					</ul>
+				</div>
+			</div>
+		</nav>
+	</div>
+</section>
+
+<style lang="postcss">
+	@reference 'tailwindcss';
+
+	.filters-scroller {
+		position: relative;
+		mask-image: linear-gradient(
+			to right,
+			rgba(0, 0, 0, 0) calc(var(--spacing) * 0),
+			rgba(0, 0, 0, 1) calc(var(--spacing) * 3),
+			rgba(0, 0, 0, 1) calc(100% - var(--spacing) * 8),
+			rgba(0, 0, 0, 0) calc(100% - var(--spacing) * 3)
+		);
+
+		@variant @3xl {
+			mask-image: linear-gradient(
+				to right,
+				rgba(0, 0, 0, 0) calc(var(--spacing) * 0),
+				rgba(0, 0, 0, 1) calc(var(--spacing) * 4),
+				rgba(0, 0, 0, 1) calc(100% - var(--spacing) * 9),
+				rgba(0, 0, 0, 0) calc(100% - var(--spacing) * 3)
+			);
+		}
+	}
+</style>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/FeaturedCategories.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/FeaturedCategories.svelte
@@ -11,14 +11,14 @@
 		{page.data.t('home.pageHeadingDescription')}
 	</h3>
 	<div class="w-full">
-		<nav class="pt-2 pb-4 @5xl:pt-3 @5xl:pb-5" aria-label={page.data.t('home.searchShortcuts')}>
+		<nav class="pt-2 pb-4 @5xl:pt-3 @5xl:pb-5" aria-labelledby="explore-categories">
 			<div class="flex w-full items-center justify-center">
 				<div
 					tabindex="-1"
 					class="filters-scroller scrollbar-hidden flex items-center overflow-x-scroll px-3 py-1 @3xl:px-4"
 				>
 					<h4
-						id="search-for"
+						id="explore-categories"
 						class="mr-3 hidden font-serif font-medium whitespace-nowrap @xl:block @5xl:text-[1.0625rem]"
 					>
 						{page.data.t('search.exploreCategories')}


### PR DESCRIPTION
## Description
### Solves
I've extracted the stuff we said we want to remove from the homepage search context, and put it in a component of its own.
This gives us the possibility to still show it on the front page on a place of our choosing.

<img width="1160" height="134" alt="Skärmavbild 2026-04-30 kl  10 04 10" src="https://github.com/user-attachments/assets/b9143c79-eb62-4f00-b06a-30d70b14902c" />.

I think:
* the text is very clarifying and should be kept
* The categories add 'information scent'
* They work well together
* No need to throw this away

### Summary of changes

* create `FeaturedCategories.svelte`