### PR TITLE
feat(lxl-web): Handle legacy setorg parameter

### DIFF
--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import type { RequestEvent } from '@sveltejs/kit';
+import { redirect, type RequestEvent } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { defaultLocale, getSupportedLocale, Locales } from '$lib/i18n/locales';
 import { DERIVED_LENSES } from '$lib/types/display';
@@ -27,6 +27,12 @@ export const handle = async ({ event, resolve }) => {
 
 	event.locals.vocab = vocabUtil;
 	event.locals.display = displayUtil;
+
+	const legacySetOrg = event.url.searchParams.get('setorg');
+	if (legacySetOrg) {
+		const clean = legacySetOrg.replaceAll(/[^A-Za-z0-9]/g, '');
+		redirect(302, `?_r=itemHeldByOrg:${clean}`);
+	}
 
 	const site = getSite(event);
 


### PR DESCRIPTION
For example https://libris.kb.se?setorg=ARKM

Uses `itemHeldByOrg` instead of `library`. When using `library` sigel has higer priority that org code. Which would lead to "Sök inom ArkDes Bibliotek" instead of "Sök inom ArkDes". Maybe that is what we want? Let's sort that out and adjust accordingly later.