### PR TITLE
fix(lxl-web): Hide explore link for empty collections

### DIFF
--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -440,7 +440,7 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 				{@render holdingsButton()}
 			</div>
 		{/if}
-		{#if bibliographyLink}
+		{#if (bibliographyLink && item?.numberOfItems) || 0 > 10}
 			{@const numItems = formatNumItems(item?.numberOfItems)}
 			<div class="card-explore mt-2">
 				<a


### PR DESCRIPTION
Hide "Visa samlingens innehåll" link for empty collections.
Define "empty" as ten or less. For example OSGO contains a single record

This is mostly a workaround for search API not including `@reverse.isPartOf` for bibliographies.