### PR TITLE
Add excludeEplikt and excludePreliminary to grammar

### DIFF
--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -33,7 +33,7 @@ QualifierInnerGroup { "(" qualifierOrcomb? ")" }
   bOperatorEq { ":" | "=" | "~" }
   strliteral { '"' (!["\\] | "\\" _)* '"' }
   str { ![:~><=()"\ ]+ }
-  filterAlias { "includeEplikt" | "includePreliminary" | "existsImage" | "alias-myLibraries" | "freeOnline" | "_suecia" | "_collections" }
+  filterAlias { "excludeEplikt" | "includeEplikt" | "excludePreliminary" | "includePreliminary" | "existsImage" | "alias-myLibraries" | "freeOnline" | "_suecia" | "_collections" }
   space { @whitespace+ }
 
   @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, filterAlias, str, space}


### PR DESCRIPTION
@jesperengstrom @johanbissemattsson what more is needed to get a formatted pill for `excludePreliminary`?

<img width="602" height="190" alt="bild" src="https://github.com/user-attachments/assets/7a70964e-2527-4602-b9af-92990fe7f5d1" />
