### PR TITLE
feat(lxlweb): set legacy cookies

### DIFF
--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -85,6 +85,8 @@ export const handle = async ({ event, resolve }) => {
 
 		const host = event.url.hostname === 'localhost' ? event.url.hostname : `.${event.url.hostname}`;
 
+		let anyUpgraded = false;
+
 		for (const name of LEGACY_COOKIES) {
 			const value = event.cookies.get(name);
 
@@ -96,16 +98,20 @@ export const handle = async ({ event, resolve }) => {
 					httpOnly: true,
 					path: '/'
 				});
+
+				anyUpgraded = true;
 			}
 		}
 
-		event.cookies.set('cookiesDomainUpgraded', 'true', {
-			maxAge: 60 * 60 * 24 * 365, // 365 days
-			secure: true,
-			sameSite: 'strict',
-			httpOnly: true,
-			path: '/'
-		});
+		if (anyUpgraded) {
+			event.cookies.set('cookiesDomainUpgraded', 'true', {
+				maxAge: 60 * 60 * 24 * 365, // 365 days
+				secure: true,
+				sameSite: 'strict',
+				httpOnly: true,
+				path: '/'
+			});
+		}
 	}
 
 	// set HTML lang

--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -77,6 +77,37 @@ export const handle = async ({ event, resolve }) => {
 	}
 	event.locals.userSettings = userSettings;
 
+	// set legacy cookies site-wide
+	const upgraded = event.cookies.get('cookiesDomainUpgraded');
+
+	if (!upgraded) {
+		const LEGACY_COOKIES = ['myLibrary', 'myOrg', 'myPosts', 'showrecView'];
+
+		const host = event.url.hostname === 'localhost' ? event.url.hostname : `.${event.url.hostname}`;
+
+		for (const name of LEGACY_COOKIES) {
+			const value = event.cookies.get(name);
+
+			if (value) {
+				event.cookies.set(name, value, {
+					secure: true,
+					domain: host,
+					sameSite: 'lax',
+					httpOnly: true,
+					path: '/'
+				});
+			}
+		}
+
+		event.cookies.set('cookiesDomainUpgraded', 'true', {
+			maxAge: 60 * 60 * 24 * 365, // 365 days
+			secure: true,
+			sameSite: 'strict',
+			httpOnly: true,
+			path: '/'
+		});
+	}
+
 	// set HTML lang
 	// https://github.com/sveltejs/kit/issues/3091#issuecomment-1112589090
 	const path = event.url.pathname;


### PR DESCRIPTION
## Description
### Solves

Check for legacy cookies  `['myLibrary', 'myOrg', 'myPosts', 'showrecView']` and set them site-wide incl subdomains (`.${domain}`)
Also set a flag that we've done it once.

NO IDEA IF THIS WORKS 🙃 

