### PR TITLE
fix(lxl-web): Remove left margin in SearchResultItem

### DIFF
--- a/lxl-web/src/lib/components/SearchResultItem.svelte
+++ b/lxl-web/src/lib/components/SearchResultItem.svelte
@@ -169,18 +169,6 @@
 <style lang="postcss">
 	@reference "tailwindcss";
 
-	.decorated-card-heading-top,
-	.decorated-card-heading,
-	.decorated-card-heading-extra,
-	.decorated-card-body,
-	.decorated-card-footer {
-		margin-left: calc(var(--spacing) * 2);
-
-		@variant sm {
-			margin-left: calc(var(--spacing) * 6);
-		}
-	}
-
 	.decorated-card-heading {
 		& :global(.transliteration) {
 			font-size: var(--text-2xs);


### PR DESCRIPTION
before:
<img width="1919" height="946" alt="Skärmbild från 2026-05-04 19-27-46" src="https://github.com/user-attachments/assets/d540a421-db10-455c-8bbe-0e63f2ad01f6" />

after:
<img width="1836" height="951" alt="Skärmbild från 2026-05-04 19-27-17" src="https://github.com/user-attachments/assets/3bd91da4-381c-4179-9d8f-f5588384d319" />
