### PR TITLE
fix(lxl-web): Fix collapsed supersearch on resource page load

### DIFF
--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -278,7 +278,8 @@
 				selection: {
 					anchor: searchContext.initialStateBeforeMount.selection?.anchor,
 					head: searchContext.initialStateBeforeMount.selection?.head
-				}
+				},
+				userEvent: 'input.complete'
 			});
 		}
 		searchContext.getQuery = () => q;

--- a/packages/supersearch/src/lib/components/CodeMirror.svelte
+++ b/packages/supersearch/src/lib/components/CodeMirror.svelte
@@ -1,4 +1,6 @@
 <script lang="ts" module>
+	import { Transaction } from '@codemirror/state';
+
 	export type Selection = {
 		from: number;
 		to: number;
@@ -10,6 +12,7 @@
 	export type ChangeCodeMirrorEvent = {
 		value: string;
 		selection: Selection;
+		userEvent: UserEvent | undefined;
 	};
 
 	export type SelectCodeMirrorEvent = Selection;
@@ -30,6 +33,7 @@
 		isViewUpdateSyncableEffect,
 		syncedTransaction
 	} from '$lib/utils/isViewUpdateSyncableEffect.js';
+	import type { UserEvent } from '$lib/types/superSearch.js';
 
 	type CodeMirrorProps = {
 		value?: string;
@@ -73,6 +77,9 @@
 			});
 			if (update.docChanged) {
 				value = update.state.doc.toString();
+				const userEvent = update.transactions[0].annotation(Transaction.userEvent) as
+					| UserEvent
+					| undefined;
 				onchange({
 					value,
 					selection: {
@@ -81,7 +88,8 @@
 						anchor: update.state.selection.main.anchor,
 						head: update.state.selection.main.head,
 						empty: update.state.selection.main.empty
-					}
+					},
+					userEvent
 				});
 			}
 		}
@@ -150,7 +158,8 @@
 				anchor: selection.main.anchor,
 				head: selection.main.head,
 				empty: selection.main.empty
-			}
+			},
+			userEvent: 'delete'
 		});
 	}
 

--- a/packages/supersearch/src/lib/components/SuperSearch.svelte
+++ b/packages/supersearch/src/lib/components/SuperSearch.svelte
@@ -309,7 +309,11 @@
 	}
 
 	function handleChangeCodeMirror(event: ChangeCodeMirrorEvent) {
-		if (!dialog?.open && value.trim() !== event.value.trim()) {
+		if (
+			!dialog?.open &&
+			event.userEvent !== 'input.complete' &&
+			value.trim() !== event.value.trim()
+		) {
 			showExpandedSearch();
 		}
 		value = event.value;


### PR DESCRIPTION
## Description

### Solves

Removes initially expanded supersearch dialogs (on e.g. `/find?_q=category:%22saogf:Sk%25C3%25B6nlitteratur%22`).

### Summary of changes

- Pass along `userEvent` to`ChangeCodeMirrorEvent`
- Don't show expanded search on `input.complete` events
- Set initial mount change to `input.complete`