### PR TITLE
feat(lxl-web): Move dismissed banner to separate session cookie

### DIFF
--- a/lxl-web/src/app.d.ts
+++ b/lxl-web/src/app.d.ts
@@ -17,6 +17,7 @@ declare global {
 			vocab: VocabUtil;
 			display: DisplayUtil;
 			userSettings: UserSettings;
+			dismissedBanner: boolean;
 			site?: Site;
 			subsetMapping?: DisplayMapping[];
 			qualifierSuggestionsByLocale: Record<

--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -83,6 +83,11 @@ export const handle = async ({ event, resolve }) => {
 	}
 	event.locals.userSettings = userSettings;
 
+	const dismissedBannerCookie = event.cookies.get('dismissed-banner');
+	if (dismissedBannerCookie) {
+		event.locals.dismissedBanner = JSON.parse(dismissedBannerCookie);
+	}
+
 	// set legacy cookies site-wide
 	const upgraded = event.cookies.get('cookiesDomainUpgraded');
 

--- a/lxl-web/src/lib/i18n/cookieConsent/en.js
+++ b/lxl-web/src/lib/i18n/cookieConsent/en.js
@@ -39,6 +39,11 @@ export default {
 							duration: '1 year'
 						},
 						{
+							name: 'dismissed-banner',
+							description: 'Used to hide the top banner.',
+							duration: 'Current session'
+						},
+						{
 							name: 'techaro.lol-anubis-auth',
 							description:
 								"Saved when your browser has passed a security check against automated bots. It means you don't have to go through the check again on each page visit.",

--- a/lxl-web/src/lib/i18n/cookieConsent/sv.js
+++ b/lxl-web/src/lib/i18n/cookieConsent/sv.js
@@ -40,6 +40,11 @@ export default {
 							duration: '1 år'
 						},
 						{
+							name: 'dismissed-banner',
+							description: 'Används för att dölja bannern i sidhuvudet.',
+							duration: 'Nuvarande session'
+						},
+						{
 							name: 'techaro.lol-anubis-auth',
 							description:
 								'Sparas när din webbläsare klarat en säkerhetskontroll som skyddar mot automatiserade bottar. Den gör att du slipper genomgå kontrollen på nytt vid varje sidbesök.',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -16,10 +16,9 @@
 	import AppBanner from '$lib/components/AppBanner.svelte';
 	import AppMenuContent from '$lib/components/AppMenuContent.svelte';
 	import SearchMapping from '$lib/components/find/SearchMapping.svelte';
-	import { getUserSettings } from '$lib/contexts/userSettings';
+	import Cookies from 'js-cookie';
 
 	const searchContext = getSearchContext();
-	const userSettings = getUserSettings();
 
 	let mounted: boolean = $state(false);
 	let menuToggleElement: HTMLButtonElement | HTMLAnchorElement | undefined = $state();
@@ -29,7 +28,7 @@
 	let shadowSentinelElement: HTMLElement | undefined = $state();
 	let shadowObserver: IntersectionObserver | undefined = $state();
 	let expandedMenu = $state(page.url.hash === '#menu');
-	let dismissedBanner: boolean = $derived(userSettings.dismissedNewBanner || false);
+	let dismissedBanner: boolean = $derived(page.data.dismissedBanner);
 
 	const otherLangCode = $derived(
 		Object.keys(Locales).find((locale) => locale !== page.data.locale) as LocaleCode
@@ -49,7 +48,10 @@
 	const subset = $derived(page.data.subsetMapping);
 
 	function handleDismissBanner() {
-		userSettings.setDismissedNewBanner();
+		Cookies.set('dismissed-banner', 'true', {
+			sameSite: 'strict'
+		});
+		dismissedBanner = true;
 	}
 
 	function showExpandedMenu() {

--- a/lxl-web/src/routes/+layout.server.ts
+++ b/lxl-web/src/routes/+layout.server.ts
@@ -2,6 +2,7 @@ import { getSupportedLocale } from '$lib/i18n/locales';
 
 export async function load({ locals, url, params }) {
 	const userSettings = locals.userSettings;
+	const dismissedBanner = locals.dismissedBanner;
 	const locale = getSupportedLocale(params?.lang); // will use default locale if no lang param
 
 	// create dependency to react to _r changes
@@ -13,6 +14,7 @@ export async function load({ locals, url, params }) {
 
 	return {
 		userSettings,
+		dismissedBanner,
 		subsetMapping,
 		siteName,
 		qualifierSuggestions

--- a/lxl-web/src/routes/+layout.ts
+++ b/lxl-web/src/routes/+layout.ts
@@ -8,6 +8,7 @@ export async function load({ params, data, url }) {
 
 	const base = locale === baseLocale ? '/' : `/${locale}`;
 	const userSettings = data.userSettings;
+	const dismissedBanner = data.dismissedBanner;
 	const subsetMapping = data.subsetMapping;
 	const siteName = data.siteName;
 	const qualifierSuggestions = data.qualifierSuggestions;
@@ -18,6 +19,7 @@ export async function load({ params, data, url }) {
 		localizeHref,
 		base,
 		userSettings,
+		dismissedBanner,
 		subsetMapping,
 		siteName,
 		qualifierSuggestions


### PR DESCRIPTION
## Description

### Solves
Moves the dismissed banner flag to a [separate session](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies#removal_defining_the_lifetime_of_a_cookie) cookie (which is deleted when the "current session" ends).

I think this can be preferred initially but can later easily be changed back to a custom max-age, separate from the max-age of userSettings.

### Summary of changes

- Move dismissed banner flag to separate session cookie
- Add description to cookie consent

