### PR TITLE
fix(lxlweb): show tilde in pill

### DIFF
--- a/lxl-web/src/lib/components/find/SearchMapping.svelte
+++ b/lxl-web/src/lib/components/find/SearchMapping.svelte
@@ -46,11 +46,13 @@
 						>
 					{:else}
 						<!-- free text search -->
-						<span class="flex h-full items-center gap-1 pl-1.5">
-							<span>{displayStr}</span>
+						<span class="flex items-center">
+							<span class="border-accent-200 flex h-7.75 items-center rounded-l-md border px-1.5"
+								>{displayStr}</span
+							>
 							<a
 								href={resolve(page.data.localizeHref(up?.['@id']))}
-								class="lxl-qualifier-remove"
+								class="lxl-qualifier-remove flex h-7.75 items-center"
 								aria-label={`${page.data.t('search.removeFilter')} ${displayStr}`}
 							>
 								<IconClose aria-hidden="true" />

--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -78,6 +78,7 @@
 	>
 {/snippet}
 {#snippet valueLabelSnippet()}
+	{@const tilde = operator === '~' && isRedundantKeyLabel}
 	<span
 		class={[keyLabel && operator ? 'lxl-qualifier-value' : 'lxl-qualifier-alias', 'cursor-text']}
 		data-qualifier-value={value}
@@ -85,7 +86,7 @@
 		tabindex="-1"
 		{onclick}
 		onkeypress={onclick}
-		>{#if image || type}{@render imageSnippet()}{/if}{valueLabel}</span
+		>{#if image || type}{@render imageSnippet()}{/if}{#if tilde}{'~ '}{/if}{valueLabel}</span
 	>
 {/snippet}
 {#snippet removeLinkSnippet()}


### PR DESCRIPTION
## Description
### Solves

* Show tilde in pill so that the 'modes' can be visually distinguished
* Fix broken 'free text query' pill in search mapping component

Before: 
<img width="720" height="216" alt="Skärmavbild 2026-05-05 kl  15 21 14" src="https://github.com/user-attachments/assets/b0fe84b7-f3ee-4d23-bba9-b1a04959d614" />

After:

<img width="720" height="216" alt="Skärmavbild 2026-05-05 kl  15 19 58" src="https://github.com/user-attachments/assets/0a8c2d3e-22d8-4d99-86a8-a889ebb9c3a7" />

### Summary of changes

* show tilde in pill
* Fix free text pill in `SearchMapping` 
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 