### PR TITLE
fix(lxweb): temporarily fix image size

### DIFF
--- a/lxl-web/src/lib/utils/auxd.ts
+++ b/lxl-web/src/lib/utils/auxd.ts
@@ -5,7 +5,8 @@ import {
 	type Image,
 	type KbvImageObject,
 	type ImageResolution,
-	IMAGE_OBJECT_TYPE
+	IMAGE_OBJECT_TYPE,
+	Width
 } from '$lib/types/auxd';
 import { Concepts, type FramedData, JsonLd, Owl } from '$lib/types/xl';
 import { first, isObject, asArray } from '$lib/utils/xl';
@@ -43,8 +44,10 @@ export function bestSize(from: Image | undefined, minWidthPx: number): ImageReso
 
 	const fallbackSize = sizes[sizes.length - 1];
 	if (fallbackSize && minWidthPx) {
-		const _hardcodedSize = fallbackSize.url.replace('.full.', `.${minWidthPx}.`);
-		fallbackSize.url = _hardcodedSize;
+		if (minWidthPx === Width.SMALL) {
+			const _hardcodedSize = fallbackSize.url.replace('.full.', `.${minWidthPx}.`);
+			fallbackSize.url = _hardcodedSize;
+		}
 		return fallbackSize;
 	}
 

--- a/lxl-web/src/lib/utils/auxd.ts
+++ b/lxl-web/src/lib/utils/auxd.ts
@@ -43,10 +43,10 @@ export function bestSize(from: Image | undefined, minWidthPx: number): ImageReso
 	if (result) return result;
 
 	const fallbackSize = sizes[sizes.length - 1];
-	if (fallbackSize && minWidthPx) {
+	if (fallbackSize) {
 		if (minWidthPx === Width.SMALL) {
-			const _hardcodedSize = fallbackSize.url.replace('.full.', `.${minWidthPx}.`);
-			fallbackSize.url = _hardcodedSize;
+			const _thumbUrl = fallbackSize.url.replace('.full.', `.${minWidthPx}.`);
+			fallbackSize.url = _thumbUrl;
 		}
 		return fallbackSize;
 	}

--- a/lxl-web/src/lib/utils/auxd.ts
+++ b/lxl-web/src/lib/utils/auxd.ts
@@ -38,7 +38,18 @@ export function bestSize(from: Image | undefined, minWidthPx: number): ImageReso
 	}
 	const sizes = from.sizes;
 	const result = sizes.find((i) => i.widthPx >= minWidthPx);
-	return result || sizes[sizes.length - 1];
+	// REMOVE ME - TEMP SEARCH & REPLACE IN IMG URL
+	if (result) return result;
+
+	const fallbackSize = sizes[sizes.length - 1];
+	if (fallbackSize && minWidthPx) {
+		const _hardcodedSize = fallbackSize.url.replace('.full.', `.${minWidthPx}.`);
+		fallbackSize.url = _hardcodedSize;
+		return fallbackSize;
+	}
+
+	return undefined;
+	// return result || sizes[sizes.length - 1];
 }
 
 export function getImages(thing: FramedData, lang: LocaleCode): Image[] {


### PR DESCRIPTION
## Description
### Solves

temporarily alter image url with `minWidthPx` IF not found in sizes array and `minWidthPx === 128`

~~But see http://localhost:5173/zgq4vdq0w4mkxd27?_q=category%3A%22saogf%3AFacklitteratur%22
replacing `full` with `256` here results in 404
What sizes can we count on? Only do this when minWidthPx === 128?~~
