### PR TITLE
fix(lxlweb): cite: don't crash on contribution without agent

### DIFF
--- a/lxl-web/src/lib/utils/cslFromMainEntity.ts
+++ b/lxl-web/src/lib/utils/cslFromMainEntity.ts
@@ -29,7 +29,7 @@ const CSL_KBV_MAPPING: Partial<Record<keyof CSLJSON, string>> = {
 interface Contribution {
 	'@type'?: string;
 	role?: { '@id'?: string }[];
-	agent: Agent | Agent[];
+	agent?: Agent | Agent[];
 }
 
 interface Agent {
@@ -99,6 +99,9 @@ function getRole(contribution: Contribution): Partial<CSLRoles> | false {
 		if (role) {
 			role = role.replace('https://id.kb.se/relator/', '');
 			const name = getName(contribution.agent);
+			if (!name) {
+				return false;
+			}
 			switch (role) {
 				case 'author':
 					return { author: name };
@@ -146,8 +149,11 @@ function getFallbackRole(contribution: Contribution) {
 	return false;
 }
 
-function getName(agent: Agent | Agent[]): CSLName[] {
+function getName(agent: Agent | Agent[] | undefined): CSLName[] | null {
 	const flattenedAgent = Array.isArray(agent) ? agent[0] : agent;
+	if (!flattenedAgent) {
+		return null;
+	}
 	const name: Partial<CSLName> = {};
 	if (flattenedAgent.familyName) {
 		name.family = flattenedAgent.familyName;


### PR DESCRIPTION
The citation API would crash when encountering a contribution without an agent, e.g.:
```
 curl "http://localhost:5173/api/sv/cite?id=https://libris-qa.kb.se/x6s1g7vdvtss6qdv&format=bibtex"
{"message":"Internal Error"}⏎
```
=>
```
[500] GET /api/sv/cite
TypeError: Cannot read properties of undefined (reading 'familyName')
    at getName (src/lib/utils/cslFromMainEntity.ts:152:21)
    at getRole (src/lib/utils/cslFromMainEntity.ts:101:17)
    at mapContribution (src/lib/utils/cslFromMainEntity.ts:72:22)
    at cslFromMainEntity (src/lib/utils/cslFromMainEntity.ts:60:23)
    at GET (src/routes/api/[[lang=lang]]/cite/+server.ts:28:17)
```

Because of the first contribution here:
```json
        "contribution": [
          {
            "role": [
              {
                "@id": "https://id.kb.se/relator/composer"
              }
            ],
            "@type": "PrimaryContribution"
          },
          {
            "role": [
              {
                "@id": "https://id.kb.se/relator/arranger"
              }
            ],
            "@type": "Contribution",
            "agent": {
              "@type": "Person",
              "givenName": "Sid",
              "familyName": "Robinovitch"
            }
          }
        ],
```
After this fix:
```
curl "http://localhost:5173/api/sv/cite?id=https://libris-qa.kb.se/x6s1g7vdvtss6qdv&format=bibtex"
@misc{Robinovitch1990Mosaic,
	address = {New York},
	author = {Robinovitch, Sid},
	year = {1990},
	publisher = {Transcontinental Music Publications},
	title = {Mosaic of {Jewish} folksong : Ladino, {Yemenite} and {Israeli} folk songs},
}
``` 