### PR TITLE
feat(lxlweb): log full query on 5xx error

### DIFF
--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { redirect, type RequestEvent } from '@sveltejs/kit';
+import { redirect, type HandleServerError, type RequestEvent } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { defaultLocale, Locales } from '$lib/i18n/locales';
 import { DERIVED_LENSES } from '$lib/types/display';
@@ -240,3 +240,10 @@ function getSite(event: RequestEvent): Site | null {
 function configuredSubDomains(): string[] {
 	return env.SUBSITES?.split(',').map((s) => s.trim()) || [];
 }
+
+export const handleError: HandleServerError = ({ error, event, status }) => {
+	if (status >= 500) {
+		console.error(`[${status}] ${event.request.method} ${event.url.pathname}${event.url.search}`);
+		console.error(error);
+	}
+};


### PR DESCRIPTION
Before:
```
[500] GET /api/sv/cite
TypeError: Cannot read properties of undefined (reading 'familyName')
    at getName (src/lib/utils/cslFromMainEntity.ts:152:21)
    ...
```

After:
```
[500] GET /api/sv/cite?id=https://libris-qa.kb.se/x6s1g7vdvtss6qdv&format=bibtex
TypeError: Cannot read properties of undefined (reading 'familyName')
    at getName (/home/andjen/lxl/lxlviewer/lxl-web/src/lib/utils/cslFromMainEntity.ts:152:21)
    ...
```