### PR TITLE
feat(lxlweb): instant key labels

### DIFF
--- a/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
+++ b/lxl-web/src/lib/components/supersearch/SuperSearchWrapper.svelte
@@ -222,7 +222,13 @@
 			// Make sure supersearch doesn't use '_r' section of mapping
 			const filteredPageMapping = pageMapping?.filter((m) => m.variable === '_q');
 			const filteredSuggestMapping = suggestMapping?.filter((m) => m.variable === '_q');
-			return getLabelFromMappings(key, value, filteredPageMapping, filteredSuggestMapping);
+			return getLabelFromMappings(
+				key,
+				value,
+				filteredPageMapping,
+				filteredSuggestMapping,
+				page.data.qualifierSuggestions
+			);
 		}
 		return lxlQualifierPlugin(getLabels, renderer);
 	});

--- a/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
+++ b/lxl-web/src/lib/utils/getLabelsFromMapping.svelte.ts
@@ -1,4 +1,4 @@
-import type { DisplayMapping } from '$lib/types/search';
+import type { DisplayMapping, QualifierSuggestion2 } from '$lib/types/search';
 import { JsonLd } from '$lib/types/xl';
 
 let prevSuggestMapping: DisplayMapping[] | undefined;
@@ -7,10 +7,19 @@ function getLabelFromMappings(
 	key: string,
 	value?: string,
 	pageMapping?: DisplayMapping[],
-	suggestMapping?: DisplayMapping[]
+	suggestMapping?: DisplayMapping[],
+	qualifierSuggestions?: QualifierSuggestion2[]
 ) {
 	const bestSuggestMapping = suggestMapping?.length ? suggestMapping : prevSuggestMapping;
 
+	// need a key label only - look in the cached list
+	if (qualifierSuggestions && key && (!value || value === '()')) {
+		let keyLabel = getKeyLabelFromList(key, qualifierSuggestions);
+		if (keyLabel) {
+			keyLabel = keyLabel.charAt(0).toUpperCase() + keyLabel.slice(1);
+			return { key, keyLabel, invalid: false, isRedundantKeyLabel: false };
+		}
+	}
 	const pageLabels = iterateMapping(key, value, pageMapping);
 	const suggestLabels = iterateMapping(key, value, bestSuggestMapping);
 
@@ -85,6 +94,11 @@ function iterateMapping(
 		}
 	}
 	return { keyLabel, valueLabel, removeLink, invalid, type, id, isRedundantKeyLabel };
+}
+
+function getKeyLabelFromList(key: string, suggestion: QualifierSuggestion2[]) {
+	const match = suggestion.find((s) => s.key === key || s.queryCodes.includes(key));
+	return match?.label ?? null;
 }
 
 export default getLabelFromMappings;

--- a/lxl-web/tests/supersearch-lxlweb.spec.ts
+++ b/lxl-web/tests/supersearch-lxlweb.spec.ts
@@ -275,6 +275,7 @@ test('qualifier keys can be added using keyboard only', async ({ page, context }
 	await page.keyboard.press('ArrowDown');
 	await page.keyboard.press('Enter');
 	await expect(page.getByRole('combobox').first()).toContainText('Författare/upphov');
+	await page.waitForResponse((res) => res.url().includes('/supersearch?') && res.status() === 200);
 	await page.keyboard.press('a');
 	await page.keyboard.press('ArrowRight');
 	await page.keyboard.press('b');


### PR DESCRIPTION
## Description
### Solves

When adding a filter (from suggestions) or typing a qualifier key, we don't need to wait for suggestion mappings, we have all the querycodes available. Just find & show the label.

### Summary of changes

Summary of changes
* pass `qualifierSuggestions` to `getLabelsFromMapping` 
* Search it if only needing a key label