### PR TITLE
feat(lxlweb): handle deleted records (410) properly

### DIFF
--- a/lxl-web/src/lib/components/Error.svelte
+++ b/lxl-web/src/lib/components/Error.svelte
@@ -8,6 +8,9 @@
 		if (page.status === 404) {
 			return getPageTitle(page.data.t('errors.notFound'), page.data.siteName);
 		}
+		if (page.status === 410) {
+			return getPageTitle(page.data.t('errors.gone'), page.data.siteName);
+		}
 		return getPageTitle(page.data.t('errors.somethingWentWrong'), page.data.siteName);
 	}
 </script>
@@ -41,6 +44,14 @@
 			<a class="link-subtle" href={page.data.localizeHref(page.data.base)}
 				>{page.data.t('errors.backToStartPage')}</a
 			>
+		</p>
+	{:else if page.status === 410}
+		<h2 class="pb-4 text-lg font-medium">{page.data.t('errors.gone')}</h2>
+		<p>{page.data.t('errors.goneDescription')}</p>
+		<p class="pt-4">
+			<a class="link-subtle" href={page.data.localizeHref(page.data.base)}
+				>{page.data.t('errors.backToStartPage')}
+			</a>
 		</p>
 	{:else if page.error?.message}
 		<h2 class="pb-4 text-lg font-medium">{page.data.t('errors.somethingWentWrong')}</h2>

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -232,6 +232,8 @@ export default {
 		somethingWentWrong: 'Something went wrong',
 		notAvailable: 'Information is not available',
 		notFound: 'Page not found',
+		gone: 'Record has been deleted',
+		goneDescription: 'This record no longer exists in Libris.',
 		wrongLink: "Did you click on a link that didn't work?",
 		sendEmail: 'Send an e-mail to',
 		customerService: 'Libris customer service',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -230,6 +230,8 @@ export default {
 		somethingWentWrong: 'Något gick fel',
 		notAvailable: 'Information saknas',
 		notFound: 'Sidan hittades inte',
+		gone: 'Posten har tagits bort',
+		goneDescription: 'Den här posten finns inte längre i Libris.',
 		wrongLink: 'Klickade du på en länk i Libris som inte fungerade?',
 		sendEmail: 'Skicka e-post till',
 		customerService: 'Libris kundservice',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+layout.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+layout.server.ts
@@ -36,5 +36,7 @@ export const load = async ({ url, fetch, params }) => {
 			return { data, error };
 		}
 	}
-	return { citations: getData() };
+	// only stream if there's a cite param, otherwise the non-awaited promise
+	// breaks error status propagation (e.g. 410)
+	return { citations: id ? getData() : undefined };
 };

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -61,13 +61,16 @@ export const load = async ({ params, locals, fetch, url }) => {
 	}
 
 	if (!resourceRes.ok) {
+		let apiError: ApiError | undefined;
 		try {
-			const err = (await resourceRes.json()) as ApiError;
-			throw error(err.status_code, { message: err.message, status: err.status });
+			apiError = (await resourceRes.json()) as ApiError;
 		} catch (e) {
 			console.warn(e);
-			throw error(resourceRes?.status, { message: resourceRes?.statusText });
 		}
+		throw error(apiError?.status_code || resourceRes.status, {
+			message: apiError?.message || resourceRes.statusText,
+			status: apiError?.status
+		});
 	}
 
 	const resource = await resourceRes.json();


### PR DESCRIPTION
Deleted records e.g. https://libris.kb.se/k41knrq6hmptfrpf were not handled properly. The server returned a HTTP 200 while showing a generic "Something went wrong" page with the text
```
410
Something went wrong
Gone
```
So the 410 was received from backend but not propagated.

With this fix we return the actual status code and show a custom 410 message.
```
 curl -I "http://localhost:5173/k41knrq6hmptfrpf"
HTTP/1.1 410 Gone
```
and
```
410
Record has been deleted

This record no longer exists in Libris.

[Back to the home page](http://localhost:5173/en)
```