### PR TITLE
fix(lxlweb): square brackets in query causing page to break

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -369,11 +369,9 @@
 			<li class="hidden lg:block">
 				<a
 					class="action"
-					href={resolve(
-						page.data.localizeHref(page.url.pathname + page.url.search + page.url.hash, {
-							locale: otherLangCode
-						})
-					)}
+					href={page.data.localizeHref(page.url.pathname + page.url.search + page.url.hash, {
+						locale: otherLangCode
+					})}
 					hreflang={otherLangCode}
 					aria-label={page.data.t('header.changeLang')}
 					aria-labelledby={IDs.appBarChangeLangLabel}

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -34,6 +34,17 @@
 		Object.keys(Locales).find((locale) => locale !== page.data.locale) as LocaleCode
 	);
 
+	const otherLangLink = $derived.by(() => {
+		const search = page.url.searchParams.toString();
+
+		return page.data.localizeHref(
+			page.url.pathname + (search ? `?${search}` : '') + page.url.hash,
+			{
+				locale: otherLangCode
+			}
+		);
+	});
+
 	const isHomeRoute = $derived(page.route.id === '/(app)/[[lang=lang]]');
 	const isFindRoute = $derived(page.route.id === '/(app)/[[lang=lang]]/find');
 	const showSearchInputOnMobile = $derived(isHomeRoute || isFindRoute);
@@ -369,9 +380,7 @@
 			<li class="hidden lg:block">
 				<a
 					class="action"
-					href={page.data.localizeHref(page.url.pathname + page.url.search + page.url.hash, {
-						locale: otherLangCode
-					})}
+					href={resolve(otherLangLink)}
 					hreflang={otherLangCode}
 					aria-label={page.data.t('header.changeLang')}
 					aria-labelledby={IDs.appBarChangeLangLabel}

--- a/lxl-web/tests/find.spec.ts
+++ b/lxl-web/tests/find.spec.ts
@@ -141,3 +141,8 @@ test('can paginate to next and previous', async ({ page }) => {
 	await page.getByTestId('pagination').getByLabel('Föregående sida').click();
 	await expect(page).not.toHaveURL(/_offset=/);
 });
+
+test('can handle square brackets in query', async ({ page }) => {
+	await page.goto('/find?_q=[test]');
+	await expect(page.getByTestId('supersearch').nth(0)).toBeVisible();
+});


### PR DESCRIPTION
## Description
### Solves

a query like `https://libris.kb.se/find?_q=[hej]` causes the page to break
Mostly a theoretical issue, same query inputted from the search field gets encoded.

Problem is `resolve()` uses square brackets as template for slugs, see https://svelte.dev/docs/kit/$app-paths#resolve
so we need to re-encode the search params before using it.

### Summary of changes

* Calculate more safe `otherLangLink` 
* Add test