### PR TITLE
fix(lxl-web): Place cookie consent first in tab order

### DIFF
--- a/lxl-web/src/lib/components/CookieConsent.svelte
+++ b/lxl-web/src/lib/components/CookieConsent.svelte
@@ -14,6 +14,7 @@
 	const matomoTracker = getMatomoTracker();
 
 	const config: CookieConsent.CookieConsentConfig = {
+		root: '#cookie-consent-container',
 		guiOptions: {
 			consentModal: {
 				layout: 'bar',

--- a/lxl-web/src/lib/components/CookieConsent.svelte
+++ b/lxl-web/src/lib/components/CookieConsent.svelte
@@ -7,6 +7,9 @@
 	import enTranslations from '$lib/i18n/cookieConsent/en';
 	import { page } from '$app/state';
 	import { getMatomoTracker } from '$lib/contexts/matomo';
+	import { getCookieConsentContext } from '$lib/contexts/cookieConsent';
+
+	let cookieConsentContext = getCookieConsentContext();
 
 	const matomoTracker = getMatomoTracker();
 
@@ -46,6 +49,12 @@
 			} else {
 				$matomoTracker?.forgetConsentGiven();
 			}
+		},
+		onModalShow: () => {
+			cookieConsentContext.visibleModal = true;
+		},
+		onModalHide: () => {
+			cookieConsentContext.visibleModal = false;
 		},
 		language: {
 			default: page.data.locale,

--- a/lxl-web/src/lib/contexts/cookieConsent.ts
+++ b/lxl-web/src/lib/contexts/cookieConsent.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'svelte';
+
+export const [getCookieConsentContext, setCookieConsentContext] = createContext<{
+	visibleModal: boolean | undefined;
+}>();

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppSearch.svelte
@@ -4,9 +4,10 @@
 	import addDefaultSearchParams from '$lib/utils/addDefaultSearchParams';
 	import getSortedSearchParams from '$lib/utils/getSortedSearchParams';
 	import { displayMappingToString } from '$lib/utils/displayMappingToString';
-
+	import { getCookieConsentContext } from '$lib/contexts/cookieConsent';
 	let cursor: number | null = $state(null);
 
+	const cookieConsentContext = getCookieConsentContext();
 	const isHomeRoute = $derived(page.route.id === '/(app)/[[lang=lang]]');
 
 	const ariaLabelledBy = $derived(isHomeRoute ? 'page-title' : undefined);
@@ -16,7 +17,7 @@
 			? `${page.data.t('header.searchSubsetPlaceholder')}: ${displayMappingToString(page.data.subsetMapping)}`
 			: page.data.t('header.searchPlaceholder')
 	);
-	const autofocus = $derived(isHomeRoute ? true : undefined);
+	const autofocus = $derived(isHomeRoute && !cookieConsentContext.visibleModal ? true : undefined);
 
 	const pageParams = $derived.by(() => {
 		let p = getSortedSearchParams(addDefaultSearchParams(page.url.searchParams));

--- a/lxl-web/src/routes/+layout.server.ts
+++ b/lxl-web/src/routes/+layout.server.ts
@@ -1,6 +1,6 @@
 import { getSupportedLocale } from '$lib/i18n/locales';
 
-export async function load({ locals, url, params }) {
+export async function load({ locals, url, params, cookies }) {
 	const userSettings = locals.userSettings;
 	const dismissedBanner = locals.dismissedBanner;
 	const locale = getSupportedLocale(params?.lang); // will use default locale if no lang param
@@ -17,6 +17,7 @@ export async function load({ locals, url, params }) {
 		dismissedBanner,
 		subsetMapping,
 		siteName,
-		qualifierSuggestions
+		qualifierSuggestions,
+		initialCookieConsentModal: !cookies.get('cc_cookie')
 	};
 }

--- a/lxl-web/src/routes/+layout.svelte
+++ b/lxl-web/src/routes/+layout.svelte
@@ -40,9 +40,9 @@
 </script>
 
 <div class="flex min-h-screen flex-col">
+	<div id="cookie-consent-container" class="contents"><CookieConsent /></div>
 	<Matomo>
 		<svelte:boundary>{@render children()}</svelte:boundary>
-		<CookieConsent />
 	</Matomo>
 </div>
 

--- a/lxl-web/src/routes/+layout.svelte
+++ b/lxl-web/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
 	import '$lib/styles/nprogress.css';
 	import Matomo from '$lib/components/Matomo.svelte';
 	import CookieConsent from '$lib/components/CookieConsent.svelte';
+	import { setCookieConsentContext } from '$lib/contexts/cookieConsent';
 
 	const { children } = $props();
 
@@ -17,6 +18,11 @@
 		showSpinner: false
 	});
 
+	let cookieConsentState: { visibleModal: boolean | undefined } = $state({
+		visibleModal: page.data.initialCookieConsentModal
+	});
+
+	setCookieConsentContext(cookieConsentState);
 	setUserSettings(page.data.userSettings);
 
 	let progressBarTimeout: ReturnType<typeof setTimeout> | undefined = undefined;

--- a/lxl-web/src/routes/+layout.ts
+++ b/lxl-web/src/routes/+layout.ts
@@ -12,6 +12,7 @@ export async function load({ params, data, url }) {
 	const subsetMapping = data.subsetMapping;
 	const siteName = data.siteName;
 	const qualifierSuggestions = data.qualifierSuggestions;
+	const initialCookieConsentModal = data.initialCookieConsentModal;
 
 	return {
 		locale,
@@ -22,6 +23,7 @@ export async function load({ params, data, url }) {
 		dismissedBanner,
 		subsetMapping,
 		siteName,
-		qualifierSuggestions
+		qualifierSuggestions,
+		initialCookieConsentModal
 	};
 }


### PR DESCRIPTION
## Description

### Solves

Places the cookie consent modal first in the tab order.

We should however think about moving the modal to the top before merging (as on Funkas website) so the contents follows the visual hierachy. An alternative could be adding a backdrop behind the modal.

### Summary of changes

- Add context for cookie consent modal visiblity
- Add cookie consent first in tab order
- Autofocus search after modal has been closed
