### PR TITLE
fix(lxlweb): citation publisher hasPart

### DIFF
--- a/lxl-web/src/lib/utils/cslFromMainEntity.ts
+++ b/lxl-web/src/lib/utils/cslFromMainEntity.ts
@@ -10,8 +10,14 @@ const CSL_KBV_MAPPING: Partial<Record<keyof CSLJSON, string>> = {
 	title: `hasTitle[0].computedLabel`,
 	shortTitle: `hasTitle[0].mainTitle`,
 	'container-title': `join(', ', isPartOf[].hasTitle[0].computedLabel)`,
-	publisher: `join(', ', publication[].agent.computedLabel)`,
-	'publisher-place': `join(', ', publication[].place[].computedLabel)`,
+	publisher: `join(', ', [
+    publication[].agent.computedLabel[],
+    publication[].hasPart[].agent.computedLabel[]
+  ][])`,
+	'publisher-place': `join(', ', [
+    publication[].place[].computedLabel[],
+    publication[].hasPart[].place[].computedLabel[]
+  ][])`,
 	issued: `{"date-parts": [[ (publication[0].year || '') ]] }`,
 	'number-of-pages': `join(', ', extent[].computedLabel)`,
 	edition: `editionStatement`,


### PR DESCRIPTION
## Description
### Solves

Fixes `publication.hasPart` not being included in citations.

[old](https://gamla.libris.kb.se/bib/21895208)

<img width="457" height="64" alt="Skärmavbild 2026-05-11 kl  15 18 31" src="https://github.com/user-attachments/assets/72f1d6e7-9762-4b35-befe-8e029ccf7cc6" />

[new](https://libris.kb.se/xg8px6882bp7z66?cite=xg8px6882bp7z66)
<img width="446" height="95" alt="Skärmavbild 2026-05-11 kl  15 19 26" src="https://github.com/user-attachments/assets/6e42fd39-5168-4d5a-8a3a-759f79bbc5c6" />

[fix](http://localhost:5173/xg8px6882bp7z66?cite=xg8px6882bp7z66)
<img width="446" height="95" alt="Skärmavbild 2026-05-11 kl  15 19 48" src="https://github.com/user-attachments/assets/cdf8f1b8-e307-458e-946e-0f80b9688ac5" />

Note that "Routledge" is missing from gamla Libris. Even thought it's clearly the NY publishing house. So this is an improvement? https://libris.kb.se/katalogisering/xg8px6882bp7z66

### Summary of changes

* update publisher `jmespath` queries