### PR TITLE
fix(lxl-web): max width for bibliography (markdown) descriptions

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -855,7 +855,7 @@
 					"@id": "Bibliography-web-overview",
 					"@type": "fresnel:Lens",
 					"classLensDomain": "Bibliography",
-					"showProperties": ["comment"]
+					"showProperties": []
 				}
 			}
 		},

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -608,6 +608,10 @@
 			}
 		}
 
+		& :global(.markdown) {
+			max-width: 60ch;
+		}
+
 		& :global(.contribution) {
 			font-size: var(--text-base);
 			@apply mb-2;


### PR DESCRIPTION
- max width for bibliography (markdown) descriptions
    - do this on markdown class or something else?
- remove comment from Bibliography-web-overview since they are always a shorter version of description (?)

before:
<img width="953" height="954" alt="Skärmbild från 2026-05-18 13-57-41" src="https://github.com/user-attachments/assets/429d44ce-8c8c-4a31-9c5f-1606ded5913a" />

after:
<img width="940" height="921" alt="Skärmbild från 2026-05-18 13-57-28" src="https://github.com/user-attachments/assets/70468f35-d328-45cd-ae4f-7b6d8723f835" />


markdown plugin picks up manual newlines so will remove them from KVINNSAM description:
<img width="810" height="601" alt="Skärmbild från 2026-05-18 13-57-11" src="https://github.com/user-attachments/assets/25d356e7-57b8-4397-93ce-05764026fc60" />
