### PR TITLE
fix(lxlweb): fallback labels for facets

### DIFF
--- a/lxl-web/src/lib/utils/search.server.ts
+++ b/lxl-web/src/lib/utils/search.server.ts
@@ -489,7 +489,7 @@ function mapSlices(
 							locale,
 							translate,
 							undefined,
-							dimension + '/' + str
+							dimension + '/' + o.object[JsonLd.ID]
 						)
 					}),
 					totalItems: o.totalItems,

--- a/lxl-web/src/lib/utils/search.server.ts
+++ b/lxl-web/src/lib/utils/search.server.ts
@@ -31,7 +31,7 @@ import {
 } from '$lib/types/search';
 
 import { getTranslator, type TranslateFn } from '$lib/i18n';
-import { type LocaleCode as LangCode } from '$lib/i18n/locales';
+import { defaultLocale, type LocaleCode as LangCode } from '$lib/i18n/locales';
 import type { MyLibrariesType } from '$lib/types/userSettings';
 import { LxlLens } from '$lib/types/display';
 import { Width } from '$lib/types/auxd';
@@ -480,6 +480,13 @@ function mapSlices(
 			...('search' in slice && { search: slice.search }),
 			values: slice.observation.map((o) => {
 				const str = toString(displayUtil.lensAndFormat(o.object, LensType.Chip, locale)) || '';
+
+				let label = toLite(displayUtil.lensAndFormat(o.object, LensType.Chip, locale));
+				if (Array.isArray(label) && label.length === 0) {
+					// fallback to default locale
+					label = toLite(displayUtil.lensAndFormat(o.object, LensType.Chip, defaultLocale));
+				}
+
 				return {
 					...('_selected' in o && { selected: o._selected }),
 					...('sliceByDimension' in o && {
@@ -489,13 +496,13 @@ function mapSlices(
 							locale,
 							translate,
 							undefined,
-							dimension + '/' + str
+							dimension + '/' + o.object[JsonLd.ID]
 						)
 					}),
 					totalItems: o.totalItems,
 					view: replacePath(o.view, usePath),
-					label: toLite(displayUtil.lensAndFormat(o.object, LensType.Chip, locale)),
-					str: str,
+					label,
+					str,
 					discriminator: discriminator(o.object, slice.dimension)
 				};
 			})

--- a/lxl-web/src/lib/utils/search.server.ts
+++ b/lxl-web/src/lib/utils/search.server.ts
@@ -31,7 +31,7 @@ import {
 } from '$lib/types/search';
 
 import { getTranslator, type TranslateFn } from '$lib/i18n';
-import { defaultLocale, type LocaleCode as LangCode } from '$lib/i18n/locales';
+import { type LocaleCode as LangCode } from '$lib/i18n/locales';
 import type { MyLibrariesType } from '$lib/types/userSettings';
 import { LxlLens } from '$lib/types/display';
 import { Width } from '$lib/types/auxd';
@@ -480,13 +480,6 @@ function mapSlices(
 			...('search' in slice && { search: slice.search }),
 			values: slice.observation.map((o) => {
 				const str = toString(displayUtil.lensAndFormat(o.object, LensType.Chip, locale)) || '';
-
-				let label = toLite(displayUtil.lensAndFormat(o.object, LensType.Chip, locale));
-				if (Array.isArray(label) && label.length === 0) {
-					// fallback to default locale
-					label = toLite(displayUtil.lensAndFormat(o.object, LensType.Chip, defaultLocale));
-				}
-
 				return {
 					...('_selected' in o && { selected: o._selected }),
 					...('sliceByDimension' in o && {
@@ -496,13 +489,13 @@ function mapSlices(
 							locale,
 							translate,
 							undefined,
-							dimension + '/' + o.object[JsonLd.ID]
+							dimension + '/' + str
 						)
 					}),
 					totalItems: o.totalItems,
 					view: replacePath(o.view, usePath),
-					label,
-					str,
+					label: toLite(displayUtil.lensAndFormat(o.object, LensType.Chip, locale)),
+					str: str,
 					discriminator: discriminator(o.object, slice.dimension)
 				};
 			})


### PR DESCRIPTION
## Description

### Solves

Adds a fallback for facet labels. When they don't  have an english label, `toLite` returns []. If we want to keep it that way we must perform a length check and then try the default locale.

But the real bug here is `dimension`. It used `str` to create a 'path' for the user setting. But `str` is also the label; when it's missing it created an unmatchable user setting, resulting in the facet not being able to expand. It also created two different settings for swedish and english for the same thing:

`"librissearch:findCategory/Moving image/librissearch:identifyCategory":"OPEN",
"librissearch:findCategory/Rörlig bild/librissearch:identifyCategory":"OPEN"}}`

### Summary of changes

* update `mapSlices`
