### PR TITLE
fix(lxlweb): try/catch on json parse libris session cookie

### DIFF
--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -91,7 +91,15 @@ export const handle = async ({ event, resolve }) => {
 	// fjärrlån
 	const librisSessionCookie = event.cookies.get('LIBRIS_SESSION');
 	if (librisSessionCookie) {
-		event.locals.librisSession = JSON.parse(librisSessionCookie);
+		try {
+			const parsed = JSON.parse(librisSessionCookie);
+			event.locals.librisSession = parsed;
+		} catch (err) {
+			console.error('Invalid libris session cookie', err);
+			event.cookies.delete('LIBRIS_SESSION', {
+				path: '/'
+			});
+		}
 	}
 
 	// set legacy cookies site-wide


### PR DESCRIPTION
## Description
### Tickets involved

### Solves

Add try/catch when parsing the `LIBRIS_SESSION` (fjärrlån) cookie. To prevent app from breaking when tampering with the cookie, since it is httpOnly.

### Summary of changes

* update `hooks.server.ts`
