### PR TITLE
feat(lxlweb): show error ID if available

### DIFF
--- a/lxl-web/src/app.d.ts
+++ b/lxl-web/src/app.d.ts
@@ -12,6 +12,7 @@ declare global {
 	namespace App {
 		interface Error {
 			status?: string;
+			errorId?: string;
 		}
 		interface Locals {
 			vocab: VocabUtil;

--- a/lxl-web/src/lib/components/Error.svelte
+++ b/lxl-web/src/lib/components/Error.svelte
@@ -55,8 +55,13 @@
 				>{page.data.t('errors.backToStartPage')}
 			</a>
 		</p>
-	{:else if page.error?.message}
+	{:else if page.error}
 		<h2 class="pb-4 text-lg font-medium">{page.data.t('errors.somethingWentWrong')}</h2>
-		<p>{page.error.message}</p>
+		{#if page.error.errorId}
+			<p>{page.data.t('errors.errorWithErrorId')}</p>
+			<p class="pt-4">{page.data.t('errors.errorIdLabel')}: {page.error.errorId}</p>
+		{:else}
+			<p>{page.data.t('errors.errorWithoutErrorId')}</p>
+		{/if}
 	{/if}
 </div>

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -243,7 +243,11 @@ export default {
 		followUp: ', and we will investigate the error.',
 		backToStartPage: 'Back to the home page',
 		mailSubject: 'Incorrect link',
-		mailBody: 'Incorrect reference to the page'
+		mailBody: 'Incorrect reference to the page',
+		errorWithErrorId:
+			'Please try reloading the page. If the problem persists, report the error ID below.',
+		errorWithoutErrorId: 'Please try reloading the page.',
+		errorIdLabel: 'Error ID'
 	},
 	general: {
 		collapseAll: 'Collapse all',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -241,7 +241,11 @@ export default {
 		followUp: ', så undersöker vi felet.',
 		backToStartPage: 'Tillbaka till startsidan',
 		mailSubject: 'Felaktig länk',
-		mailBody: 'Felaktig referens till sidan'
+		mailBody: 'Felaktig referens till sidan',
+		errorWithErrorId:
+			'Prova att ladda om sidan. Vänligen rapportera felkoden nedan om felet kvarstår.',
+		errorWithoutErrorId: 'Prova att ladda om sidan.',
+		errorIdLabel: 'Felkod'
 	},
 	general: {
 		collapseAll: 'Stäng alla',

--- a/lxl-web/src/lib/remotes/searchResult.remote.ts
+++ b/lxl-web/src/lib/remotes/searchResult.remote.ts
@@ -30,7 +30,11 @@ export const getSearchResults = query(SearchResultsSchema, async (params) => {
 
 	if (!res.ok) {
 		const err = (await res.json()) as ApiError;
-		return error(err.status_code, { message: err.message, status: err.status });
+		return error(err.status_code, {
+			message: err.message,
+			status: err.status,
+			...(err.error_id && { errorId: err.error_id })
+		});
 	}
 
 	const displayUtil = locals.display;
@@ -59,7 +63,11 @@ export const getAdjecentSearchResult = query(v.string(), async (viewId) => {
 
 	if (!res.ok) {
 		const err = (await res.json()) as ApiError;
-		return error(err.status_code, { message: err.message, status: err.status });
+		return error(err.status_code, {
+			message: err.message,
+			status: err.status,
+			...(err.error_id && { errorId: err.error_id })
+		});
 	}
 
 	const data = (await res.json()) as PartialCollectionView;

--- a/lxl-web/src/lib/types/api.ts
+++ b/lxl-web/src/lib/types/api.ts
@@ -4,6 +4,7 @@ export type ApiError = {
 	message: string;
 	status_code: NumericRange<400, 599>;
 	status: string;
+	error_id?: string;
 };
 
 export interface HoldingStatus {

--- a/lxl-web/src/lib/utils/relations.server.ts
+++ b/lxl-web/src/lib/utils/relations.server.ts
@@ -36,7 +36,11 @@ export async function getRelations(
 
 	if (!res.ok) {
 		const err = (await res.json()) as ApiError;
-		throw error(err.status_code, { message: err.message, status: err.status });
+		throw error(err.status_code, {
+			message: err.message,
+			status: err.status,
+			...(err.error_id && { errorId: err.error_id })
+		});
 	}
 
 	const data = (await res.json()) as PartialCollectionView;

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -75,7 +75,8 @@ export const load = async ({ params, locals, fetch, url }) => {
 		}
 		throw error(apiError?.status_code || resourceRes.status, {
 			message: apiError?.message || resourceRes.statusText,
-			status: apiError?.status
+			status: apiError?.status,
+			...(apiError?.error_id && { errorId: apiError.error_id })
 		});
 	}
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.server.ts
@@ -60,7 +60,11 @@ export const load = async ({ params, url, locals, fetch, depends }) => {
 			}
 		} else {
 			const err = (await recordsRes.json()) as ApiError;
-			throw error(err.status_code, { message: err.message, status: err.status });
+			throw error(err.status_code, {
+				message: err.message,
+				status: err.status,
+				...(err.error_id && { errorId: err.error_id })
+			});
 		}
 	}
 


### PR DESCRIPTION
With https://github.com/libris/librisxl/pull/1770 we now get `error_id` from the backend, so show it if available.

Before (try it with `/find?_q=doi%3Afoo`):
```
500
Something went wrong

Invalid property chain axiom for shorthand property 'doi'.
```
(internal, should not be seen by users, annoying to correlate with logs)

After:
```
500
Something went wrong

Please try reloading the page. If the problem persists, report the error ID below.

Error ID: 4ac902be-ad56-43da-9df8-343600d6d977
```
(easily searchable in logs)