### PR TITLE
fix(lxlweb): dont parse non-json LIBRIS_SESSION cookie

### DIFF
--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -91,15 +91,7 @@ export const handle = async ({ event, resolve }) => {
 	// fjärrlån
 	const librisSessionCookie = event.cookies.get('LIBRIS_SESSION');
 	if (librisSessionCookie) {
-		try {
-			const parsed = JSON.parse(librisSessionCookie);
-			event.locals.librisSession = parsed;
-		} catch (err) {
-			console.error('Invalid libris session cookie', err);
-			event.cookies.delete('LIBRIS_SESSION', {
-				path: '/'
-			});
-		}
+		event.locals.librisSession = librisSessionCookie;
 	}
 
 	// set legacy cookies site-wide


### PR DESCRIPTION
## Description
### Solves

Don't `JSON.parse` the `LIBRIS_SESSION` cookie. It's not json.

