### PR TITLE
fix(lxlweb): Agent styling tweaks

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -330,11 +330,11 @@ body:has(.dismissed-banner) {
 		}
 
 		/* persons */
-		& .agent-lifespan {
+		& .agent-extra {
 			font-weight: var(--font-weight-normal);
 			color: var(--color-subtle);
 		}
-		& a:hover .agent-lifespan {
+		& a:hover .agent-extra {
 			color: inherit;
 		}
 

--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -330,11 +330,11 @@ body:has(.dismissed-banner) {
 		}
 
 		/* persons */
-		& .agent-extra {
+		& .person-extra {
 			font-weight: var(--font-weight-normal);
 			color: var(--color-subtle);
 		}
-		& a:hover .agent-extra {
+		& a:hover .person-extra {
 			color: inherit;
 		}
 

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -408,9 +408,9 @@
 						"familyName",
 						"name",
 						"marc:numeration",
-						"lifeSpan",
 						"marc:titlesAndOtherWordsAssociatedWithAName",
-						"fullerFormOfName"
+						"fullerFormOfName",
+						"lifeSpan"
 					]
 				},
 				"Title": {
@@ -1615,16 +1615,16 @@
 				"fresnel:contentFirst": ""
 			}
 		},
-		"Agent-lifeSpan-format": {
-			"@id": "Agent-lifeSpan-format",
+		"Person-format": {
+			"@id": "Person-format",
 			"@type": "fresnel:Format",
-			"fresnel:classFormatDomain": ["Agent"],
+			"fresnel:classFormatDomain": ["Person"],
 			"fresnel:propertyFormatDomain": [
 				"lifeSpan",
 				"marc:titlesAndOtherWordsAssociatedWithAName",
 				"fullerFormOfName"
 			],
-			"fresnel:propertyStyle": ["agent-extra"]
+			"fresnel:propertyStyle": ["person-extra"]
 		},
 		"Role-format": {
 			"@id": "Role-format",

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -1619,8 +1619,12 @@
 			"@id": "Agent-lifeSpan-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Agent"],
-			"fresnel:propertyFormatDomain": ["lifeSpan"],
-			"fresnel:propertyStyle": ["agent-lifespan"]
+			"fresnel:propertyFormatDomain": [
+				"lifeSpan",
+				"marc:titlesAndOtherWordsAssociatedWithAName",
+				"fullerFormOfName"
+			],
+			"fresnel:propertyStyle": ["agent-extra"]
 		},
 		"Role-format": {
 			"@id": "Role-format",

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -1090,18 +1090,26 @@
 			}
 		},
 		"commaBeforeProperty-format": {
-			"TODO": "fullerFormOfName skrivs alltid med parenteser i libris nu, ska det vara så?",
 			"@id": "commaBeforeProperty-format",
 			"@type": "fresnel:Format",
 			"fresnel:propertyFormatDomain": [
 				"lifeSpan",
 				"name",
-				"marc:numeration",
-				"marc:titlesAndOtherWordsAssociatedWithAName",
-				"fullerFormOfName"
+				"marc:titlesAndOtherWordsAssociatedWithAName"
 			],
 			"fresnel:propertyFormat": {
 				"fresnel:contentBefore": ", ",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"noCommaBeforeProperty-format": {
+			"TODO": "fullerFormOfName skrivs alltid med parenteser i libris nu, ska det vara så?",
+			"@id": "noCommaBeforeProperty-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Agent"],
+			"fresnel:propertyFormatDomain": ["fullerFormOfName", "marc:numeration"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": " ",
 				"fresnel:contentFirst": ""
 			}
 		},

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -787,7 +787,7 @@
 			}
              */
 
-			& :global(.agent-lifespan),
+			& :global(.agent-extra),
 			& :global(.language) {
 				display: none;
 			}

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -787,7 +787,7 @@
 			}
              */
 
-			& :global(.agent-extra),
+			& :global(.person-extra),
 			& :global(.language) {
 				display: none;
 			}

--- a/lxl-web/src/lib/components/SearchResultList.svelte
+++ b/lxl-web/src/lib/components/SearchResultList.svelte
@@ -188,7 +188,7 @@
 				}
 			}
 		}
-		& :global(.agent-lifespan),
+		& :global(.agent-extra),
 		& :global(.contribution-role) {
 			display: none;
 		}

--- a/lxl-web/src/lib/components/SearchResultList.svelte
+++ b/lxl-web/src/lib/components/SearchResultList.svelte
@@ -188,7 +188,7 @@
 				}
 			}
 		}
-		& :global(.agent-extra),
+		& :global(.person-extra),
 		& :global(.contribution-role) {
 			display: none;
 		}

--- a/lxl-web/src/lib/components/supersearch/Suggestion.svelte
+++ b/lxl-web/src/lib/components/supersearch/Suggestion.svelte
@@ -209,7 +209,7 @@
 	}
 
 	.suggestion-contribution {
-		& :global(.agent-extra) {
+		& :global(.person-extra) {
 			display: none;
 		}
 

--- a/lxl-web/src/lib/components/supersearch/Suggestion.svelte
+++ b/lxl-web/src/lib/components/supersearch/Suggestion.svelte
@@ -209,7 +209,7 @@
 	}
 
 	.suggestion-contribution {
-		& :global(.agent-lifespan) {
+		& :global(.agent-extra) {
 			display: none;
 		}
 


### PR DESCRIPTION
## Description
### Solves

Discussed tweaks of Person styling throughout:

* Don't bolden `marc:titlesAndOtherWordsAssociatedWithAName`, `fullerFormOfName` (in addition to `lifeSpan`)
* Rename class `.agent-lifespan` -> `.person-extra`
* Change order; put `lifeSpan` last
* Don't add comma before `fullerFormOfName`, `marc:numeration`

Examples:
<img width="642" height="335" alt="Skärmavbild 2026-05-21 kl  10 11 42" src="https://github.com/user-attachments/assets/97de4126-38db-4180-b763-171757d33710" />

<img width="751" height="316" alt="Skärmavbild 2026-05-21 kl  10 05 02" src="https://github.com/user-attachments/assets/06277acb-8d91-477e-a0f1-985a2467f40e" />

<img width="604" height="422" alt="Skärmavbild 2026-05-21 kl  10 10 35" src="https://github.com/user-attachments/assets/cd4a1464-00f9-4b28-988e-a5d99a8f0667" />


### Summary of changes

* `display-web` tweaks
