### PR TITLE
fix(lxl-web): fallback locale for lang containers

### DIFF
--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -213,7 +213,7 @@ async function loadUtil(): Promise<Util> {
 	});
 
 	const vocabUtil = new VocabUtil(vocab, context);
-	const displayUtil = new DisplayUtil(display, vocabUtil);
+	const displayUtil = new DisplayUtil(display, vocabUtil, Object.keys(Locales));
 
 	DERIVED_LENSES.forEach((l) => displayUtil.registerDerivedLens(l));
 

--- a/lxl-web/src/lib/utils/xl.server.ts
+++ b/lxl-web/src/lib/utils/xl.server.ts
@@ -251,15 +251,18 @@ export class DisplayUtil {
 
 	private readonly lensCache: Record<string, Lens> = {};
 
+	readonly locales: LangCode[];
+
 	// x -> xByLang
 	langContainerAlias: Record<PropertyName, PropertyName> = {};
 
 	// xByLang -> x
 	langContainerAliasInverted: Record<PropertyName, PropertyName> = {};
 
-	constructor(display: DisplayJsonLd, vocabUtil: VocabUtil) {
+	constructor(display: DisplayJsonLd, vocabUtil: VocabUtil, locales: LangCode[]) {
 		this.display = display;
 		this.vocabUtil = vocabUtil;
+		this.locales = locales;
 		this.buildLangContainerAliasMap();
 		this.expandInheritedLensProperties();
 
@@ -1076,8 +1079,26 @@ class Formatter {
 	}
 
 	private pickLanguage(container: LangContainer) {
-		// TODO handle missing
-		return container[this.locale] || container[JsonLd.NONE];
+		if (container[this.locale]) {
+			return container[this.locale];
+		}
+
+		if (container[JsonLd.NONE]) {
+			return container[JsonLd.NONE];
+		}
+
+		for (const locale of this.displayUtil.locales) {
+			if (container[locale]) {
+				return container[locale];
+			}
+		}
+
+		const langKeys = Object.keys(container);
+		if (langKeys.length > 0) {
+			return container[langKeys.toSorted()[0]];
+		}
+
+		return '{???}';
 	}
 }
 


### PR DESCRIPTION
1. selected locale
2. `@none` i.e. non-language-tagged value
3. other locale from locales. In the order passed in displayUtil constructor.
4. any other language present. Sorted for predictability
5. `{???}` - non-empty recognizable string so that issues with missing labels are surfaced
    - empty language container shouldn't be possible. so shouldn't happen 