### PR TITLE
feat(lxl-web): set favourite libraries via link

### DIFF
--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -59,12 +59,6 @@ export const handle = async ({ event, resolve }) => {
 	let cookieEdit = false;
 	let redirectHome = false;
 
-	if (event.url.searchParams.has(SettingsParams.wipeSettings)) {
-		userSettings = {};
-		cookieEdit = true;
-		redirectHome = true;
-	}
-
 	if (event.url.searchParams.has('_debug')) {
 		let flags = event.url.searchParams
 			.getAll('_debug')

--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -88,7 +88,7 @@ export const handle = async ({ event, resolve }) => {
 			.map((s) => s.trim())
 			.map((s) => LIBRARY_URI_PREFIX + s)
 			.filter((id) => getLibrary(id) || getOrgMembers(id).length > 0)
-			.forEach((l) => (myLibraries[l] = '')); // label is obsolete
+			.forEach((l) => (myLibraries[l] = ''));
 		userSettings.myLibraries = myLibraries;
 
 		cookieEdit = true;

--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { redirect, type HandleServerError, type RequestEvent } from '@sveltejs/kit';
+import { type HandleServerError, redirect, type RequestEvent } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { defaultLocale, Locales } from '$lib/i18n/locales';
 import { DERIVED_LENSES } from '$lib/types/display';
@@ -8,9 +8,10 @@ import type { Site } from '$lib/types/site';
 import { DebugFlags, type MyLibrariesType, type UserSettings } from '$lib/types/userSettings';
 import displayWeb from '$lib/assets/json/display-web.json';
 import { DisplayUtil, VocabUtil } from '$lib/utils/xl.server';
-import { startRefreshLibraries } from '$lib/utils/getLibraries.server';
+import { getLibrary, getOrgMembers, startRefreshLibraries } from '$lib/utils/getLibraries.server';
 import { getSubsetMapping } from '$lib/utils/subsetCache.server';
 import { getQualifierSuggestions } from '$lib/utils/getQualifierSuggestions.server';
+import { LIBRARY_URI_PREFIX } from '$lib/utils/holdings';
 
 type QualifierSuggestionsByLocale = Record<keyof typeof Locales, QualifierSuggestion2[]>;
 type Util = [VocabUtil, DisplayUtil, QualifierSuggestionsByLocale];
@@ -51,6 +52,13 @@ export const handle = async ({ event, resolve }) => {
 		}
 	}
 	let cookieEdit = false;
+	let redirectHome = false;
+
+	if (event.url.searchParams.has('wipeSettings')) {
+		userSettings = {};
+		cookieEdit = true;
+		redirectHome = true;
+	}
 
 	if (event.url.searchParams.has('_debug')) {
 		let flags = event.url.searchParams
@@ -72,6 +80,21 @@ export const handle = async ({ event, resolve }) => {
 		cookieEdit = true;
 	}
 
+	const setMyLibraries = event.url.searchParams.get('favouriteLibraries');
+	if (setMyLibraries) {
+		const myLibraries: MyLibrariesType = {};
+		setMyLibraries
+			.split(',')
+			.map((s) => s.trim())
+			.map((s) => LIBRARY_URI_PREFIX + s)
+			.filter((id) => getLibrary(id) || getOrgMembers(id).length > 0)
+			.forEach((l) => (myLibraries[l] = '')); // label is obsolete
+		userSettings.myLibraries = myLibraries;
+
+		cookieEdit = true;
+		redirectHome = true;
+	}
+
 	if (cookieEdit) {
 		event.cookies.set('userSettings', JSON.stringify(userSettings), {
 			maxAge: 60 * 60 * 24 * 365, // 365 days
@@ -81,6 +104,11 @@ export const handle = async ({ event, resolve }) => {
 			path: '/'
 		});
 	}
+
+	if (redirectHome) {
+		redirect(302, '/');
+	}
+
 	event.locals.userSettings = userSettings;
 
 	const dismissedBannerCookie = event.cookies.get('dismissed-banner');

--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -5,7 +5,12 @@ import { defaultLocale, Locales } from '$lib/i18n/locales';
 import { DERIVED_LENSES } from '$lib/types/display';
 import type { QualifierSuggestion2 } from '$lib/types/search';
 import type { Site } from '$lib/types/site';
-import { DebugFlags, type MyLibrariesType, type UserSettings } from '$lib/types/userSettings';
+import {
+	DebugFlags,
+	type MyLibrariesType,
+	SettingsParams,
+	type UserSettings
+} from '$lib/types/userSettings';
 import displayWeb from '$lib/assets/json/display-web.json';
 import { DisplayUtil, VocabUtil } from '$lib/utils/xl.server';
 import { getLibrary, getOrgMembers, startRefreshLibraries } from '$lib/utils/getLibraries.server';
@@ -54,7 +59,7 @@ export const handle = async ({ event, resolve }) => {
 	let cookieEdit = false;
 	let redirectHome = false;
 
-	if (event.url.searchParams.has('wipeSettings')) {
+	if (event.url.searchParams.has(SettingsParams.wipeSettings)) {
 		userSettings = {};
 		cookieEdit = true;
 		redirectHome = true;
@@ -80,8 +85,8 @@ export const handle = async ({ event, resolve }) => {
 		cookieEdit = true;
 	}
 
-	const setMyLibraries = event.url.searchParams.get('favouriteLibraries');
-	if (setMyLibraries) {
+	const setMyLibraries = event.url.searchParams.get(SettingsParams.favouriteLibraries);
+	if (setMyLibraries !== undefined && setMyLibraries !== null) {
 		const myLibraries: MyLibrariesType = {};
 		setMyLibraries
 			.split(',')
@@ -103,10 +108,6 @@ export const handle = async ({ event, resolve }) => {
 			httpOnly: false, // allow the client to write to this cookie
 			path: '/'
 		});
-	}
-
-	if (redirectHome) {
-		redirect(302, '/');
 	}
 
 	event.locals.userSettings = userSettings;
@@ -181,6 +182,12 @@ export const handle = async ({ event, resolve }) => {
 	event.locals.subsetMapping = subsetMapping;
 
 	event.locals.qualifierSuggestionsByLocale = qualifierSuggestionsByLocale;
+
+	if (redirectHome) {
+		const path = lang === defaultLocale ? '/' : '/' + lang;
+		const query = _r ? '?_r=' + _r : '';
+		redirect(302, path + query);
+	}
 
 	return resolve(event, {
 		transformPageChunk: ({ html }) => html.replace('%lang%', lang).replace('%theme%', dataTheme)

--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -16,7 +16,7 @@ import { DisplayUtil, VocabUtil } from '$lib/utils/xl.server';
 import { getLibrary, getOrgMembers, startRefreshLibraries } from '$lib/utils/getLibraries.server';
 import { getSubsetMapping } from '$lib/utils/subsetCache.server';
 import { getQualifierSuggestions } from '$lib/utils/getQualifierSuggestions.server';
-import { LIBRARY_URI_PREFIX } from '$lib/utils/holdings';
+import { updateSettings } from '$lib/utils/userSettings.svelte';
 
 type QualifierSuggestionsByLocale = Record<keyof typeof Locales, QualifierSuggestion2[]>;
 type Util = [VocabUtil, DisplayUtil, QualifierSuggestionsByLocale];
@@ -79,16 +79,12 @@ export const handle = async ({ event, resolve }) => {
 		cookieEdit = true;
 	}
 
-	const setMyLibraries = event.url.searchParams.get(SettingsParams.favouriteLibraries);
-	if (setMyLibraries !== undefined && setMyLibraries !== null) {
-		const myLibraries: MyLibrariesType = {};
-		setMyLibraries
-			.split(',')
-			.map((s) => s.trim())
-			.map((s) => LIBRARY_URI_PREFIX + s)
-			.filter((id) => getLibrary(id) || getOrgMembers(id).length > 0)
-			.forEach((l) => (myLibraries[l] = ''));
-		userSettings.myLibraries = myLibraries;
+	if (Object.values(SettingsParams).some((p) => event.url.searchParams.has(p))) {
+		updateSettings(
+			userSettings,
+			event.url.searchParams,
+			(id) => !!(getLibrary(id) || getOrgMembers(id).length > 0)
+		);
 
 		cookieEdit = true;
 		redirectHome = true;

--- a/lxl-web/src/lib/components/Citations.svelte
+++ b/lxl-web/src/lib/components/Citations.svelte
@@ -112,9 +112,9 @@
 							>
 								<BiCopy />
 								{#if wasCopied[format.key]}
-									{page.data.t('citations.copied')}
+									{page.data.t('general.copied')}
 								{:else}
-									{page.data.t('citations.copyToClipboard')}
+									{page.data.t('general.copyToClipboard')}
 								{/if}
 							</button>
 							{#if isFileFormat && id}

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -418,7 +418,7 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 						onclick={() =>
 							alreadyAdded
 								? userSettings.removeLibrary(item.libraryId)
-								: userSettings.addLibrary(item.libraryId, item.displayStr)}
+								: userSettings.addLibrary(item.libraryId)}
 					>
 						{#if alreadyAdded}
 							<BiHeartFill aria-hidden="true" class="text-primary-600" />

--- a/lxl-web/src/lib/components/my-pages/Libraries.svelte
+++ b/lxl-web/src/lib/components/my-pages/Libraries.svelte
@@ -47,6 +47,10 @@
 	function onResponse() {
 		const params = new SvelteURLSearchParams();
 		params.set('q', searchPhrase);
+		if (page.url.searchParams.has('_r')) {
+			params.set('_r', page.url.searchParams.get('_r') as string);
+		}
+
 		goto(page.url.pathname + `?${params.toString()}`, { replaceState: true, keepFocus: true });
 	}
 

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -75,12 +75,10 @@ export default {
 		noResultsFor: 'No results for',
 		hitsFor: 'hits for',
 		settingsLinkHeading: 'Permanent link for settings',
-		settingsLinkDescription: 'Copy a link to access the Libris homepage with your saved settings.',
-		settingsLink: 'Link for the favorite libraries above',
-		wipeAndSettingsLink: 'Link to clear all settings and select the favorite libraries above',
-		wipeLink: 'Link to clear all settings',
-		wipeDescription:
-			'Clears everything, including the most recently selected citation style, filter panel sorting, and so on.'
+		settingsLinkDescription:
+			'Paste the link into a browser to access Libris with your settings saved.',
+		settingsLink:
+			'Copy this link to go to the Libris homepage with your selected favorite libraries'
 	},
 	footer: {
 		logo: 'National Library of Sweden logotype',

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -73,7 +73,14 @@ export default {
 		findLibrary: 'Search library or location',
 		findAndAdd: 'Find and add favourite libraries',
 		noResultsFor: 'No results for',
-		hitsFor: 'hits for'
+		hitsFor: 'hits for',
+		settingsLinkHeading: 'Permanent link for settings',
+		settingsLinkDescription: 'Copy a link to access the Libris homepage with your saved settings.',
+		settingsLink: 'Link for the favorite libraries above',
+		wipeAndSettingsLink: 'Link to clear all settings and select the favorite libraries above',
+		wipeLink: 'Link to clear all settings',
+		wipeDescription:
+			'Clears everything, including the most recently selected citation style, filter panel sorting, and so on.'
 	},
 	footer: {
 		logo: 'National Library of Sweden logotype',

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -76,9 +76,7 @@ export default {
 		hitsFor: 'hits for',
 		settingsLinkHeading: 'Permanent link for settings',
 		settingsLinkDescription:
-			'Paste the link into a browser to access Libris with your settings saved.',
-		settingsLink:
-			'Copy this link to go to the Libris homepage with your selected favorite libraries'
+			'Paste the link into a browser to go to the Libris start page with your selected libraries.'
 	},
 	footer: {
 		logo: 'National Library of Sweden logotype',
@@ -271,7 +269,9 @@ export default {
 		add: 'Add',
 		remove: 'Remove',
 		show: 'Show',
-		approx: 'approx.'
+		approx: 'approx.',
+		copyToClipboard: 'Copy to clipboard',
+		copied: 'Copied!'
 	},
 	tableOfContents: {
 		onThisPage: 'On this page',
@@ -356,8 +356,6 @@ export default {
 		createCitation: 'Create citation',
 		selectFormat: 'Select format',
 		allFormats: 'All formats',
-		copyToClipboard: 'Copy to clipboard',
-		copied: 'Copied!',
 		saveAsFile: 'Save as file'
 	},
 	horizontalList: {

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -71,7 +71,15 @@ export default {
 		findLibrary: 'Sök efter bibliotek',
 		findAndAdd: 'Hitta och lägg till favoritbibliotek',
 		noResultsFor: 'Inga sökträffar för',
-		hitsFor: 'träffar för'
+		hitsFor: 'träffar för',
+		settingsLinkHeading: 'Permanent länk för inställningarna',
+		settingsLinkDescription:
+			'Kopiera en länk för att komma till Libris startsida med sparade inställningar.',
+		settingsLink: 'Länk för favoritbiblioteken ovan',
+		wipeAndSettingsLink: 'Länk för att rensa alla inställningar och välja favoritbiblioteken ovan',
+		wipeLink: 'Länk för att rensa alla inställningar',
+		wipeDescription:
+			'Rensar allting. Inklusive senast vald citeringsstil, vald sortering i filterpanelen och så vidare.'
 	},
 	footer: {
 		logo: 'Kungliga bibliotekets logotyp',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -74,12 +74,9 @@ export default {
 		hitsFor: 'träffar för',
 		settingsLinkHeading: 'Permanent länk för inställningarna',
 		settingsLinkDescription:
-			'Kopiera en länk för att komma till Libris startsida med sparade inställningar.',
-		settingsLink: 'Länk för favoritbiblioteken ovan',
-		wipeAndSettingsLink: 'Länk för att rensa alla inställningar och välja favoritbiblioteken ovan',
-		wipeLink: 'Länk för att rensa alla inställningar',
-		wipeDescription:
-			'Rensar allting. Inklusive senast vald citeringsstil, vald sortering i filterpanelen och så vidare.'
+			'Klistra in länken i en webbläsare så kommer du till Libris med dina inställningar sparade.',
+		settingsLink:
+			'Kopiera den här länken för att komma till Libris startsida med dina valda favoritbibliotek'
 	},
 	footer: {
 		logo: 'Kungliga bibliotekets logotyp',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -74,9 +74,7 @@ export default {
 		hitsFor: 'träffar för',
 		settingsLinkHeading: 'Permanent länk för inställningarna',
 		settingsLinkDescription:
-			'Klistra in länken i en webbläsare så kommer du till Libris med dina inställningar sparade.',
-		settingsLink:
-			'Kopiera den här länken för att komma till Libris startsida med dina valda favoritbibliotek'
+			'Klistra in länken i en webbläsare så kommer du till Libris startsida med dina valda favoritbibliotek.'
 	},
 	footer: {
 		logo: 'Kungliga bibliotekets logotyp',
@@ -269,7 +267,9 @@ export default {
 		add: 'Lägg till',
 		remove: 'Ta bort',
 		show: 'Visa',
-		approx: 'ca'
+		approx: 'ca',
+		copyToClipboard: 'Kopiera till urklipp',
+		copied: 'Kopierad!'
 	},
 	tableOfContents: {
 		onThisPage: 'På den här sidan',

--- a/lxl-web/src/lib/types/userSettings.ts
+++ b/lxl-web/src/lib/types/userSettings.ts
@@ -33,3 +33,8 @@ export type UserSettings = {
 export enum DebugFlags {
 	ES_SCORE = 'esScore'
 }
+
+export enum SettingsParams {
+	wipeSettings = 'wipeSettings',
+	favouriteLibraries = 'favouriteLibraries'
+}

--- a/lxl-web/src/lib/types/userSettings.ts
+++ b/lxl-web/src/lib/types/userSettings.ts
@@ -1,6 +1,7 @@
 import type { AvailableCitationFormat } from '$lib/types/citation';
 import type { LibraryId } from './holdings';
 
+// label string is obsolete and not used
 export type MyLibrariesType = Record<LibraryId, string>;
 
 export enum ExpandedState {

--- a/lxl-web/src/lib/types/userSettings.ts
+++ b/lxl-web/src/lib/types/userSettings.ts
@@ -35,6 +35,5 @@ export enum DebugFlags {
 }
 
 export enum SettingsParams {
-	wipeSettings = 'wipeSettings',
 	favouriteLibraries = 'favouriteLibraries'
 }

--- a/lxl-web/src/lib/utils/holdings.test.ts
+++ b/lxl-web/src/lib/utils/holdings.test.ts
@@ -32,15 +32,15 @@ describe('getBibIdsByInstanceId', () => {
 describe('getLibsFromHoldings', () => {
 	it('Returns favourite library present in the holdings list', () => {
 		const userSettings = new UserSettings({});
-		userSettings.addLibrary('https://libris.kb.se/library/S', 'Kungliga biblioteket');
-		userSettings.addLibrary('https://libris.kb.se/library/foo', 'Mitt bibliotek');
+		userSettings.addLibrary('https://libris.kb.se/library/S');
+		userSettings.addLibrary('https://libris.kb.se/library/foo');
 		const byType = getHoldersByType(getHoldingsByType(workCenteredMainEntity));
 
 		expect(getLibsFromHoldings(userSettings.myLibraries, byType)).toStrictEqual([
 			'https://libris.kb.se/library/S'
 		]);
 
-		userSettings.addLibrary('https://libris.kb.se/library/H', 'Frescatibilbioteket');
+		userSettings.addLibrary('https://libris.kb.se/library/H');
 
 		expect(getLibsFromHoldings(userSettings.myLibraries, byType)).toStrictEqual([
 			'https://libris.kb.se/library/S',

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -16,6 +16,8 @@ import { stripAnchor } from '$lib/utils/http';
 import getAtPath from '$lib/utils/getAtPath';
 import { USE_HOLDING_PANE } from '$lib/constants/panels';
 
+export const LIBRARY_URI_PREFIX = 'https://libris.kb.se/library/';
+
 export function getHoldingsLink(url: URL, value: string) {
 	const newSearchParams = new URLSearchParams([...Array.from(url.searchParams.entries())]);
 	newSearchParams.set('holdings', value);
@@ -139,10 +141,7 @@ function getLinksToItemFor(
 }
 
 export function isLibraryOrg(id: LibraryId): boolean {
-	if (id && typeof id === 'string' && id.startsWith('https://libris.kb.se/library/org/')) {
-		return true;
-	}
-	return false;
+	return !!(id && typeof id === 'string' && id.startsWith(LIBRARY_URI_PREFIX + 'org/'));
 }
 
 /**

--- a/lxl-web/src/lib/utils/stripPrefix.test.ts
+++ b/lxl-web/src/lib/utils/stripPrefix.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { stripPrefix } from './stripPrefix';
+
+describe('stripPrefix', () => {
+	it('returns undefined if undefined', () => {
+		expect(stripPrefix(undefined, 'prefix')).toBe(undefined);
+	});
+	it('returns stripped if match', () => {
+		expect(stripPrefix('prefixFoo', 'prefix')).toBe('Foo');
+		expect(stripPrefix('   xxx', '   ')).toBe('xxx');
+		expect(stripPrefix('foo', 'foo')).toBe('');
+	});
+	it('same if no match', () => {
+		expect(stripPrefix('prefixFoo', 'prefix1')).toBe('prefixFoo');
+		expect(stripPrefix('prefixFoo', 'Prefix')).toBe('prefixFoo');
+		expect(stripPrefix('prefixFoo', 'prefixFoo1')).toBe('prefixFoo');
+	});
+});

--- a/lxl-web/src/lib/utils/stripPrefix.ts
+++ b/lxl-web/src/lib/utils/stripPrefix.ts
@@ -1,0 +1,7 @@
+export function stripPrefix<T extends string | undefined>(s: T, prefix: string): T {
+	if (!s) {
+		return s;
+	}
+
+	return s.startsWith(prefix) ? (s.slice(prefix.length) as T) : s;
+}

--- a/lxl-web/src/lib/utils/userSettings.svelte.ts
+++ b/lxl-web/src/lib/utils/userSettings.svelte.ts
@@ -45,7 +45,8 @@ export class UserSettings {
 
 	removeLibrary(libraryId: string) {
 		const myLibs = { ...this.settings?.myLibraries };
-		if (myLibs[libraryId]) {
+
+		if (Object.hasOwn(myLibs, libraryId)) {
 			delete myLibs[libraryId];
 			this.update('myLibraries', myLibs);
 		}

--- a/lxl-web/src/lib/utils/userSettings.svelte.ts
+++ b/lxl-web/src/lib/utils/userSettings.svelte.ts
@@ -1,7 +1,13 @@
 import Cookies from 'js-cookie';
-import { ExpandedState, type UserSettings as UserSettingsType } from '$lib/types/userSettings';
+import {
+	ExpandedState,
+	SettingsParams,
+	type UserSettings as UserSettingsType
+} from '$lib/types/userSettings';
 import type { AvailableCitationFormat } from '$lib/types/citation';
 import type { LibraryId } from '$lib/types/holdings';
+import { stripPrefix } from '$lib/utils/stripPrefix';
+import { LIBRARY_URI_PREFIX } from '$lib/utils/holdings';
 
 export class UserSettings {
 	private settings: UserSettingsType = $state({});
@@ -133,5 +139,18 @@ export class UserSettings {
 
 	get dismissedNewBanner() {
 		return this.settings.dismissedNewBanner;
+	}
+
+	toURLSearchParams(): URLSearchParams {
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const p = new URLSearchParams();
+
+		const libs = Object.keys(this.settings.myLibraries || {})
+			.map((id) => stripPrefix(id, LIBRARY_URI_PREFIX))
+			.join(',');
+		p.set(SettingsParams.favouriteLibraries, libs);
+
+		p.sort();
+		return p;
 	}
 }

--- a/lxl-web/src/lib/utils/userSettings.svelte.ts
+++ b/lxl-web/src/lib/utils/userSettings.svelte.ts
@@ -35,10 +35,10 @@ export class UserSettings {
 		});
 	}
 
-	addLibrary(libraryId: LibraryId, label: string) {
+	addLibrary(libraryId: LibraryId) {
 		const myLibs = { ...this.settings?.myLibraries };
 		if (!myLibs[libraryId]) {
-			myLibs[libraryId] = label;
+			myLibs[libraryId] = '';
 			this.update('myLibraries', myLibs);
 		}
 	}

--- a/lxl-web/src/lib/utils/userSettings.svelte.ts
+++ b/lxl-web/src/lib/utils/userSettings.svelte.ts
@@ -1,6 +1,7 @@
 import Cookies from 'js-cookie';
 import {
 	ExpandedState,
+	type MyLibrariesType,
 	SettingsParams,
 	type UserSettings as UserSettingsType
 } from '$lib/types/userSettings';
@@ -142,15 +143,37 @@ export class UserSettings {
 	}
 
 	toURLSearchParams(): URLSearchParams {
-		// eslint-disable-next-line svelte/prefer-svelte-reactivity
-		const p = new URLSearchParams();
+		return toUrlSearchParams(this.settings);
+	}
+}
 
-		const libs = Object.keys(this.settings.myLibraries || {})
-			.map((id) => stripPrefix(id, LIBRARY_URI_PREFIX))
-			.join(',');
-		p.set(SettingsParams.favouriteLibraries, libs);
+function toUrlSearchParams(userSettings: UserSettingsType): URLSearchParams {
+	// eslint-disable-next-line svelte/prefer-svelte-reactivity
+	const p = new URLSearchParams();
 
-		p.sort();
-		return p;
+	const libs = Object.keys(userSettings.myLibraries || {})
+		.map((id) => stripPrefix(id, LIBRARY_URI_PREFIX))
+		.join(',');
+	p.set(SettingsParams.favouriteLibraries, libs);
+
+	p.sort();
+	return p;
+}
+
+export function updateSettings(
+	userSettings: UserSettingsType,
+	params: URLSearchParams,
+	isValidLibrary: (id: string) => boolean
+) {
+	const setMyLibraries = params.get(SettingsParams.favouriteLibraries);
+	if (setMyLibraries !== undefined && setMyLibraries !== null) {
+		const myLibraries: MyLibrariesType = {};
+		setMyLibraries
+			.split(',')
+			.map((s) => s.trim())
+			.map((s) => LIBRARY_URI_PREFIX + s)
+			.filter(isValidLibrary)
+			.forEach((l) => (myLibraries[l] = ''));
+		userSettings.myLibraries = myLibraries;
 	}
 }

--- a/lxl-web/src/lib/utils/userSettings.test.ts
+++ b/lxl-web/src/lib/utils/userSettings.test.ts
@@ -3,8 +3,8 @@ import { UserSettings } from './userSettings.svelte';
 
 const s = {
 	myLibraries: {
-		'https://libris.kb.se/library/Nodi': 'Ale bibliotek',
-		'https://libris.kb.se/library/org/BIN': 'Biblioteken i Norrbotten'
+		'https://libris.kb.se/library/Nodi': '',
+		'https://libris.kb.se/library/org/BIN': ''
 	},
 	facetSort: {
 		'rdf:type': 'hits.asc',
@@ -23,11 +23,11 @@ describe('userSettings util', () => {
 	});
 
 	it('can add a library', () => {
-		userSettings.addLibrary('https://libris.kb.se/library/Bole', 'Bollebygds bibliotek');
+		userSettings.addLibrary('https://libris.kb.se/library/Bole');
 		expect(userSettings.myLibraries).toStrictEqual({
-			'https://libris.kb.se/library/Bole': 'Bollebygds bibliotek',
-			'https://libris.kb.se/library/Nodi': 'Ale bibliotek',
-			'https://libris.kb.se/library/org/BIN': 'Biblioteken i Norrbotten'
+			'https://libris.kb.se/library/Bole': '',
+			'https://libris.kb.se/library/Nodi': '',
+			'https://libris.kb.se/library/org/BIN': ''
 		});
 	});
 
@@ -35,7 +35,7 @@ describe('userSettings util', () => {
 		userSettings.removeLibrary('https://libris.kb.se/library/Bole');
 		userSettings.removeLibrary('https://libris.kb.se/library/Nodi');
 		expect(userSettings.myLibraries).toStrictEqual({
-			'https://libris.kb.se/library/org/BIN': 'Biblioteken i Norrbotten'
+			'https://libris.kb.se/library/org/BIN': ''
 		});
 	});
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/my-pages/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/my-pages/+page.svelte
@@ -4,15 +4,12 @@
 	import Libraries from '$lib/components/my-pages/Libraries.svelte';
 	import Meta from '$lib/components/Meta.svelte';
 	import { getUserSettings } from '$lib/contexts/userSettings';
-	import { SettingsParams } from '$lib/types/userSettings';
 
 	const pageTitle = $derived(page.data.t('myPages.pageTitle'));
 	const q = $derived(page.url.searchParams.get('q'));
 
-	const myCookie = $derived(getUserSettings());
-
-	const query = $derived(
-		myCookie.toURLSearchParams().toString().replaceAll('%2F', '/').replaceAll('%2C', ',')
+	const setSettingsQuery = $derived(
+		getUserSettings().toURLSearchParams().toString().replaceAll('%2F', '/').replaceAll('%2C', ',')
 	);
 </script>
 
@@ -34,25 +31,12 @@
 	<h2 class="font-heading mt-6 text-xl font-medium">
 		{page.data.t('myPages.settingsLinkHeading')}
 	</h2>
-	{page.data.t('myPages.settingsLinkDescription')}
-	<p class="my-2">
-		<a href={page.data.localizeHref(`${page.url.origin}?${query}`)} class="link"
-			>{page.data.t('myPages.settingsLink')}</a
-		>
-	</p>
-	<div class="my-2">
-		<p>
-			<a
-				href={page.data.localizeHref(`${page.url.origin}?${SettingsParams.wipeSettings}`)}
-				class="link">{page.data.t('myPages.wipeLink')}</a
+	<div style="max-width: 60ch;">
+		{page.data.t('myPages.settingsLinkDescription')}
+		<p class="my-2">
+			<a href={page.data.localizeHref(`${page.url.origin}?${setSettingsQuery}`)} class="link"
+				>{page.data.t('myPages.settingsLink')}</a
 			>
 		</p>
-		<p>
-			<a
-				href={page.data.localizeHref(`${page.url.origin}?${SettingsParams.wipeSettings}&${query}`)}
-				class="link">{page.data.t('myPages.wipeAndSettingsLink')}</a
-			>
-		</p>
-		{page.data.t('myPages.wipeDescription')}
 	</div>
 </div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/my-pages/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/my-pages/+page.svelte
@@ -3,9 +3,17 @@
 	import { page } from '$app/state';
 	import Libraries from '$lib/components/my-pages/Libraries.svelte';
 	import Meta from '$lib/components/Meta.svelte';
+	import { getUserSettings } from '$lib/contexts/userSettings';
+	import { SettingsParams } from '$lib/types/userSettings';
 
 	const pageTitle = $derived(page.data.t('myPages.pageTitle'));
 	const q = $derived(page.url.searchParams.get('q'));
+
+	const myCookie = $derived(getUserSettings());
+
+	const query = $derived(
+		myCookie.toURLSearchParams().toString().replaceAll('%2F', '/').replaceAll('%2C', ',')
+	);
 </script>
 
 <svelte:head>
@@ -22,4 +30,29 @@
 <div class="mx-auto mt-2 w-full max-w-screen p-4 sm:px-6 md:mt-6 lg:max-w-6xl">
 	<h1 class="font-heading text-2xl font-medium">{page.data.t('myPages.myPages')}</h1>
 	<Libraries {q} />
+
+	<h2 class="font-heading mt-6 text-xl font-medium">
+		{page.data.t('myPages.settingsLinkHeading')}
+	</h2>
+	{page.data.t('myPages.settingsLinkDescription')}
+	<p class="my-2">
+		<a href={page.data.localizeHref(`${page.url.origin}?${query}`)} class="link"
+			>{page.data.t('myPages.settingsLink')}</a
+		>
+	</p>
+	<div class="my-2">
+		<p>
+			<a
+				href={page.data.localizeHref(`${page.url.origin}?${SettingsParams.wipeSettings}`)}
+				class="link">{page.data.t('myPages.wipeLink')}</a
+			>
+		</p>
+		<p>
+			<a
+				href={page.data.localizeHref(`${page.url.origin}?${SettingsParams.wipeSettings}&${query}`)}
+				class="link">{page.data.t('myPages.wipeAndSettingsLink')}</a
+			>
+		</p>
+		{page.data.t('myPages.wipeDescription')}
+	</div>
 </div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/my-pages/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/my-pages/+page.svelte
@@ -4,13 +4,34 @@
 	import Libraries from '$lib/components/my-pages/Libraries.svelte';
 	import Meta from '$lib/components/Meta.svelte';
 	import { getUserSettings } from '$lib/contexts/userSettings';
+	import BiCopy from '~icons/bi/copy';
 
 	const pageTitle = $derived(page.data.t('myPages.pageTitle'));
 	const q = $derived(page.url.searchParams.get('q'));
 
-	const setSettingsQuery = $derived(
-		getUserSettings().toURLSearchParams().toString().replaceAll('%2F', '/').replaceAll('%2C', ',')
+	const settings = $derived(getUserSettings());
+
+	const hasFavourites = $derived(
+		settings.myLibraries && Object.keys(settings.myLibraries).length > 0
 	);
+
+	const setSettingsQuery = $derived(
+		settings.toURLSearchParams().toString().replaceAll('%2F', '/').replaceAll('%2C', ',')
+	);
+
+	const settingsUrl = $derived(
+		page.url.origin + page.data.localizeHref(`${page.url.origin}?${setSettingsQuery}`)
+	);
+	let lastCopiedUrl: string = $state('');
+
+	async function handleCopySettingsUrl() {
+		const url = settingsUrl;
+		const type = 'text/plain';
+		const blob = new Blob([url], { type });
+		const data = new ClipboardItem({ [type]: blob });
+		await navigator.clipboard.write([data]);
+		lastCopiedUrl = url;
+	}
 </script>
 
 <svelte:head>
@@ -28,15 +49,23 @@
 	<h1 class="font-heading text-2xl font-medium">{page.data.t('myPages.myPages')}</h1>
 	<Libraries {q} />
 
-	<h2 class="font-heading mt-6 text-xl font-medium">
-		{page.data.t('myPages.settingsLinkHeading')}
-	</h2>
-	<div style="max-width: 60ch;">
-		{page.data.t('myPages.settingsLinkDescription')}
-		<p class="my-2">
-			<a href={page.data.localizeHref(`${page.url.origin}?${setSettingsQuery}`)} class="link"
-				>{page.data.t('myPages.settingsLink')}</a
-			>
+	<div style="max-width: 60ch;" class:collapse={!hasFavourites}>
+		<h2 class="mt-4 font-medium">
+			{page.data.t('myPages.settingsLinkHeading')}
+		</h2>
+		<p class="my-2 text-sm">
+			{page.data.t('myPages.settingsLinkDescription')}
 		</p>
+		<p class="my-2 font-mono">
+			{settingsUrl}
+		</p>
+		<button class="btn btn-accent" onclick={() => handleCopySettingsUrl()}>
+			<BiCopy />
+			{#if lastCopiedUrl === settingsUrl}
+				{page.data.t('general.copied')}
+			{:else}
+				{page.data.t('general.copyToClipboard')}
+			{/if}
+		</button>
 	</div>
 </div>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/my-pages/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/my-pages/+page.svelte
@@ -56,7 +56,7 @@
 		<p class="my-2 text-sm">
 			{page.data.t('myPages.settingsLinkDescription')}
 		</p>
-		<p class="my-2 font-mono">
+		<p id="settings-url" class="my-2 font-mono">
 			{settingsUrl}
 		</p>
 		<button class="btn btn-accent" onclick={() => handleCopySettingsUrl()}>

--- a/lxl-web/tests/settings-link.spec.ts
+++ b/lxl-web/tests/settings-link.spec.ts
@@ -8,10 +8,7 @@ test.describe('Set settings with link', async () => {
 
 		await setFavourites(page);
 
-		const link = (await page
-			.getByRole('link', { name: 'Kopiera den här länken för att komma till Libris startsida' })
-			.getAttribute('href')) as string;
-
+		const link = await page.locator('#settings-url').textContent();
 		await context.close();
 
 		const context2 = await browser.newContext();
@@ -34,9 +31,7 @@ test.describe('Set settings with link', async () => {
 
 		await setFavourites(page);
 
-		const link = (await page
-			.getByRole('link', { name: 'Kopiera den här länken för att komma till Libris startsida' })
-			.getAttribute('href')) as string;
+		const link = await page.locator('#settings-url').textContent();
 
 		await context.close();
 

--- a/lxl-web/tests/settings-link.spec.ts
+++ b/lxl-web/tests/settings-link.spec.ts
@@ -1,0 +1,77 @@
+import { expect, type Page, test } from '@playwright/test';
+
+test.describe('Set settings with link', async () => {
+	test('Link should set favourite libraries', async ({ browser }) => {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+		await page.goto('/my-pages');
+
+		await setFavourites(page);
+
+		const link = (await page
+			.getByRole('link', { name: 'Kopiera den här länken för att komma till Libris startsida' })
+			.getAttribute('href')) as string;
+
+		await context.close();
+
+		const context2 = await browser.newContext();
+		const page2 = await context2.newPage();
+
+		await page2.goto(link);
+		await expect(page2).toHaveURL(/^https?:\/\/[^/]+\/?$/); // start page, no path or params
+
+		await page2.goto('/my-pages');
+
+		await checkFavourites(page2);
+
+		await context2.close();
+	});
+
+	test('Link should set favourite libraries, respect _r', async ({ browser }) => {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+		await page.goto('/my-pages?_r=itemHeldByOrg:ARKM');
+
+		await setFavourites(page);
+
+		const link = (await page
+			.getByRole('link', { name: 'Kopiera den här länken för att komma till Libris startsida' })
+			.getAttribute('href')) as string;
+
+		await context.close();
+
+		const context2 = await browser.newContext();
+		const page2 = await context2.newPage();
+
+		await page2.goto(link);
+		await expect(page2).toHaveURL(/^https?:\/\/[^/]+\/?\?_r=itemHeldByOrg:ARKM$/); // start page
+
+		await page2.locator('a[href^="/my-pages"]').first().click();
+
+		await checkFavourites(page2);
+
+		await context2.close();
+	});
+});
+
+async function setFavourites(page: Page) {
+	await page.locator('#my-libraries-search').fill('bin');
+	await page.getByRole('button', { name: 'Lägg till' }).first().click();
+	await page.locator('#my-libraries-search').fill('nodi');
+	await expect(page.getByText('Ale bibliotek').first()).toBeVisible(); // wait for search result
+	await page.getByRole('button', { name: 'Lägg till' }).first().click();
+
+	// two my-libraries-result side-by-side. pick the right = second one
+	const selectedLibraries = page.locator('ol.my-libraries-result').nth(1).locator('li');
+	await expect(selectedLibraries).toHaveCount(2);
+	await expect(selectedLibraries.nth(0)).toContainText('Biblioteken i Norrbotten (BIN)');
+	await expect(selectedLibraries.nth(1)).toContainText('Ale bibliotek (Nodi)');
+}
+
+async function checkFavourites(page: Page) {
+	// now there's only one my-libraries-result to the right
+	const selectedLibraries2 = page.locator('ol.my-libraries-result').nth(0).locator('li');
+	await expect(selectedLibraries2).toHaveCount(2);
+	await expect(selectedLibraries2.nth(0)).toContainText('Biblioteken i Norrbotten (BIN)');
+	await expect(selectedLibraries2.nth(1)).toContainText('Ale bibliotek (Nodi)');
+}


### PR DESCRIPTION
Make it possible to set favorite libraries via query parameter.
This is an alternative / addition to setting library/org with `_r `. Can search the whole catalog but highlight some libraries.
same as `e/getPermaLink.jsp` in webbsök.

example
http://localhost:5173/?favouriteLibraries=org/BIN,Skfb
### Summary of changes

Summary of changes
* handle settings params in hooks.server.ts.
* remove obsolete label from `userSettings.myLibraries`. It was never read.
* Add settings links section to "my pages"
* fix: searching for favourite libraries in my-pages cleared _r parameter