### PR TITLE
fix(lxlweb): more specific loan status

### DIFF
--- a/lxl-web/src/lib/components/LoanStatus.svelte
+++ b/lxl-web/src/lib/components/LoanStatus.svelte
@@ -86,9 +86,10 @@
 				case 'ej utlånad':
 				case 'available':
 					return 'available';
-				case 'ej tillgänglig':
 				case 'utlånad':
 				case 'on loan':
+					return 'onLoan';
+				case 'ej tillgänglig':
 				case 'not available':
 					return 'unavailable';
 				default:

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -322,6 +322,7 @@ export default {
 		loanStatusFailed: 'Failed to get loan status',
 		available: 'Available',
 		unavailable: 'Not available',
+		onLoan: 'On loan',
 		map: 'map',
 		linkToLocal: 'Find',
 		linkToCatalog: 'Local library catalog',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -321,6 +321,7 @@ export default {
 		loanStatusFailed: 'Lånestatus kunde inte hämtas',
 		available: 'Tillgänglig',
 		unavailable: 'Ej tillgänglig',
+		onLoan: 'Utlånad',
 		map: 'karta',
 		linkToLocal: 'Hitta',
 		linkToCatalog: 'Bibliotekets lokala katalog',


### PR DESCRIPTION
We've had complaints about loan status always being shown as Unavailable/Otillgänglig even when when the actual status is On loan/Utlånad. Webbsök shows the correct status.

This is a regression, so let's be clear when we can, because "Unavailable" and "On loan" typically have two distinct meanings, where the former is used to mean that the item is missing/broken/etc.