### PR TITLE
feat(lxlweb): digitization

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -1952,8 +1952,8 @@
 				"fresnel:contentBefore": ""
 			}
 		},
-		"precededBy-succeededBy-format": {
-			"@id": "precededBy-succeededBy-format",
+		"work-instance-list-format": {
+			"@id": "work-instance-list-format",
 			"@type": "fresnel:Format",
 			"fresnel:propertyFormatDomain": [
 				"precededBy",
@@ -1977,7 +1977,8 @@
 				"relatedTo",
 				"otherPhysicalFormat",
 				"replaces",
-				"supplement"
+				"supplement",
+				"hasReproduction"
 			],
 			"fresnel:propertyStyle": ["test_list"],
 			"fresnel:valueFormat": {

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -906,7 +906,8 @@
 						"relatedTo",
 						"otherPhysicalFormat",
 						"accompaniedBy",
-						"supplement"
+						"supplement",
+						{ "inverseOf": "reproductionOf" }
 					]
 				},
 				"Item": {
@@ -991,6 +992,7 @@
 					"showProperties": [
 						"contribution",
 						"reproductionOf",
+						{ "inverseOf": "reproductionOf" },
 						"identifiedBy",
 						"indirectlyIdentifiedBy",
 						"hasTitle",

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -19,7 +19,7 @@
 		block?: boolean;
 		limit?: Record<string, number>;
 		keyed?: boolean;
-		suppressProperty?: string;
+		suppressProperty?: string[];
 	}
 
 	let {
@@ -225,7 +225,7 @@
 				/>
 			{:else}
 				{@const [propertyName, propertyData] = getProperty(data)}
-				{#if propertyName && propertyData && (suppressProperty === undefined || suppressProperty !== propertyName)}
+				{#if propertyName && propertyData && (suppressProperty === undefined || !suppressProperty.includes(propertyName))}
 					<!-- don't use 'show more' when exceeding limit by one -->
 					{@const limitTo = limit?.[propertyName]}
 					{@const delimited =

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -17,6 +17,7 @@
 	import DecoratedData from './DecoratedData.svelte';
 	import ResourceImage from './ResourceImage.svelte';
 	import ResourceHoldings from './ResourceHoldings.svelte';
+	import ResourceDigitalAccess from '$lib/components/ResourceDigitalAccess.svelte';
 	import SearchResultList from './SearchResultList.svelte';
 	import AdjecentResults from './resource/AdjecentResults.svelte';
 	import TypeIcon from '$lib/components/TypeIcon.svelte';
@@ -32,12 +33,12 @@
 	import BiChevronRight from '~icons/bi/chevron-right';
 
 	type Props = {
-		fnurgel: string;
-		uri: string;
+		fnurgel: string | undefined;
+		uri: string | null;
 		recordUri: string;
 		controlNumber: string;
 		uid?: string;
-		typeForIcon: string;
+		typeForIcon: string | undefined;
 		image: SecureImage;
 		decoratedData: {
 			headingTop: DisplayDecorated;
@@ -52,19 +53,21 @@
 			details: DisplayDecorated[];
 			token: DisplayDecorated;
 			itemInformation:
+				| []
 				| {
 						heldBy: DisplayDecorated;
 						items: DisplayDecorated[];
-				  }[]
-				| [];
+				  }[];
 		};
-		relations: Relation[];
+		relations: Relation[] | null;
 		relationsPreviewsByQualifierKey: Record<string, SearchResultItem[]>;
 		instances: SearchResultItem[] | ResourceData[]; // TODO: fix better types
 		searchResult?: ResourceSearchResult;
 		holdings: HoldingsData;
 		tableOfContents: TableOfContentsItem[];
 		adjecentSearchResults?: AdjecentSearchResult[];
+		workCard: SearchResultItem | null;
+		isWork: boolean;
 	};
 
 	const {
@@ -82,7 +85,9 @@
 		searchResult,
 		holdings,
 		tableOfContents,
-		adjecentSearchResults
+		adjecentSearchResults,
+		workCard,
+		isWork
 	}: Props = $props();
 
 	const uidPrefix = $derived(uid ? `${uid}-` : ''); // used for prefixing id's when resource is rendered inside panes
@@ -144,16 +149,16 @@
 	{/each}
 {/snippet}
 
-{#if adjecentSearchResults}
+{#if adjecentSearchResults && fnurgel}
 	<div class="border-b-neutral @container border-b">
 		<AdjecentResults {fnurgel} {adjecentSearchResults} />
 	</div>
 {/if}
-{#if page.data.workCard && !page.data.isWork}
+{#if workCard && !isWork}
 	<div
 		class="back-to-work border-b-neutral border-b hover:[&_.arrow]:-translate-x-1 [&.arrow]:transition-transform"
 	>
-		<Suggestion item={page.data.workCard}>
+		<Suggestion item={workCard}>
 			{#snippet leadingContent()}
 				<div class="mr-4 flex items-center gap-1 ease-in-out">
 					<IconArrowRight class="arrow rotate-180 transition-transform" />
@@ -256,6 +261,13 @@
 					<h2 class="sr-only">{page.data.t('holdings.availabilityByType')}</h2>
 					<ResourceHoldings {holdings} {instances} />
 				{/if}
+				<ResourceDigitalAccess
+					eodAvailable={holdings.eodAvailable}
+					overview2={decoratedData.overview2}
+					{instances}
+					{workCard}
+					{isWork}
+				/>
 				<div class="decorated-data-section decorated-spacious">
 					{#if !hasHoldingsBtn && decoratedData.overview.some((o) => o._display?.length > 0) && decoratedData.overview2.some((o) => o._display?.length > 0)}
 						<div class="border-b-neutral mb-2 border-b"></div>
@@ -266,6 +278,13 @@
 								data={overview2}
 								showLabels={ShowLabelsOptions.DefaultOn}
 								allowFindLinks={true}
+								suppressProperty={[
+									'associatedMedia',
+									'isPrimaryTopicOf',
+									'hasReproduction',
+									'electronicLocator',
+									'marc:versionOfResource'
+								]}
 								block
 								limit={{ contribution: 5, hasVariant: 5 }}
 							/>
@@ -281,7 +300,7 @@
 						/>
 					</div>
 					<div class="flex items-center gap-2">
-						{#if decoratedData.summary.length || instances?.length > 1 || relations.length || decoratedData.resourceTableOfContents.length}
+						{#if decoratedData.summary.length || instances?.length > 1 || relations?.length || decoratedData.resourceTableOfContents.length}
 							<a
 								class="btn btn-primary my-2 h-8 w-fit rounded-full px-4 text-sm"
 								href="#{uidPrefix}details"
@@ -292,7 +311,7 @@
 								{page.data.t('resource.moreDetails')}
 							</a>
 						{/if}
-						{#if instances?.length === 1}
+						{#if instances?.length === 1 && fnurgel}
 							<a
 								class="btn btn-primary my-2 h-8 w-fit rounded-full px-4 text-sm"
 								href={getCiteLink(page.url, fnurgel)}
@@ -335,7 +354,7 @@
 					{/if}
 				</section>
 			{/if}
-			{#if relations.length}
+			{#if relations?.length}
 				<section>
 					<h2 id={`${uidPrefix}relations`} class="mb-6 text-xl font-medium">
 						{page.data.t('resource.relations')}
@@ -384,7 +403,7 @@
 									<SearchResultList
 										type="horizontal"
 										items={relationsPreviewsByQualifierKey[relationItem.qualifierKey]}
-										suppressProperty={relationItem.qualifierKey}
+										suppressProperty={[relationItem.qualifierKey]}
 									/>
 								</div>
 							</li>

--- a/lxl-web/src/lib/components/ResourceDigitalAccess.svelte
+++ b/lxl-web/src/lib/components/ResourceDigitalAccess.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { ShowLabelsOptions } from '$lib/types/decoratedData';
+	import type { EodAvailable } from '$lib/types/holdings';
+	import type { ResourceData } from '$lib/types/resourceData';
+	import type { SearchResultItem } from '$lib/types/search';
+	import { BibDb, type DisplayDecorated } from '$lib/types/xl';
+	import { getResourceDigitalAccess } from '$lib/utils/getResourceDigitalAccess';
+	import DecoratedData from './DecoratedData.svelte';
+	import BiLaptop from '~icons/bi/laptop';
+	import BiChevronRight from '~icons/bi/chevron-right';
+
+	type Props = {
+		overview2: DisplayDecorated[];
+		instances: SearchResultItem[] | ResourceData[];
+		eodAvailable: EodAvailable;
+		workCard: SearchResultItem | null;
+		isWork: boolean;
+	};
+	const { overview2, instances, eodAvailable, workCard, isWork }: Props = $props();
+
+	const { online, hasReproduction } = $derived(
+		getResourceDigitalAccess(overview2, instances, workCard, isWork)
+	);
+	const hasDigitalAccess = $derived(online || hasReproduction || eodAvailable);
+</script>
+
+{#if hasDigitalAccess}
+	<div class="resource-access my-2 flex flex-col gap-3">
+		{#if online}
+			<div>
+				<p class="flex items-center gap-2 font-semibold">
+					<BiLaptop class="text-subtle" />
+					<span>{page.data.t('search.existsOnline')}:</span>
+				</p>
+				<DecoratedData
+					data={online}
+					showLabels={ShowLabelsOptions.Never}
+					block
+					limit={{
+						associatedMedia: 1,
+						isPrimaryTopicOf: 1,
+						electronicLocator: 1,
+						'marc:versionOfResource': 1
+					}}
+				/>
+			</div>
+		{/if}
+		{#if hasReproduction}
+			<div>
+				<p class="flex items-center gap-2 font-semibold">
+					<BiLaptop class="text-subtle" />
+					<span>{page.data.t('resource.digitizationAvailable')}:</span>
+				</p>
+				<DecoratedData
+					data={hasReproduction}
+					allowLinks={true}
+					showLabels={ShowLabelsOptions.Never}
+					block
+					limit={{ hasReproduction: 1 }}
+				/>
+			</div>
+		{:else if eodAvailable}
+			<details>
+				<summary class="cursor-pointer">
+					<p class="flex items-center gap-1 font-semibold">
+						<span class="chevron text-subtle transition-transform">
+							<BiChevronRight />
+						</span>
+						<span>{page.data.t('resource.requestDigitization')}</span>
+					</p>
+				</summary>
+				<div class="my-2 rounded-md border border-neutral-200 p-2">
+					<p class="mb-2 text-sm">{page.data.t('resource.digitizationInfo')}.</p>
+					<ul>
+						{#each eodAvailable as library (library[BibDb.eodUri])}
+							<li>
+								<a class="ext-link" href={library[BibDb.eodUri]}>{library.displayStr}</a>
+							</li>
+						{/each}
+					</ul>
+				</div>
+			</details>
+		{/if}
+	</div>
+{/if}
+
+<style lang="postcss">
+	details[open] {
+		& .chevron {
+			transform: rotate(90deg);
+		}
+	}
+
+	:global(
+		.resource-access *[data-type='Instance'],
+		.resource-access *[data-type='DigitalResource']
+	) {
+		display: block;
+		width: fit-content;
+	}
+</style>

--- a/lxl-web/src/lib/components/ResourceDigitalAccess.svelte
+++ b/lxl-web/src/lib/components/ResourceDigitalAccess.svelte
@@ -75,7 +75,9 @@
 					<ul>
 						{#each eodAvailable as library (library.displayStr)}
 							<li>
-								<a class="ext-link" href={library[BibDb.eodUri]}>{library.displayStr}</a>
+								<a class="ext-link" target="_blank" href={library[BibDb.eodUri]}
+									>{library.displayStr}</a
+								>
 							</li>
 						{/each}
 					</ul>

--- a/lxl-web/src/lib/components/ResourceDigitalAccess.svelte
+++ b/lxl-web/src/lib/components/ResourceDigitalAccess.svelte
@@ -73,7 +73,7 @@
 				<div class="my-2 rounded-md border border-neutral-200 p-2">
 					<p class="mb-2 text-sm">{page.data.t('resource.digitizationInfo')}.</p>
 					<ul>
-						{#each eodAvailable as library (library[BibDb.eodUri])}
+						{#each eodAvailable as library (library.displayStr)}
 							<li>
 								<a class="ext-link" href={library[BibDb.eodUri]}>{library.displayStr}</a>
 							</li>

--- a/lxl-web/src/lib/components/SearchResultItem.svelte
+++ b/lxl-web/src/lib/components/SearchResultItem.svelte
@@ -14,7 +14,7 @@
 		lazyImage?: boolean;
 		highPriorityImage?: boolean;
 		fadeInImage?: boolean;
-		suppressProperty?: string;
+		suppressProperty?: string[];
 	};
 
 	let {

--- a/lxl-web/src/lib/components/SearchResultList.svelte
+++ b/lxl-web/src/lib/components/SearchResultList.svelte
@@ -18,7 +18,7 @@
 		lazyImages?: boolean;
 		fadeInImages?: boolean;
 		listElement?: HTMLUListElement | undefined;
-		suppressProperty?: string;
+		suppressProperty?: string[];
 	};
 
 	let {

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -296,7 +296,11 @@ export default {
 		showIn: 'Show metadata in',
 		librisCataloging: 'Libris cataloging',
 		librisOld: 'old Libris',
-		request: 'Request'
+		request: 'Request',
+		digitizationAvailable: 'Digitization available',
+		requestDigitization: 'Request digitization',
+		digitizationInfo:
+			'The book can, for a fee, be digitized and sent to you by email as a PDF file. The libraries that provide this service are listed below.'
 	},
 	holdings: {
 		availabilityByType: 'Availability by type',

--- a/lxl-web/src/lib/i18n/locales/en.js
+++ b/lxl-web/src/lib/i18n/locales/en.js
@@ -300,7 +300,7 @@ export default {
 		digitizationAvailable: 'Digitization available',
 		requestDigitization: 'Request digitization',
 		digitizationInfo:
-			'The book can, for a fee, be digitized and sent to you by email as a PDF file. The libraries that provide this service are listed below.'
+			'The book can, for a fee, be digitized and sent to you by email as a PDF file. The libraries that provide this service are listed below'
 	},
 	holdings: {
 		availabilityByType: 'Availability by type',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -295,7 +295,11 @@ export default {
 		showIn: 'Visa metadata i',
 		librisCataloging: 'Libris katalogisering',
 		librisOld: 'gamla Libris',
-		request: 'Beställ'
+		request: 'Beställ',
+		digitizationAvailable: 'Finns digitiserad',
+		requestDigitization: 'Beställ digitisering',
+		digitizationInfo:
+			'Boken kan mot en kostnad digitiseras och skickas via epost till dig som en PDF-fil. Nedan listas de bibliotek som tillhandahåller tjänsten'
 	},
 	holdings: {
 		availabilityByType: 'Tillgänglighet utifrån medietyp',

--- a/lxl-web/src/lib/i18n/locales/sv.js
+++ b/lxl-web/src/lib/i18n/locales/sv.js
@@ -299,7 +299,7 @@ export default {
 		digitizationAvailable: 'Finns digitiserad',
 		requestDigitization: 'Beställ digitisering',
 		digitizationInfo:
-			'Boken kan mot en kostnad digitiseras och skickas via epost till dig som en PDF-fil. Nedan listas de bibliotek som tillhandahåller tjänsten'
+			'Boken kan mot en kostnad digitiseras och skickas via epost till dig som en pdf-fil. Nedan listas de bibliotek som tillhandahåller tjänsten'
 	},
 	holdings: {
 		availabilityByType: 'Tillgänglighet utifrån medietyp',

--- a/lxl-web/src/lib/types/holdings.ts
+++ b/lxl-web/src/lib/types/holdings.ts
@@ -60,6 +60,7 @@ export interface LibraryFull extends LibraryChip {
 	isPartOf: { [JsonLd.ID]: OrgId };
 	[BibDb.ils]: Record<string, string>;
 	[BibDb.lopac]: Record<string, string>;
+	[BibDb.eodUri]?: string;
 	[BibDb.address]?: Record<string, string>[];
 	[BibDb.linkResolver]?: LinkResolver;
 	[BibDb.latitude]?: number;

--- a/lxl-web/src/lib/types/holdings.ts
+++ b/lxl-web/src/lib/types/holdings.ts
@@ -79,6 +79,8 @@ export interface LibraryWithLinks extends LibraryFull {
 	distance?: number;
 }
 
+export type EodAvailable = Required<Pick<LibraryWithLinks, 'displayStr' | BibDb.eodUri>>[] | null;
+
 export interface LibraryWithLinksAndInstances extends LibraryWithLinks {
 	_instances: BibIdData;
 }
@@ -148,6 +150,7 @@ export type HoldingsData = {
 	byInstanceId: HoldersByInstanceId;
 	byType: HoldersByType;
 	holdingLibraries: Record<LibraryId, LibraryWithLinks | null>;
+	eodAvailable: EodAvailable;
 };
 
 export type LatLng = {

--- a/lxl-web/src/lib/utils/getEodAvailable.server.ts
+++ b/lxl-web/src/lib/utils/getEodAvailable.server.ts
@@ -1,0 +1,63 @@
+import type { LibraryWithLinks } from '$lib/types/holdings';
+import { BibDb, JsonLd, type FramedData } from '$lib/types/xl';
+
+export type EodAvailable = Required<Pick<LibraryWithLinks, 'displayStr' | BibDb.eodUri>>[] | null;
+const YEARS_OLD_ENOUGH = 90;
+
+/**
+ * If resource meets criteria, return a list of holding libraries where you can request digitization
+ */
+export function getEodAvailable(
+	instances: FramedData[],
+	holdingLibraries: Record<string, LibraryWithLinks | null>
+): EodAvailable {
+	if (instances.length === 1 && isPrint(instances[0])) {
+		// single instance, print
+		const publication = Array.isArray(instances[0]?.publication)
+			? instances[0]?.publication[0]
+			: instances[0]?.publication;
+		if (isOldEnough(publication?.year)) {
+			// old enough
+			const eodLibs = getEodLibs(holdingLibraries);
+			if (eodLibs?.length) {
+				// holding libraries supporting eod
+				return eodLibs;
+			}
+		}
+	}
+	return null;
+}
+
+function isPrint(instance: FramedData) {
+	return instance?.category?.find(
+		(c: FramedData) => c[JsonLd.ID] === 'https://id.kb.se/term/saobf/Print'
+	);
+}
+
+function isOldEnough(publicationYear: string | undefined) {
+	if (publicationYear && typeof publicationYear === 'string') {
+		const yearParsed = parseInt(publicationYear, 10);
+
+		if (Number.isNaN(yearParsed)) {
+			return false;
+		}
+
+		const currentYear = new Date().getFullYear();
+		return yearParsed < currentYear - YEARS_OLD_ENOUGH;
+	}
+	return false;
+}
+
+function getEodLibs(libs: Record<string, LibraryWithLinks | null>): EodAvailable {
+	if (libs) {
+		return Object.values(libs)
+			.filter((l) => l?.[BibDb.eodUri])
+			.map((l) => {
+				return {
+					[BibDb.eodUri]: l?.[BibDb.eodUri] as string,
+					displayStr: l?.displayStr as string
+				};
+			});
+	}
+	return null;
+}

--- a/lxl-web/src/lib/utils/getEodAvailable.server.ts
+++ b/lxl-web/src/lib/utils/getEodAvailable.server.ts
@@ -1,7 +1,6 @@
-import type { LibraryWithLinks } from '$lib/types/holdings';
+import type { EodAvailable, LibraryWithLinks } from '$lib/types/holdings';
 import { BibDb, JsonLd, type FramedData } from '$lib/types/xl';
 
-export type EodAvailable = Required<Pick<LibraryWithLinks, 'displayStr' | BibDb.eodUri>>[] | null;
 const YEARS_OLD_ENOUGH = 90;
 
 /**

--- a/lxl-web/src/lib/utils/getEodAvailable.server.ts
+++ b/lxl-web/src/lib/utils/getEodAvailable.server.ts
@@ -61,7 +61,7 @@ function parseYear(publicationYear: string) {
 		return parseInt(decadeMatch[0], 10) * 10 + 10;
 	}
 
-	const centuryMatch = publicationYear.match(/\d{2}[?unxX]{2}/);
+	const centuryMatch = publicationYear.match(/\d{2}(\?\?|uu|nn|xx|XX)/);
 	if (centuryMatch) {
 		return parseInt(centuryMatch[0], 10) * 100 + 100;
 	}

--- a/lxl-web/src/lib/utils/getEodAvailable.server.ts
+++ b/lxl-web/src/lib/utils/getEodAvailable.server.ts
@@ -1,7 +1,7 @@
 import type { EodAvailable, LibraryWithLinks } from '$lib/types/holdings';
 import { BibDb, JsonLd, type FramedData } from '$lib/types/xl';
 
-const YEARS_OLD_ENOUGH = 90;
+export const YEARS_OLD_ENOUGH = 90;
 
 /**
  * If resource meets criteria, return a list of holding libraries where you can request digitization
@@ -34,18 +34,39 @@ function isPrint(instance: FramedData) {
 	);
 }
 
-function isOldEnough(publicationYear: string | undefined) {
+export function isOldEnough(
+	publicationYear: string | undefined,
+	currentYear: number = new Date().getFullYear()
+) {
 	if (publicationYear && typeof publicationYear === 'string') {
-		const yearParsed = parseInt(publicationYear, 10);
+		const yearParsed = parseYear(publicationYear);
 
 		if (Number.isNaN(yearParsed)) {
 			return false;
 		}
 
-		const currentYear = new Date().getFullYear();
-		return yearParsed < currentYear - YEARS_OLD_ENOUGH;
+		return yearParsed <= currentYear - YEARS_OLD_ENOUGH;
 	}
 	return false;
+}
+
+function parseYear(publicationYear: string) {
+	const yearMatch = publicationYear.match(/\d{4}/);
+	if (yearMatch) {
+		return parseInt(yearMatch[0], 10);
+	}
+
+	const decadeMatch = publicationYear.match(/\d{3}[?unxX]/);
+	if (decadeMatch) {
+		return parseInt(decadeMatch[0], 10) * 10 + 10;
+	}
+
+	const centuryMatch = publicationYear.match(/\d{2}[?unxX]{2}/);
+	if (centuryMatch) {
+		return parseInt(centuryMatch[0], 10) * 100 + 100;
+	}
+
+	return Number.NaN;
 }
 
 function getEodLibs(libs: Record<string, LibraryWithLinks | null>, id: string): EodAvailable {

--- a/lxl-web/src/lib/utils/getEodAvailable.server.ts
+++ b/lxl-web/src/lib/utils/getEodAvailable.server.ts
@@ -8,7 +8,8 @@ const YEARS_OLD_ENOUGH = 90;
  */
 export function getEodAvailable(
 	instances: FramedData[],
-	holdingLibraries: Record<string, LibraryWithLinks | null>
+	holdingLibraries: Record<string, LibraryWithLinks | null>,
+	controlNumber: string
 ): EodAvailable {
 	if (instances.length === 1 && isPrint(instances[0])) {
 		// single instance, print
@@ -17,7 +18,7 @@ export function getEodAvailable(
 			: instances[0]?.publication;
 		if (isOldEnough(publication?.year)) {
 			// old enough
-			const eodLibs = getEodLibs(holdingLibraries);
+			const eodLibs = getEodLibs(holdingLibraries, controlNumber);
 			if (eodLibs?.length) {
 				// holding libraries supporting eod
 				return eodLibs;
@@ -47,16 +48,20 @@ function isOldEnough(publicationYear: string | undefined) {
 	return false;
 }
 
-function getEodLibs(libs: Record<string, LibraryWithLinks | null>): EodAvailable {
-	if (libs) {
+function getEodLibs(libs: Record<string, LibraryWithLinks | null>, id: string): EodAvailable {
+	if (libs && id) {
 		return Object.values(libs)
 			.filter((l) => l?.[BibDb.eodUri])
 			.map((l) => {
 				return {
-					[BibDb.eodUri]: l?.[BibDb.eodUri] as string,
+					[BibDb.eodUri]: createEodLink(l?.[BibDb.eodUri] as string, id),
 					displayStr: l?.displayStr as string
 				};
 			});
 	}
 	return null;
+}
+
+function createEodLink(linkTemplateEod: string, id: string) {
+	return linkTemplateEod.replace(/%BIB_*ID%/, id);
 }

--- a/lxl-web/src/lib/utils/getEodAvailable.test.ts
+++ b/lxl-web/src/lib/utils/getEodAvailable.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { isOldEnough, YEARS_OLD_ENOUGH } from '$lib/utils/getEodAvailable.server';
+
+describe('eodAvailable', () => {
+	it('handles publication year', () => {
+		const cases: [string, number, boolean][] = [
+			['1930', 1929 + YEARS_OLD_ENOUGH, false],
+			['1930', 1930 + YEARS_OLD_ENOUGH, true],
+			['1930', 1931 + YEARS_OLD_ENOUGH, true],
+
+			['193', 1930 + YEARS_OLD_ENOUGH, false],
+			['abc', 2026, false]
+		];
+
+		for (const c of cases) {
+			const [publicationYear, currentYear, result] = c;
+			expect(isOldEnough(publicationYear, currentYear), `${c}`).toStrictEqual(result);
+			const bracketed = `[${publicationYear}]`;
+			expect(isOldEnough(bracketed, currentYear), `${bracketed} ${c}`).toStrictEqual(result);
+		}
+	});
+
+	it('handles uncertain publication year', () => {
+		const cases: [string, number, boolean][] = [
+			['193¤', 1920 + YEARS_OLD_ENOUGH, false],
+			['193¤', 1929 + YEARS_OLD_ENOUGH, false],
+			['193¤', 1930 + YEARS_OLD_ENOUGH, false],
+			['193¤', 1939 + YEARS_OLD_ENOUGH, false],
+			['193¤', 1940 + YEARS_OLD_ENOUGH, true],
+
+			['17¤¤', 1799 + YEARS_OLD_ENOUGH, false],
+			['17¤¤', 1800 + YEARS_OLD_ENOUGH, true],
+
+			['18¤¤', 1899 + YEARS_OLD_ENOUGH, false],
+			['18¤¤', 1900 + YEARS_OLD_ENOUGH, true],
+			['18¤¤', 1915 + YEARS_OLD_ENOUGH, true],
+			['18¤¤', 2000 + YEARS_OLD_ENOUGH, true],
+
+			['19¤¤', 1999 + YEARS_OLD_ENOUGH, false],
+			['19¤¤', 2000 + YEARS_OLD_ENOUGH, true]
+		];
+
+		for (const c of cases) {
+			const [publicationYear, currentYear, result] = c;
+			for (const char of ['?', 'u', 'n', 'x', 'X']) {
+				const uncertainYear = publicationYear.replaceAll('¤', char);
+				expect(isOldEnough(uncertainYear, currentYear), `${c}`).toStrictEqual(result);
+				const bracketed = `[${uncertainYear}]`;
+				expect(isOldEnough(bracketed, currentYear), `${bracketed} ${c}`).toStrictEqual(result);
+			}
+		}
+	});
+});

--- a/lxl-web/src/lib/utils/getResourceDigitalAccess.ts
+++ b/lxl-web/src/lib/utils/getResourceDigitalAccess.ts
@@ -1,0 +1,35 @@
+import type { ResourceData } from '$lib/types/resourceData';
+import type { SearchResultItem } from '$lib/types/search';
+import { type DisplayDecorated } from '$lib/types/xl';
+
+type DigitalAccess = {
+	online?: DisplayDecorated;
+	hasReproduction?: DisplayDecorated;
+};
+
+export function getResourceDigitalAccess(
+	overview2: DisplayDecorated[],
+	instances: SearchResultItem[] | ResourceData[],
+	workCard: SearchResultItem | null,
+	isWork: boolean
+): DigitalAccess {
+	const result: DigitalAccess = {};
+	const hasReproduction = overview2?.[1]?._display?.filter(
+		(p: DisplayDecorated) => p?.hasReproduction
+	);
+
+	if (isWork) {
+		// associatedMedia, isPrimaryTopicOf etc
+		result.online = workCard?.mediaLinks;
+	}
+	if (instances.length === 1) {
+		result.online = instances[0]?.mediaLinks;
+	}
+
+	if (hasReproduction && hasReproduction.length) {
+		// already digitized
+		result.hasReproduction = hasReproduction;
+	}
+
+	return result;
+}

--- a/lxl-web/src/lib/utils/relations.server.ts
+++ b/lxl-web/src/lib/utils/relations.server.ts
@@ -50,7 +50,7 @@ export async function getRelations(
 			const params = p.view[JsonLd.ID].split('?')[1];
 			const q = new URLSearchParams(params).get('_q') as string;
 			const predicateIri = p.predicate[JsonLd.ID] as string;
-			const qualifierKey = getUriSlug(predicateIri);
+			const qualifierKey = getUriSlug(predicateIri) as string;
 			const label = capitalize(vocabUtil.getLabelByLang(predicateIri, locale) || qualifierKey);
 			const preferLike: boolean = getAtPath(p.predicate, [Base.category, '*', JsonLd.ID])
 				.map(getUriSlug)

--- a/lxl-web/src/lib/utils/search.server.ts
+++ b/lxl-web/src/lib/utils/search.server.ts
@@ -624,7 +624,12 @@ function getMediaLinks(
 	copyMediaLinksToWork(_item);
 	const formatted = displayUtil.lensAndFormat(_item, LensType.WebOverview2, locale);
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const [mediaLinks, _] = pickProperty(formatted, ['associatedMedia']);
+	const [mediaLinks, _] = pickProperty(formatted, [
+		'associatedMedia',
+		'isPrimaryTopicOf',
+		'electronicLocator',
+		'marc:versionOfResource'
+	]);
 	if (mediaLinks._display?.length) {
 		return mediaLinks;
 	}

--- a/lxl-web/src/lib/utils/search.server.ts
+++ b/lxl-web/src/lib/utils/search.server.ts
@@ -622,6 +622,18 @@ function getMediaLinks(
 ): DisplayDecorated | null {
 	const _item = { ...item };
 	copyMediaLinksToWork(_item);
+
+	// remove digipic
+	if (_item.isPrimaryTopicOf && Array.isArray(_item.isPrimaryTopicOf)) {
+		_item.isPrimaryTopicOf = _item.isPrimaryTopicOf.filter((i) => {
+			const note = i?.cataloguersNote;
+			if (Array.isArray(note)) {
+				return !note.includes('digipic');
+			}
+			return note !== 'digipic';
+		});
+	}
+
 	const formatted = displayUtil.lensAndFormat(_item, LensType.WebOverview2, locale);
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [mediaLinks, _] = pickProperty(formatted, [

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -371,14 +371,15 @@ export const load = async ({ params, locals, fetch, url }) => {
 		eodAvailable: null
 	};
 
-	holdings.eodAvailable = getEodAvailable(_instances, holdings.holdingLibraries);
+	const controlNumber = resource['controlNumber'] as string;
+	holdings.eodAvailable = getEodAvailable(_instances, holdings.holdingLibraries, controlNumber);
 
 	const refinedOrgs = getRefinedOrgs(myLibraries, [subsetMapping, searchResult?.mapping]);
 
 	return {
 		uri: resourceId,
 		recordUri: resource['@id'] as string,
-		controlNumber: resource['controlNumber'] as string,
+		controlNumber,
 		type: mainEntity[JsonLd.TYPE] as string,
 		typeForIcon: getTypeForIcon(typeLike), // FIXME
 		title: toString(heading),

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -14,7 +14,11 @@ import {
 } from '$lib/types/xl.js';
 import { LxlLens } from '$lib/types/display';
 import { type ApiError } from '$lib/types/api.js';
-import type { PartialCollectionView, ResourceSearchResult } from '$lib/types/search.js';
+import type {
+	PartialCollectionView,
+	ResourceSearchResult,
+	SearchResultItem
+} from '$lib/types/search.js';
 import type { TableOfContentsItem } from '$lib/components/TableOfContents.svelte';
 import type { HoldingsData, HoldingItem } from '$lib/types/holdings.js';
 import { type Relation } from '$lib/types/relations';
@@ -39,6 +43,7 @@ import {
 	displayMappings
 } from '$lib/utils/search.server';
 import { getRefinedOrgs } from '$lib/utils/getRefinedOrgs.server';
+import { getEodAvailable } from '$lib/utils/getEodAvailable.server';
 import { getSearchResults } from '$lib/remotes/searchResult.remote';
 import { SearchResultsSchema } from '$lib/schemas/searchResult';
 import { copyMediaLinksToWork } from '$lib/utils/copyMediaLinksToWork.server';
@@ -131,7 +136,7 @@ export const load = async ({ params, locals, fetch, url }) => {
 		delete mainEntity['language'];
 	}
 
-	const _instances = mainEntity?.['@reverse']?.instanceOf || [];
+	const _instances = mainEntity?.[JsonLd.REVERSE]?.instanceOf || [];
 
 	if (_instances.length == 1 && typeLike.select.length > 0) {
 		_instances[0]['_select'] = typeLike.select;
@@ -140,7 +145,7 @@ export const load = async ({ params, locals, fetch, url }) => {
 	const isWorkSingleInstance = _instances.length == 1;
 
 	const headingThing = isWorkSingleInstance
-		? (mainEntity['@reverse']['instanceOf'][0] as FramedData)
+		? (mainEntity[JsonLd.REVERSE]['instanceOf'][0] as FramedData)
 		: mainEntity;
 
 	const workTitle = isWorkSingleInstance
@@ -183,8 +188,12 @@ export const load = async ({ params, locals, fetch, url }) => {
 	];
 
 	let searchResult: ResourceSearchResult | undefined;
-	let instances;
-	let itemInformation: Record<string, DisplayDecorated>[] = [];
+	let instances: SearchResultItem[] = [];
+
+	let itemInformation: {
+		heldBy: DisplayDecorated;
+		items: DisplayDecorated[];
+	}[] = [];
 
 	if (mainEntity?.[JsonLd.REVERSE]?.instanceOf?.length > 0) {
 		const sortedInstances = getSortedInstances(mainEntity?.[JsonLd.REVERSE]?.instanceOf);
@@ -280,7 +289,7 @@ export const load = async ({ params, locals, fetch, url }) => {
 
 	/** TODO: Better error handling while fetching relations previews */
 	const relationsPreviews = await Promise.all(
-		relations.map(async (relation) => {
+		(relations || []).map(async (relation) => {
 			const url = new URL(relation.previewUrl);
 			const params = Object.fromEntries(url.searchParams);
 
@@ -290,11 +299,11 @@ export const load = async ({ params, locals, fetch, url }) => {
 			}
 		})
 	);
-	const relationsPreviewsByQualifierKey = relations.reduce(
+	const relationsPreviewsByQualifierKey = (relations || []).reduce(
 		(acc, currentRelation, relationIndex) => {
 			return {
 				...acc,
-				[currentRelation.qualifierKey]: relationsPreviews[relationIndex].items
+				[currentRelation.qualifierKey]: relationsPreviews?.[relationIndex]?.items
 			};
 		},
 		{}
@@ -317,7 +326,7 @@ export const load = async ({ params, locals, fetch, url }) => {
 					}
 				]
 			: []),
-		...(relations.length
+		...(relations?.length
 			? [
 					{
 						id: 'relations',
@@ -358,8 +367,11 @@ export const load = async ({ params, locals, fetch, url }) => {
 		byInstanceId: getHoldingsByInstanceId(mainEntity, displayUtil, locale),
 		byType,
 		bibIdData: getBibIdsByInstanceId(mainEntity, displayUtil, resource, locale),
-		holdingLibraries: getHoldingLibraries(byType)
+		holdingLibraries: getHoldingLibraries(byType),
+		eodAvailable: null
 	};
+
+	holdings.eodAvailable = getEodAvailable(_instances, holdings.holdingLibraries);
 
 	const refinedOrgs = getRefinedOrgs(myLibraries, [subsetMapping, searchResult?.mapping]);
 
@@ -367,7 +379,7 @@ export const load = async ({ params, locals, fetch, url }) => {
 		uri: resourceId,
 		recordUri: resource['@id'] as string,
 		controlNumber: resource['controlNumber'] as string,
-		type: mainEntity[JsonLd.TYPE],
+		type: mainEntity[JsonLd.TYPE] as string,
 		typeForIcon: getTypeForIcon(typeLike), // FIXME
 		title: toString(heading),
 		relations,

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.server.ts
@@ -87,7 +87,7 @@ export const load = async ({ params, locals, fetch, url }) => {
 
 	const resource = await resourceRes.json();
 
-	let workCard;
+	let workCard: SearchResultItem | null = null;
 	let isWork = false;
 
 	if (resource.mainEntity?.['@reverse']?.instanceOf) {

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -97,6 +97,8 @@
 		searchResult={data.searchResult}
 		tableOfContents={data.tableOfContents}
 		adjecentSearchResults={page.state.adjecentSearchResults}
+		workCard={data.workCard}
+		isWork={data.isWork}
 	/>
 	{#if holdingsParam}
 		<Modal close={() => handleCloseModal('holdings')}>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/[fnurgel=fnurgel]/+page.svelte
@@ -87,7 +87,6 @@
 		uri={data.uri}
 		recordUri={data.recordUri}
 		controlNumber={data.controlNumber}
-		type={data.type}
 		typeForIcon={data.typeForIcon}
 		image={data.image}
 		decoratedData={data.decoratedData}


### PR DESCRIPTION
## Description
### Solves

A section below the holding buttons on resource pages now more clearly show the ”digitization status” of a resource (can be improved in several steps). This is done by a new component, `ResourceDigitalAccess`. 

It can take 3 different forms:

* **Finns online:** displays the combined contents of  `associatedMedia`, `isPrimaryTopicOf`, `electronicLocator` and `marc:versionOfResource`. These are included in `overview2` but now also added to `workCard.mediaLinks` for convenience (which mean they could also included in the card ’online’ button later on)

<img width="695" height="159" alt="Skärmavbild 2026-05-28 kl  12 29 43" src="https://github.com/user-attachments/assets/2aa62a00-6d0b-43f9-b4ca-0f2a22352e78" />

[Example](http://localhost:5173/9s2g6qpv7j59f46p)

----

* **Finns digitiserad** - displays the contents of `hasReproduction`
<img width="818" height="177" alt="Skärmavbild 2026-05-28 kl  12 26 00" src="https://github.com/user-attachments/assets/f9d65669-996c-4216-bd24-05ed80179609" />

[Example](http://localhost:5173/l4x1qwkx4xlj5r2)

-----

* **Beställ digitisering** - displays in the case of 
1) no `hasReproduction` 
2) the presence of `page.data.holdings.eodAvailable` (i.e a holding library offers the service)

<img width="818" height="242" alt="Skärmavbild 2026-05-28 kl  12 23 59" src="https://github.com/user-attachments/assets/c18cb648-c613-457c-a15a-fcccc9dd80fe" />

[Example](http://localhost:5173/l3wktpwx101vmh0?_q=lasse-maja)

`eodAvailable` also checks the data against some criteria and then passes links and labels for available libraries. 
The criteria are:
1) Instance
2) `category === 'text'`
3) `publication.year` older than 90 years
4) Holding libraries have eod link templates

-----

#### TODO:
`otherPhysicalFormat` should (when linked) probably be included in 'Finns digitiserad'.

<img width="511" height="242" alt="Skärmavbild 2026-05-28 kl  12 21 02" src="https://github.com/user-attachments/assets/c5461a4b-d172-4a47-be4f-41d5e1d15ab5" />

[Example](http://localhost:5173/9tm0wx7m5h35l20)

### Summary of changes

* Add `hasReproduction` to instance `overview2` and `details`
* Add `"bibdb:eodUri"` to `LibraryFull` type
* `supressProperty` is now a list that can handle more than one suppressed prop
* Add `getEodAvailable.ts` util and pass `holdings.eodAvailable` data
* Add `isPrimaryTopicOf`, `electronicLocator`, `marc:versionOfResource` to card `mediaLinks`
* Add `ResourceDigitalAccess` component and `getResourceDigitalAccess` util function
* Filter out `isPrimaryTopicOf` "digipic"