### PR TITLE
fix(lxlweb):prevent duplicate searchresult keys, fix alias-myLibraris pill

### DIFF
--- a/lxl-web/src/lib/utils/xl.server.ts
+++ b/lxl-web/src/lib/utils/xl.server.ts
@@ -1103,7 +1103,7 @@ class Formatter {
 			return container[langKeys.toSorted()[0]];
 		}
 
-		return '{???}';
+		return undefined;
 	}
 }
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/find/+page.svelte
@@ -95,7 +95,7 @@
 					<SearchResultToolbar {searchResult} />
 					<SearchResultInfo {searchResult} />
 					<ol aria-labelledby="search-results" class="flex flex-col">
-						{#each searchResult.items as item (item['@id'])}
+						{#each searchResult.items as item, index (item['@id'] + index)}
 							<li>
 								<SearchCard {item} />
 							</li>


### PR DESCRIPTION
## Description
### Solves

1) Prevent ui crashing because of identical search result keys (`@id`) 
(like currently on QA)

<img width="901" height="563" alt="Skärmavbild 2026-05-29 kl  14 01 02" src="https://github.com/user-attachments/assets/8080b0e4-088d-4eda-b0de-2124acb4a6c4" />

2) fix `alias-myLibraries` label by allowing it to reach the local i18n files

<img width="412" height="62" alt="Skärmavbild 2026-05-29 kl  14 09 19" src="https://github.com/user-attachments/assets/5e0a43ac-a1b5-4430-accd-58d339ec2847" />

