### PR TITLE
fix(lxlweb): revert hardcoded thumb size fix

### DIFF
--- a/lxl-web/src/lib/utils/auxd.ts
+++ b/lxl-web/src/lib/utils/auxd.ts
@@ -1,4 +1,3 @@
-import { Width } from '$lib/types/auxd';
 import type { Image, ImageResolution } from '$lib/types/auxd';
 
 export function bestSize(from: Image, minWidthPx: number): ImageResolution;
@@ -9,18 +8,5 @@ export function bestSize(from: Image | undefined, minWidthPx: number): ImageReso
 	}
 	const sizes = from.sizes;
 	const result = sizes.find((i) => i.widthPx >= minWidthPx);
-	// REMOVE ME - TEMP SEARCH & REPLACE IN IMG URL
-	if (result) return result;
-
-	const fallbackSize = sizes[sizes.length - 1];
-	if (fallbackSize) {
-		if (minWidthPx === Width.SMALL) {
-			const _thumbUrl = fallbackSize.url.replace('.full.', `.${minWidthPx}.`);
-			fallbackSize.url = _thumbUrl;
-		}
-		return fallbackSize;
-	}
-
-	return undefined;
-	// return result || sizes[sizes.length - 1];
+	return result || sizes[sizes.length - 1];
 }


### PR DESCRIPTION
## Description
### Solves

Revert last-minute fix that hardcoded 128px url for the tumbs. https://github.com/libris/lxlviewer/pull/1596
Now that the images are in order, we don't need it and it breaks some tumbs (in cases where `FULL` is _smaller_ than 128 -> no `SMALL` size).

example: https://libris.kb.se/find?_q=contributor~%22libris:tr579dvc1gxsfwj%23it%22+existsImage

### Summary of changes

* revert change
