### PR TITLE
fix(lxlweb): type icons + card cleanup

### DIFF
--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -38,7 +38,7 @@
 		recordUri: string;
 		controlNumber: string;
 		uid?: string;
-		typeForIcon: string | undefined;
+		typeForIcon: string[];
 		image: SecureImage;
 		decoratedData: {
 			headingTop: DisplayDecorated;
@@ -192,7 +192,7 @@
 					{image}
 					type={typeForIcon}
 					alt={page.data.t('general.instanceCover')}
-					thumbnailTargetWidth={'Bibliography' === typeForIcon
+					thumbnailTargetWidth={typeForIcon.includes('Bibliography')
 						? ImageWidth.FULL
 						: ImageWidth.MEDIUM}
 					linkToFull

--- a/lxl-web/src/lib/components/ResourceImage.svelte
+++ b/lxl-web/src/lib/components/ResourceImage.svelte
@@ -12,7 +12,7 @@
 		image: Image;
 		alt?: string;
 		linkToFull?: boolean;
-		type?: string;
+		type?: string[];
 		thumbnailTargetWidth?: number;
 		showPlaceholder?: boolean;
 		loading?: 'eager' | 'lazy';
@@ -22,7 +22,7 @@
 		image,
 		alt,
 		linkToFull = false,
-		type = '',
+		type = [],
 		thumbnailTargetWidth = Width.SMALL,
 		showPlaceholder = true,
 		loading = 'eager'
@@ -30,7 +30,7 @@
 
 	let thumb = $derived(image ? bestSize(image, thumbnailTargetWidth) : undefined);
 	let full = $derived(image ? bestSize(image, Width.FULL) : undefined);
-	let geometry = $derived(type === 'Person' ? 'circle' : 'rectangle');
+	let geometry = $derived(type.includes('Person') ? 'circle' : 'rectangle');
 </script>
 
 {#snippet img(res: ImageResolution, imgClass?: string | string[])}

--- a/lxl-web/src/lib/components/TypeIcon.svelte
+++ b/lxl-web/src/lib/components/TypeIcon.svelte
@@ -29,7 +29,7 @@
 	import type { SVGAttributes } from 'svelte/elements';
 	import type { Component } from 'svelte';
 
-	type Props = { type: string; class?: string };
+	type Props = { type: string[]; class?: string };
 	type IconType = Component<SVGAttributes<SVGSVGElement>>;
 
 	const { type, class: className = '' }: Props = $props();
@@ -49,13 +49,18 @@
 		Work: BiSlashLg,
 		Family: BiPeople,
 
-		// categories / old work types
-		Cartography: BiMap,
-		Kartor: BiMap,
+		// 'book'
+		_book: BiBook,
+		_book_braille: BiBook,
+		Text: BiBook,
 		Literature: BiBook,
 		'Sk%C3%B6nlitteratur': BiBook,
 		Facklitteratur: BiBook,
 		'Barn-%20och%20ungdomslitteratur': BiBook,
+
+		// categories / old work types
+		Cartography: BiMap,
+		Kartor: BiMap,
 		'Kartografiskt%20material': BiMap,
 		MovingImage: BiFilm,
 		Music: BiMusicNoteBeamed,
@@ -64,6 +69,7 @@
 		ThreeDimensionalForm: BiBox,
 		Software: BiLaptop,
 		StillImage: BiCardImage,
+		Bilder: BiCardImage,
 
 		Audiobook: BiSoundWave,
 		'Ljudb%C3%B6cker': BiSoundWave,
@@ -82,16 +88,19 @@
 		MixedMaterial: BiBoxes,
 		Multimedia: BiLaptop,
 
-		Text: BiBook,
-
 		// New work types
 		Collection: BiBoxes,
-		Integrating: BiDatabase
+		Integrating: BiDatabase,
+
+		OnlineResource: BiLaptop
 
 		//Serial: ???,
 	};
 
-	const TypeIcon = $derived(ICONS?.[type]);
+	const TypeIcon = $derived.by(() => {
+		const key = Array.isArray(type) && type.find((key) => key in ICONS);
+		return key ? ICONS[key] : undefined;
+	});
 </script>
 
 {#if TypeIcon}

--- a/lxl-web/src/lib/components/TypeIcon.svelte
+++ b/lxl-web/src/lib/components/TypeIcon.svelte
@@ -52,11 +52,11 @@
 		// 'book'
 		_book: BiBook,
 		_book_braille: BiBook,
-		Text: BiBook,
 		Literature: BiBook,
 		'Sk%C3%B6nlitteratur': BiBook,
 		Facklitteratur: BiBook,
 		'Barn-%20och%20ungdomslitteratur': BiBook,
+		// Text: BiBook,
 
 		// categories / old work types
 		Cartography: BiMap,
@@ -69,7 +69,6 @@
 		ThreeDimensionalForm: BiBox,
 		Software: BiLaptop,
 		StillImage: BiCardImage,
-		Bilder: BiCardImage,
 
 		Audiobook: BiSoundWave,
 		'Ljudb%C3%B6cker': BiSoundWave,
@@ -90,9 +89,7 @@
 
 		// New work types
 		Collection: BiBoxes,
-		Integrating: BiDatabase,
-
-		OnlineResource: BiLaptop
+		Integrating: BiDatabase
 
 		//Serial: ???,
 	};

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -240,8 +240,8 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 		<div class="card-content grid">
 			<header class="card-header" id={titleId}>
 				<p class="card-header-top">
-					<TypeIcon type={item.typeForIcon} class="text-2xs mb-px inline" />
 					{#if item.typeStr && !hideType}
+						<TypeIcon type={item.typeForIcon} class="text-2xs mb-px inline" />
 						<span class="font-medium">
 							{item.typeStr}
 						</span>
@@ -330,6 +330,8 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 			{#if item.selectTypeStr}
 				<span class="text-body font-medium">{item.selectTypeStr}</span>
 				<!-- eslint-disable-next-line svelte/no-useless-mustaches -->
+			{/if}
+			{#if item.selectTypeStr && item[LensType.WebCardFooter]?._display?.length}
 				<span class="hidden whitespace-pre-wrap md:inline">{' · '}</span>
 			{/if}
 			<span>

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -241,7 +241,10 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 			<header class="card-header" id={titleId}>
 				<p class="card-header-top">
 					{#if item.typeStr && !hideType}
-						<TypeIcon type={item.typeForIcon} class="text-2xs mb-px inline" />
+						<TypeIcon
+							type={item.typeForIcon}
+							class="text-2xs mr-px mb-px inline align-text-bottom"
+						/>
 						<span class="font-medium">
 							{item.typeStr}
 						</span>

--- a/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
+++ b/lxl-web/src/lib/components/supersearch/QualifierPill.svelte
@@ -50,7 +50,7 @@
 		{#if image}
 			<img src={image} alt="" class="mr-0.75 mb-0.75 inline size-5 rounded-full object-contain" />
 		{:else if type}
-			<TypeIcon {type} class="mr-0.75 mb-0.75 inline text-sm" />
+			<TypeIcon type={[type]} class="mr-0.75 mb-0.75 inline text-sm" />
 		{/if}
 	</span>
 {/snippet}

--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -55,7 +55,7 @@ export interface SearchResultItem {
 	[LensType.WebCardHeaderTop]: DisplayDecorated;
 	[LensType.WebCardFooter]: DisplayDecorated;
 	image: SecureImageResolution | undefined;
-	typeForIcon: string; // FIXME
+	typeForIcon: string[]; // FIXME
 	typeStr: string;
 	selectTypeStr: string; // FIXME
 	mediaLinks: DisplayDecorated | null;

--- a/lxl-web/src/lib/utils/bookAspectRatio.ts
+++ b/lxl-web/src/lib/utils/bookAspectRatio.ts
@@ -1,16 +1,17 @@
-export function bookAspectRatio(iconTypeStr: string) {
-	return (
-		iconTypeStr &&
-		[
-			'Literature',
-			'Ej%20sk%C3%B6nlitteratur',
-			'Facklitteratur',
-			'Sk%C3%B6nlitteratur',
-			'Barn-%20och%20ungdomslitteratur',
-			'Text',
-			'Seriella%20publikationer',
-			'Periodika',
-			'NotatedMusic'
-		].includes(iconTypeStr)
-	);
+export function bookAspectRatio(iconTypeStr: string[]) {
+	return Array.isArray(iconTypeStr) && iconTypeStr.some((t) => BOOKTYPE.includes(t));
 }
+
+const BOOKTYPE = [
+	'_book',
+	'_book_braille',
+	'Literature',
+	'Ej%20sk%C3%B6nlitteratur',
+	'Facklitteratur',
+	'Sk%C3%B6nlitteratur',
+	'Barn-%20och%20ungdomslitteratur',
+	'Text',
+	'Seriella%20publikationer',
+	'Periodika',
+	'NotatedMusic'
+];

--- a/lxl-web/src/lib/utils/bookAspectRatio.ts
+++ b/lxl-web/src/lib/utils/bookAspectRatio.ts
@@ -10,7 +10,6 @@ const BOOKTYPE = [
 	'Facklitteratur',
 	'Sk%C3%B6nlitteratur',
 	'Barn-%20och%20ungdomslitteratur',
-	'Text',
 	'Seriella%20publikationer',
 	'Periodika',
 	'NotatedMusic'

--- a/lxl-web/src/lib/utils/getTypeLike.server.ts
+++ b/lxl-web/src/lib/utils/getTypeLike.server.ts
@@ -82,6 +82,7 @@ const FIND_RULES = [
 const DEFS = {
 	[_BOOK]: {
 		[JsonLd.TYPE]: 'ManifestationForm',
+		[JsonLd.ID]: '_book',
 		prefLabelByLang: {
 			en: 'Book',
 			sv: 'Bok'
@@ -89,6 +90,7 @@ const DEFS = {
 	},
 	[_BOOK_BRAILLE]: {
 		[JsonLd.TYPE]: 'ManifestationForm',
+		[JsonLd.ID]: '_book_braille',
 		prefLabelByLang: {
 			en: 'Book (braille)',
 			sv: 'Bok (punktskrift)'
@@ -222,34 +224,21 @@ export function toTypes(typeLike: TypeLike) {
 
 export default getTypeLike;
 
-const PRIORITIZED_ICONS = [
-	'Audiobook',
-	'NotatedMusic',
-	'Ljudb%C3%B6cker',
-	'Kit',
-	'Databaser',
-	'Seriella%20publikationer',
-	'Periodika',
-	'Kartor',
-	'Kartglober'
-];
-
 // TODO this is just a temporary implementation for exploring different ways of displaying categories
 export function getTypeForIcon(typeLike: TypeLike) {
-	for (const t of typeLike.identify.concat(typeLike.find)) {
+	const result = [];
+	for (const t of typeLike.identify
+		.concat(typeLike.find)
+		.concat(typeLike.select)
+		.concat(typeLike.none)) {
 		if (t) {
 			const slugStr = slug(((t[JsonLd.ID] as string) || '').replace('/bibdb/', '/bibdb:'));
-			if (slugStr && PRIORITIZED_ICONS.includes(slugStr)) {
-				return slugStr;
-			}
+			result.push(slugStr);
 		}
 	}
-
-	return typeLike.find.length > 0 && typeLike.find[0] !== undefined
-		? slug(((typeLike.find[0][JsonLd.ID] as string) || '').replace('/bibdb/', '/bibdb:'))
-		: '';
+	return result.filter((t) => !!t);
 }
 
 export function slug(s: string) {
-	return s === undefined ? undefined : s.split('/').pop();
+	return s === undefined ? '' : s.split('/').pop() || '';
 }

--- a/lxl-web/src/lib/utils/search.server.ts
+++ b/lxl-web/src/lib/utils/search.server.ts
@@ -158,7 +158,7 @@ export function asSearchResultItem(
 				auxdSecret
 			),
 			typeStr: typeStr(getTypeLike(i, vocabUtil), displayUtil, locale),
-			typeForIcon: getTypeForIcon(getTypeLike(i, vocabUtil)) || '', // FIXME
+			typeForIcon: getTypeForIcon(getTypeLike(i, vocabUtil)), // FIXME
 			selectTypeStr: selectTypeStr(getTypeLike(i, vocabUtil), displayUtil, locale), // FIXME
 			numberOfHolders: getHoldersCount(i, vocabUtil),
 			mediaLinks: getMediaLinks(i, displayUtil, locale),

--- a/lxl-web/src/lib/utils/xl.server.ts
+++ b/lxl-web/src/lib/utils/xl.server.ts
@@ -881,11 +881,14 @@ class Formatter {
 
 		if (Array.isArray(value) && asArray(result[Fmt.STYLE]).includes('sort()')) {
 			value.filter(isObject).forEach((v) => {
-				v._str = toString(this.formatValues(v, className, propertyName)).toLowerCase();
+				const _str = toString(this.formatValues(v, className, propertyName)).toLowerCase();
+				if (_str) {
+					v._str = _str;
+				}
 			});
 			value.sort((a, b) => {
-				const cmp = (x) => (isObject(x) ? x._str : typeof x === 'string' ? x : `${x}`);
-				return cmp(a).localeCompare(cmp(b), this.locale);
+				const cmp = (x) => (isObject(x) ? x?._str : typeof x === 'string' ? x : `${x}`);
+				return cmp(a)?.localeCompare(cmp(b), this.locale);
 			});
 		}
 


### PR DESCRIPTION
## Description
### Solves

Tried to cleanup the cards and add more type icons  where we can.

**1) Cleanup**
We have a lot of this:

<img width="791" height="512" alt="Skärmavbild 2026-06-04 kl  15 02 58" src="https://github.com/user-attachments/assets/fd745776-9b81-43af-a6ca-f9b1715b6dd4" />
.

If we conditionally check the `_MultipleTypes` `_str` before adding it, `cleanupData` can purge the entire empty branch which removes the junk:

<img width="791" height="512" alt="Skärmavbild 2026-06-04 kl  15 03 04" src="https://github.com/user-attachments/assets/27925e34-ba54-468e-9c48-7104b2a5ebeb" />


----

**2) More icons**
The aim here was to get book icons for stuff we _say_ are books:

<img width="475" height="478" alt="Skärmavbild 2026-06-04 kl  12 39 12" src="https://github.com/user-attachments/assets/3a96b170-e46c-4e62-a4bd-93d3b8e1c730" />

The proposal is to add a `@id: _book` to our fake book type. Then make `typeForIcon` an array of types with descending priority, that can act as fallback values for icons:

<img width="461" height="256" alt="Skärmavbild 2026-06-04 kl  14 29 23" src="https://github.com/user-attachments/assets/7fd4f950-1276-4115-8605-e7c98a06679d" />

This also means some new categories get icons, like posters, postcards etc, falling back to `StillImage`

<img width="596" height="286" alt="Skärmavbild 2026-06-04 kl  14 34 49" src="https://github.com/user-attachments/assets/916ccecc-b91f-499b-b03f-55c9567b03e2" />

...but this still gets a book because we defined an icon for Facklitteratur etc

<img width="582" height="142" alt="Skärmavbild 2026-06-04 kl  14 37 45" src="https://github.com/user-attachments/assets/7edaa224-6474-4ef2-b1e3-0f1957991ff7" />

### Summary of changes

Summary of changes
