### PR TITLE
fix(lxlweb): fix select option invisible text bug

### DIFF
--- a/lxl-web/src/app.css
+++ b/lxl-web/src/app.css
@@ -235,6 +235,11 @@
 	summary::-webkit-details-marker {
 		display: none;
 	}
+
+	option {
+		color: var(--color-body);
+		background: var(--color-page);
+	}
 }
 
 @layer components {


### PR DESCRIPTION
## Description
### Solves

Fix select option text not visible on PC Edge/Chrome

<img width="240" height="320" alt="image0" src="https://github.com/user-attachments/assets/44933f69-7b44-4fc3-bd56-d4fe9473af8b" />

`<select>` had `text-transparent` which was inherited by the options. Not on mac because of system-ui look.
Setting a global text and background rule for `<option>`

<img width="240" height="320" alt="image1" src="https://github.com/user-attachments/assets/c4cd61da-19bb-4483-8a91-93de302cdb96" />


### Summary of changes

* Add option css rule to fix invisible text on pc