### PR TITLE
fix(lxlweb): show fjarrlan btn for work single instance

### DIFF
--- a/lxl-web/src/lib/components/ResourceHoldings.svelte
+++ b/lxl-web/src/lib/components/ResourceHoldings.svelte
@@ -78,7 +78,7 @@
 			</a>
 		</li>
 	{/each}
-	{#if page.data.librisSession && !page.data.isWork}
+	{#if page.data.librisSession && page.data?.instances?.length === 1}
 		<li>
 			<a
 				class="btn btn-cta bg-primary-800 border-primary-800 hover:bg-primary-900 hover:border-primary-900 @md:max-w-sm"


### PR DESCRIPTION
## Description
### Solves

The condition for displaying fjärrlån btn did not cover works with a single linked instance:
https://libris.kb.se/scwhhrl2q74wfdmd

The instance page looks much better but is unreachable in the ui:
https://libris.kb.se/s9sjqtf6qfwzg918

* Work is missing bibliography
* Work can't get the citation right

Maybe some other maneuver fixes all this...
