### PR TITLE
feat(lxl-web): Print CSS

### DIFF
--- a/lxl-web/src/lib/components/ExpandableArea.svelte
+++ b/lxl-web/src/lib/components/ExpandableArea.svelte
@@ -49,7 +49,7 @@
 
 {#if canCollapse}
 	<button
-		class="delimiter link-subtle"
+		class="delimiter link-subtle print:hidden"
 		type="button"
 		aria-expanded={expanded}
 		onclick={() => (expanded = !expanded)}
@@ -74,5 +74,16 @@
 		height: 80px;
 		width: 100%;
 		background: linear-gradient(to top, white, transparent);
+	}
+
+	@media print {
+		.content-clip {
+			height: auto;
+			overflow: visible;
+		}
+
+		.fade {
+			display: none;
+		}
 	}
 </style>

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -449,10 +449,10 @@
 							</div>
 						{/each}
 						{#if decoratedData.itemInformation.length}
-							<details class="mt-4">
+							<details class="mt-4 print:hidden print:break-before-page open:print:block">
 								<summary class="flex cursor-pointer items-center gap-1">
 									<span
-										class="chevron text-subtle flex h-3 origin-center rotate-0 items-center transition-transform"
+										class="chevron text-subtle flex h-3 origin-center rotate-0 items-center transition-transform print:hidden"
 									>
 										<BiChevronRight />
 									</span>

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -150,13 +150,13 @@
 {/snippet}
 
 {#if adjecentSearchResults && fnurgel}
-	<div class="border-b-neutral @container border-b">
+	<div class="border-b-neutral @container border-b print:hidden">
 		<AdjecentResults {fnurgel} {adjecentSearchResults} />
 	</div>
 {/if}
 {#if workCard && !isWork}
 	<div
-		class="back-to-work border-b-neutral border-b hover:[&_.arrow]:-translate-x-1 [&.arrow]:transition-transform"
+		class="back-to-work border-b-neutral border-b print:hidden hover:[&_.arrow]:-translate-x-1 [&.arrow]:transition-transform"
 	>
 		<Suggestion item={workCard}>
 			{#snippet leadingContent()}
@@ -172,7 +172,7 @@
 {/if}
 <article class="@container @3xl:[&_[id]]:scroll-mt-36">
 	{#if tableOfContents.length}
-		<section data-testid="toc-mobile" class="contents @7xl:hidden">
+		<section data-testid="toc-mobile" class="contents @7xl:hidden print:hidden">
 			<TableOfContents items={tableOfContents} {uidPrefix} mobile />
 		</section>
 	{/if}
@@ -180,7 +180,7 @@
 		class="max-w-10xl wide:max-w-screen mx-auto flex flex-col gap-3 px-3 @sm:gap-6 @sm:px-6 @3xl:grid @3xl:grid-cols-(--two-grid-cols) @3xl:gap-9 @7xl:grid-cols-(--three-grid-cols) @7xl:px-12"
 	>
 		{#if tableOfContents.length}
-			<div class="order-last hidden @7xl:block">
+			<div class="order-last hidden @7xl:block print:hidden">
 				<section data-testid="toc" class="sticky py-3 @sm:py-6">
 					<TableOfContents items={tableOfContents} />
 				</section>
@@ -258,7 +258,7 @@
 					{/each}
 				</div>
 				{#if hasHoldingsBtn}
-					<h2 class="sr-only">{page.data.t('holdings.availabilityByType')}</h2>
+					<h2 class="sr-only print:hidden">{page.data.t('holdings.availabilityByType')}</h2>
 					<ResourceHoldings {holdings} {instances} />
 				{/if}
 				<ResourceDigitalAccess
@@ -299,7 +299,7 @@
 							limit={{ contribution: 5, hasVariant: 10, hasPart: 10 }}
 						/>
 					</div>
-					<div class="flex items-center gap-2">
+					<div class="flex items-center gap-2 print:hidden">
 						{#if decoratedData.summary.length || instances?.length > 1 || relations?.length || decoratedData.resourceTableOfContents.length}
 							<a
 								class="btn btn-primary my-2 h-8 w-fit rounded-full px-4 text-sm"
@@ -325,7 +325,7 @@
 				</div>
 			</section>
 			{#if decoratedData.summary.length}
-				<section>
+				<section class="print:break-before-page">
 					<h2 id={`${uidPrefix}summary`} class="mb-3 text-xl font-medium">
 						{page.data.t('resource.summary')}
 					</h2>
@@ -343,7 +343,7 @@
 				</section>
 			{/if}
 			{#if instances?.length > 1}
-				<section>
+				<section class="print:break-before-page print:break-after-page">
 					<h2 id="{uidPrefix}editions" class="mb-4 text-xl font-medium">
 						{page.data.t('resource.editions')}
 					</h2>
@@ -355,7 +355,7 @@
 				</section>
 			{/if}
 			{#if relations?.length}
-				<section>
+				<section class="print:hidden">
 					<h2 id={`${uidPrefix}relations`} class="mb-6 text-xl font-medium">
 						{page.data.t('resource.relations')}
 					</h2>
@@ -431,7 +431,7 @@
 			{/if}
 			{#if decoratedData.details.length && decoratedData.details.some((d) => d[Fmt.DISPLAY] && d[Fmt.DISPLAY].length > 0)}
 				<section
-					class="-mx-3 bg-neutral-100 px-3 pb-6 @sm:-mx-6 @sm:px-6 @2xl:mx-0 @2xl:rounded-lg"
+					class="-mx-3 bg-neutral-100 px-3 pb-6 @sm:-mx-6 @sm:px-6 @2xl:mx-0 @2xl:rounded-lg print:break-before-page print:px-0"
 				>
 					<h2 id="{uidPrefix}details" class="my-4 text-xl font-medium">
 						{page.data.t('resource.details')}
@@ -488,7 +488,7 @@
 					</div>
 				</section>
 			{/if}
-			<div class="text-sm">
+			<div class="text-sm print:hidden">
 				<p>
 					{page.data.t('resource.uriLink')}: <a href={uri} class="link">{uri}</a>
 				</p>

--- a/lxl-web/src/lib/components/ResourceDigitalAccess.svelte
+++ b/lxl-web/src/lib/components/ResourceDigitalAccess.svelte
@@ -61,7 +61,7 @@
 				/>
 			</div>
 		{:else if eodAvailable}
-			<details>
+			<details class="print:hidden">
 				<summary class="cursor-pointer">
 					<p class="flex items-center gap-1 font-semibold">
 						<span class="chevron text-subtle transition-transform">

--- a/lxl-web/src/lib/components/ResourceHoldings.svelte
+++ b/lxl-web/src/lib/components/ResourceHoldings.svelte
@@ -30,7 +30,7 @@
 	}
 </script>
 
-<ul class="@container my-4 flex flex-wrap gap-2">
+<ul class="@container my-4 flex flex-wrap gap-2 print:hidden">
 	{#each Object.keys(holdings.byType) as type (type)}
 		{@const myLibsHoldingByType = getLibsFromHoldings(
 			myLibraries,

--- a/lxl-web/src/lib/components/ResourceImage.svelte
+++ b/lxl-web/src/lib/components/ResourceImage.svelte
@@ -69,7 +69,10 @@
 					{/if}
 				</span>
 			{/if}
-			<span class="truncate" use:popover={{ title: image?.usageAndAccessPolicy.title }}>
+			<span
+				class="truncate print:hidden"
+				use:popover={{ title: image?.usageAndAccessPolicy.title }}
+			>
 				<InfoIcon class="inline" />
 				{#if image.usageAndAccessPolicy.link}
 					<a href={image.usageAndAccessPolicy.link} target="_blank" class="ext-link">
@@ -86,7 +89,7 @@
 		</figcaption>
 	</figure>
 {:else if showPlaceholder}
-	<div class="mb-6 flex items-center justify-center">
+	<div class="mb-6 flex items-center justify-center print:hidden">
 		<img
 			src={placeholder}
 			alt=""

--- a/lxl-web/src/lib/components/Toolbar.svelte
+++ b/lxl-web/src/lib/components/Toolbar.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <div
-	class="flex h-(--toolbar-height) place-content-between items-center gap-2 overflow-hidden border-b border-b-neutral-200 px-2 lg:px-3"
+	class="flex h-(--toolbar-height) place-content-between items-center gap-2 overflow-hidden border-b border-b-neutral-200 px-2 lg:px-3 print:hidden"
 >
 	{#if leadingActions}
 		<div class="flex gap-1">

--- a/lxl-web/src/lib/components/find/LeadingPane.svelte
+++ b/lxl-web/src/lib/components/find/LeadingPane.svelte
@@ -42,7 +42,7 @@
 	aria-label={page.data.t('panes.leadingPane')}
 	id="leading-pane"
 	class={[
-		'leading-pane sticky top-0 z-10 hidden w-0 sm:block',
+		'leading-pane sticky top-0 z-10 hidden w-0 sm:block print:hidden',
 		// Enable transition for the collapse animation. But disable it while resizing the panel!
 		!isDragging && 'transition-[padding] duration-150 ease-in motion-reduce:transition-none'
 	]}

--- a/lxl-web/src/lib/components/find/Pagination.svelte
+++ b/lxl-web/src/lib/components/find/Pagination.svelte
@@ -82,7 +82,7 @@
 	<nav
 		aria-label={page.data.t('search.pagination')}
 		data-testid="pagination"
-		class="pagination @container/pagination mt-4 py-4"
+		class="pagination @container/pagination mt-4 py-4 print:hidden"
 	>
 		<ol class="flex items-center justify-center">
 			<!-- prev -->

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -179,7 +179,7 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 	{/if}
 {/snippet}
 
-<div class="search-card-container @container/card">
+<div class="search-card-container @container/card print:break-inside-avoid">
 	<article
 		{id}
 		class={[
@@ -379,7 +379,7 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 			</span>
 		</footer>
 		{#if allowActions}
-			<div class="card-actions ml-auto flex w-full justify-end gap-1 pt-3">
+			<div class="card-actions ml-auto flex w-full justify-end gap-1 pt-3 print:hidden">
 				{#if firstMediaLink}
 					{#snippet mediaLinksPopover()}
 						<DecoratedData

--- a/lxl-web/src/lib/components/find/SearchResultInfo.svelte
+++ b/lxl-web/src/lib/components/find/SearchResultInfo.svelte
@@ -79,14 +79,14 @@
 	</div>
 	{#each page.data.searchResult.mapping as m (m)}
 		{#if m.toEquals}
-			<p>
+			<p class="print:hidden">
 				<a href={page.data.localizeHref(m.toEquals['@id'])} class="link-subtle"
 					>{page.data.t('search.showEquals')} <i>{m.displayStr}</i></a
 				>
 			</p>
 		{/if}
 		{#if m.toLike}
-			<p>
+			<p class="print:hidden">
 				<a href={page.data.localizeHref(m.toLike['@id'])} class="link-subtle"
 					>{page.data.t('search.showLike')} <i>{m.displayStr}</i></a
 				>

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -192,13 +192,13 @@
 
 <a
 	href="#content"
-	class="bg-primary-700 text-page fixed -top-full left-0 z-999 flex h-9 w-full items-center justify-center font-medium focus:top-0"
+	class="bg-primary-700 text-page fixed -top-full left-0 z-999 flex h-9 w-full items-center justify-center font-medium focus:top-0 print:hidden"
 >
 	{page.data.t('header.skipToContent')}
 </a>
 <header
 	class={[
-		'app-bar @container sticky z-40 grid',
+		'app-bar @container sticky z-40 grid print:hidden',
 		isHomeRoute && 'home',
 		isHomeRoute && showBackground && 'bg-app-bar',
 		isHomeRoute && showShadow && 'shadow-app-bar',

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/SiteFooter.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/SiteFooter.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <footer
-	class="mt-auto flex flex-col justify-between gap-8 bg-neutral-100 px-4 py-8 sm:flex-row sm:px-8"
+	class="mt-auto flex flex-col justify-between gap-8 bg-neutral-100 px-4 py-8 sm:flex-row sm:px-8 print:hidden"
 >
 	<div class="flex flex-col gap-4 sm:flex-row sm:gap-16 [&_li>*]:text-sm [&_p]:font-medium">
 		<nav class="flex flex-col gap-2" aria-labelledby="nav-info">


### PR DESCRIPTION
Add basic print styling for resource page and hit list.

- hide header, footer, buttons, filter panel etc.
    - number of libraries is now hidden, ok?
- put sections on diffent pages. except summary and toc
- hide "related" section
- no x padding in "details" section
- show full unclipped summary
- only show "Library specific information (holding)" if expanded
- hide "request digitization"
- avoid page split inside search result card
- hide placeholder image
