### PR TITLE
fix(lxlweb): fix missing org names

### DIFF
--- a/lxl-web/src/lib/components/HoldingsPanel.svelte
+++ b/lxl-web/src/lib/components/HoldingsPanel.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { getUserSettings } from '$lib/contexts/userSettings';
-	import type { LibraryWithLinksAndInstances, OrgId, UnknownLibrary } from '$lib/types/holdings';
+	import type {
+		LibOrg,
+		LibraryWithLinksAndInstances,
+		OrgId,
+		UnknownLibrary
+	} from '$lib/types/holdings';
 	import { JsonLd } from '$lib/types/xl';
-	import { getLibsFromHoldings, isLibraryOrg } from '$lib/utils/holdings';
+	import { getHeldBy, isLibraryOrg } from '$lib/utils/holdings';
 	import { getLibraryIdsFromMapping } from '$lib/utils/getLibraryIdsFromMapping';
 	import { sortByDistance, userLocation } from '$lib/utils/geolocation.svelte';
 	import HoldingsNearMeBtn from './HoldingsNearMeBtn.svelte';
@@ -20,15 +25,13 @@
 
 	let { holders, searchPhrase = $bindable() }: Props = $props();
 
-	type OrgWithMembers = {
-		[JsonLd.ID]: string;
-		_orgLabel: string;
+	type OrgWithMembers = Omit<LibOrg, '_members'> & {
 		_members: LibraryWithLinksAndInstances[];
 	};
 
 	type NestedLibraries = LibraryWithLinksAndInstances | OrgWithMembers | UnknownLibrary;
 
-	const libOrgs: Record<OrgId, string[]> = page.data.refinedOrgs;
+	const refinedOrgs: Record<OrgId, LibOrg> = page.data.refinedOrgs;
 	const { myLibraries } = getUserSettings();
 	const numHolders = $derived(holders?.length);
 	let location = $derived(userLocation.coords);
@@ -53,7 +56,7 @@
 	const myLibsHolders = $derived.by(() => {
 		if (!myLibraries) return [];
 		const holderIds = holders.map((holder) => holder[JsonLd.ID]);
-		const ids = getLibsFromHoldings(myLibraries, holderIds, libOrgs);
+		const ids = getHeldBy(myLibraries, holderIds, refinedOrgs);
 		return buildNestedLibraries(ids, myLibraries, holders);
 	});
 
@@ -75,25 +78,23 @@
 		if (!ids || !labelMap) return [];
 
 		const result: NestedLibraries[] = [];
-
 		for (const id of ids) {
 			if (isLibraryOrg(id)) {
-				const memberIds = libOrgs?.[id];
+				const org = refinedOrgs?.[id];
 
-				if (!memberIds) {
+				if (!org) {
 					console.warn('Failed to lookup holding org', id);
 					continue;
 				}
 
-				const members = memberIds
-					.map((memberId) => holders.find((h) => h[JsonLd.ID] === memberId))
+				const _members = org._members
+					?.map((memberId) => holders.find((h) => h[JsonLd.ID] === memberId))
 					.filter(Boolean) as NestedLibraries[];
 
-				if (members.length) {
+				if (_members.length) {
 					result.push({
-						[JsonLd.ID]: id,
-						_orgLabel: labelMap[id],
-						_members: members
+						...org,
+						_members
 					} as OrgWithMembers);
 				}
 				continue;
@@ -158,7 +159,7 @@
 								<span aria-hidden="true" class="text-subtle text-base">
 									<BiHouses class="text-subtle size-3" />
 								</span>
-								<span>{holder._orgLabel}</span>
+								<span>{holder.name}</span>
 							</h3>
 							<ul class="mb-2 ml-3 flex flex-col gap-2">
 								{#each holder._members as member (`mylibs-member${member[JsonLd.ID]}`)}

--- a/lxl-web/src/lib/components/HoldingsPanel.svelte
+++ b/lxl-web/src/lib/components/HoldingsPanel.svelte
@@ -155,7 +155,7 @@
 				{#each section.data as holder, i (`mylibs-${holder[JsonLd.ID]}-${i}`)}
 					{#if '_members' in holder}
 						<li>
-							<h3 class="mb-3 flex items-center gap-2">
+							<h3 class="mb-3 flex items-center gap-2" data-testid="holdings-org-label">
 								<span aria-hidden="true" class="text-subtle text-base">
 									<BiHouses class="text-subtle size-3" />
 								</span>

--- a/lxl-web/src/lib/components/MyLibsHoldingIndicator.svelte
+++ b/lxl-web/src/lib/components/MyLibsHoldingIndicator.svelte
@@ -1,24 +1,31 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import popover from '$lib/actions/popover';
-	import { getUserSettings } from '$lib/contexts/userSettings';
+	import type { LibOrg, LibraryId, LibraryWithLinks, OrgId } from '$lib/types/holdings';
+	import { isLibraryOrg } from '$lib/utils/holdings';
 	import BiHouseHeart from '~icons/bi/house-heart';
 
 	type IndicatorProps = {
 		libraries: string[];
+		holdingLibraries?: Record<LibraryId, LibraryWithLinks | null>;
+		refinedOrgs?: Record<OrgId, LibOrg>;
 	};
-	const { libraries }: IndicatorProps = $props();
-	const { myLibraries } = getUserSettings();
+	const { libraries, holdingLibraries, refinedOrgs }: IndicatorProps = $props();
 
+	// libraries can be an array of labels or ids (libraries and orgs then needed for lookup)
 	const indicatorText = $derived.by(() => {
-		if (myLibraries) {
-			return (
-				page.data.t('holdings.availableAt') +
-				': ' +
-				libraries.map((lib) => myLibraries[lib] || '').join(', ')
-			);
-		}
-		return '';
+		let availableAt = `${page.data.t('holdings.availableAt')}: `;
+		let libNames = libraries.map((l) => {
+			if (holdingLibraries && refinedOrgs) {
+				if (isLibraryOrg(l)) {
+					return refinedOrgs[l]?.name;
+				} else {
+					return holdingLibraries[l]?.name;
+				}
+			} else return l;
+		});
+
+		return availableAt + libNames.join(', ');
 	});
 </script>
 

--- a/lxl-web/src/lib/components/ResourceHoldings.svelte
+++ b/lxl-web/src/lib/components/ResourceHoldings.svelte
@@ -8,7 +8,7 @@
 	import type { ResourceData } from '$lib/types/resourceData';
 	import { LxlLens } from '$lib/types/display';
 	import { getLibraryIdsFromMapping } from '$lib/utils/getLibraryIdsFromMapping';
-	import { getHoldingsLink, getLibsFromHoldings, handleClickHoldings } from '$lib/utils/holdings';
+	import { getHoldingsLink, getHeldBy, handleClickHoldings } from '$lib/utils/holdings';
 	import MyLibsHoldingIndicator from '$lib/components/MyLibsHoldingIndicator.svelte';
 
 	interface Props {
@@ -32,12 +32,12 @@
 
 <ul class="@container my-4 flex flex-wrap gap-2 print:hidden">
 	{#each Object.keys(holdings.byType) as type (type)}
-		{@const myLibsHoldingByType = getLibsFromHoldings(
+		{@const myLibsHoldingByType = getHeldBy(
 			myLibraries,
 			holdings.byType[type],
 			page.data.refinedOrgs
 		)}
-		{@const subsetHoldingByType = getLibsFromHoldings(
+		{@const subsetHoldingByType = getHeldBy(
 			subsetLibraries,
 			holdings.byType[type],
 			page.data.refinedOrgs
@@ -58,7 +58,11 @@
 			>
 				{#if myLibsHoldingByType}
 					<div class="mr-1 text-lg">
-						<MyLibsHoldingIndicator libraries={myLibsHoldingByType} />
+						<MyLibsHoldingIndicator
+							libraries={myLibsHoldingByType}
+							holdingLibraries={holdings.holdingLibraries}
+							refinedOrgs={page.data.refinedOrgs}
+						/>
 					</div>
 				{/if}
 				<span class="text-nowrap">{getLocalizedType(type)}</span>

--- a/lxl-web/src/lib/types/holdings.ts
+++ b/lxl-web/src/lib/types/holdings.ts
@@ -40,6 +40,14 @@ type RecordId = string;
 export type LibraryId = string;
 export type OrgId = string;
 
+export type LibOrg = {
+	[JsonLd.ID]: OrgId;
+	[JsonLd.TYPE]: 'bibdb:Organization';
+	name: string;
+	code: string;
+	_members?: LibraryId[];
+};
+
 export type LibraryRecord = {
 	[JsonLd.ID]: RecordId;
 	[JsonLd.TYPE]: 'Record';

--- a/lxl-web/src/lib/utils/getLibraries.server.ts
+++ b/lxl-web/src/lib/utils/getLibraries.server.ts
@@ -1,6 +1,7 @@
 import { env } from '$env/dynamic/private';
 import { error } from '@sveltejs/kit';
 import type {
+	LibOrg,
 	LibraryFull,
 	LibraryId,
 	LibraryRecord,
@@ -20,19 +21,33 @@ type Data = {
 }[];
 
 type LibrariesCache = Map<LibraryId, LibraryWithLinks>;
-type OrgIndex = Map<OrgId, string[]>;
+type OrgCache = Map<OrgId, LibOrg>;
 
 let librariesCache: LibrariesCache = new Map();
-let orgIndex: OrgIndex = new Map();
+let orgCache: OrgCache = new Map();
 
 const REFRESH_INTERVAL = 12 * 60 * 60 * 1000; // 12 hrs?
 let intervalStarted = false;
 
+async function fetchLibOrgs() {
+	const orgsArr = (await doFetch('bibdb:Organization')) as LibOrg[];
+	const libraryMap = new Map(orgsArr.map((org) => [org[JsonLd.ID], org]));
+	return libraryMap;
+}
+
 async function fetchLibraries(displayUtil: DisplayUtil, locale: LocaleCode) {
+	const libraryArr = (await doFetch('Library')) as LibraryFull[];
+	const libraryMap = new Map(
+		libraryArr.map((lib) => [lib[JsonLd.ID], withLinks(lib, displayUtil, locale)])
+	);
+	return libraryMap;
+}
+
+async function doFetch(type: string) {
 	const start = Date.now();
 
 	const res = await fetch(
-		`${env.API_URL}/api/emm/full?selection=type:Library&download=.ndjsonld.gz`
+		`${env.API_URL}/api/emm/full?selection=type:${type}&download=.ndjsonld.gz`
 	);
 	if (!res.ok) {
 		return error(res.status);
@@ -44,14 +59,11 @@ async function fetchLibraries(displayUtil: DisplayUtil, locale: LocaleCode) {
 		.split('\n')
 		.map((line) => JSON.parse(line));
 
-	const libraryArr = buildData(data);
-	const libraryMap = new Map(
-		libraryArr.map((lib) => [lib[JsonLd.ID], withLinks(lib, displayUtil, locale)])
-	);
+	const builtData = buildData(data);
 
 	const end = Date.now();
-	console.log(`Fetching all libraries took ${(end - start).toFixed(1)} ms`);
-	return libraryMap;
+	console.log(`Fetching all of type ${type} took ${(end - start).toFixed(1)} ms`);
+	return builtData;
 }
 
 function withLinks(
@@ -68,7 +80,7 @@ function withLinks(
 }
 
 function buildData(data: Data) {
-	const libraries: LibraryFull[] = [];
+	const libraries: LibraryFull[] | LibOrg[] = [];
 
 	for (const lib of data) {
 		const graph = lib?.[JsonLd.GRAPH];
@@ -76,6 +88,7 @@ function buildData(data: Data) {
 
 		let record: LibraryRecord | null = null;
 		let library: LibraryFull | null = null;
+		let org: LibOrg | null = null;
 
 		for (const item of graph) {
 			const type = item[JsonLd.TYPE];
@@ -83,6 +96,8 @@ function buildData(data: Data) {
 				record = item as LibraryRecord;
 			} else if (type === 'Library') {
 				library = item as LibraryFull;
+			} else if (type === 'bibdb:Organization') {
+				org = item as LibOrg;
 			}
 		}
 
@@ -91,22 +106,27 @@ function buildData(data: Data) {
 				...library,
 				meta: record
 			});
+		} else if (org) {
+			libraries.push(org);
 		}
 	}
 	return libraries;
 }
 
-function buildOrgIndex(libraryMap: LibrariesCache): OrgIndex {
-	const index: Map<OrgId, string[]> = new Map();
+function buildOrgIndex(libraries: LibrariesCache, orgs: OrgCache): Map<OrgId, LibOrg> {
+	const index: Map<OrgId, LibOrg> = new Map();
 
-	for (const [libId, data] of libraryMap) {
+	for (const [libId, data] of libraries) {
 		const orgId = data?.isPartOf?.[JsonLd.ID];
 		if (!orgId) continue;
 
 		if (!index.has(orgId)) {
-			index.set(orgId, []);
+			const org = orgs.get(orgId);
+			if (org) {
+				index.set(orgId, { ...org, _members: [] });
+			}
 		}
-		index.get(orgId)!.push(libId);
+		index.get(orgId)!._members?.push(libId);
 	}
 	return index;
 }
@@ -119,18 +139,20 @@ export function getLibrary(id: string) {
 	return librariesCache.get(id) ?? null;
 }
 
-export function getOrgs() {
-	return orgIndex ?? [];
+export function getOrg(id: string) {
+	return orgCache.get(id) ?? null;
 }
 
 export function getOrgMembers(id: OrgId): LibraryId[] | [] {
-	return orgIndex.get(id) ?? [];
+	return getOrg(id)?._members || [];
 }
 
 export async function refreshLibraries(displayUtil: DisplayUtil, locale: LocaleCode) {
 	const libraries = await fetchLibraries(displayUtil, locale);
+	const orgs = await fetchLibOrgs();
+
 	librariesCache = libraries;
-	orgIndex = buildOrgIndex(libraries);
+	orgCache = buildOrgIndex(libraries, orgs);
 }
 
 export async function startRefreshLibraries(displayUtil: DisplayUtil, locale: LocaleCode) {

--- a/lxl-web/src/lib/utils/getRefinedOrgs.server.ts
+++ b/lxl-web/src/lib/utils/getRefinedOrgs.server.ts
@@ -1,7 +1,7 @@
-import type { LibraryId, OrgId } from '$lib/types/holdings';
+import type { LibOrg, OrgId } from '$lib/types/holdings';
 import type { DisplayMapping } from '$lib/types/search';
 import type { MyLibrariesType } from '$lib/types/userSettings';
-import { getOrgMembers } from './getLibraries.server';
+import { getOrg } from './getLibraries.server';
 import { getLibraryIdsFromMapping } from './getLibraryIdsFromMapping';
 import { isLibraryOrg } from './holdings';
 
@@ -11,7 +11,7 @@ import { isLibraryOrg } from './holdings';
 export function getRefinedOrgs(
 	libraries?: MyLibrariesType,
 	mapping: (DisplayMapping[] | undefined)[] = []
-): Record<OrgId, LibraryId[]> {
+): Record<OrgId, LibOrg> {
 	const mappingIds = getLibraryIdsFromMapping(mapping) ?? {};
 
 	const mappingOrgs = Object.keys(mappingIds).filter(isLibraryOrg);
@@ -19,9 +19,12 @@ export function getRefinedOrgs(
 
 	const orgIds = new Set([...mappingOrgs, ...myLibsOrgs]);
 
-	const result: Record<OrgId, LibraryId[]> = {};
+	const result: Record<OrgId, LibOrg> = {};
 	for (const orgId of orgIds) {
-		result[orgId] = getOrgMembers(orgId);
+		const org = getOrg(orgId);
+		if (org) {
+			result[orgId] = org;
+		}
 	}
 
 	return result;

--- a/lxl-web/src/lib/utils/holdings.test.ts
+++ b/lxl-web/src/lib/utils/holdings.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getBibIdsByInstanceId, getHoldersByType, getHoldingsByType } from './holdings.server';
-import { getLibsFromHoldings } from './holdings';
+import { getHeldBy } from './holdings';
 import mainEntity from '$lib/assets/json/test-data/main-entity.json';
 import record from '$lib/assets/json/test-data/record.json';
 import { UserSettings } from './userSettings.svelte';
@@ -29,20 +29,20 @@ describe('getBibIdsByInstanceId', () => {
 	});
 });
 
-describe('getLibsFromHoldings', () => {
+describe('getHeldBy', () => {
 	it('Returns favourite library present in the holdings list', () => {
 		const userSettings = new UserSettings({});
 		userSettings.addLibrary('https://libris.kb.se/library/S');
 		userSettings.addLibrary('https://libris.kb.se/library/foo');
 		const byType = getHoldersByType(getHoldingsByType(workCenteredMainEntity));
 
-		expect(getLibsFromHoldings(userSettings.myLibraries, byType)).toStrictEqual([
+		expect(getHeldBy(userSettings.myLibraries, byType)).toStrictEqual([
 			'https://libris.kb.se/library/S'
 		]);
 
 		userSettings.addLibrary('https://libris.kb.se/library/H');
 
-		expect(getLibsFromHoldings(userSettings.myLibraries, byType)).toStrictEqual([
+		expect(getHeldBy(userSettings.myLibraries, byType)).toStrictEqual([
 			'https://libris.kb.se/library/S',
 			'https://libris.kb.se/library/H'
 		]);

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -3,6 +3,7 @@ import type {
 	BibIdObj,
 	HoldersByType,
 	HoldingLinks,
+	LibOrg,
 	LibraryFull,
 	LibraryId,
 	LibraryWithLinks,
@@ -145,13 +146,13 @@ export function isLibraryOrg(id: LibraryId): boolean {
 }
 
 /**
- * Get Library id:s that are holders of a resource -
+ * From a selection of libs, get id:s that are holders of a resource -
  * orgs will be included if passed (with its members) as argument
  */
-export function getLibsFromHoldings(
+export function getHeldBy(
 	myLibraries: MyLibrariesType | undefined,
 	holdings: string[] | HoldersByType | HoldersByType[string],
-	orgs?: Record<string, string[]>
+	orgs?: Record<OrgId, LibOrg>
 ): (LibraryId | OrgId)[] | undefined {
 	if (!myLibraries) return undefined;
 
@@ -162,19 +163,16 @@ export function getLibsFromHoldings(
 	const result = new Set<LibraryId | OrgId>();
 
 	for (const libId of Object.keys(myLibraries)) {
-		if (isLibraryOrg(libId)) {
-			if (orgs) {
-				const orgMembers = orgs[libId];
-
-				if (orgMembers && Array.isArray(orgMembers)) {
-					for (const memberId of orgMembers) {
-						// add the org to result - not the member sigel
-						if (holdingSet.has(memberId)) {
-							result.add(libId);
-						}
+		if (isLibraryOrg(libId) && orgs) {
+			const orgMembers = orgs[libId]._members;
+			if (orgMembers && Array.isArray(orgMembers)) {
+				for (const memberId of orgMembers) {
+					// add the org to result - not the member sigel
+					if (holdingSet.has(memberId)) {
+						result.add(libId);
 					}
-					continue;
 				}
+				continue;
 			}
 		}
 

--- a/lxl-web/src/lib/utils/search.server.ts
+++ b/lxl-web/src/lib/utils/search.server.ts
@@ -43,7 +43,8 @@ import { isLibraryOrg } from '$lib/utils/holdings';
 import { getRefinedOrgs } from '$lib/utils/getRefinedOrgs.server';
 import { copyMediaLinksToWork } from '$lib/utils/copyMediaLinksToWork.server';
 import { getHoldersByType, getHoldersCount, getHoldingsByType } from '$lib/utils/holdings.server';
-import { getLibsFromHoldings } from '$lib/utils/holdings';
+import { getHeldBy } from '$lib/utils/holdings';
+import { getLibrary, getOrg } from '$lib/utils/getLibraries.server';
 import getTypeLike, { getTypeForIcon, toTypes, type TypeLike } from '$lib/utils/getTypeLike.server';
 import capitalize from '$lib/utils/capitalize';
 import { ACCESS_FILTERS, MY_LIBRARIES_FILTER_ALIAS } from '$lib/constants/facets';
@@ -409,7 +410,8 @@ function asItemDebugInfo(i: ApiItemDebugInfo, maxScores: Record<string, number>)
 function getHeldByLibraries(item: FramedData, libraries: MyLibrariesType) {
 	const orgs = getRefinedOrgs(libraries);
 	const holdersByType = getHoldersByType(getHoldingsByType(item));
-	return getLibsFromHoldings(libraries, holdersByType, orgs);
+	const h = getHeldBy(libraries, holdersByType, orgs);
+	return h?.map((i) => (isLibraryOrg(i) ? getOrg(i)?.name : getLibrary(i)?.name));
 }
 
 function isFreeTextQuery(property: unknown): boolean {

--- a/lxl-web/tests/holdings.spec.ts
+++ b/lxl-web/tests/holdings.spec.ts
@@ -29,7 +29,7 @@ test('Holdings panel hightlights refined libraries', async ({ page }) => {
 
 	// no favourite libraries section
 	const favLibrariesSection = specialSections.getByText('Favoritbibliotek');
-	await expect(favLibrariesSection).not.toBeVisible();
+	await expect(favLibrariesSection).not.toBeAttached();
 
 	// org grouping label
 	const holdingsOrgLabel = specialSections
@@ -53,7 +53,7 @@ test('Holdings panel highlights favourite libraries', async ({ page }) => {
 
 	// no refined section
 	const refinedSection = specialSections.getByText('Avgränsade bibliotek');
-	await expect(refinedSection).not.toBeVisible();
+	await expect(refinedSection).not.toBeAttached();
 
 	// org grouping label
 	const holdingsOrgLabel = specialSections

--- a/lxl-web/tests/holdings.spec.ts
+++ b/lxl-web/tests/holdings.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test';
+
+// using /fxqqg6xr2062ndl since this test post _should_ be stable in terms of holdings
+
+test('Holdings panel displays a card', async ({ page }) => {
+	await page.goto('/fxqqg6xr2062ndl?holdings=PhysicalResource');
+	await expect(page.locator('dialog [data-testid="search-card"]')).toBeVisible();
+});
+
+test('Holdings panel has a search', async ({ page }) => {
+	await page.goto('/fxqqg6xr2062ndl?holdings=PhysicalResource');
+	await expect(page.locator('dialog input[type="search"]')).toBeVisible();
+});
+
+test('Holdings panel has a toggle near me', async ({ page }) => {
+	await page.goto('/fxqqg6xr2062ndl?holdings=PhysicalResource');
+	await expect(page.locator('dialog button[role="switch"]')).toBeVisible();
+});
+
+test('Holdings panel hightlights refined libraries', async ({ page }) => {
+	await page.goto(
+		'/fxqqg6xr2062ndl?_q=library%3A"libris%3Alibrary%2Forg%2FKB"&holdings=PhysicalResource'
+	);
+	const specialSections = page.locator('dialog .special-section');
+
+	// refined section
+	const refinedSection = specialSections.getByText('Avgränsade bibliotek');
+	await expect(refinedSection).toBeVisible();
+
+	// no favourite libraries section
+	const favLibrariesSection = specialSections.getByText('Favoritbibliotek');
+	await expect(favLibrariesSection).not.toBeVisible();
+
+	// org grouping label
+	const holdingsOrgLabel = specialSections
+		.getByTestId('holdings-org-label')
+		.getByText('Kungliga biblioteket');
+	await expect(holdingsOrgLabel).toBeVisible();
+
+	// 1 holding library
+	const members = specialSections.filter({ hasText: 'Avgränsade bibliotek' }).locator('.holder');
+	await expect(members).toHaveCount(1);
+});
+
+test('Holdings panel highlights favourite libraries', async ({ page }) => {
+	await page.goto('/?favouriteLibraries=org/KB');
+	await page.goto('/fxqqg6xr2062ndl?holdings=PhysicalResource');
+	const specialSections = page.locator('dialog .special-section');
+
+	// favourite libraries section
+	const favLibrariesSection = specialSections.getByText('Favoritbibliotek');
+	await expect(favLibrariesSection).toBeVisible();
+
+	// no refined section
+	const refinedSection = specialSections.getByText('Avgränsade bibliotek');
+	await expect(refinedSection).not.toBeVisible();
+
+	// org grouping label
+	const holdingsOrgLabel = specialSections
+		.getByTestId('holdings-org-label')
+		.getByText('Kungliga biblioteket');
+	await expect(holdingsOrgLabel).toBeVisible();
+
+	// 1 holding library
+	const members = specialSections.filter({ hasText: 'Favoritbibliotek' }).locator('.holder');
+	await expect(members).toHaveCount(1);
+});
+
+test('Holdings panel can highlight both favourite and refined libraries', async ({ page }) => {
+	await page.goto('/?favouriteLibraries=org/KB');
+	await page.goto(
+		'/fxqqg6xr2062ndl?_q=library%3A"libris%3Alibrary%2Forg%2FKB"&holdings=PhysicalResource'
+	);
+	const specialSections = page.locator('dialog .special-section');
+
+	//refined section
+	const refinedSection = specialSections.getByText('Avgränsade bibliotek');
+	await expect(refinedSection).toBeVisible();
+
+	// favourite libraries section
+	const favLibrariesSection = specialSections.getByText('Favoritbibliotek');
+	await expect(favLibrariesSection).toBeVisible();
+});

--- a/lxl-web/tests/holdings.spec.ts
+++ b/lxl-web/tests/holdings.spec.ts
@@ -18,9 +18,7 @@ test('Holdings panel has a toggle near me', async ({ page }) => {
 });
 
 test('Holdings panel hightlights refined libraries', async ({ page }) => {
-	await page.goto(
-		'/fxqqg6xr2062ndl?_q=library%3A"libris%3Alibrary%2Forg%2FKB"&holdings=PhysicalResource'
-	);
+	await page.goto('/fxqqg6xr2062ndl?_q=library%3A"sigel%3Aorg%2FKB"&holdings=PhysicalResource');
 	const specialSections = page.locator('dialog .special-section');
 
 	// refined section
@@ -68,9 +66,7 @@ test('Holdings panel highlights favourite libraries', async ({ page }) => {
 
 test('Holdings panel can highlight both favourite and refined libraries', async ({ page }) => {
 	await page.goto('/?favouriteLibraries=org/KB');
-	await page.goto(
-		'/fxqqg6xr2062ndl?_q=library%3A"libris%3Alibrary%2Forg%2FKB"&holdings=PhysicalResource'
-	);
+	await page.goto('/fxqqg6xr2062ndl?_q=library%3A"sigel%3Aorg%2FKB"&holdings=PhysicalResource');
 	const specialSections = page.locator('dialog .special-section');
 
 	//refined section


### PR DESCRIPTION
## Description
### Solves

Removing labels from myLibraries cookie resulted in missing labels in panel and on fav libraries icon on hover.
This became increasingly complicated as we don't store the names for bibdb:Orgs anywhere else.

The solution is to fetch and cache all the orgs together with the libs. The scheduled fetch now does both
`fetchLibraries()` and `fetchLibOrgs()`.

You can then get it by `getOrg(id)`
`RefinedOrgs` does this, so we get a subset of the orgs based on current selection, with needed data.

Upside: we now display (almost) fresh data.

<img width="502" height="159" alt="Skärmavbild 2026-06-11 kl  13 52 56" src="https://github.com/user-attachments/assets/62a11867-b9d1-4813-b1da-f46c2552927f" />
 
<img width="478" height="403" alt="Skärmavbild 2026-06-11 kl  13 54 05" src="https://github.com/user-attachments/assets/1f90f04c-8027-4f91-b196-45fd1d6ea455" />.

Wrote tests for the panel so this won't happen again, using a test post where (hopefully) the holdings are stable.

### Summary of changes

* fetch and cache bibdb:org in `fetchLibOrgs()`, add `getOrg` function
* Add `LibOrg` type
* Refactor `refinedOrgs`
* Needed subsequent UI changes
* rename `getLibsFromHoldings` -> `getHeldBy`
* write tests