### PR TITLE
fix(lxlweb): Show instance card for a single linked instance

### DIFF
--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -311,7 +311,7 @@
 								{page.data.t('resource.moreDetails')}
 							</a>
 						{/if}
-						{#if instances?.length === 1 && fnurgel}
+						{#if !isWork && instances?.length === 1 && fnurgel}
 							<a
 								class="btn btn-primary my-2 h-8 w-fit rounded-full px-4 text-sm"
 								href={getCiteLink(page.url, fnurgel)}
@@ -342,7 +342,7 @@
 					<ExpandableArea content={summary} collapsedHeightPx={instances?.length > 1 ? 200 : 400} />
 				</section>
 			{/if}
-			{#if instances?.length > 1}
+			{#if isWork && instances?.length}
 				<section class="print:break-before-page print:break-after-page">
 					<h2 id="{uidPrefix}editions" class="mb-4 text-xl font-medium">
 						{page.data.t('resource.editions')}


### PR DESCRIPTION
## Description
### Solves

Works with a single linked instance provides no way of navigating to that instance, while the information on work itself is not always sufficient. [Example](https://libris.kb.se/7s1nh5xm50c5w929)

In the long term, information should maybe be combined in the manner of local work + instance.
But for now tweaking the condition for when displaying the instance list.

Also make sure cite button does not appear for Work.

<img width="995" height="558" alt="Skärmavbild 2026-06-12 kl  13 30 55" src="https://github.com/user-attachments/assets/0bf45c60-9f3a-450b-8722-c449c99d21fd" />

[Example](http://localhost:5173/7s1nh5xm50c5w929?_q=seriesMembership%3A%28Doktorns+d%C3%B6ttrar%29)
[More examples in series](http://localhost:5173/find?_q=seriesMembership:%28Doktorns+d%C3%B6ttrar%29)

### Summary of changes

* Tweak instances list condition
* Tweak cite button condition