### PR TITLE
fix(lxlweb): Fix adjacent search results using non-fnurgels

### DIFF
--- a/lxl-web/src/lib/remotes/searchResult.remote.ts
+++ b/lxl-web/src/lib/remotes/searchResult.remote.ts
@@ -56,7 +56,7 @@ export const getSearchResults = query(SearchResultsSchema, async (params) => {
 });
 
 export const getAdjecentSearchResult = query(v.string(), async (viewId) => {
-	const { fetch, url } = getRequestEvent();
+	const { fetch, url, locals, params } = getRequestEvent();
 	const searchParams = new URL(url.origin + viewId).searchParams;
 	searchParams.set('_stats', 'falseThisRequest');
 	const res = await fetch(`${env.API_URL}/find.jsonld?${searchParams.toString()}`);
@@ -71,5 +71,12 @@ export const getAdjecentSearchResult = query(v.string(), async (viewId) => {
 	}
 
 	const data = (await res.json()) as PartialCollectionView;
-	return asAdjecentSearchResult(data);
+	const result = await asResult(
+		data,
+		locals.display,
+		locals.vocab,
+		getSupportedLocale(params.lang),
+		''
+	);
+	return asAdjecentSearchResult(result);
 });

--- a/lxl-web/src/lib/utils/adjecentSearchResult.ts
+++ b/lxl-web/src/lib/utils/adjecentSearchResult.ts
@@ -1,10 +1,9 @@
-import type { SearchResult, PartialCollectionView } from '$lib/types/search';
+import { JsonLd } from '$lib/types/xl';
+import type { SearchResult } from '$lib/types/search';
 import type { AdjecentSearchResult } from '$lib/types/search';
 import { relativizeUrl, stripAnchor, trimSlashes } from '$lib/utils/http';
 
-export function asAdjecentSearchResult(
-	data: SearchResult | PartialCollectionView
-): AdjecentSearchResult {
+export function asAdjecentSearchResult(data: SearchResult): AdjecentSearchResult {
 	const {
 		'@id': id,
 		itemOffset,
@@ -17,7 +16,7 @@ export function asAdjecentSearchResult(
 		items
 	} = data;
 	return {
-		'@id': id,
+		[JsonLd.ID]: id,
 		itemOffset,
 		itemsPerPage,
 		totalItems,
@@ -25,8 +24,8 @@ export function asAdjecentSearchResult(
 		last,
 		next,
 		previous,
-		items: items.map(({ '@id': itemId }) => ({
-			'@id': itemId as string
+		items: items.map(({ [JsonLd.ID]: itemId }) => ({
+			[JsonLd.ID]: itemId as string
 		}))
 	};
 }


### PR DESCRIPTION
## Description

### Tickets involved
[LWS-427](https://kbse.atlassian.net/browse/LWS-427)

### Solves

Adjacent search results not working when fetching next/prev results for Bilbiographies, subjects etc. Non-fnurgel links resulting in 404 page.

This is because when `adjacentSearchResults` fetches new results, they are not formatted. 
Unformatted results have record id:s in `meta.@id`
`asResult` puts them in `@id`. Hence the confusion. 

Format before using. We should however manage both variants . See https://github.com/libris/lxlviewer/pull/1637

### Summary of changes

* use `asResult` in `getAdjecentSearchResult`
