### PR TITLE
fix(lxl-web): display all contributors in hasPart

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -332,19 +332,16 @@
 								"category"
 							]
 						},
-						"translationOf",
 						"legalDate",
 						"version",
 						"musicMedium",
 						"musicKey",
 						"marc:arrangedStatementForMusic",
 						"originDate",
-						"language",
 						{
-							"alternateProperties": [
-								{ "subPropertyOf": "contribution", "range": "PrimaryContribution" }
-							]
-						}
+							"alternateProperties": ["contribution", "language"]
+						},
+						"translationOf"
 					]
 				},
 				"Instance": {
@@ -1431,7 +1428,11 @@
 			"fresnel:propertyFormatDomain": ["contribution"],
 			"fresnel:propertyStyle": ["contribution", "nolabel"],
 			"fresnel:valueFormat": {
-				"fresnel:contentBefore": "",
+				"fresnel:contentBefore": ", ",
+				"fresnel:contentFirst": ""
+			},
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": ". — ",
 				"fresnel:contentFirst": ""
 			}
 		},
@@ -1886,9 +1887,9 @@
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Work"],
 			"fresnel:propertyFormatDomain": ["translationOf"],
-			"fresnel:propertyStyle": ["translationOf"],
+			"fresnel:propertyStyle": ["translationOf", "label", "force-sublevel-label"],
 			"fresnel:propertyFormat": {
-				"fresnel:contentBefore": " = ",
+				"fresnel:contentBefore": ". —  ",
 				"fresnel:contentFirst": ""
 			}
 		},

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -144,7 +144,7 @@
 
 	function shouldShowLabels() {
 		return (
-			isTopLevel() &&
+			(isTopLevel() || hasStyle(data, 'force-sublevel-label')) &&
 			(showLabels === ShowLabelsOptions.Always ||
 				(showLabels === ShowLabelsOptions.DefaultOn && !hasStyle(data, 'nolabel')) ||
 				(showLabels === ShowLabelsOptions.DefaultOff && hasStyle(data, 'label')))

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -810,8 +810,7 @@
 			}
              */
 
-			& :global(.person-extra),
-			& :global(.language) {
+			& :global(.person-extra) {
 				display: none;
 			}
 		}
@@ -819,6 +818,8 @@
 		& :global(div[data-property='hasPart']:has(> :nth-child(3))),
 		& :global(div[data-property='relationship']:has(> :nth-child(3))),
 		& :global(div[data-property='hasVariant']:has(> span[data-type='Work'])) {
+			padding-left: 1em;
+
 			& :global(> span)::before,
 			& :global(> a)::before {
 				content: ' • ';

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -666,6 +666,11 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 		& :global(div[data-property='identifiedBy']) {
 			color: var(--color-subtle);
 		}
+
+		& :global(.contribution > ._contentBefore),
+		:global(.contribution > ._contentAfter) {
+			display: none;
+		}
 	}
 
 	/* card in dialog */


### PR DESCRIPTION
* Show all contributors in Work hasPart. Not only primary contribution.
    * Put translationOf last with an inline label. (Instead of "=" which is wrong)
    * Do more of an ISBD style with period + em-dash separating props for one part/work.
* Fix empty hasPart displayed when part only contained language
* See follow-up PR which fixes rendering of bullet lists (by actually using list element)

### Tickets involved
[LWS-437](https://kbse.atlassian.net/browse/LWS-437)

Examples
http://localhost:5173/find?_q=hasPart.translationOf%3A()

<img width="1889" height="480" alt="Skärmbild från 2026-06-15 13-16-17" src="https://github.com/user-attachments/assets/b194be87-df45-419d-a836-3123d198ef9f" />

<img width="1890" height="710" alt="Skärmbild från 2026-06-15 13-18-04" src="https://github.com/user-attachments/assets/a8112cde-14d9-4120-9815-49a549d7dec8" />

Fix empty hasPart disaplyed when part only contained language:
<img width="1888" height="307" alt="Skärmbild från 2026-06-15 13-17-14" src="https://github.com/user-attachments/assets/4e521884-cde3-48a0-b96f-b8af4430a1a3" />
