### PR TITLE
feat(lxl-web/decorated-data): Use ul for bullet lists

### DIFF
--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -299,7 +299,9 @@
 						"startYear",
 						"endYear",
 						"date",
-						"marc:publicationStatus"
+						"marc:publicationStatus",
+						"marc:sequenceStatus",
+						"appliesTo"
 					]
 				},
 				"ProvisionActivity": {
@@ -1229,6 +1231,16 @@
 			],
 			"fresnel:propertyFormat": {
 				"fresnel:contentBefore": ", ",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"ProvisionActivity-space-format": {
+			"@id": "ProvisionActivity-space-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["ProvisionActivity"],
+			"fresnel:propertyFormatDomain": ["marc:sequenceStatus", "appliesTo"],
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": " ",
 				"fresnel:contentFirst": ""
 			}
 		},

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -1214,7 +1214,7 @@
 				"manufacture",
 				"marc:primaryProvisionActivity"
 			],
-			"fresnel:propertyStyle": ["provisionActivity", "label"]
+			"fresnel:propertyStyle": ["provisionActivity", "label", "ul-when-multiple"]
 		},
 		"ProvisionActivity-comma-format": {
 			"@id": "ProvisionActivity-comma-format",
@@ -1298,6 +1298,12 @@
 				"fresnel:contentBefore": "; ",
 				"fresnel:contentFirst": ""
 			}
+		},
+		"hasTitle-format": {
+			"@id": "hasTitle-format",
+			"@type": "fresnel:Format",
+			"fresnel:propertyFormatDomain": ["hasTitle"],
+			"fresnel:propertyStyle": ["ul-when-multiple"]
 		},
 		"subtitle-format": {
 			"@id": "subtitle-format",
@@ -1458,11 +1464,16 @@
 				"fresnel:contentFirst": ""
 			}
 		},
+		"bibliography-format": {
+			"@id": "sorted-format",
+			"@type": "bibliography-format",
+			"fresnel:propertyFormatDomain": ["bibliography"],
+			"fresnel:propertyStyle": ["sort()", "ul"]
+		},
 		"sorted-format": {
 			"@id": "sorted-format",
 			"@type": "fresnel:Format",
 			"fresnel:propertyFormatDomain": [
-				"bibliography",
 				"classification",
 				"closeMatch",
 				"hasDataset",
@@ -1539,18 +1550,25 @@
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Work"],
 			"fresnel:propertyFormatDomain": ["hasPart"],
-			"fresnel:propertyStyle": ["label"],
-			"fresnel:valueFormat": {
-				"fresnel:contentBefore": "",
-				"fresnel:contentFirst": ""
-			}
+			"fresnel:propertyStyle": ["label", "ul"]
 		},
 		"Work-relationship-format": {
 			"@id": "Work-relationship-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Work"],
 			"fresnel:propertyFormatDomain": ["relationship"],
-			"fresnel:propertyStyle": ["label"],
+			"fresnel:propertyStyle": ["label", "ul"],
+			"fresnel:valueFormat": {
+				"fresnel:contentBefore": "",
+				"fresnel:contentFirst": ""
+			}
+		},
+		"Work-hasVariant-format": {
+			"@id": "Agent-hasVariant-format",
+			"@type": "fresnel:Format",
+			"fresnel:classFormatDomain": ["Work"],
+			"fresnel:propertyFormatDomain": ["hasVariant"],
+			"fresnel:propertyStyle": ["label", "ul"],
 			"fresnel:valueFormat": {
 				"fresnel:contentBefore": "",
 				"fresnel:contentFirst": ""
@@ -1601,7 +1619,11 @@
 			"@id": "hasNote-format",
 			"@type": "fresnel:Format",
 			"fresnel:propertyFormatDomain": ["hasNote"],
-			"fresnel:propertyStyle": ["hasNote"]
+			"fresnel:propertyStyle": ["hasNote", "ul"],
+			"fresnel:valueFormat": {
+				"fresnel:contentBefore": "",
+				"fresnel:contentFirst": ""
+			}
 		},
 		"Classification-format": {
 			"@id": "Classification-format",
@@ -1731,7 +1753,7 @@
 			"fresnel:resourceStyle": ["findToTop()"]
 		},
 		"KeyTitle-format": {
-			"@id": "Role-format",
+			"@id": "KeyTitle-format",
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["KeyTitle"],
 			"fresnel:resourceFormat": {
@@ -2031,7 +2053,7 @@
 				"supplement",
 				"hasReproduction"
 			],
-			"fresnel:propertyStyle": ["test_list"],
+			"fresnel:propertyStyle": ["ul-when-multiple"],
 			"fresnel:valueFormat": {
 				"fresnel:contentBefore": ""
 			}

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -1552,10 +1552,22 @@
 			"fresnel:resourceStyle": ["findToTop()"]
 		},
 		"needs-label-format": {
-			"@id": "Subject-format",
+			"@id": "needs-label-format",
 			"@type": "fresnel:Format",
 			"fresnel:propertyFormatDomain": ["category", "subject", "seriesMembership", "isPartOf"],
 			"fresnel:propertyStyle": ["label"]
+		},
+		"seriesMembership-format": {
+			"@id": "seriesMembership-format",
+			"@type": "fresnel:Format",
+			"fresnel:propertyFormatDomain": ["seriesMembership"],
+			"fresnel:propertyStyle": ["label", "ul-when-multiple"]
+		},
+		"isPartOf-format": {
+			"@id": "isPartOf-format",
+			"@type": "fresnel:Format",
+			"fresnel:propertyFormatDomain": ["isPartOf"],
+			"fresnel:propertyStyle": ["label", "ul-when-multiple"]
 		},
 		"Work-hasPart-format": {
 			"@id": "Work-hasPart-format",

--- a/lxl-web/src/lib/assets/json/display-web.json
+++ b/lxl-web/src/lib/assets/json/display-web.json
@@ -332,19 +332,16 @@
 								"category"
 							]
 						},
-						"translationOf",
 						"legalDate",
 						"version",
 						"musicMedium",
 						"musicKey",
 						"marc:arrangedStatementForMusic",
 						"originDate",
-						"language",
 						{
-							"alternateProperties": [
-								{ "subPropertyOf": "contribution", "range": "PrimaryContribution" }
-							]
-						}
+							"alternateProperties": ["contribution", "language"]
+						},
+						"translationOf"
 					]
 				},
 				"Instance": {
@@ -1431,7 +1428,11 @@
 			"fresnel:propertyFormatDomain": ["contribution"],
 			"fresnel:propertyStyle": ["contribution", "nolabel"],
 			"fresnel:valueFormat": {
-				"fresnel:contentBefore": "",
+				"fresnel:contentBefore": ", ",
+				"fresnel:contentFirst": ""
+			},
+			"fresnel:propertyFormat": {
+				"fresnel:contentBefore": ". — ",
 				"fresnel:contentFirst": ""
 			}
 		},
@@ -1886,9 +1887,9 @@
 			"@type": "fresnel:Format",
 			"fresnel:classFormatDomain": ["Work"],
 			"fresnel:propertyFormatDomain": ["translationOf"],
-			"fresnel:propertyStyle": ["translationOf"],
+			"fresnel:propertyStyle": ["translationOf", "label", "force-sublevel-label"],
 			"fresnel:propertyFormat": {
-				"fresnel:contentBefore": " = ",
+				"fresnel:contentBefore": ". —  ",
 				"fresnel:contentFirst": ""
 			}
 		},

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -8,6 +8,7 @@
 	import { hasStyle, getStyle, getResourceId, getPropertyValue } from '$lib/utils/resourceData';
 	import { relativizeUrl, trimSlashes } from '$lib/utils/http';
 	import { getSupportedLocale } from '$lib/i18n/locales';
+	import Wrapper from './Wrapper.svelte';
 
 	interface Props {
 		data: ResourceData;
@@ -21,6 +22,8 @@
 		keyed?: boolean;
 		suppressProperty?: string[];
 		isInsideLinkElement?: boolean;
+		isLi?: boolean;
+		isLiChild: boolean;
 	}
 
 	let {
@@ -34,7 +37,9 @@
 		limit = undefined,
 		keyed = true,
 		suppressProperty = undefined,
-		isInsideLinkElement = false
+		isInsideLinkElement = false,
+		isLi = false,
+		isLiChild = false
 	}: Props = $props();
 
 	let key = $derived(keyed && data); // an ugly work-around to fix duplicate content on out transitions when closing modals (not entirely sure what the root cause is...) – we should try to remove the need for this when updating to Svelte 5.
@@ -85,6 +90,15 @@
 		return 'span';
 	}
 
+	function isUl(data: ResourceData, propertyData: ResourceData): boolean {
+		return (
+			!!getStyle(data)?.includes('ul') ||
+			(!!getStyle(data)?.includes('ul-when-multiple') &&
+				Array.isArray(propertyData) &&
+				propertyData.length > 1)
+		);
+	}
+
 	/* Conditionally add popover action so it's only added when needed */
 	function conditionalPopover(node: HTMLElement, data: ResourceData) {
 		if (allowPopovers && ((depth > 1 && hasStyle(data, 'link')) || hasStyle(data, 'definition'))) {
@@ -118,7 +132,9 @@
 
 	function shouldShowContentBefore() {
 		if (getPropertyValue(data, Fmt.CONTENT_BEFORE)) {
-			if (block) {
+			if (isLiChild) {
+				return false;
+			} else if (block) {
 				return !isTopLevel();
 			} else {
 				return true;
@@ -129,7 +145,9 @@
 
 	function shouldShowContentAfter() {
 		if (getPropertyValue(data, Fmt.CONTENT_AFTER)) {
-			if (block) {
+			if (isLiChild) {
+				return false;
+			} else if (block) {
 				return !isTopLevel();
 			} else {
 				return true;
@@ -156,42 +174,14 @@
   @component
 	Component used for rendering decorated data.
 -->
+
 {#key key}
 	{#if data && typeof data === 'object'}
 		{#if Array.isArray(data)}
 			{#each data as arrayItem (arrayItem)}
-				<DecoratedData
-					data={arrayItem}
-					depth={depth + 1}
-					{showLabels}
-					{block}
-					{allowLinks}
-					{allowFindLinks}
-					{allowPopovers}
-					{limit}
-					{keyed}
-					{suppressProperty}
-					{isInsideLinkElement}
-				/>
-			{/each}
-		{:else}
-			{#if shouldShowContentBefore()}
-				<span class={`${Fmt.CONTENT_BEFORE} ${getStyleClasses(data)}`}>
-					{data[Fmt.CONTENT_BEFORE]}
-				</span>
-			{/if}
-			{#if data[JsonLd.TYPE]}
-				{@const link = getLink(data)}
-				<svelte:element
-					this={getElementType(data)}
-					href={link}
-					target={link && hasStyle(data, 'ext-link') ? '_blank' : null}
-					data-type={data[JsonLd.TYPE]}
-					class={getStyleClasses(data)}
-					use:conditionalPopover={data}
-				>
+				<Wrapper condition={isLi} withElement="li">
 					<DecoratedData
-						data={data[Fmt.DISPLAY]}
+						data={arrayItem}
 						depth={depth + 1}
 						{showLabels}
 						{block}
@@ -201,103 +191,161 @@
 						{limit}
 						{keyed}
 						{suppressProperty}
-						isInsideLinkElement={isInsideLinkElement || !!link}
+						{isInsideLinkElement}
+						isLiChild={isLi}
 					/>
-				</svelte:element>
-			{:else if data[JsonLd.VALUE]}
-				<DecoratedData
-					data={data[JsonLd.VALUE]}
-					depth={depth + 1}
-					{showLabels}
-					{block}
-					{allowLinks}
-					{allowFindLinks}
-					{allowPopovers}
-					{keyed}
-					{suppressProperty}
-					{isInsideLinkElement}
-				/>
-			{:else if data[Fmt.DISPLAY]}
-				<DecoratedData
-					data={data[Fmt.DISPLAY]}
-					depth={depth + 1}
-					{showLabels}
-					{block}
-					{allowLinks}
-					{allowFindLinks}
-					{allowPopovers}
-					{keyed}
-					{suppressProperty}
-					{isInsideLinkElement}
-				/>
-			{:else}
-				{@const [propertyName, propertyData] = getProperty(data)}
-				{#if propertyName && propertyData && (suppressProperty === undefined || !suppressProperty.includes(propertyName))}
-					<!-- don't use 'show more' when exceeding limit by one -->
-					{@const limitTo = limit?.[propertyName]}
-					{@const delimited =
-						limitTo && Array.isArray(propertyData) && propertyData.length > limitTo + 1}
-					<svelte:element
-						this={getElementType(propertyData)}
-						data-property={propertyName}
-						class={getStyleClasses(data)}
-					>
-						{#if shouldShowLabels() && typeof data[Fmt.LABEL] === 'string'}
-							<svelte:element this={block ? 'div' : 'span'}>
-								<!-- Add inner span with inline-block to achieve first letter capitalization while still supporting inline whitespaces -->
-								<span class={['inline-block first-letter:capitalize', block && 'property-label']}>
-									{data[Fmt.LABEL]}
-								</span>
-								<!-- eslint-disable-next-line svelte/no-useless-mustaches -->
-								{' '}
-							</svelte:element>
-						{/if}
-						{#if Fmt.HTML in data}
-							<div class="markdown [&>p]:mb-2 [&>ul]:list-inside [&>ul]:list-disc">
-								<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-								{@html propertyData}
-							</div>
-						{:else}
-							<DecoratedData
-								data={delimited && !delimitedShown ? propertyData.slice(0, limitTo) : propertyData}
-								depth={depth + 1}
-								{showLabels}
-								{block}
-								{allowLinks}
-								{allowFindLinks}
-								{allowPopovers}
-								{keyed}
-								{suppressProperty}
-								{isInsideLinkElement}
-							/>
-						{/if}
-						{#if delimited}
-							{#if allowLinks}
-								{@const delimitText = delimitedShown
-									? page.data.t('search.showFewer')
-									: `${page.data.t('search.showMore')} (+${propertyData.length - limitTo})`}
-								<button
-									class="delimiter link-subtle"
-									type="button"
-									onclick={() => (delimitedShown = !delimitedShown)}>{delimitText}</button
-								>
-							{:else}
-								<span class="delimiter"
-									>{` +${propertyData.length - limitTo} ${page.data.t('general.more')}`}</span
-								>
-							{/if}
-						{/if}
-					</svelte:element>
+				</Wrapper>
+			{/each}
+		{:else}
+			<Wrapper condition={isLi} withElement="li">
+				{#if shouldShowContentBefore()}
+					<span class={`${Fmt.CONTENT_BEFORE} ${getStyleClasses(data)}`}>
+						{data[Fmt.CONTENT_BEFORE]}
+					</span>
 				{/if}
-			{/if}
-			{#if shouldShowContentAfter()}
-				<span class={`${Fmt.CONTENT_AFTER} ${getStyleClasses(data)}`}>
-					{data[Fmt.CONTENT_AFTER]}
-				</span>
-			{/if}
+				{#if data[JsonLd.TYPE]}
+					{@const link = getLink(data)}
+					<svelte:element
+						this={getElementType(data)}
+						href={link}
+						target={link && hasStyle(data, 'ext-link') ? '_blank' : null}
+						data-type={data[JsonLd.TYPE]}
+						class={getStyleClasses(data)}
+						use:conditionalPopover={data}
+					>
+						<DecoratedData
+							data={data[Fmt.DISPLAY]}
+							depth={depth + 1}
+							{showLabels}
+							{block}
+							{allowLinks}
+							{allowFindLinks}
+							{allowPopovers}
+							{limit}
+							{keyed}
+							{suppressProperty}
+							isInsideLinkElement={isInsideLinkElement || !!link}
+						/>
+					</svelte:element>
+				{:else if data[JsonLd.VALUE]}
+					<DecoratedData
+						data={data[JsonLd.VALUE]}
+						depth={depth + 1}
+						{showLabels}
+						{block}
+						{allowLinks}
+						{allowFindLinks}
+						{allowPopovers}
+						{keyed}
+						{suppressProperty}
+						{isInsideLinkElement}
+					/>
+				{:else if data[Fmt.DISPLAY]}
+					<DecoratedData
+						data={data[Fmt.DISPLAY]}
+						depth={depth + 1}
+						{showLabels}
+						{block}
+						{allowLinks}
+						{allowFindLinks}
+						{allowPopovers}
+						{keyed}
+						{suppressProperty}
+						{isInsideLinkElement}
+					/>
+				{:else}
+					{@const [propertyName, propertyData] = getProperty(data)}
+					{#if propertyName && propertyData && (suppressProperty === undefined || !suppressProperty.includes(propertyName))}
+						<!-- don't use 'show more' when exceeding limit by one -->
+						{@const limitTo = limit?.[propertyName]}
+						{@const delimited =
+							limitTo && Array.isArray(propertyData) && propertyData.length > limitTo + 1}
+						{@const elementType = getElementType(propertyData)}
+						{@const hasUl = isUl(data, propertyData)}
+						<svelte:element
+							this={elementType}
+							data-property={propertyName}
+							class={[getStyleClasses(data), hasUl && 'ul']}
+						>
+							{#if shouldShowLabels() && typeof data[Fmt.LABEL] === 'string'}
+								<svelte:element this={block ? 'div' : 'span'}>
+									<!-- Add inner span with inline-block to achieve first letter capitalization while still supporting inline whitespaces -->
+									<span class={['inline-block first-letter:capitalize', block && 'property-label']}>
+										{data[Fmt.LABEL]}
+									</span>
+									<!-- eslint-disable-next-line svelte/no-useless-mustaches -->
+									{' '}
+								</svelte:element>
+							{/if}
+							{#if Fmt.HTML in data}
+								<div class="markdown [&>p]:mb-2 [&>ul]:list-inside [&>ul]:list-disc">
+									<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+									{@html propertyData}
+								</div>
+							{:else if hasUl}
+								<ul data-property={propertyName}>
+									<DecoratedData
+										data={delimited && !delimitedShown
+											? propertyData.slice(0, limitTo)
+											: propertyData}
+										depth={depth + 1}
+										{showLabels}
+										{block}
+										{allowLinks}
+										{allowFindLinks}
+										{allowPopovers}
+										{keyed}
+										{suppressProperty}
+										{isInsideLinkElement}
+										isLi={true}
+									/>
+								</ul>
+							{:else}
+								<DecoratedData
+									data={delimited && !delimitedShown
+										? propertyData.slice(0, limitTo)
+										: propertyData}
+									depth={depth + 1}
+									{showLabels}
+									{block}
+									{allowLinks}
+									{allowFindLinks}
+									{allowPopovers}
+									{keyed}
+									{suppressProperty}
+									{isInsideLinkElement}
+								/>
+							{/if}
+							{#if delimited}
+								{#if allowLinks}
+									{@const delimitText = delimitedShown
+										? page.data.t('search.showFewer')
+										: `${page.data.t('search.showMore')} (+${propertyData.length - limitTo})`}
+									<button
+										class="delimiter link-subtle"
+										type="button"
+										onclick={() => (delimitedShown = !delimitedShown)}>{delimitText}</button
+									>
+								{:else}
+									<span class="delimiter"
+										>{` +${propertyData.length - limitTo} ${page.data.t('general.more')}`}</span
+									>
+								{/if}
+							{/if}
+						</svelte:element>
+					{/if}
+				{/if}
+				{#if shouldShowContentAfter()}
+					<span class={`${Fmt.CONTENT_AFTER} ${getStyleClasses(data)}`}>
+						{data[Fmt.CONTENT_AFTER]}
+					</span>
+				{/if}
+			</Wrapper>
 		{/if}
 	{:else}
-		{data}
+		<Wrapper condition={isLi} withElement="li">
+			{data}
+		</Wrapper>
 	{/if}
 {/key}
 

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -144,7 +144,7 @@
 
 	function shouldShowLabels() {
 		return (
-			isTopLevel() &&
+			(isTopLevel() || hasStyle(data, 'force-sublevel-label')) &&
 			(showLabels === ShowLabelsOptions.Always ||
 				(showLabels === ShowLabelsOptions.DefaultOn && !hasStyle(data, 'nolabel')) ||
 				(showLabels === ShowLabelsOptions.DefaultOff && hasStyle(data, 'label')))

--- a/lxl-web/src/lib/components/DecoratedData.svelte
+++ b/lxl-web/src/lib/components/DecoratedData.svelte
@@ -101,7 +101,11 @@
 
 	/* Conditionally add popover action so it's only added when needed */
 	function conditionalPopover(node: HTMLElement, data: ResourceData) {
-		if (allowPopovers && ((depth > 1 && hasStyle(data, 'link')) || hasStyle(data, 'definition'))) {
+		if (
+			allowPopovers &&
+			!isInsideLinkElement &&
+			((depth > 1 && hasStyle(data, 'link')) || hasStyle(data, 'definition'))
+		) {
 			const id = getResourceId(data);
 			if (id) {
 				return popover(node, {

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -810,8 +810,7 @@
 			}
              */
 
-			& :global(.person-extra),
-			& :global(.language) {
+			& :global(.person-extra) {
 				display: none;
 			}
 		}
@@ -819,6 +818,8 @@
 		& :global(div[data-property='hasPart']:has(> :nth-child(3))),
 		& :global(div[data-property='relationship']:has(> :nth-child(3))),
 		& :global(div[data-property='hasVariant']:has(> span[data-type='Work'])) {
+			padding-left: 1em;
+
 			& :global(> span)::before,
 			& :global(> a)::before {
 				content: ' • ';

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -678,36 +678,8 @@
 			white-space: nowrap;
 		}
 
-		& :global(.hasNote > *) {
-			display: block;
-		}
-
 		& :global(.test_list > *) {
 			display: block;
-		}
-
-		& :global(.hasNote > span)::before {
-			content: ' • ';
-			color: var(--color-subtle);
-		}
-
-		& :global(.hasNote > ._contentBefore),
-		:global(.hasNote > ._contentAfter) {
-			display: none;
-		}
-
-		& :global(div[data-property='hasTitle'] > span) {
-			display: block;
-		}
-
-		& :global(div[data-property='hasTitle'] > span)::before {
-			content: ' • ';
-			color: var(--color-subtle);
-		}
-
-		& :global(div[data-property='hasTitle'] > ._contentBefore),
-		:global(div[data-property='hasTitle'] > ._contentAfter) {
-			display: none;
 		}
 
 		/* hide double dash - */
@@ -721,43 +693,8 @@
 			white-space: nowrap;
 		}
 
-		& :global(.genre-form) {
-			@apply py-3;
-		}
-
 		& :global(.coverage) {
 			color: var(--color-subtle);
-		}
-
-		& :global(.provisionActivity:has(> span:nth-of-type(2)) .property-label) {
-			display: block;
-			/*font-size: var(--text-2xs);*/
-		}
-
-		& :global(.provisionActivity:has(> span:nth-of-type(2))) {
-			@apply py-1;
-
-			& :global(> ._contentBefore),
-			:global(> ._contentAfter) {
-				display: none;
-			}
-
-			& :global(> span) {
-				display: block;
-			}
-
-			& :global(> span)::before {
-				content: ' • ';
-				color: var(--color-subtle);
-			}
-
-			& :global(span[data-type='PrimaryPublication']) {
-			}
-
-			& :global(span[data-type='Publication']) {
-				/* color: var(--color-subtle); */
-				/* font-weight: var(--font-weight-light); */
-			}
 		}
 
 		& :global(span.Title-type) {
@@ -777,78 +714,53 @@
 			color: var(--color-subtle);
 		}
 
-		& :global(div[data-property='hasPart']),
-		& :global(div[data-property='relationship']),
-		& :global(div[data-property='hasVariant'] > span[data-type='Work']) {
+		& :global(ul[data-property]) {
+			list-style-type: disc;
+			/* list-style-type: "• "; */
+
+			& :global(li) {
+				margin-left: 1em;
+			}
+
+			& :global(li::marker) {
+				color: var(--color-subtle);
+			}
+
+			& :global(.block) {
+				display: inline;
+			}
+
+			& :global(div:has(> .property-label)) {
+				display: inline;
+			}
+
+			& :global(.property-label) {
+				color: var(--color-body);
+				font-style: italic;
+			}
+
+			& :global(.property-label):not(:empty)::after {
+				color: var(--color-body);
+				content: ': ';
+			}
+
 			& :global(.contribution) {
 				font-size: var(--text-md);
 				@apply mb-0;
 				@apply mt-0;
 			}
 
-			& :global(.contribution > span) {
-				display: inline;
-			}
-
-			/* There shouldn't exist multiple PrimaryContribution, but it does */
-			&
-				:global(
-					span[data-type='PrimaryContribution']:has(+ span[data-type='PrimaryContribution'])
-				)::after {
-				content: '; ';
-			}
-
-			/* TODO, what about translationOf in parts? e.g. w8hp61lvtrstrtn0  */
-			/*
-			& :global(span[data-property='translationOf'])::before {
-				content: '{';
-				color: var(--color-subtle);
-			}
-			& :global(span[data-property='translationOf'])::after {
-				content: '}';
-				color: var(--color-subtle);
-			}
-             */
-
 			& :global(.person-extra) {
 				display: none;
 			}
-		}
 
-		& :global(div[data-property='hasPart']:has(> :nth-child(3))),
-		& :global(div[data-property='relationship']:has(> :nth-child(3))),
-		& :global(div[data-property='hasVariant']:has(> span[data-type='Work'])) {
-			padding-left: 1em;
-
-			& :global(> span)::before,
-			& :global(> a)::before {
-				content: ' • ';
-				color: var(--color-subtle);
+			& :global(.main-title) {
+				font-weight: var(--font-weight-semibold);
 			}
 
-			& :global(> span),
-			& :global(> a) {
-				display: block;
+			& :global(.translationOf .main-title) {
+				font-weight: var(--font-weight-normal);
 			}
-
-			& :global(> span._contentBefore) {
-				display: none;
-			}
-		}
-
-		& :global(div[data-property='bibliography'] > a) {
-			display: block;
-			width: fit-content;
-		}
-
-		& :global(div[data-property='bibliography'] > a)::before {
-			content: ' • ';
-			color: var(--color-subtle);
-		}
-
-		& :global(div[data-property='bibliography'] > ._contentBefore),
-		:global(div[data-property='bibliography'] > ._contentAfter) {
-			display: none;
 		}
 	}
 
@@ -872,9 +784,9 @@
 			content: ' ; ';
 		}
 
-		& :global(div[data-property='hasPart']:has(> :nth-child(3))),
-		& :global(div[data-property='relationship']:has(> :nth-child(3))) {
+		& :global(div .ul) {
 			@apply py-1;
+			max-width: 80ch;
 		}
 
 		& :global(div[data-property='_select']) {
@@ -931,8 +843,7 @@
 			@apply mt-1;
 		}
 
-		& :global(div[data-property='hasTitle'] > span[data-type='Title']) {
-			/* color: var(--color-subtle); */
+		& :global(ul[data-property='hasTitle'] > li > span[data-type='Title']) {
 			font-weight: var(--font-weight-semibold);
 		}
 	}

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -637,6 +637,10 @@
 			@apply mt-1;
 		}
 
+		& :global([data-type='PrimaryContribution'] > [data-property='agent']) {
+			font-weight: var(--font-weight-semibold);
+		}
+
 		& :global(.contribution-role) {
 			font-size: var(--text-sm);
 			color: var(--color-subtle);
@@ -758,7 +762,8 @@
 				font-weight: var(--font-weight-semibold);
 			}
 
-			& :global(.translationOf .main-title) {
+			& :global(.translationOf .main-title),
+			& :global([data-type='PrimaryContribution'] > [data-property='agent']) {
 				font-weight: var(--font-weight-normal);
 			}
 		}

--- a/lxl-web/src/lib/components/Resource.svelte
+++ b/lxl-web/src/lib/components/Resource.svelte
@@ -815,6 +815,11 @@
 				margin-bottom: 0;
 			}
 		}
+
+		& :global([data-property='publication'] [data-property='marc:sequenceStatus']),
+		& :global([data-property='publication'] [data-property='appliesTo']) {
+			display: none;
+		}
 	}
 
 	.decorated-spacious {
@@ -850,6 +855,17 @@
 
 		& :global(ul[data-property='hasTitle'] > li > span[data-type='Title']) {
 			font-weight: var(--font-weight-semibold);
+		}
+
+		& :global(li > span[data-type='PrimaryPublication']) {
+			font-weight: var(--font-weight-semibold);
+		}
+
+		& :global([data-property='publication'] [data-property='marc:sequenceStatus']),
+		& :global([data-property='publication'] [data-property='appliesTo']) {
+			font-weight: var(--font-weight-normal);
+			color: var(--color-subtle);
+			font-size: var(--text-2xs);
 		}
 	}
 

--- a/lxl-web/src/lib/components/Wrapper.svelte
+++ b/lxl-web/src/lib/components/Wrapper.svelte
@@ -1,0 +1,11 @@
+<script>
+	let { condition, withElement, children } = $props();
+</script>
+
+{#if condition}
+	<svelte:element this={withElement}>
+		{@render children()}
+	</svelte:element>
+{:else}
+	{@render children()}
+{/if}

--- a/lxl-web/src/lib/components/find/SearchCard.svelte
+++ b/lxl-web/src/lib/components/find/SearchCard.svelte
@@ -666,6 +666,11 @@ see https://github.com/libris/lxlviewer/pull/1336/files/c2d45b319782da2d39d0ca0c
 		& :global(div[data-property='identifiedBy']) {
 			color: var(--color-subtle);
 		}
+
+		& :global(.contribution > ._contentBefore),
+		:global(.contribution > ._contentAfter) {
+			display: none;
+		}
 	}
 
 	/* card in dialog */


### PR DESCRIPTION
Follow-up to https://github.com/libris/lxlviewer/pull/1639 (stacked)

* use actual ul for vertical listing of values.
    * Instead of faked lists (block with ::before bullet points). Fixes alignment when line breaks inside list values. And of course more semantically correct.
    * activated by setting propertyStyle `ul` or `ul-when-multiple` (should we name them in a way that indicates that they are "special"? Didn't use `ul()` since "stylers" are all implemented in one place)
    * unfortunately big diff in `DecoratedData`. It's mostly because of the conditional `<li>` that has to be inserted. I think the recursion structure of the `DecoratedData` component can be refactored later. It became a bit more ugly now with both `isLi` (render as `<li>`) and `isLiChild` (no contentBefore/contentAfter in child of `<li>`).
* remove a lot of special casing CSS in Resource.svelte
* improve display of hasPart/relationship Work a little - semibold titles.
* bonus: semibold PrimaryContribution agent https://github.com/libris/lxlviewer/commit/9ef15b9bd95305ebbc267424b8ebfb4d74d16a37
* bonus: semibold PrimaryPublication in details (when multiple). Show marc:sequenceStatus, appliesTo, e.g."Sammanfattad utgivningstid", "Nuvarande / Senaste utgivare" https://github.com/libris/lxlviewer/commit/ed8713af7a9fe552acc74eeb447ef97fa8866e79

<img width="1217" height="604" alt="Skärmbild från 2026-06-15 14-17-18" src="https://github.com/user-attachments/assets/16adade8-3f11-4055-9713-b30fefd0ac9d" />
<img width="1891" height="313" alt="Skärmbild från 2026-06-15 13-36-55" src="https://github.com/user-attachments/assets/6dad4517-e505-4399-b69f-eae33651282a" />

<img width="1630" height="550" alt="Skärmbild från 2026-06-15 14-19-07" src="https://github.com/user-attachments/assets/2ab30347-d080-4f5f-9896-46fa2e2e3f9e" />
