### PR TITLE
feat(lxl-web/filters): Render descriptions and description remarks on…

### DIFF
--- a/lxl-web/src/lib/types/search.ts
+++ b/lxl-web/src/lib/types/search.ts
@@ -291,7 +291,8 @@ export interface QualifierSuggestion2 {
 }
 
 export interface QualifierDefinition extends QualifierSuggestion2 {
-	comment?: string;
+	filterDescription?: string;
+	descriptionRemark?: string[];
 	propertyChainAxiom?: PropertyChain[];
 }
 

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/filters/+page.server.ts
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/filters/+page.server.ts
@@ -51,8 +51,9 @@ function mapSearchFilterDefinition(
 			label: toString(display.lensAndFormat(def, LensType.Chip, locale)),
 			queryCodes: (asArray(def['librisQueryCode']) || []) as string[],
 			altLabels: otherLangLabels,
-			...(def['commentByLang']?.[locale] && { comment: def['commentByLang'][locale] }),
-			...(propertyChain && { propertyChainAxiom: propertyChain })
+			filterDescription: def['ls:filterDescription'] as string,
+			...(propertyChain && { propertyChainAxiom: propertyChain }),
+			descriptionRemark: (asArray(def['ls:descriptionRemark']) || []) as string[]
 		};
 	} catch (error) {
 		console.warn('Error mapping filter definition', error);

--- a/lxl-web/src/routes/(app)/[[lang=lang]]/help/filters/+page.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/help/filters/+page.svelte
@@ -71,7 +71,18 @@
 						</ul>
 					</td>
 					<td class={['grid grid-cols-1 gap-3 sm:grid-cols-2']}>
-						<span>{f.comment}</span>
+						<div>
+							<span class="whitespace-pre-line">{f.filterDescription}</span>
+							{#if f.descriptionRemark}
+								<div class="mt-4">
+									{#each f.descriptionRemark as remark, i (i)}
+										<div>
+											<span>ⓘ {remark}</span>
+										</div>
+									{/each}
+								</div>
+							{/if}
+						</div>
 						{#if f.propertyChainAxiom}
 							<div>
 								<span class="text-2s text-subtle">{page.data.t('help.searchIn')}</span>


### PR DESCRIPTION
Depends on https://github.com/libris/definitions/pull/609

### Summary of changes

Render descriptions and description remarks on search filter help page.

<img width="750" height="1003" alt="Screenshot from 2026-06-15 16-23-25" src="https://github.com/user-attachments/assets/83a80a1e-9b69-41c2-aabf-8798e9d08748" />

