### PR TITLE
fix(lxlweb): temporarily fix frontpage intro height

### DIFF
--- a/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
+++ b/lxl-web/src/routes/(app)/[[lang=lang]]/AppBar.svelte
@@ -524,8 +524,8 @@
 		top: var(--banner-height, 0);
 		background: var(--color-app-bar);
 		box-shadow: 0 1px 0 0 var(--color-primary-200);
-		height: round(calc(61.08vh + var(--banner-height, 0)), 1px);
-		height: round(calc(61.08svh + var(--banner-height, 0)), 1px);
+		height: round(calc(61.08vh + 56px), 1px);
+		height: round(calc(61.08svh + 56px), 1px);
 	}
 
 	.app-bar-shadow-trigger {


### PR DESCRIPTION
## Description
### Solves

Ever since the beta banner disappeared, the intro segment looks awful on mobile.
To temporarily fix until next iteration, just hardcode the banner height value, for which it was is obviously built.

<img width="542" height="238" alt="Skärmavbild 2026-06-16 kl  14 29 49" src="https://github.com/user-attachments/assets/9d76ccfb-94cc-4c30-97e8-01884e7172b5" />
<img width="542" height="238" alt="Skärmavbild 2026-06-16 kl  14 30 06" src="https://github.com/user-attachments/assets/8a1784fd-c74f-42ac-a73d-2bc8791041fb" />
