### PR TITLE
fix(lxlquery): handle unclosed quotes + pills

### DIFF
--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -7,7 +7,7 @@ andcomb { term ( AndOperator term | term )* }
 term { String | Group | UTerm | Qualifier }
 Group { "(" orcomb? ")" }
 UTerm { UOperator term }
-String { strliteral | str }
+String { strliteral | StrliteralIncomplete | str }
 Qualifier { 
   ( QualifierKey { String } QualifierOperator { bOperator } QualifierValue { String } ) | 
   ( QualifierKey { String } QualifierOperator { bOperatorEq } QualifierValue { qualifierTerm } ) |
@@ -31,12 +31,13 @@ QualifierInnerGroup { "(" qualifierOrcomb? ")" }
   UOperator { "NOT" | "INTE" }
   bOperator {"<" | ">" | "<=" | ">=" }
   bOperatorEq { ":" | "=" | "~" }
-  strliteral { '"' (!["\\] | "\\" _)* '"' }
+  strliteral { '"' (!["\\\n()] | "\\" ![\n])* '"' }
+  StrliteralIncomplete { '"' (!["\\\n \t\r():=~<>] | "\\" ![\n \t\r():=~<>])* }
   str { ![:~><=()"\ ]+ }
   filterAlias { "excludeEplikt" | "includeEplikt" | "excludePreliminary" | "includePreliminary" | "existsImage" | "alias-myLibraries" | "freeOnline" | "_suecia" | "_collections" }
   space { @whitespace+ }
 
-  @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, filterAlias, str, space}
+  @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, filterAlias, strliteral, StrliteralIncomplete, str, space }
 }
 
 @detectDelim

--- a/packages/codemirror-lang-lxlquery/src/syntax.grammar
+++ b/packages/codemirror-lang-lxlquery/src/syntax.grammar
@@ -7,7 +7,7 @@ andcomb { term ( AndOperator term | term )* }
 term { String | Group | UTerm | Qualifier }
 Group { "(" orcomb? ")" }
 UTerm { UOperator term }
-String { strliteral | StrliteralIncomplete | str }
+String { strliteral | strliteralIncomplete | str }
 Qualifier { 
   ( QualifierKey { String } QualifierOperator { bOperator } QualifierValue { String } ) | 
   ( QualifierKey { String } QualifierOperator { bOperatorEq } QualifierValue { qualifierTerm } ) |
@@ -32,12 +32,12 @@ QualifierInnerGroup { "(" qualifierOrcomb? ")" }
   bOperator {"<" | ">" | "<=" | ">=" }
   bOperatorEq { ":" | "=" | "~" }
   strliteral { '"' (!["\\\n()] | "\\" ![\n])* '"' }
-  StrliteralIncomplete { '"' (!["\\\n \t\r():=~<>] | "\\" ![\n \t\r():=~<>])* }
+  strliteralIncomplete { '"' (!["\\\n \t\r():=~<>] | "\\" ![\n \t\r():=~<>])* }
   str { ![:~><=()"\ ]+ }
   filterAlias { "excludeEplikt" | "includeEplikt" | "excludePreliminary" | "includePreliminary" | "existsImage" | "alias-myLibraries" | "freeOnline" | "_suecia" | "_collections" }
   space { @whitespace+ }
 
-  @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, filterAlias, strliteral, StrliteralIncomplete, str, space }
+  @precedence { OrOperator, AndOperator, UOperator, bOperator, bOperatorEq, filterAlias, strliteral, strliteralIncomplete, str, space }
 }
 
 @detectDelim

--- a/packages/codemirror-lang-lxlquery/test/cases.txt
+++ b/packages/codemirror-lang-lxlquery/test/cases.txt
@@ -423,7 +423,7 @@ NOT
 Query(UTerm(UOperator ⚠))
 
 
-# fail unclosed quote (does not fail since token strliteralIncomplete)
+# NO fail unclosed quote (does not fail since token strliteralIncomplete)
 
 "Astrid Lind
 
@@ -431,6 +431,69 @@ Query(UTerm(UOperator ⚠))
 
 Query(String String)
 
+
+# handle unclosed quote + qualifier
+
+" förf:("Astid Lindgren")
+
+==>
+
+Query(
+  String,
+  Qualifier(
+    QualifierKey(String),
+    QualifierOperator,
+    QualifierValue(
+      QualifierOuterGroup(
+        String
+      )
+    )
+  )
+)
+
+# handle unclosed quote in qualifier + qualifier
+
+item:("akka) item:("packa")
+
+==>
+
+Query(
+  Qualifier(
+    QualifierKey(
+      String),
+    QualifierOperator,
+    QualifierValue(
+      QualifierOuterGroup(
+        String
+      )
+    )
+  ),
+  Qualifier(
+    QualifierKey(
+      String
+    ),
+    QualifierOperator,
+    QualifierValue(
+      QualifierOuterGroup(
+        String
+      )
+    )
+  )
+)
+
+
+# expectedly mishandle unclosed quote + qualifier without group
+
+" förf:"Astid Lindgren"
+
+==>
+
+Query(
+  String,
+  String,
+  String,
+  String
+)
 
 # allow empty paren
 

--- a/packages/codemirror-lang-lxlquery/test/cases.txt
+++ b/packages/codemirror-lang-lxlquery/test/cases.txt
@@ -423,13 +423,13 @@ NOT
 Query(UTerm(UOperator ⚠))
 
 
-# fail unclosed quote
+# fail unclosed quote (does not fail since token strliteralIncomplete)
 
 "Astrid Lind
 
 ==>
 
-Query(⚠ String String)
+Query(String String)
 
 
 # allow empty paren


### PR DESCRIPTION
## Description
### Solves

Needs to be thoroughly tested…

An attempt to fix the fact that a single quote char can break the pill rendering:

<img width="800" height="56" alt="gif1" src="https://github.com/user-attachments/assets/b7dc8da6-e876-4810-b5d7-8992c79c8b8c" />.

This is of course because the `"` makes everything up until the next quote parse as a `strLiteral`, swallowing the subsequent qualifier.

We need to allow the stray `”` to parse as something allowed inside a QualifierValue, in order for the qualifier to stay intact. 
If we add a new token for the incomplete quoted string, `StrliteralIncomplete`, and include it in the definition of `String`, it now "adds upp", allowing the rest to stay intact too. (a little deceiving, because it is in fact an invalid query)

<img width="800" height="56" alt="gif2" src="https://github.com/user-attachments/assets/21f014ba-b459-4171-ac7f-9bdb65e12c7e" />.

But we still have a problem:

<img width="800" height="56" alt="gif3" src="https://github.com/user-attachments/assets/f14b6c2a-916b-4b7f-8e78-cb40dc2dc7b5" />.

The parser still sees the quoted string `” contribution:(”` instead of an incomplete string and a qualifier.

The only thing I've come up with is to disallow certain chars in quoted strings. When the parser sees `()`,  or `():=~<>` in a incomplete quoted string, it breaks and instead goes with the qualifier:

<img width="800" height="56" alt="gif4" src="https://github.com/user-attachments/assets/1d45cbb1-afa6-4e69-aaf5-fa1380561731" />.

**Downsides / tradeoffs**

More convoluted grammar
We lose the "error highlighting" of unclosed quotes, since it's now part of the grammar
Will probably never be 100% waterproof:

the query
`" title:"hello"`

Will still be parsed as a the string literal `" title:"` (as long as we don't disallow more chars here)

This should only be merged in combination with a fix to make sure the api don't wipe groups () from the query. These are now key to recognizing qualifiers in these cases.

### Summary of changes

* Update grammar
