### PR TITLE
fix(lxlweb): don't crash in getHeldBy on missing org

### DIFF
--- a/lxl-web/src/lib/utils/holdings.test.ts
+++ b/lxl-web/src/lib/utils/holdings.test.ts
@@ -47,4 +47,15 @@ describe('getHeldBy', () => {
 			'https://libris.kb.se/library/H'
 		]);
 	});
+
+	it('Ignores orgs missing from the org index', () => {
+		const userSettings = new UserSettings({});
+		userSettings.addLibrary('https://libris.kb.se/library/S');
+		userSettings.addLibrary('https://libris.kb.se/library/org/GOMU');
+		const byType = getHoldersByType(getHoldingsByType(workCenteredMainEntity));
+
+		expect(getHeldBy(userSettings.myLibraries, byType, {})).toStrictEqual([
+			'https://libris.kb.se/library/S'
+		]);
+	});
 });

--- a/lxl-web/src/lib/utils/holdings.ts
+++ b/lxl-web/src/lib/utils/holdings.ts
@@ -164,7 +164,7 @@ export function getHeldBy(
 
 	for (const libId of Object.keys(myLibraries)) {
 		if (isLibraryOrg(libId) && orgs) {
-			const orgMembers = orgs[libId]._members;
+			const orgMembers = orgs[libId]?._members;
 			if (orgMembers && Array.isArray(orgMembers)) {
 				for (const memberId of orgMembers) {
 					// add the org to result - not the member sigel


### PR DESCRIPTION
I noticed occasional 500 errors in prod:
```
[500] GET /find?_q=something&_cursor=15&_limit=20&_offset=0&_sort=&_spell=true
TypeError: Cannot read properties of undefined (reading '_members')
    at getHeldBy (file:///data/packages/lxlweb-4001/build/server/chunks/holdings-BAo2QGfb.js:105:38)
    at getHeldByLibraries (file:///data/packages/lxlweb-4001/build/server/chunks/search.server-DWX7h352.js:505:13)
    at file:///data/packages/lxlweb-4001/build/server/chunks/search.server-DWX7h352.js:271:28
    at Array.map (<anonymous>)
    at asSearchResultItem (file:///data/packages/lxlweb-4001/build/server/chunks/search.server-DWX7h352.js:262:17)
    at asResult (file:///data/packages/lxlweb-4001/build/server/chunks/search.server-DWX7h352.js:239:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async load (file:///data/packages/lxlweb-4001/build/server/chunks/11-B1mPktAO.js:93:24)
    at async fn (file:///data/packages/lxlweb-4001/build/server/index.js:1266:23)
    at async load_server_data (file:///data/packages/lxlweb-4001/build/server/index.js:1257:18)
```
The problem is that `getHeldBy` assumes that every org in a user's `myLibraries` has a matching entry in `orgs`, but this is not necessarily true, as `orgs` is the result of `getRefinedOrgs(libraries)` which keeps only those for which `isLibraryOrg` is true.

This can happen if the user has favorited an org with no member libraries (if that's possible...?), or if the org (which is stored in a cookie) has been deleted or renamed, or possibly (at startup) due to a race condition if `refreshLibraries` hasn't finished.

Anyway, for the unlucky visitor this results in virtually _all_ search result pages and individual records simply crashing with a 500 error, until that cookie is cleared. So let's fix that.