### PR TITLE
feat(lxlweb): make library fetching more robust; warm up caches on startup

### DIFF
--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -1,5 +1,10 @@
 import fs from 'fs';
-import { type HandleServerError, redirect, type RequestEvent } from '@sveltejs/kit';
+import {
+	type HandleServerError,
+	redirect,
+	type RequestEvent,
+	type ServerInit
+} from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { defaultLocale, Locales } from '$lib/i18n/locales';
 import { DERIVED_LENSES } from '$lib/types/display';
@@ -23,14 +28,20 @@ type Util = [VocabUtil, DisplayUtil, QualifierSuggestionsByLocale];
 let utilCache: Promise<Util> | undefined;
 
 // Warm up caches immediately on startup instead of waiting for a request
-loadUtilCached()
-	.then(([, displayUtil]) => startRefreshLibraries(displayUtil, defaultLocale))
-	.catch((err) => console.error('Startup initialization failed:', err));
+export const init: ServerInit = async () => {
+	try {
+		const [, displayUtil] = await loadUtilCached();
+		startRefreshLibraries(displayUtil, defaultLocale);
+	} catch (err) {
+		// This is OK, handle() will retry
+		console.error('Startup initialization failed:', err);
+	}
+};
 
 export const handle = async ({ event, resolve }) => {
 	const [vocabUtil, displayUtil, qualifierSuggestionsByLocale] = await loadUtilCached();
 
-	// Fallback in case startup init failed. No-op if refresh aleady started.
+	// Fallback in case startup init failed. No-op if refresh already started.
 	startRefreshLibraries(displayUtil, defaultLocale);
 
 	event.locals.vocab = vocabUtil;

--- a/lxl-web/src/hooks.server.ts
+++ b/lxl-web/src/hooks.server.ts
@@ -20,16 +20,18 @@ import { updateSettings } from '$lib/utils/userSettings.svelte';
 
 type QualifierSuggestionsByLocale = Record<keyof typeof Locales, QualifierSuggestion2[]>;
 type Util = [VocabUtil, DisplayUtil, QualifierSuggestionsByLocale];
-let utilCache: Util | undefined;
-let initLibraries: boolean = false;
+let utilCache: Promise<Util> | undefined;
+
+// Warm up caches immediately on startup instead of waiting for a request
+loadUtilCached()
+	.then(([, displayUtil]) => startRefreshLibraries(displayUtil, defaultLocale))
+	.catch((err) => console.error('Startup initialization failed:', err));
 
 export const handle = async ({ event, resolve }) => {
 	const [vocabUtil, displayUtil, qualifierSuggestionsByLocale] = await loadUtilCached();
 
-	if (!initLibraries) {
-		initLibraries = true;
-		await startRefreshLibraries(displayUtil, defaultLocale);
-	}
+	// Fallback in case startup init failed. No-op if refresh aleady started.
+	startRefreshLibraries(displayUtil, defaultLocale);
 
 	event.locals.vocab = vocabUtil;
 	event.locals.display = displayUtil;
@@ -192,9 +194,12 @@ function isValidMyLibraries(value: unknown): value is MyLibrariesType {
 	return true;
 }
 
-async function loadUtilCached() {
+function loadUtilCached() {
 	if (!utilCache) {
-		utilCache = await loadUtil();
+		utilCache = loadUtil().catch((err) => {
+			utilCache = undefined;
+			throw err;
+		});
 	}
 	return utilCache;
 }

--- a/lxl-web/src/lib/utils/getLibraries.server.ts
+++ b/lxl-web/src/lib/utils/getLibraries.server.ts
@@ -27,7 +27,10 @@ let librariesCache: LibrariesCache = new Map();
 let orgCache: OrgCache = new Map();
 
 const REFRESH_INTERVAL = 12 * 60 * 60 * 1000; // 12 hrs?
+const RETRY_INTERVAL = 30 * 1000; // retry every 30s until the first successful load
 let intervalStarted = false;
+let firstAttemptStarted = false;
+let retryScheduled = false;
 
 async function fetchLibOrgs() {
 	const orgsArr = (await doFetch('bibdb:Organization')) as LibOrg[];
@@ -155,17 +158,43 @@ export async function refreshLibraries(displayUtil: DisplayUtil, locale: LocaleC
 	orgCache = buildOrgIndex(libraries, orgs);
 }
 
-export async function startRefreshLibraries(displayUtil: DisplayUtil, locale: LocaleCode) {
+export function startRefreshLibraries(displayUtil: DisplayUtil, locale: LocaleCode) {
+	if (firstAttemptStarted) return;
+	firstAttemptStarted = true;
+
+	// If first refresh on startup fails, keep trying every 30s and don't
+	// schedule the regular refresh interval until this has succeeded
+	refreshLibraries(displayUtil, locale)
+		.then(() => scheduleRefreshInterval(displayUtil, locale))
+		.catch((err) => {
+			console.error('Initial library fetch failed:', err);
+			scheduleRetryUntilInitialized(displayUtil, locale);
+		});
+}
+
+function scheduleRefreshInterval(displayUtil: DisplayUtil, locale: LocaleCode) {
 	if (intervalStarted) return; // avoid multiple intervals
 	intervalStarted = true;
-
-	refreshLibraries(displayUtil, locale).catch((err) =>
-		console.error('Initial library fetch failed:', err)
-	);
 
 	setInterval(() => {
 		refreshLibraries(displayUtil, locale).catch((err) =>
 			console.error('Scheduled library refresh failed:', err)
 		);
 	}, REFRESH_INTERVAL).unref();
+}
+
+function scheduleRetryUntilInitialized(displayUtil: DisplayUtil, locale: LocaleCode) {
+	if (retryScheduled) return;
+	retryScheduled = true;
+
+	const timer: NodeJS.Timeout = setInterval(() => {
+		refreshLibraries(displayUtil, locale)
+			.then(() => {
+				clearInterval(timer);
+				retryScheduled = false;
+				scheduleRefreshInterval(displayUtil, locale);
+			})
+			.catch((err) => console.error('Library fetch retry failed:', err));
+	}, RETRY_INTERVAL);
+	timer.unref();
 }


### PR DESCRIPTION
Previously, if `startRefreshLibraries` failed (for example, because the EMM API was unavailable), lxlweb would run with no library/org data for at least 12 hours (until a regularly scheduled refresh succeeded).

This PR does a couple things:

- Loading/caching of libraries/orgs/util is done immediately at start-up instead of when the first request comes in (but it deliberately still doesn't block any requests if loading hasn't finished).
- If the initial `refreshLibraries` fails, it keeps trying every 30 seconds instead of waiting for 12 hours. Only after a successful fetch does it schedule the 12-hour refresh interval.

Related to #1649 